### PR TITLE
make: fix PATH for go execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMG		?= $(REPO):$(TAG)
 DOCKER_BUILDKIT		:= 1
 GO111MODULE			:= off
 KUBEBUILDER_ASSETS	:= $(CURDIR)/bin/deps
-PATH				:= $(CURDIR)/bin/deps:$(CURDIR)/bin/deps/go/bin:$(PATH)
+PATH				:= $(CURDIR)/bin/deps/go/bin:$(CURDIR)/bin/deps:$(PATH)
 GOROOT				:= $(CURDIR)/bin/deps/go
 GOVERSION			:= $(shell go version)
 


### PR DESCRIPTION
Minor change to PATH in the Makefile to make "go" executable.