### PR TITLE
Cpuset incorrectly set

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1279,7 +1279,7 @@
   revision = "0317810137be915b9cf888946c6e115c1bfac693"
 
 [[projects]]
-  digest = "1:c89cbf8dda5c3addd250e2407c9090fb87455f849b724ae7cf4cc5f5ea3d9946"
+  digest = "1:72ff367f476e217e2a2ea5ac5d3da75677bd2746059bfeb617d22a9cb55373d3"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/api/legacyscheme",
@@ -1304,6 +1304,7 @@
     "pkg/features",
     "pkg/fieldpath",
     "pkg/kubelet/apis",
+    "pkg/kubelet/cm/cpuset",
     "pkg/kubelet/types",
     "pkg/master/ports",
     "pkg/scheduler/algorithm",
@@ -1465,6 +1466,7 @@
     "k8s.io/client-go/tools/record",
     "k8s.io/code-generator/cmd/deepcopy-gen",
     "k8s.io/kubernetes/pkg/controller/endpoint",
+    "k8s.io/kubernetes/pkg/kubelet/cm/cpuset",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
     "sigs.k8s.io/controller-runtime/pkg/controller",

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -100,6 +100,9 @@ spec:
           limits:
             cpu: 30
             memory: 115G
+          requests:
+            cpu: 30
+            memory: 115G
         placement:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/cluster/resource/resource.go
+++ b/pkg/controller/cluster/resource/resource.go
@@ -191,6 +191,16 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.Cluster, si
 								"-c",
 								fmt.Sprintf("cp -a /sidecar/* %s", naming.SharedDirName),
 							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("200M"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("200M"),
+								},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "shared",
@@ -396,6 +406,16 @@ func sysctlInitContainer(sysctls []string) *corev1.Container {
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &opt,
 		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
+			},
+		},
 		Command: []string{
 			"/bin/sh",
 			"-c",
@@ -430,6 +450,16 @@ func agentContainer(c *scyllav1alpha1.Cluster) *corev1.Container {
 				Name:      "scylla-agent-config-volume",
 				MountPath: naming.ScyllaAgentConfigDirName,
 				ReadOnly:  true,
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
 			},
 		},
 	}

