### PR TITLE
Propose resource request update for scylla manager agent sidecar

### DIFF
--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -455,8 +455,8 @@ func agentContainer(c *scyllav1alpha1.Cluster) *corev1.Container {
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("200M"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("10M"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),


### PR DESCRIPTION
Propose resource request update for scylla manager agent sidecar starting at 5 percent

Rationale:
 If the DB is pinned to max 1 CPU per pod, with scylla manager agent sidecar also at 1 CPU is quite a lot

Could we start at: cpu 50m, memory 10M; and max out to cpu 1, memory 200M?
This would be beneficial for developer testing and k8s will scale it vertically for production

**Description of your changes:**
Update resource.go for scylla manager agent

**Which issue is resolved by this Pull Request:**
Resolves # None

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.