### PR TITLE
Fix link for scylla_cluster_crd.md

### DIFF
--- a/docs/generic.md
+++ b/docs/generic.md
@@ -28,7 +28,7 @@ kubectl -n scylla-operator-system get pod
 
 Now that the operator is running, we can create an instance of a Scylla cluster by creating an instance of the `clusters.scylla.scylladb.com` resource.
 Some of that resource's values are configurable, so feel free to browse `cluster.yaml` and tweak the settings to your liking.
-Full details for all the configuration options can be found in the [Scylla Cluster CRD documentation](scylla-cluster-crd.md).
+Full details for all the configuration options can be found in the [Scylla Cluster CRD documentation](scylla_cluster_crd.md).
 
 When you are ready to create a Scylla cluster, simply run:
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Link to scylla_cluster_crd.md was pointing to scylla-cluster-crd.md which would give 404

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.