### PR TITLE
Configure scylla.yaml through config map

### DIFF
--- a/config/crds/scylla_v1alpha1_cluster.yaml
+++ b/config/crds/scylla_v1alpha1_cluster.yaml
@@ -66,6 +66,9 @@ spec:
                       resources:
                         description: Resources the Scylla Pods will use.
                         type: object
+                      scyllaConfigMap:
+                        description: Scylla config map name to customize scylla.yaml
+                        type: string
                       storage:
                         description: Storage describes the underlying storage that
                           Scylla will consume.
@@ -84,6 +87,7 @@ spec:
                     - members
                     - storage
                     - resources
+                    - scyllaConfigMap
                     type: object
                   type: array
               required:

--- a/docs/generic.md
+++ b/docs/generic.md
@@ -81,6 +81,23 @@ cluster = Cluster(['simple-cluster-client.scylla.svc'])
 session = cluster.connect()
 ```
 
+## Configure Scylla
+
+The operator can take a ConfigMap and apply it to the scylla.yaml configuration file.
+This is done by adding a ConfigMap to Kubernetes and refering to this in the Rack specification.
+The ConfigMap is just a file called `scylla.yaml` that has the properties you want to change in it.
+The operator will take the default properties for the rest of the configuration. 
+
+* Create a ConfigMap the default name that the operator uses is `scylla-config`:
+```console
+kubectl create configmap scylla-config -n scylla --from-file=/path/to/scylla.yaml
+```
+* Wait for the mount to propagate and then restart the cluster:
+```console
+kubectl rollout restart -n scylla statefulset/simple-cluster-us-east-1-us-east-1a
+```
+* The new config should be applied automatically by the operator, check the logs to be sure.
+
 ## Scale Up
 
 The operator supports scale up of a rack as well as addition of new racks. To make the changes, you can use:

--- a/docs/generic.md
+++ b/docs/generic.md
@@ -88,9 +88,9 @@ This is done by adding a ConfigMap to Kubernetes and refering to this in the Rac
 The ConfigMap is just a file called `scylla.yaml` that has the properties you want to change in it.
 The operator will take the default properties for the rest of the configuration. 
 
-* Create a ConfigMap the default name that the operator uses is `scylla-config`:
+* Create a ConfigMap named `scyllaCnfig` like this:
 ```console
-kubectl create configmap scylla-config -n scylla --from-file=/path/to/scylla.yaml
+kubectl create configmap scyllaConfig -n scylla --from-file=/path/to/scylla.yaml
 ```
 * Wait for the mount to propagate and then restart the cluster:
 ```console

--- a/docs/minikube.md
+++ b/docs/minikube.md
@@ -90,7 +90,24 @@ kubectl -n scylla edit clusters.scylla.scylladb.com simple-cluster
 ```console
 kubectl -n scylla describe clusters.scylla.scylladb.com simple-cluster
 ```
-  
+
+## Configure Scylla
+
+The operator can take a ConfigMap and apply it to the scylla.yaml configuration file.
+This is done by adding a ConfigMap to Kubernetes and refering to this in the Rack specification.
+The ConfigMap is just a file called `scylla.yaml` that has the properties you want to change in it.
+The operator will take the default properties for the rest of the configuration. 
+
+* Create a ConfigMap the default name that the operator uses is `scylla-config`:
+```console
+kubectl create configmap scylla-config -n scylla --from-file=/path/to/scylla.yaml
+```
+* Wait for the mount to propagate and then restart the cluster:
+```console
+kubectl rollout restart -n scylla statefulset/simple-cluster-us-east-1-us-east-1a
+```
+* The new config should be applied automatically by the operator, check the logs to be sure.
+
 ## Clean Up
  
 To clean up all resources associated with this walk-through, you can run the commands below.

--- a/docs/minikube.md
+++ b/docs/minikube.md
@@ -98,9 +98,9 @@ This is done by adding a ConfigMap to Kubernetes and refering to this in the Rac
 The ConfigMap is just a file called `scylla.yaml` that has the properties you want to change in it.
 The operator will take the default properties for the rest of the configuration. 
 
