### PR TITLE
operator: deployment of Alternator now supported

### DIFF
--- a/config/crds/scylla_v1alpha1_cluster.yaml
+++ b/config/crds/scylla_v1alpha1_cluster.yaml
@@ -36,6 +36,14 @@ spec:
             agentVersion:
               description: Version of Scylla Manager Agent to use. Defaults to "latest".
               type: string
+            alternator:
+              description: Alternator designates this cluster an Alternator cluster
+              properties:
+                port:
+                  description: Port on which to bind the Alternator API
+                  format: int32
+                  type: integer
+              type: object
             cpuset:
               description: CpuSet determines if the cluster will use cpu-pinning for
                 max performance.

--- a/docs/generic.md
+++ b/docs/generic.md
@@ -120,6 +120,33 @@ Checking the logs of the running scylla instances can be done like this:
 kubectl -n scylla logs simple-cluster-us-east-1-us-east-1a-0 scylla
 ```
 
+### Deploying Alternator
+
+The operator is also capable of deploying [Alternator](https://www.scylladb.com/alternator/) instead of the regular Scylla.
+This requires a small change in the cluster definition.
+Change the `cluster.yaml` file from this:
+```yaml
+spec:
+  version: 4.0.0
+  agentVersion: 2.0.2
+  developerMode: true
+  datacenter:
+    name: us-east-1
+```
+to this:
+```yaml
+spec:
+  version: 4.0.0
+  alternator:
+    port: 8000
+  agentVersion: 2.0.2
+  developerMode: true
+  datacenter:
+    name: us-east-1
+```
+You can specify whichever port you want.
+Once this is done the regular CQL ports will no longer be available, the cluster is a pure Alienator cluster.
+
 ## Accessing the Database
 
 * From kubectl:
@@ -147,6 +174,8 @@ from cassandra.cluster import Cluster
 cluster = Cluster(['simple-cluster-client.scylla.svc'])
 session = cluster.connect()
 ```
+
+If you are running the Alternator you can access the API on the port you specified using plain http.
 
 ## Configure Scylla
 

--- a/examples/generic/operator.yaml
+++ b/examples/generic/operator.yaml
@@ -43,6 +43,14 @@ spec:
             agentVersion:
               description: Version of Scylla Manager Agent to use. Defaults to "latest".
               type: string
+            alternator:
+              description: Alternator designates this cluster an Alternator cluster
+              properties:
+                port:
+                  description: Port on which to bind the Alternator API
+                  format: int32
+                  type: integer
+              type: object
             cpuset:
               description: CpuSet determines if the cluster will use cpu-pinning for
                 max performance.

--- a/examples/gke/operator.yaml
+++ b/examples/gke/operator.yaml
@@ -43,6 +43,14 @@ spec:
             agentVersion:
               description: Version of Scylla Manager Agent to use. Defaults to "latest".
               type: string
+            alternator:
+              description: Alternator designates this cluster an Alternator cluster
+              properties:
+                port:
+                  description: Port on which to bind the Alternator API
+                  format: int32
+                  type: integer
+              type: object
             cpuset:
               description: CpuSet determines if the cluster will use cpu-pinning for
                 max performance.

--- a/pkg/apis/scylla/v1alpha1/cluster_types.go
+++ b/pkg/apis/scylla/v1alpha1/cluster_types.go
@@ -48,6 +48,8 @@ type ClusterSpec struct {
 	Version string `json:"version"`
 	// Repository to pull the image from.
 	Repository *string `json:"repository,omitempty"`
+	// Alternator designates this cluster an Alternator cluster
+	Alternator *AlternatorSpec `json:"alternator,omitempty"`
 	// Version of Scylla Manager Agent to use. Defaults to "latest".
 	AgentVersion *string `json:"agentVersion"`
 	// Repository to pull the agent image from. Defaults to "scylladb/scylla-manager-agent".
@@ -106,6 +108,15 @@ type StorageSpec struct {
 	Capacity string `json:"capacity"`
 	// Name of storageClass to request
 	StorageClassName *string `json:"storageClassName,omitempty"`
+}
+
+type AlternatorSpec struct {
+	// Port on which to bind the Alternator API
+	Port int32 `json:"port,omitempty"`
+}
+
+func (a *AlternatorSpec) Enabled() bool {
+	return a != nil && a.Port > 0
 }
 
 // ClusterStatus is the status of a Scylla Cluster

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -181,7 +181,9 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		fmt.Sprintf("--developer-mode=%s", devMode),
 		fmt.Sprintf("--smp=%s", options.GetSidecarOptions().CPU),
 	}
-
+	if cluster.Spec.Alternator.Enabled() {
+		args = append(args, fmt.Sprintf("--alternator-port=%d", cluster.Spec.Alternator.Port))
+	}
 	// See if we need to use cpu-pinning
 	// TODO: Add more checks to make sure this is valid.
 	// eg. parse the cpuset and check the number of cpus is the same as cpu limits


### PR DESCRIPTION
There is now a cluster spec flag "alternator" that instructs the operator to deploy Alternator instead of the regular Scylla.

Fixes: #71 