### PR TITLE
gke: moved helper images to scylladb repos

### DIFF
--- a/examples/gke/cpu-policy-daemonset.yaml
+++ b/examples/gke/cpu-policy-daemonset.yaml
@@ -92,7 +92,7 @@ spec:
       serviceAccountName: cpu-policy-daemonset
       containers:
       - name: cpu-policy
-        image: yanniszark/kubectl:1.11.5
+        image: scylladb/kubectl:1.11.5
         imagePullPolicy: Always
         env:
           - name: NODE

--- a/examples/gke/raid-daemonset.yaml
+++ b/examples/gke/raid-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
           effect: NoSchedule
       containers:
       - name: raid-local-disks
-        image: yanniszark/raid-setup:0.1
+        image: scylladb/raid-setup:0.1
         env:
           - name: RAID_DIR
             value: "/mnt/hostfs/mnt/raid-disks/disk0"


### PR DESCRIPTION
The images `kubectl` and `raid-setup` have been move to scylladb repository.

Fixes: #119 