-* Create a ConfigMap the default name that the operator uses is `scylla-config`:
+* Create a ConfigMap named `scyllaConfig` like this:
 ```console
-kubectl create configmap scylla-config -n scylla --from-file=/path/to/scylla.yaml
+kubectl create configmap scyllaConfig -n scylla --from-file=/path/to/scylla.yaml
 ```
 * Wait for the mount to propagate and then restart the cluster:
 ```console

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -87,6 +87,7 @@ spec:
     name: us-east-1
     racks:
       - name: us-east-1a
+        scyllaConfigMap: "scyllaConfig"
         members: 3
         storage:
           capacity: 5Gi

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -87,6 +87,7 @@ spec:
     name: <gcp_zone>
     racks:
       - name: <gcp_region>
+        scylla_config_map: "scylla-config"
         members: 2
         storage:
           storageClassName: local-raid-disks

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -87,7 +87,7 @@ spec:
     name: <gcp_zone>
     racks:
       - name: <gcp_region>
-        scylla_config_map: "scylla-config"
+        scyllaConfigMap: "scyllaConfig"
         members: 2
         storage:
           storageClassName: local-raid-disks

--- a/examples/minikube/cluster.yaml
+++ b/examples/minikube/cluster.yaml
@@ -87,7 +87,7 @@ spec:
     name: us-east-1
     racks:
       - name: us-east-1a
-        scylla_config_map: "scylla-config"
+        scyllaConfigMap: "scyllaConfig"
         members: 1
         storage:
           capacity: 5Gi

--- a/examples/minikube/cluster.yaml
+++ b/examples/minikube/cluster.yaml
@@ -87,6 +87,7 @@ spec:
     name: us-east-1
     racks:
       - name: us-east-1a
+        scylla_config_map: "scylla-config"
         members: 1
         storage:
           capacity: 5Gi

--- a/pkg/apis/scylla/v1alpha1/cluster_types.go
+++ b/pkg/apis/scylla/v1alpha1/cluster_types.go
@@ -78,6 +78,8 @@ type RackSpec struct {
 	Placement *PlacementSpec `json:"placement,omitempty"`
 	// Resources the Scylla Pods will use.
 	Resources corev1.ResourceRequirements `json:"resources"`
+	// Scylla config map name to customize scylla.yaml
+	ScyllaConfig string `json:"scylla_config_map"`
 }
 
 type PlacementSpec struct {

--- a/pkg/apis/scylla/v1alpha1/cluster_types.go
+++ b/pkg/apis/scylla/v1alpha1/cluster_types.go
@@ -79,7 +79,7 @@ type RackSpec struct {
 	// Resources the Scylla Pods will use.
 	Resources corev1.ResourceRequirements `json:"resources"`
 	// Scylla config map name to customize scylla.yaml
-	ScyllaConfig string `json:"scylla_config_map"`
+	ScyllaConfig string `json:"scyllaConfigMap"`
 }
 
 type PlacementSpec struct {

--- a/pkg/controller/cluster/resource/resource.go
+++ b/pkg/controller/cluster/resource/resource.go
@@ -98,6 +98,11 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 		placement = &scyllav1alpha1.PlacementSpec{}
 	}
 	opt := true
+	scyllaConfigMap := r.ScyllaConfig
+	// TODO: Remove when updating the config map name is implemented
+	if scyllaConfigMap == "" {
+		scyllaConfigMap = "scyllaConfig"
+	}
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            naming.StatefulSetNameForRack(r, c),

--- a/pkg/controller/cluster/resource/resource.go
+++ b/pkg/controller/cluster/resource/resource.go
@@ -98,6 +98,10 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 		placement = &scyllav1alpha1.PlacementSpec{}
 	}
 	opt := true
+	scyllaConfigMap := r.ScyllaConfig
+	if scyllaConfigMap == "" {
+		scyllaConfigMap = "scylla-config"
+	}
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            naming.StatefulSetNameForRack(r, c),
@@ -138,7 +142,7 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "scylla-config",
+										Name: scyllaConfigMap,
 									},
 									Optional: &opt,
 								},

--- a/pkg/controller/cluster/resource/resource.go
+++ b/pkg/controller/cluster/resource/resource.go
@@ -97,7 +97,7 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 	if placement == nil {
 		placement = &scyllav1alpha1.PlacementSpec{}
 	}
-
+	opt := true
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            naming.StatefulSetNameForRack(r, c),
@@ -131,6 +131,17 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 							Name: "shared",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "scylla-config-volume",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "scylla-config",
+									},
+									Optional: &opt,
+								},
 							},
 						},
 					},
@@ -243,6 +254,11 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 								{
 									Name:      "shared",
 									MountPath: naming.SharedDirName,
+									ReadOnly:  true,
+								},
+								{
+									Name:      "scylla-config-volume",
+									MountPath: naming.ScyllaConfigDirName,
 									ReadOnly:  true,
 								},
 							},

--- a/pkg/controller/cluster/resource/resource.go
+++ b/pkg/controller/cluster/resource/resource.go
@@ -98,10 +98,6 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 		placement = &scyllav1alpha1.PlacementSpec{}
 	}
 	opt := true
-	scyllaConfigMap := r.ScyllaConfig
-	if scyllaConfigMap == "" {
-		scyllaConfigMap = "scylla-config"
-	}
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            naming.StatefulSetNameForRack(r, c),
@@ -138,11 +134,11 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 							},
 						},
 						{
-							Name: "scylla-config-volume",
+							Name: "scyllaConfigVolume",
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: scyllaConfigMap,
+										Name: r.ScyllaConfig,
 									},
 									Optional: &opt,
 								},
@@ -261,7 +257,7 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 									ReadOnly:  true,
 								},
 								{
-									Name:      "scylla-config-volume",
+									Name:      "scyllaConfigVolume",
 									MountPath: naming.ScyllaConfigDirName,
 									ReadOnly:  true,
 								},

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -61,7 +61,7 @@ const (
 
 	SharedDirName = "/mnt/shared"
 
-	ScyllaConfigDirName = "/mnt/scylla-config"
+	ScyllaConfigDirName = "/mnt/config"
 	ScyllaConfigName    = "scylla.yaml"
 
 	DataDir = "/var/lib/scylla"

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -61,6 +61,9 @@ const (
 
 	SharedDirName = "/mnt/shared"
 
+	ScyllaConfigDirName = "/mnt/scylla-config"
+	ScyllaConfigName    = "scylla.yaml"
+
 	DataDir = "/var/lib/scylla"
 
 	JolokiaJarName = "jolokia.jar"


### PR DESCRIPTION
Allows for configuring `scylla.yaml` through a config map.

Fixes: #31 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.