--- a/pkg/webhook/default_server/cluster/validating/cluster_validation.go
+++ b/pkg/webhook/default_server/cluster/validating/cluster_validation.go
@@ -36,13 +36,12 @@ func checkValues(c *scyllav1alpha1.Cluster) (allowed bool, msg string) {
 			// Requests == Limits or only Limits must be set for QOS class guaranteed
 			requests := rack.Resources.Requests
 			if requests != nil {
-				if requests.Cpu().MilliValue() == 0 {
+				if requests.Cpu().MilliValue() != limits.Cpu().MilliValue() {
 					return false, fmt.Sprintf("when using cpuset, cpu requests must be the same as cpu limits in rack %s", rack.Name)
 				}
-				if requests.Memory().MilliValue() == 0 {
+				if requests.Memory().MilliValue() != limits.Memory().MilliValue() {
 					return false, fmt.Sprintf("when using cpuset, memory requests must be the same as memory limits in rack %s", rack.Name)
 				}
-				return false, fmt.Sprintf("when using cpuset, requests must be the same as limits in rack %s", rack.Name)
 			}
 		}
 	}

--- a/pkg/webhook/default_server/cluster/validating/cluster_validation.go
+++ b/pkg/webhook/default_server/cluster/validating/cluster_validation.go
@@ -33,7 +33,7 @@ func checkValues(c *scyllav1alpha1.Cluster) (allowed bool, msg string) {
 				return false, fmt.Sprintf("when using cpuset, you must use whole cpu cores, but rack %s has %dm", rack.Name, cores)
 			}
 
-			// Requests == Limits or only Limits must be set for QOS class guaranteed
+			// Requests == Limits and Requests must be set and equal for QOS class guaranteed
 			requests := rack.Resources.Requests
 			if requests != nil {
 				if requests.Cpu().MilliValue() != limits.Cpu().MilliValue() {
@@ -42,6 +42,9 @@ func checkValues(c *scyllav1alpha1.Cluster) (allowed bool, msg string) {
 				if requests.Memory().MilliValue() != limits.Memory().MilliValue() {
 					return false, fmt.Sprintf("when using cpuset, memory requests must be the same as memory limits in rack %s", rack.Name)
 				}
+			} else {
+				// Copy the limits
+				rack.Resources.Requests = limits.DeepCopy()
 			}
 		}
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cpuset.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/cm/cpuset",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/golang/glog:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cpuset_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/OWNERS
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- derekwaynecarr
+- vishh
+- ConnorDoyle
+- sjenning

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/cpuset.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpuset/cpuset.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpuset
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/golang/glog"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Builder is a mutable builder for CPUSet. Functions that mutate instances
+// of this type are not thread-safe.
+type Builder struct {
+	result CPUSet
+	done   bool
+}
+
+// NewBuilder returns a mutable CPUSet builder.
+func NewBuilder() Builder {
+	return Builder{
+		result: CPUSet{
+			elems: map[int]struct{}{},
+		},
+	}
+}
+
+// Add adds the supplied elements to the result. Calling Add after calling
+// Result has no effect.
+func (b Builder) Add(elems ...int) {
+	if b.done {
+		return
+	}
+	for _, elem := range elems {
+		b.result.elems[elem] = struct{}{}
+	}
+}
+
+// Result returns the result CPUSet containing all elements that were
+// previously added to this builder. Subsequent calls to Add have no effect.
+func (b Builder) Result() CPUSet {
+	b.done = true
+	return b.result
+}
+
+// CPUSet is a thread-safe, immutable set-like data structure for CPU IDs.
+type CPUSet struct {
+	elems map[int]struct{}
+}
+
+// NewCPUSet returns a new CPUSet containing the supplied elements.
+func NewCPUSet(cpus ...int) CPUSet {
+	b := NewBuilder()
+	for _, c := range cpus {
+		b.Add(c)
+	}
+	return b.Result()
+}
+
+// Size returns the number of elements in this set.
+func (s CPUSet) Size() int {
+	return len(s.elems)
+}
+
+// IsEmpty returns true if there are zero elements in this set.
+func (s CPUSet) IsEmpty() bool {
+	return s.Size() == 0
+}
+
+// Contains returns true if the supplied element is present in this set.
+func (s CPUSet) Contains(cpu int) bool {
+	_, found := s.elems[cpu]
+	return found
+}
+
+// Equals returns true if the supplied set contains exactly the same elements
+// as this set (s IsSubsetOf s2 and s2 IsSubsetOf s).
+func (s CPUSet) Equals(s2 CPUSet) bool {
+	return reflect.DeepEqual(s.elems, s2.elems)
+}
+
+// Filter returns a new CPU set that contains all of the elements from this
+// set that match the supplied predicate, without mutating the source set.
+func (s CPUSet) Filter(predicate func(int) bool) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		if predicate(cpu) {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// FilterNot returns a new CPU set that contains all of the elements from this
+// set that do not match the supplied predicate, without mutating the source
+// set.
+func (s CPUSet) FilterNot(predicate func(int) bool) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		if !predicate(cpu) {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// IsSubsetOf returns true if the supplied set contains all the elements
+func (s CPUSet) IsSubsetOf(s2 CPUSet) bool {
+	result := true
+	for cpu := range s.elems {
+		if !s2.Contains(cpu) {
+			result = false
+			break
+		}
+	}
+	return result
+}
+
+// Union returns a new CPU set that contains all of the elements from this
+// set and all of the elements from the supplied set, without mutating
+// either source set.
+func (s CPUSet) Union(s2 CPUSet) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		b.Add(cpu)
+	}
+	for cpu := range s2.elems {
+		b.Add(cpu)
+	}
+	return b.Result()
+}
+
+// Intersection returns a new CPU set that contains all of the elements
+// that are present in both this set and the supplied set, without mutating
+// either source set.
+func (s CPUSet) Intersection(s2 CPUSet) CPUSet {
+	return s.Filter(func(cpu int) bool { return s2.Contains(cpu) })
+}
+
+// Difference returns a new CPU set that contains all of the elements that
+// are present in this set and not the supplied set, without mutating either
+// source set.
+func (s CPUSet) Difference(s2 CPUSet) CPUSet {
+	return s.FilterNot(func(cpu int) bool { return s2.Contains(cpu) })
+}
+
+// ToSlice returns a slice of integers that contains all elements from
+// this set.
+func (s CPUSet) ToSlice() []int {
+	result := []int{}
+	for cpu := range s.elems {
+		result = append(result, cpu)
+	}
+	sort.Ints(result)
+	return result
+}
+
+// String returns a new string representation of the elements in this CPU set
+// in canonical linux CPU list format.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func (s CPUSet) String() string {
+	if s.IsEmpty() {
+		return ""
+	}
+
+	elems := s.ToSlice()
+
+	type rng struct {
+		start int
+		end   int
+	}
+
+	ranges := []rng{{elems[0], elems[0]}}
+
+	for i := 1; i < len(elems); i++ {
+		lastRange := &ranges[len(ranges)-1]
+		// if this element is adjacent to the high end of the last range
+		if elems[i] == lastRange.end+1 {
+			// then extend the last range to include this element
+			lastRange.end = elems[i]
+			continue
+		}
+		// otherwise, start a new range beginning with this element
+		ranges = append(ranges, rng{elems[i], elems[i]})
+	}
+
+	// construct string from ranges
+	var result bytes.Buffer
+	for _, r := range ranges {
+		if r.start == r.end {
+			result.WriteString(strconv.Itoa(r.start))
+		} else {
+			result.WriteString(fmt.Sprintf("%d-%d", r.start, r.end))
+		}
+		result.WriteString(",")
+	}
+	return strings.TrimRight(result.String(), ",")
+}
+
+// MustParse CPUSet constructs a new CPU set from a Linux CPU list formatted
+// string. Unlike Parse, it does not return an error but rather panics if the
+// input cannot be used to construct a CPU set.
+func MustParse(s string) CPUSet {
+	res, err := Parse(s)
+	if err != nil {
+		glog.Fatalf("unable to parse [%s] as CPUSet: %v", s, err)
+	}
+	return res
+}
+
+// Parse CPUSet constructs a new CPU set from a Linux CPU list formatted string.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func Parse(s string) (CPUSet, error) {
+	b := NewBuilder()
+
+	// Handle empty string.
+	if s == "" {
+		return b.Result(), nil
+	}
+
+	// Split CPU list string:
+	// "0-5,34,46-48 => ["0-5", "34", "46-48"]
+	ranges := strings.Split(s, ",")
+
+	for _, r := range ranges {
+		boundaries := strings.Split(r, "-")
+		if len(boundaries) == 1 {
+			// Handle ranges that consist of only one element like "34".
+			elem, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			b.Add(elem)
+		} else if len(boundaries) == 2 {
+			// Handle multi-element ranges like "0-5".
+			start, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			end, err := strconv.Atoi(boundaries[1])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			// Add all elements to the result.
+			// e.g. "0-5", "46-48" => [0, 1, 2, 3, 4, 5, 46, 47, 48].
+			for e := start; e <= end; e++ {
+				b.Add(e)
+			}
+		}
+	}
+	return b.Result(), nil
+}
+
+// Clone returns a copy of this CPU set.
+func (s CPUSet) Clone() CPUSet {
+	b := NewBuilder()
+	for elem := range s.elems {
+		b.Add(elem)
+	}
+	return b.Result()
+}


### PR DESCRIPTION
This PR sets the resources limits of all the containers, both init- and regular containers, explicitly to ensure QoS Guaranteed.
Furthermore it makes a minor validation that the cpuset and shard (--smp) settings are optimal. It will not block deployment but logs it to inform the user that there may be a problem.

Fixes: #121, #135  