### PR TITLE
Agent container

### DIFF
--- a/config/crds/scylla_v1alpha1_cluster.yaml
+++ b/config/crds/scylla_v1alpha1_cluster.yaml
@@ -30,6 +30,12 @@ spec:
           type: object
         spec:
           properties:
+            agentRepository:
+              description: Repository to pull the agent image from. Defaults to "scylladb/scylla-manager-agent".
+              type: string
+            agentVersion:
+              description: Version of Scylla Manager Agent to use. Defaults to "latest".
+              type: string
             cpuset:
               description: CpuSet determines if the cluster will use cpu-pinning for
                 max performance.
@@ -118,6 +124,7 @@ spec:
               type: string
           required:
           - version
+          - agentVersion
           - datacenter
           type: object
         status:

--- a/config/crds/scylla_v1alpha1_cluster.yaml
+++ b/config/crds/scylla_v1alpha1_cluster.yaml
@@ -72,6 +72,10 @@ spec:
                       resources:
                         description: Resources the Scylla Pods will use.
                         type: object
+                      scyllaAgentConfig:
+                        description: Scylla config map name to customize scylla manager
+                          agent
+                        type: string
                       scyllaConfig:
                         description: Scylla config map name to customize scylla.yaml
                         type: string
@@ -94,6 +98,7 @@ spec:
                     - storage
                     - resources
                     - scyllaConfig
+                    - scyllaAgentConfig
                     type: object
                   type: array
               required:

--- a/docs/generic.md
+++ b/docs/generic.md
@@ -129,7 +129,41 @@ kubectl -n scylla edit clusters.scylla.scylladb.com simple-cluster
 ```console
 kubectl -n scylla describe clusters.scylla.scylladb.com simple-cluster
 ```
