### PR TITLE
vendor: bump go-nodetool version to correct fd leak

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -503,7 +503,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:74e1118fa74d629d0e694bd6ca72a35e681f12af9179debef678ed137d6b7867"
+  digest = "1:6ec11be01ce051ca8144cd34f62627d3a575bde02b8f6e297d89f036e175e37a"
   name = "github.com/yanniszark/go-nodetool"
   packages = [
     "client",
@@ -511,7 +511,7 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "4edbb8916da8fcfd66e5824e6e5e9c9130cc8b44"
+  revision = "cc333b9c2b54be5ed617fcaa2bf32c6fff93f719"
 
 [[projects]]
   digest = "1:3c1a69cdae3501bf75e76d0d86dc6f2b0a7421bc205c0cb7b96b19eed464a34d"

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -33,4 +33,4 @@ patchesStrategicMerge:
 images:
 - name: yanniszark/scylla-operator
   newName: yanniszark/scylla-operator
-  newTag: v0.0-47cba43
+  newTag: v0.0-ee79ff2

--- a/examples/generic/operator.yaml
+++ b/examples/generic/operator.yaml
@@ -311,7 +311,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: yanniszark/scylla-operator:v0.0-47cba43
+        image: yanniszark/scylla-operator:v0.0-ee79ff2
         imagePullPolicy: Always
         name: manager
         resources:

--- a/examples/gke/operator.yaml
+++ b/examples/gke/operator.yaml
@@ -311,7 +311,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: yanniszark/scylla-operator:v0.0-47cba43
+        image: yanniszark/scylla-operator:v0.0-ee79ff2
         imagePullPolicy: Always
         name: manager
         resources:

--- a/examples/minikube/operator.yaml
+++ b/examples/minikube/operator.yaml
@@ -311,7 +311,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: yanniszark/scylla-operator:v0.0-47cba43
+        image: yanniszark/scylla-operator:v0.0-ee79ff2
         imagePullPolicy: Always
         name: manager
         resources:

--- a/vendor/github.com/yanniszark/go-nodetool/client/client.go
+++ b/vendor/github.com/yanniszark/go-nodetool/client/client.go
@@ -114,6 +114,8 @@ func (c *client) Do(request interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to send HTTP request: %v", err)
 	}
+	defer response.Body.Close()
+
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf(
 			"unexpected server response code for request %s. "+


### PR DESCRIPTION
Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Bumped the go-nodetool version because there was a file descriptor leak in that version.

**Checklist:**
- [X] Documentation has been updated, if necessary.
- [X] Image has been built (`make docker-build`) on the last commit.