### PR TITLE
examples: scylla version 3.2.1

### DIFF
--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -81,7 +81,7 @@ metadata:
   name: simple-cluster
   namespace: scylla
 spec:
-  version: 3.0.10
+  version: 3.2.1
   agentVersion: 2.0.1
   developerMode: true
   datacenter:

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -81,7 +81,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 3.0.10
+  version: 3.2.1
   agentVersion: 2.0.1
   cpuset: true
   datacenter:

--- a/examples/minikube/cluster.yaml
+++ b/examples/minikube/cluster.yaml
@@ -81,7 +81,7 @@ metadata:
   name: simple-cluster
   namespace: scylla
 spec:
-  version: 3.0.10
+  version: 3.2.1
   agentVersion: 2.0.1
   developerMode: true
   datacenter:


### PR DESCRIPTION
Default Scylla version in the examples is 3.2.1 