### PR TITLE
Fix GKE deployment example, outdated docs

### DIFF
--- a/docs/gke.md
+++ b/docs/gke.md
@@ -51,7 +51,7 @@ For this guide, we'll create a GKE cluster with the following:
 1. A NodePool of 3 `n1-standard-32` Nodes, where the Scylla Pods will be deployed. Each of these Nodes has 8 local SSDs attached, which will later be combined into a RAID0 array. It is important to disable `autoupgrade` and `autorepair`, since they cause loss of data on local SSDs. 
 
 ```
-gcloud beta container --project "${GCP_PROJECT}" \
+gcloud container --project "${GCP_PROJECT}" \
 clusters create "${CLUSTER_NAME}" --username "admin" \
 --zone "${GCP_ZONE}" \
 --cluster-version "1.15.11-gke.3" \
@@ -68,7 +68,7 @@ clusters create "${CLUSTER_NAME}" --username "admin" \
 2. A NodePool of 2 `n1-standard-32` Nodes to deploy `cassandra-stress` later on.
 
 ```
-gcloud beta container --project "${GCP_PROJECT}" \
+gcloud container --project "${GCP_PROJECT}" \
 node-pools create "cassandra-stress-pool" \
 --cluster "${CLUSTER_NAME}" \
 --zone "${GCP_ZONE}" \
@@ -82,7 +82,7 @@ node-pools create "cassandra-stress-pool" \
 
 3. A NodePool of 1 `n1-standard-4` Node, where the operator and the monitoring stack will be deployed.
 ```
-gcloud beta container --project "${GCP_PROJECT}" \
+gcloud container --project "${GCP_PROJECT}" \
 node-pools create "operator-pool" \
 --cluster "${CLUSTER_NAME}" \
 --zone "${GCP_ZONE}" \

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -81,7 +81,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 3.2.1
+  version: 4.0.0
   agentVersion: 2.0.2
   cpuset: true
   datacenter:
@@ -89,7 +89,8 @@ spec:
     racks:
       - name: <gcp_region>
         scyllaConfig: "scylla-config"
-        members: 2
+        scyllaAgentConfig: "scylla-agent-config"
+        members: 3
         storage:
           storageClassName: local-raid-disks
           capacity: 2995G
@@ -98,14 +99,6 @@ spec:
             cpu: 30
             memory: 115G
         placement:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                  - key: failure-domain.beta.kubernetes.io/zone
-                    operator: In
-                    values:
-                      - <gcp_zone>
           tolerations:
             - key: role
               operator: Equal


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
- Resolve inconsistencies between `docs/gke.md` and `examples/gke/gke.sh`
- Bump Scylla 3.2.1 -> 4.0.0
- Fix missing `scyllaAgentConfig` in `examples/gke/cluster.yaml`
- Remove unnecessary `nodeAffinity`

**Which issue is resolved by this Pull Request:**
Resolves #87

**Checklist:**
- [X] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.