### PR TITLE
Fix generic examples

### DIFF
--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -89,6 +89,7 @@ spec:
     racks:
       - name: us-east-1a
         scyllaConfig: "scylla-config"
+        scyllaAgentConfig: "scylla-agent-config"
         members: 3
         storage:
           capacity: 5Gi

--- a/examples/generic/operator.yaml
+++ b/examples/generic/operator.yaml
@@ -332,11 +332,11 @@ spec:
         name: manager
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 2
+            memory: 100Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 1
+            memory: 50Mi
         volumeMounts:
         - mountPath: /tmp/cert
           name: webhook-server-secret


### PR DESCRIPTION
Without those change, the default value for installing the operator for generic platform does not work

   + Operator crash loop being OOM killed with default value
   + cluster.yaml does not pass webhook validation without scyllaAgentConfig

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.