### PR TITLE
[docs] Improve contributing docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,11 @@ assignees: ''
 
 ---
 
+<!-- **Are you in the right place?**
+1. For issues or feature requests, please create an issue in this repository.
+2. For general technical and non-technical questions, we are happy to help you on our [Slack](https://scylladb-users-slackin.herokuapp.com/).
+3. Did you already search the existing open issues for anything similar? -->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,13 +7,16 @@ assignees: ''
 
 ---
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- **Are you in the right place?**
+1. For issues or feature requests, please create an issue in this repository.
+2. For general technical and non-technical questions, we are happy to help you on our [Slack](https://scylladb-users-slackin.herokuapp.com/).
+3. Did you already search the existing open issues for anything similar? -->
 
-**Possible solution**
-A clear and concise description of what you want to happen.
+**Is this a bug report or feature request?**
+* Feature Request
 
-**Other Alternatives**
-A clear and concise description of any alternative solutions or features you've considered.
+**What should the feature do:**
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**What is use case behind this feature:**
+
+**Additional Information:**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
+documentation before submitting a Pull Request!
+Thank you for contributing to the Scylla Operator! -->
+
+**Description of your changes:**
+
+**Which issue is resolved by this Pull Request:**
+Resolves #
+
+**Checklist:**
+- [ ] Documentation has been updated, if necessary.
+- [ ] Image has been built (`make docker-build`) on the last commit.

--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,15 @@ IMG ?= "${REPO}:${TAG}"
 all: test local-build
 
 # Run tests
-test: generate fmt vet manifests
+test: generate fmt vet manifests vendor
 	go test ./pkg/... ./cmd/... -coverprofile cover.out
 
 # Build local-build binary
-local-build: generate fmt vet
+local-build: generate fmt vet vendor
 	go build -o bin/manager github.com/scylladb/scylla-operator/cmd
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet
+run: generate fmt vet vendor
 	go run ./cmd operator --image="${IMG}" --enable-admission-webhook=false
 
 # Install CRDs into a cluster
@@ -45,6 +45,10 @@ vet:
 # Generate code
 generate:
 	go generate ./pkg/... ./cmd/...
+
+# Ensure dependencies
+vendor:
+	dep ensure -v
 
 # Build the docker image
 docker-build: test

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,9 +2,16 @@
 
 ## Prerequisites
 
-1. [GO 1.11](https://golang.org/dl/) or greater installed
-2. Git client installed
-3. Github account
+To develop on scylla-operator, your environment must have the following:
+
+1. [Go 1.12](https://golang.org/dl/)
+    * Make sure [GOPATH](https://github.com/golang/go/wiki/SettingGOPATH) is set to `GOPATH=$HOME/go`.
+2. [Kustomize v2.0.3](https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3)
+3. [kubebuilder v1.0.7](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v1.0.7)
+4. [dep v0.5.0](https://github.com/golang/dep/releases/tag/v0.5.1)
+5. [Docker](https://docs.docker.com/install/)
+4. Git client installed
+5. Github account
 
 ## Initial Setup
 
@@ -14,7 +21,7 @@ From your browser navigate to [http://github.com/scylladb/scylla-operator](http:
 
 ### Clone Your Fork
 
-Open a console window and do the following;
+Open a console window and do the following:
 
 ```bash
 # Create the scylla operator repo path


### PR DESCRIPTION
This PR improves contributing docs by better documenting exactly what is required to set up a development environment for the scylla operator.

It also improves the BUG template and adds a PR template for github.