### PR TITLE
cluster: sysctl parameters can be applied

### DIFF
--- a/config/crds/scylla_v1alpha1_cluster.yaml
+++ b/config/crds/scylla_v1alpha1_cluster.yaml
@@ -132,6 +132,12 @@ spec:
               - version
               - repository
               type: object
+            sysctls:
+              description: 'Sysctl properties to be applied during initialization
+                given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
+              items:
+                type: string
+              type: array
             version:
               description: Version of Scylla to use.
               type: string

--- a/docs/generic.md
+++ b/docs/generic.md
@@ -120,6 +120,22 @@ Checking the logs of the running scylla instances can be done like this:
 kubectl -n scylla logs simple-cluster-us-east-1-us-east-1a-0 scylla
 ```
 
+### Configure container kernel parameters
+
+Sometimes it is necessary to run the container with different kernel parameters.
+In order to support this, the Scylla Operator defines a cluster property `sysctls` that is a list of the desired key-value pairs to set.
+
+___For example___: To increase the number events available for asynchronous IO processing in the Linux kernel to N set sysctls to`fs.aio-max-nr=N`.
+
+```yaml
+racks:
+  - name: rack-name
+    scyllaConfig: "scylla-config"
+    scyllaAgentConfig: "scylla-agent-config"
+    sysctls:
+      - "fs.aio-max-nr=2097152"
+```
+
 ### Deploying Alternator
 
 The operator is also capable of deploying [Alternator](https://www.scylladb.com/alternator/) instead of the regular Scylla.

--- a/examples/generic/operator.yaml
+++ b/examples/generic/operator.yaml
@@ -139,6 +139,12 @@ spec:
               - version
               - repository
               type: object
+            sysctls:
+              description: 'Sysctl properties to be applied during initialization
+                given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
+              items:
+                type: string
+              type: array
             version:
               description: Version of Scylla to use.
               type: string

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -90,6 +90,8 @@ spec:
       - name: <gcp_region>
         scyllaConfig: "scylla-config"
         scyllaAgentConfig: "scylla-agent-config"
+        sysctls:
+          - "fs.aio-max-nr=2097152"
         members: 2
         storage:
           storageClassName: local-raid-disks

--- a/examples/gke/operator.yaml
+++ b/examples/gke/operator.yaml
@@ -139,6 +139,12 @@ spec:
               - version
               - repository
               type: object
+            sysctls:
+              description: 'Sysctl properties to be applied during initialization
+                given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
+              items:
+                type: string
+              type: array
             version:
               description: Version of Scylla to use.
               type: string

--- a/pkg/apis/scylla/v1alpha1/cluster_types.go
+++ b/pkg/apis/scylla/v1alpha1/cluster_types.go
@@ -62,6 +62,10 @@ type ClusterSpec struct {
 	Datacenter DatacenterSpec `json:"datacenter"`
 	// User-provided image for the sidecar that replaces default.
 	SidecarImage *ImageSpec `json:"sidecarImage,omitempty"`
+	// Sysctl properties to be applied during initialization
+	// given as a list of key=value pairs.
+	// Example: fs.aio-max-nr=232323
+	Sysctls []string `json:"sysctls,omitempty"`
 }
 
 // DatacenterSpec is the desired state for a Scylla Datacenter.


### PR DESCRIPTION
This is done via the cluster crd and supplied as a list of sysctl
key-value pairs. The sysctl parameters wil be injected into the
cluster statefulset by way of an init container.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.