### PR TITLE
config: operator let's Scylla decide memory

### DIFF
--- a/cmd/options/sidecar.go
+++ b/cmd/options/sidecar.go
@@ -1,10 +1,11 @@
 package options
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // Singleton
@@ -14,8 +15,7 @@ var sidecarOpts = &sidecarOptions{
 
 type sidecarOptions struct {
 	*commonOptions
-	CPU    string
-	Memory string
+	CPU string
 }
 
 func GetSidecarOptions() *sidecarOptions {
@@ -25,7 +25,6 @@ func GetSidecarOptions() *sidecarOptions {
 func (o *sidecarOptions) AddFlags(cmd *cobra.Command) {
 	o.commonOptions.AddFlags(cmd)
 	cmd.Flags().StringVar(&o.CPU, "cpu", os.Getenv(naming.EnvVarCPU), "number of cpus to use")
-	cmd.Flags().StringVar(&o.Memory, "memory", os.Getenv(naming.EnvVarMemory), "amount of memory to use")
 }
 
 func (o *sidecarOptions) Validate() error {
@@ -34,9 +33,6 @@ func (o *sidecarOptions) Validate() error {
 	}
 	if o.CPU == "" {
 		return errors.New("cpu not set")
-	}
-	if o.Memory == "" {
-		return errors.New("memory not set")
 	}
 	return nil
 }

--- a/pkg/controller/cluster/resource/resource.go
+++ b/pkg/controller/cluster/resource/resource.go
@@ -248,16 +248,6 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 										},
 									},
 								},
-								{
-									Name: "MEMORY",
-									ValueFrom: &corev1.EnvVarSource{
-										ResourceFieldRef: &corev1.ResourceFieldSelector{
-											ContainerName: "scylla",
-											Resource:      "limits.memory",
-											Divisor:       resource.MustParse("1Mi"),
-										},
-									},
-								},
 							},
 							Resources: r.Resources,
 							VolumeMounts: []corev1.VolumeMount{

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -41,7 +41,6 @@ const (
 	EnvVarEnvVarPodName = "POD_NAME"
 	EnvVarPodNamespace  = "POD_NAMESPACE"
 	EnvVarCPU           = "CPU"
-	EnvVarMemory        = "MEMORY"
 )
 
 // Recorder Values

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -249,29 +248,13 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		devMode = "1"
 	}
 
-	// Get cpu cores
-	cpu := options.GetSidecarOptions().CPU
-
-	// Get memory
-	mem := options.GetSidecarOptions().Memory
-	// Leave some memory for other stuff
-	memNumber, _ := strconv.ParseInt(mem, 10, 64)
-	maxFn := func(x, y int64) (z int64) {
-		if z = x; x < y {
-			z = y
-		}
-		return
-	}
-	mem = fmt.Sprintf("%dM", maxFn(memNumber-700, 0))
-
 	args := []string{
 		fmt.Sprintf("--listen-address=%s", m.IP),
 		fmt.Sprintf("--broadcast-address=%s", m.StaticIP),
 		fmt.Sprintf("--broadcast-rpc-address=%s", m.StaticIP),
 		fmt.Sprintf("--seeds=%s", strings.Join(seeds, ",")),
 		fmt.Sprintf("--developer-mode=%s", devMode),
-		fmt.Sprintf("--smp=%s", cpu),
-		fmt.Sprintf("--memory=%s", mem),
+		fmt.Sprintf("--smp=%s", options.GetSidecarOptions().CPU),
 	}
 
 	// See if we need to use cpu-pinning


### PR DESCRIPTION
Since 3.1 the process by which Scylla decides the amount of memory
it should use works in a k8s setup as well. This patch drops the
additional heuristics for calculating the Scylla memory from the
operator itself.

Fixes: #32 