### PR TITLE
operator: correct resource validation when cpuset is used

### DIFF
--- a/pkg/api/v1alpha1/cluster_validation.go
+++ b/pkg/api/v1alpha1/cluster_validation.go
@@ -41,7 +41,6 @@ func checkValues(c *Cluster) error {
 				if requests.Memory().MilliValue() != limits.Memory().MilliValue() {
 					return errors.Errorf("when using cpuset, memory requests must be the same as memory limits in rack %s", rack.Name)
 				}
-				return errors.Errorf("when using cpuset, requests must be the same as limits in rack %s", rack.Name)
 			} else {
 				// Copy the limits
 				rack.Resources.Requests = limits.DeepCopy()


### PR DESCRIPTION
One of the chceks wasn't ported during v2 migration.