-  
+
+## Configure Scylla
+
+The operator can take a ConfigMap and apply it to the scylla.yaml configuration file.
+This is done by adding a ConfigMap to Kubernetes and refering to this in the Rack specification.
+The ConfigMap is just a file called `scylla.yaml` that has the properties you want to change in it.
+The operator will take the default properties for the rest of the configuration. 
+
+* Create a ConfigMap the default name that the operator uses is `scylla-config`:
+```console
+kubectl create configmap scylla-config -n scylla --from-file=/path/to/scylla.yaml
+```
+* Wait for the mount to propagate and then restart the cluster:
+```console
+kubectl rollout restart -n scylla statefulset/simple-cluster-us-east-1-us-east-1a
+```
+* The new config should be applied automatically by the operator, check the logs to be sure.
+
+Configuring `cassandra-rackdc.properties` is done by adding the file to the same mount as `scylla.yaml`.
+```console
+kubectl create configmap scylla-config -n scylla --from-file=/tmp/scylla.yaml --from-file=/tmp/cassandra-rackdc.properties -o yaml --dry-run | kubectl replace -f -
+```
+The operator will then apply the overridable properties `prefer_local` and `dc_suffix` if they are available in the provided mounted file.
+
+## Configure Scylla Manager Agent
+
+The operator creates a second container for each scylla instance that runs [Scylla Manager Agent](https://hub.docker.com/r/scylladb/scylla-manager-agent).
+This container serves as a sidecar and it's the main endpoint for [Scylla Manager](https://hub.docker.com/r/scylladb/scylla-manager) when interacting with Scylla.
+The Scylla Manager Agent can be configured with various things such as the security token used to allow access to it's API.
+
+To configure the agent you just create a new config-map called _scylla-agent-config_ and populate it with the contents in the `scylla-manager-agent.yaml` file like this:
+```console
+kubectl create configmap scylla-agent-config -n scylla --from-file=scylla-manager-agent.yaml
+```
+
 ## Clean Up
  
 To clean up all resources associated with this walk-through, you can run the commands below.

--- a/docs/minikube.md
+++ b/docs/minikube.md
@@ -114,6 +114,17 @@ kubectl create configmap scylla-config -n scylla --from-file=/tmp/scylla.yaml --
 ```
 The operator will then apply the overridable properties `prefer_local` and `dc_suffix` if they are available in the provided mounted file.
 
+## Configure Scylla Manager Agent
+
+The operator creates a second container for each scylla instance that runs [Scylla Manager Agent](https://hub.docker.com/r/scylladb/scylla-manager-agent).
+This container serves as a sidecar and it's the main endpoint for [Scylla Manager](https://hub.docker.com/r/scylladb/scylla-manager) when interacting with Scylla.
+The Scylla Manager Agent can be configured with various things such as the security token used to allow access to it's API.
+
+To configure the agent you just create a new config-map called _scylla-agent-config_ and populate it with the contents in the `scylla-manager-agent.yaml` file like this:
+```console
+kubectl create configmap scylla-agent-config -n scylla --from-file=scylla-manager-agent.yaml
+```
+
 ## Clean Up
  
 To clean up all resources associated with this walk-through, you can run the commands below.

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -82,6 +82,7 @@ metadata:
   namespace: scylla
 spec:
   version: 3.0.10
+  agentVersion: 2.0.1
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/generic/operator.yaml
+++ b/examples/generic/operator.yaml
@@ -79,6 +79,10 @@ spec:
                       resources:
                         description: Resources the Scylla Pods will use.
                         type: object
+                      scyllaAgentConfig:
+                        description: Scylla config map name to customize scylla manager
+                          agent
+                        type: string
                       scyllaConfig:
                         description: Scylla config map name to customize scylla.yaml
                         type: string
@@ -101,6 +105,7 @@ spec:
                     - storage
                     - resources
                     - scyllaConfig
+                    - scyllaAgentConfig
                     type: object
                   type: array
               required:

--- a/examples/generic/operator.yaml
+++ b/examples/generic/operator.yaml
@@ -37,6 +37,12 @@ spec:
           type: object
         spec:
           properties:
+            agentRepository:
+              description: Repository to pull the agent image from. Defaults to "scylladb/scylla-manager-agent".
+              type: string
+            agentVersion:
+              description: Version of Scylla Manager Agent to use. Defaults to "latest".
+              type: string
             cpuset:
               description: CpuSet determines if the cluster will use cpu-pinning for
                 max performance.
@@ -125,6 +131,7 @@ spec:
               type: string
           required:
           - version
+          - agentVersion
           - datacenter
           type: object
         status:

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -82,6 +82,7 @@ metadata:
   namespace: scylla
 spec:
   version: 3.0.10
+  agentVersion: 2.0.1
   cpuset: true
   datacenter:
     name: <gcp_zone>

--- a/examples/gke/operator.yaml
+++ b/examples/gke/operator.yaml
@@ -79,6 +79,10 @@ spec:
                       resources:
                         description: Resources the Scylla Pods will use.
                         type: object
+                      scyllaAgentConfig:
+                        description: Scylla config map name to customize scylla manager
+                          agent
+                        type: string
                       scyllaConfig:
                         description: Scylla config map name to customize scylla.yaml
                         type: string
@@ -101,6 +105,7 @@ spec:
                     - storage
                     - resources
                     - scyllaConfig
+                    - scyllaAgentConfig
                     type: object
                   type: array
               required:

--- a/examples/gke/operator.yaml
+++ b/examples/gke/operator.yaml
@@ -37,6 +37,12 @@ spec:
           type: object
         spec:
           properties:
+            agentRepository:
+              description: Repository to pull the agent image from. Defaults to "scylladb/scylla-manager-agent".
+              type: string
+            agentVersion:
+              description: Version of Scylla Manager Agent to use. Defaults to "latest".
+              type: string
             cpuset:
               description: CpuSet determines if the cluster will use cpu-pinning for
                 max performance.
@@ -125,6 +131,7 @@ spec:
               type: string
           required:
           - version
+          - agentVersion
           - datacenter
           type: object
         status:

--- a/examples/minikube/cluster.yaml
+++ b/examples/minikube/cluster.yaml
@@ -89,6 +89,7 @@ spec:
     racks:
       - name: us-east-1a
         scyllaConfig: "scylla-config"
+        scyllaAgentConfig: "scylla-agent-config"
         members: 1
         storage:
           capacity: 5Gi

--- a/examples/minikube/cluster.yaml
+++ b/examples/minikube/cluster.yaml
@@ -82,6 +82,7 @@ metadata:
   namespace: scylla
 spec:
   version: 3.0.10
+  agentVersion: 2.0.1
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/minikube/operator.yaml
+++ b/examples/minikube/operator.yaml
@@ -79,6 +79,10 @@ spec:
                       resources:
                         description: Resources the Scylla Pods will use.
                         type: object
+                      scyllaAgentConfig:
+                        description: Scylla config map name to customize scylla manager
+                          agent
+                        type: string
                       scyllaConfig:
                         description: Scylla config map name to customize scylla.yaml
                         type: string
@@ -101,6 +105,7 @@ spec:
                     - storage
                     - resources
                     - scyllaConfig
+                    - scyllaAgentConfig
                     type: object
                   type: array
               required:

--- a/examples/minikube/operator.yaml
+++ b/examples/minikube/operator.yaml
@@ -37,6 +37,12 @@ spec:
           type: object
         spec:
           properties:
+            agentRepository:
+              description: Repository to pull the agent image from. Defaults to "scylladb/scylla-manager-agent".
+              type: string
+            agentVersion:
+              description: Version of Scylla Manager Agent to use. Defaults to "latest".
+              type: string
             cpuset:
               description: CpuSet determines if the cluster will use cpu-pinning for
                 max performance.
@@ -125,6 +131,7 @@ spec:
               type: string
           required:
           - version
+          - agentVersion
           - datacenter
           type: object
         status:

--- a/pkg/apis/scylla/v1alpha1/cluster_types.go
+++ b/pkg/apis/scylla/v1alpha1/cluster_types.go
@@ -84,6 +84,8 @@ type RackSpec struct {
 	Resources corev1.ResourceRequirements `json:"resources"`
 	// Scylla config map name to customize scylla.yaml
 	ScyllaConfig string `json:"scyllaConfig"`
+	// Scylla config map name to customize scylla manager agent
+	ScyllaAgentConfig string `json:"scyllaAgentConfig"`
 }
 
 type PlacementSpec struct {

--- a/pkg/apis/scylla/v1alpha1/cluster_types.go
+++ b/pkg/apis/scylla/v1alpha1/cluster_types.go
@@ -48,6 +48,10 @@ type ClusterSpec struct {
 	Version string `json:"version"`
 	// Repository to pull the image from.
 	Repository *string `json:"repository,omitempty"`
+	// Version of Scylla Manager Agent to use. Defaults to "latest".
+	AgentVersion *string `json:"agentVersion"`
+	// Repository to pull the agent image from. Defaults to "scylladb/scylla-manager-agent".
+	AgentRepository *string `json:"agentRepository,omitempty"`
 	// DeveloperMode determines if the cluster runs in developer-mode.
 	DeveloperMode bool `json:"developerMode,omitempty"`
 	// CpuSet determines if the cluster will use cpu-pinning for max performance.

--- a/pkg/controller/cluster/resource/resource.go
+++ b/pkg/controller/cluster/resource/resource.go
@@ -343,7 +343,6 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 								{
 									Name:      naming.PVCTemplateName,
 									MountPath: naming.DataDir,
-									ReadOnly:  true,
 								},
 								{
 									Name:      "scylla-agent-config-volume",

--- a/pkg/controller/cluster/resource/resource.go
+++ b/pkg/controller/cluster/resource/resource.go
@@ -313,6 +313,24 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 								},
 							},
 						},
+						{
+							Name:            "scylla-manager-agent",
+							Image:           "scylladb/scylla-manager-agent:2.0.1",
+							ImagePullPolicy: "IfNotPresent",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "agent-rest-api",
+									ContainerPort: 10001,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      naming.PVCTemplateName,
+									MountPath: naming.DataDir,
+									ReadOnly:  true,
+								},
+							},
+						},
 					},
 					ServiceAccountName: naming.ServiceAccountNameForMembers(c),
 					Affinity:           &placement.Affinity,

--- a/pkg/controller/cluster/resource/resource.go
+++ b/pkg/controller/cluster/resource/resource.go
@@ -16,7 +16,10 @@ import (
 	"k8s.io/kubernetes/pkg/controller/endpoint"
 )
 
-const officialScyllaRepo = "scylladb/scylla"
+const (
+	officialScyllaRepo             = "scylladb/scylla"
+	officialScyllaManagerAgentRepo = "scylladb/scylla-manager-agent"
+)
 
 func HeadlessServiceForCluster(c *scyllav1alpha1.Cluster) *corev1.Service {
 	return &corev1.Service{
@@ -315,7 +318,7 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 						},
 						{
 							Name:            "scylla-manager-agent",
-							Image:           "scylladb/scylla-manager-agent:2.0.1",
+							Image:           agentImageForCluster(c),
 							ImagePullPolicy: "IfNotPresent",
 							Ports: []corev1.ContainerPort{
 								{
@@ -363,4 +366,16 @@ func imageForCluster(c *scyllav1alpha1.Cluster) string {
 		repo = *c.Spec.Repository
 	}
 	return fmt.Sprintf("%s:%s", repo, c.Spec.Version)
+}
+
+func agentImageForCluster(c *scyllav1alpha1.Cluster) string {
+	repo := officialScyllaManagerAgentRepo
+	if c.Spec.AgentRepository != nil {
+		repo = *c.Spec.AgentRepository
+	}
+	version := "latest"
+	if c.Spec.AgentVersion != nil {
+		version = *c.Spec.AgentVersion
+	}
+	return fmt.Sprintf("%s:%s", repo, version)
 }

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -62,6 +62,7 @@ const (
 	SharedDirName = "/mnt/shared"
 
 	ScyllaConfigDirName        = "/mnt/scylla-config"
+	ScyllaAgentConfigDirName   = "/mnt/scylla-agent-config"
 	ScyllaConfigName           = "scylla.yaml"
 	ScyllaRackDCPropertiesName = "cassandra-rackdc.properties"
 


### PR DESCRIPTION
This patch creates a new container in the same pod as Scylla with the Scylla Manager Agent running.
This is a prerequisite for the use of Scylla Manager as well as the removal of the JMX interaction.