### PR TITLE
docs,minikube: decrease scylla memory for local dev

### DIFF
--- a/docs/generic.md
+++ b/docs/generic.md
@@ -21,7 +21,7 @@ Fortunately there are ways to make life easier and [Minikube](https://minikube.s
 
 We need to give minikube a little bit more resources than default so start minikube like this:
 ```console
-minikube start --cpus=6 --memory=6144
+minikube start --cpus=6
 ```
 
 Then make kubectl aware of this local installation like this:

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -96,7 +96,7 @@ spec:
         resources:
           requests:
             cpu: 1
-            memory: 2Gi
+            memory: 1Gi
           limits:
             cpu: 1
-            memory: 2Gi
+            memory: 1Gi


### PR DESCRIPTION
Decreased ram for the generic example and dropped memory setting for minikube docs.

Fixes: #127 