### PR TITLE
examples: EKS demo example (#44)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ uninstall: manifests
 cert-manager:
 	cat config/certmanager/cert-manager.yaml > examples/generic/cert-manager.yaml
 	cat config/certmanager/cert-manager.yaml > examples/gke/cert-manager.yaml
+	cat config/certmanager/cert-manager.yaml > examples/eks/cert-manager.yaml
 	kubectl apply -f examples/generic/cert-manager.yaml
 	kubectl -n cert-manager wait --for=condition=ready pod -l app=cert-manager --timeout=60s
 	kubectl -n cert-manager wait --for=condition=ready pod -l app=cainjector --timeout=60s
@@ -53,6 +54,7 @@ manifests: bin/deps controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) webhook rbac:roleName=manager-role paths="$(PKG)" output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=config/rbac/bases
 	kustomize build config/default > examples/generic/operator.yaml
 	kustomize build config/default > examples/gke/operator.yaml
+	kustomize build config/default > examples/eks/operator.yaml
 # Run go fmt against code
 fmt:
 	go fmt $(PKG)

--- a/docs/eks.md
+++ b/docs/eks.md
@@ -1,0 +1,112 @@
+# Deploying Scylla on EKS
+
+This guide is focused on deploying Scylla on EKS with improved performance. 
+Performance tricks used by the script won't work with different machine tiers.
+It sets up the kubelets on EKS nodes to run with [static cpu policy](https://kubernetes.io/blog/2018/07/24/feature-highlight-cpu-manager/) and uses [local sdd disks](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/local-ssd) in RAID0 for maximum performance.
+
+Most of the commands used to setup the Scylla cluster are the same for all environments
+As such we have tried to keep them separate in the [general guide](generic.md).
+
+## TL;DR;
+
+If you don't want to run the commands step-by-step, you can just run a script that will set everything up for you:
+```bash
+# Edit according to your preference
+EKS_ZONE=us-east-1a
+
+# From inside the examples/eks folder
+cd examples/eks
+./eks.sh -z "$EKS_ZONE"
+```
+
+:warning: Make sure to pass a ZONE (ex.: eu-central-1a) and not a REGION (ex.: eu-central-1).
+
+After you deploy, see how you can [benchmark your cluster with cassandra-stress](#benchmark-with-cassandra-stress).
+
+## Walkthrough
+
+### EKS Setup
+
+#### Configure environment variables
+
+First of all, we export all the configuration options as environment variables.
+Edit according to your own environment.
+
+```
+EKS_ZONE=us-east-1a
+CLUSTER_NAME=scylla-demo
+```
+
+#### Creating a EKS cluster
+
+For this guide, we'll create a EKS cluster with the following:
+
+* A NodeGroup of 3 `i3-2xlarge` Nodes, where the Scylla Pods will be deployed. These nodes will only accept pods having `scylla-clusters` toleration. 
+
+```
+  - name: scylla-pool
+    instanceType: i3.2xlarge
+    desiredCapacity: 3
+    labels:
+      pool: "scylla-pool"
+    taints:
+      role: "scylla-clusters:NoSchedule"
+    ssh:
+      allow: true
+    kubeletExtraConfig:
+      cpuManagerPolicy: static
+```
+
+* A NodeGroup of 4 `c4.2xlarge` Nodes to deploy `cassandra-stress` later on. These nodes will only accept pods having `cassandra-stress` toleration.
+
+```
+  - name: cassandra-stress-pool
+    instanceType: c4.2xlarge
+    desiredCapacity: 4
+    labels:
+      pool: "cassandra-stress-pool"
+    taints:
+      role: "cassandra-stress:NoSchedule"
+    ssh:
+      allow: true
+```
+
+* A NodeGroup of 1 `i3.large` Node, where the monitoring stack and operator will be deployed.
+```
+  - name: monitoring-pool
+    instanceType: i3.large
+    desiredCapacity: 1
+    labels:
+      pool: "monitoring-pool"
+    ssh:
+      allow: true
+```
+
+### Installing Required Tools 
+
+#### Installing script third party dependencies
+
+Script requires several dependencies:
+- Helm - See: https://docs.helm.sh/using_helm/#installing-helm
+- eksctl - See: https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html
+- kubectl - See: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+
+
+#### Install the local provisioner
+
+We deploy the local volume provisioner, which will discover their mount points and make them available as PersistentVolumes.
+```
+helm install --name local-provisioner examples/eks/provisioner
+```
+
+### Installing the Scylla Operator and Scylla
+
+Now you can follow the [generic guide](generic.md) to launch your Scylla cluster in a highly performant environment.
+
+#### Deleting a EKS cluster
+
+Once you are done with your experiments delete your cluster using following command:
+
+```
+eksctl delete cluster <cluster_name>
+```

--- a/docs/eks.md
+++ b/docs/eks.md
@@ -96,7 +96,7 @@ Script requires several dependencies:
 
 We deploy the local volume provisioner, which will discover their mount points and make them available as PersistentVolumes.
 ```
-helm install --name local-provisioner examples/eks/provisioner
+helm install local-provisioner examples/eks/provisioner
 ```
 
 ### Installing the Scylla Operator and Scylla

--- a/examples/dashboards.sh
+++ b/examples/dashboards.sh
@@ -26,7 +26,7 @@ done
 
 if [[ "x${TARGET}" == "x" ]]
 then
-  echo "-t/--target (gke,generic) is mandatory"
+  echo "-t/--target (gke,generic,eks) is mandatory"
   exit
 fi
 

--- a/examples/eks/cert-manager.yaml
+++ b/examples/eks/cert-manager.yaml
@@ -1,0 +1,7221 @@
+# Copyright YEAR The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# Source: cert-manager/templates/templates.regular.out
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.1'
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
+  names:
+    kind: Issuer
+    listKind: IssuerList
+    plural: issuers
+    singular: issuer
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          type: object
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              type: object
+              required:
+              - privateKeySecretRef
+              - server
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                externalAccountBinding:
+                  description: ExternalAccountBinding is a reference to a CA external
+                    account of the ACME server.
+                  type: object
+                  required:
+                  - keyAlgorithm
+                  - keyID
+                  - keySecretRef
+                  properties:
+                    keyAlgorithm:
+                      description: keyAlgorithm is the MAC key algorithm that the
+                        key is used for. Valid values are "HS256", "HS384" and "HS512".
+                      type: string
+                      enum:
+                      - HS256
+                      - HS384
+                      - HS512
+                    keyID:
+                      description: keyID is the ID of the CA key that the External
+                        Account is bound to.
+                      type: string
+                    keySecretRef:
+                      description: keySecretRef is a Secret Key Selector referencing
+                        a data item in a Kubernetes Secret which holds the symmetric
+                        MAC key of the External Account Binding. The `key` is the
+                        index string that is paired with the key data in the Secret
+                        and should not be confused with the key data itself, or indeed
+                        with the External Account Binding keyID above. The secret
+                        key stored in the Secret **must** be un-padded, base64 URL
+                        encoded data.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      dns01:
+                        type: object
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            type: object
+                            required:
+                            - accountSecretRef
+                            - host
+                            properties:
+                              accountSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              host:
+                                type: string
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            type: object
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            properties:
+                              accessTokenSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              clientSecretSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              clientTokenSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              serviceConsumerDomain:
+                                type: string
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            type: object
+                            required:
+                            - resourceGroupName
+                            - subscriptionID
+                            properties:
+                              clientID:
+                                description: if both this and ClientSecret are left
+                                  unset MSI will be used
+                                type: string
+                              clientSecretSecretRef:
+                                description: if both this and ClientID are left unset
+                                  MSI will be used
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              environment:
+                                type: string
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                description: when specifying ClientID and ClientSecret
+                                  then this field is also needed
+                                type: string
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            type: object
+                            required:
+                            - project
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            type: object
+                            required:
+                            - email
+                            properties:
+                              apiKeySecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              apiTokenSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              email:
+                                type: string
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            type: string
+                            enum:
+                            - None
+                            - Follow
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            type: object
+                            required:
+                            - tokenSecretRef
+                            properties:
+                              tokenSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            type: object
+                            required:
+                            - nameserver
+                            properties:
+                              nameserver:
+                                description: The IP address or hostname of an authoritative
+                                  DNS server supporting RFC2136 in the form host:port.
+                                  If the host is an IPv6 address it must be enclosed
+                                  in square brackets (e.g [2001:db8::1]) ; port is
+                                  optional. This field is required.
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            type: object
+                            required:
+                            - region
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            type: object
+                            required:
+                            - groupName
+                            - solverName
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                x-kubernetes-preserve-unknown-fields: true
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                      http01:
+                        description: ACMEChallengeSolverHTTP01 contains configuration
+                          detailing how to solve HTTP01 challenges within a Kubernetes
+                          cluster. Typically this is accomplished through creating
+                          'routes' of some description that configure ingress controllers
+                          to direct traffic to 'solver pods', which are responsible
+                          for responding to the ACME server's HTTP requests.
+                        type: object
+                        properties:
+                          ingress:
+                            description: The ingress based HTTP01 challenge solver
+                              will solve challenges by creating or modifying Ingress
+                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                              to 'challenge solver' pods that are provisioned by cert-manager
+                              for each Challenge to be completed.
+                            type: object
+                            properties:
+                              class:
+                                description: The ingress class to use when creating
+                                  Ingress resources to solve ACME challenges that
+                                  use this challenge solver. Only one of 'class' or
+                                  'name' may be specified.
+                                type: string
+                              ingressTemplate:
+                                description: Optional ingress template used to configure
+                                  the ACME challenge solver ingress used for HTTP01
+                                  challenges
+                                type: object
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the ingress
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        description: Annotations that should be added
+                                          to the created ACME HTTP01 solver ingress.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      labels:
+                                        description: Labels that should be added to
+                                          the created ACME HTTP01 solver ingress.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                              name:
+                                description: The name of the ingress resource that
+                                  should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  is typically used in conjunction with ingress controllers
+                                  like ingress-gce, which maintains a 1:1 mapping
+                                  between external IPs and ingress resources.
+                                type: string
+                              podTemplate:
+                                description: Optional pod template used to configure
+                                  the ACME challenge solver pods used for HTTP01 challenges
+                                type: object
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the pod
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        description: Annotations that should be added
+                                          to the create ACME HTTP01 solver pods.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      labels:
+                                        description: Labels that should be added to
+                                          the created ACME HTTP01 solver pods.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                  spec:
+                                    description: PodSpec defines overrides for the
+                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                      'affinity' and 'tolerations' fields are supported
+                                      currently. All other fields will be ignored.
+                                    type: object
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling
+                                          constraints
+                                        type: object
+                                        properties:
+                                          nodeAffinity:
+                                            description: Describes node affinity scheduling
+                                              rules for the pod.
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node matches the
+                                                  corresponding matchExpressions;
+                                                  the node(s) with the highest sum
+                                                  are the most preferred.
+                                                type: array
+                                                items:
+                                                  description: An empty preferred
+                                                    scheduling term matches all objects
+                                                    with implicit weight 0 (i.e. it's
+                                                    a no-op). A null preferred scheduling
+                                                    term matches no objects (i.e.
+                                                    is also a no-op).
+                                                  type: object
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  properties:
+                                                    preference:
+                                                      description: A node selector
+                                                        term, associated with the
+                                                        corresponding weight.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          type: array
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          type: array
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                    weight:
+                                                      description: Weight associated
+                                                        with matching the corresponding
+                                                        nodeSelectorTerm, in the range
+                                                        1-100.
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to an update), the system
+                                                  may or may not try to eventually
+                                                  evict the pod from its node.
+                                                type: object
+                                                required:
+                                                - nodeSelectorTerms
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    description: Required. A list
+                                                      of node selector terms. The
+                                                      terms are ORed.
+                                                    type: array
+                                                    items:
+                                                      description: A null or empty
+                                                        node selector term matches
+                                                        no objects. The requirements
+                                                        of them are ANDed. The TopologySelectorTerm
+                                                        type implements a subset of
+                                                        the NodeSelectorTerm.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          type: array
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          type: array
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                          podAffinity:
+                                            description: Describes pod affinity scheduling
+                                              rules (e.g. co-locate this pod in the
+                                              same node, zone, etc. as some other
+                                              pod(s)).
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node has pods
+                                                  which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                type: array
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  type: object
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to a pod label update),
+                                                  the system may or may not try to
+                                                  eventually evict the pod from its
+                                                  node. When there are multiple elements,
+                                                  the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                type: array
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                          podAntiAffinity:
+                                            description: Describes pod anti-affinity
+                                              scheduling rules (e.g. avoid putting
+                                              this pod in the same node, zone, etc.
+                                              as some other pod(s)).
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the anti-affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  anti-affinity expressions, etc.),
+                                                  compute a sum by iterating through
+                                                  the elements of this field and adding
+                                                  "weight" to the sum if the node
+                                                  has pods which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                type: array
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  type: object
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the anti-affinity
+                                                  requirements specified by this field
+                                                  are not met at scheduling time,
+                                                  the pod will not be scheduled onto
+                                                  the node. If the anti-affinity requirements
+                                                  specified by this field cease to
+                                                  be met at some point during pod
+                                                  execution (e.g. due to a pod label
+                                                  update), the system may or may not
+                                                  try to eventually evict the pod
+                                                  from its node. When there are multiple
+                                                  elements, the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                type: array
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                      nodeSelector:
+                                        description: 'NodeSelector is a selector which
+                                          must be true for the pod to fit on a node.
+                                          Selector which must match a node''s labels
+                                          for the pod to be scheduled on that node.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      tolerations:
+                                        description: If specified, the pod's tolerations.
+                                        type: array
+                                        items:
+                                          description: The pod this Toleration is
+                                            attached to tolerates any taint that matches
+                                            the triple <key,value,effect> using the
+                                            matching operator <operator>.
+                                          type: object
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint
+                                                effect to match. Empty means match
+                                                all taint effects. When specified,
+                                                allowed values are NoSchedule, PreferNoSchedule
+                                                and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that
+                                                the toleration applies to. Empty means
+                                                match all taint keys. If the key is
+                                                empty, operator must be Exists; this
+                                                combination means to match all values
+                                                and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's
+                                                relationship to the value. Valid operators
+                                                are Exists and Equal. Defaults to
+                                                Equal. Exists is equivalent to wildcard
+                                                for value, so that a pod can tolerate
+                                                all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents
+                                                the period of time the toleration
+                                                (which must be of effect NoExecute,
+                                                otherwise this field is ignored) tolerates
+                                                the taint. By default, it is not set,
+                                                which means tolerate the taint forever
+                                                (do not evict). Zero and negative
+                                                values will be treated as 0 (evict
+                                                immediately) by the system.
+                                              type: integer
+                                              format: int64
+                                            value:
+                                              description: Value is the taint value
+                                                the toleration matches to. If the
+                                                operator is Exists, the value should
+                                                be empty, otherwise just a regular
+                                                string.
+                                              type: string
+                              serviceType:
+                                description: Optional service type for Kubernetes
+                                  solver service
+                                type: string
+                      selector:
+                        description: Selector selects a set of DNSNames on the Certificate
+                          resource that should be solved using this challenge solver.
+                        type: object
+                        properties:
+                          dnsNames:
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            type: array
+                            items:
+                              type: string
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            type: array
+                            items:
+                              type: string
+                          matchLabels:
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
+                            type: object
+                            additionalProperties:
+                              type: string
+            ca:
+              type: object
+              required:
+              - secretName
+              properties:
+                crlDistributionPoints:
+                  description: The CRL distribution points is an X.509 v3 certificate
+                    extension which identifies the location of the CRL from which
+                    the revocation of this certificate can be checked. If not set
+                    certificate will be issued without CDP. Values are strings.
+                  type: array
+                  items:
+                    type: string
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+            selfSigned:
+              type: object
+              properties:
+                crlDistributionPoints:
+                  description: The CRL distribution points is an X.509 v3 certificate
+                    extension which identifies the location of the CRL from which
+                    the revocation of this certificate can be checked. If not set
+                    certificate will be issued without CDP. Values are strings.
+                  type: array
+                  items:
+                    type: string
+            vault:
+              type: object
+              required:
+              - auth
+              - path
+              - server
+              properties:
+                auth:
+                  description: Vault authentication
+                  type: object
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    kubernetes:
+                      description: This contains a Role and Secret with a ServiceAccount
+                        token to authenticate with vault.
+                      type: object
+                      required:
+                      - role
+                      - secretRef
+                      properties:
+                        mountPath:
+                          description: The Vault mountPath here is the mount path
+                            to use when authenticating with Vault. For example, setting
+                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                            to authenticate with Vault. If unspecified, the default
+                            value "/v1/auth/kubernetes" will be used.
+                          type: string
+                        role:
+                          description: A required field containing the Vault Role
+                            to assume. A Role binds a Kubernetes ServiceAccount with
+                            a set of Vault policies.
+                          type: string
+                        secretRef:
+                          description: The required Secret field containing a Kubernetes
+                            ServiceAccount JWT used for authenticating with Vault.
+                            Use of 'ambient credentials' is not supported.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  type: string
+                  format: byte
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              type: object
+              required:
+              - zone
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  type: object
+                  required:
+                  - apiTokenSecretRef
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  type: object
+                  required:
+                  - credentialsRef
+                  - url
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certificate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      type: string
+                      format: byte
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          type: object
+          properties:
+            acme:
+              type: object
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+            conditions:
+              type: array
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                type: object
+                required:
+                - status
+                - type
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    type: string
+                    format: date-time
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+---
+# Source: cert-manager/templates/templates.regular.out
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: orders.acme.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.1'
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: acme.cert-manager.io
+  preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
+  names:
+    kind: Order
+    listKind: OrderList
+    plural: orders
+    singular: order
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
+      description: Order is a type to represent an Order with an ACME server
+      type: object
+      required:
+      - metadata
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          required:
+          - csr
+          - issuerRef
+          properties:
+            commonName:
+              description: CommonName is the common name as specified on the DER encoded
+                CSR. If CommonName is not specified, the first DNSName specified will
+                be used as the CommonName. At least one of CommonName or a DNSNames
+                must be set. This field must match the corresponding field on the
+                DER encoded CSR.
+              type: string
+            csr:
+              description: Certificate signing request bytes in DER encoding. This
+                will be used when finalizing the order. This field must be set on
+                the order.
+              type: string
+              format: byte
+            dnsNames:
+              description: DNSNames is a list of DNS names that should be included
+                as part of the Order validation process. If CommonName is not specified,
+                the first DNSName specified will be used as the CommonName. At least
+                one of CommonName or a DNSNames must be set. This field must match
+                the corresponding field on the DER encoded CSR.
+              type: array
+              items:
+                type: string
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Order. If the Issuer does not
+                exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Order will be marked as
+                failed.
+              type: object
+              required:
+              - name
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+        status:
+          type: object
+          properties:
+            authorizations:
+              description: Authorizations contains data returned from the ACME server
+                on what authorizations must be completed in order to validate the
+                DNS names specified on the Order.
+              type: array
+              items:
+                description: ACMEAuthorization contains data returned from the ACME
+                  server on an authorization that must be completed in order validate
+                  a DNS name on an ACME Order resource.
+                type: object
+                required:
+                - url
+                properties:
+                  challenges:
+                    description: Challenges specifies the challenge types offered
+                      by the ACME server. One of these challenge types will be selected
+                      when validating the DNS name and an appropriate Challenge resource
+                      will be created to perform the ACME challenge process.
+                    type: array
+                    items:
+                      description: Challenge specifies a challenge offered by the
+                        ACME server for an Order. An appropriate Challenge resource
+                        can be created to perform the ACME challenge process.
+                      type: object
+                      required:
+                      - token
+                      - type
+                      - url
+                      properties:
+                        token:
+                          description: Token is the token that must be presented for
+                            this challenge. This is used to compute the 'key' that
+                            must also be presented.
+                          type: string
+                        type:
+                          description: Type is the type of challenge being offered,
+                            e.g. http-01, dns-01
+                          type: string
+                        url:
+                          description: URL is the URL of this challenge. It can be
+                            used to retrieve additional metadata about the Challenge
+                            from the ACME server.
+                          type: string
+                  identifier:
+                    description: Identifier is the DNS name to be validated as part
+                      of this authorization
+                    type: string
+                  initialState:
+                    description: InitialState is the initial state of the ACME authorization
+                      when first fetched from the ACME server. If an Authorization
+                      is already 'valid', the Order controller will not create a Challenge
+                      resource for the authorization. This will occur when working
+                      with an ACME server that enables 'authz reuse' (such as Let's
+                      Encrypt's production endpoint). If not set and 'identifier'
+                      is set, the state is assumed to be pending and a Challenge will
+                      be created.
+                    type: string
+                    enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                  url:
+                    description: URL is the URL of the Authorization that must be
+                      completed
+                    type: string
+                  wildcard:
+                    description: Wildcard will be true if this authorization is for
+                      a wildcard DNS name. If this is true, the identifier will be
+                      the *non-wildcard* version of the DNS name. For example, if
+                      '*.example.com' is the DNS name being validated, this field
+                      will be 'true' and the 'identifier' field will be 'example.com'.
+                    type: boolean
+            certificate:
+              description: Certificate is a copy of the PEM encoded certificate for
+                this Order. This field will be populated after the order has been
+                successfully finalized with the ACME server, and the order has transitioned
+                to the 'valid' state.
+              type: string
+              format: byte
+            failureTime:
+              description: FailureTime stores the time that this order failed. This
+                is used to influence garbage collection and back-off.
+              type: string
+              format: date-time
+            finalizeURL:
+              description: FinalizeURL of the Order. This is used to obtain certificates
+                for this order once it has been completed.
+              type: string
+            reason:
+              description: Reason optionally provides more information about a why
+                the order is in the current state.
+              type: string
+            state:
+              description: State contains the current state of this Order resource.
+                States 'success' and 'expired' are 'final'
+              type: string
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
+            url:
+              description: URL of the Order. This will initially be empty when the
+                resource is first created. The Order controller will populate this
+                field when the Order is first processed. This field will be immutable
+                after it is initially set.
+              type: string
+---
+# Source: cert-manager/templates/templates.regular.out
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificaterequests.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.1'
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
+  names:
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+    - cr
+    - crs
+    singular: certificaterequest
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
+      description: CertificateRequest is a type to represent a Certificate Signing
+        Request
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertificateRequestSpec defines the desired state of CertificateRequest
+          type: object
+          required:
+          - csr
+          - issuerRef
+          properties:
+            csr:
+              description: Byte slice containing the PEM encoded CertificateSigningRequest
+              type: string
+              format: byte
+            duration:
+              description: Requested certificate default Duration
+              type: string
+            isCA:
+              description: IsCA will mark the resulting certificate as valid for signing.
+                This implies that the 'cert sign' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the CertificateRequest
+                will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times. The group field refers to the API group
+                of the issuer which defaults to 'cert-manager.io' if empty.
+              type: object
+              required:
+              - name
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+            usages:
+              description: Usages is the set of x509 actions that are enabled for
+                a given key. Defaults are ('digital signature', 'key encipherment')
+                if empty
+              type: array
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                  Valid KeyUsage values are as follows: "signing", "digital signature",
+                  "content commitment", "key encipherment", "key agreement", "data
+                  encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                  only", "any", "server auth", "client auth", "code signing", "email
+                  protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                  user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                  sgc"'
+                type: string
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+        status:
+          description: CertificateStatus defines the observed state of CertificateRequest
+            and resulting signed certificate.
+          type: object
+          properties:
+            ca:
+              description: Byte slice containing the PEM encoded certificate authority
+                of the signed certificate.
+              type: string
+              format: byte
+            certificate:
+              description: Byte slice containing a PEM encoded signed certificate
+                resulting from the given certificate signing request.
+              type: string
+              format: byte
+            conditions:
+              type: array
+              items:
+                description: CertificateRequestCondition contains condition information
+                  for a CertificateRequest.
+                type: object
+                required:
+                - status
+                - type
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    type: string
+                    format: date-time
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                  type:
+                    description: Type of the condition, currently ('Ready', 'InvalidRequest').
+                    type: string
+            failureTime:
+              description: FailureTime stores the time that this CertificateRequest
+                failed. This is used to influence garbage collection and back-off.
+              type: string
+              format: date-time
+---
+# Source: cert-manager/templates/templates.regular.out
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.1'
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.secretName
+    name: Secret
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
+  names:
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+    - cert
+    - certs
+    singular: certificate
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: Certificate is a type to represent a Certificate from ACME
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateSpec defines the desired state of Certificate.
+              A valid Certificate requires at least one of a CommonName, DNSName,
+              or URISAN to be valid.
+            type: object
+            required:
+            - issuerRef
+            - secretName
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                type: array
+                items:
+                  type: string
+              duration:
+                description: Certificate default Duration
+                type: string
+              emailSANs:
+                description: EmailSANs is a list of Email Subject Alternative Names
+                  to be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses to be used on the
+                  Certificate
+                type: array
+                items:
+                  type: string
+              isCA:
+                description: IsCA will mark this Certificate as valid for signing.
+                  This implies that the 'cert sign' usage is set
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+              keyAlgorithm:
+                description: KeyAlgorithm is the private key algorithm of the corresponding
+                  private key for this certificate. If provided, allowed values are
+                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
+                  and key size of 2048 will be used for "rsa" key algorithm.
+                type: string
+                enum:
+                - rsa
+                - ecdsa
+              keyEncoding:
+                description: KeyEncoding is the private key cryptography standards
+                  (PKCS) for this certificate's private key to be encoded in. If provided,
+                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  be used by default.
+                type: string
+                enum:
+                - pkcs1
+                - pkcs8
+              keySize:
+                description: KeySize is the key bit size of the corresponding private
+                  key for this certificate. If provided, value must be between 2048
+                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                  to "ecdsa".
+                type: integer
+                maximum: 8192
+                minimum: 0
+              keystores:
+                description: Keystores configures additional keystore output formats
+                  stored in the `secretName` Secret resource.
+                type: object
+                properties:
+                  jks:
+                    description: JKS configures options for storing a JKS keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables JKS keystore creation for the
+                          Certificate. If true, a file named `keystore.jks` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the JKS keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                  pkcs12:
+                    description: PKCS12 configures options for storing a PKCS12 keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables PKCS12 keystore creation for the
+                          Certificate. If true, a file named `keystore.p12` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the PKCS12 keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+              organization:
+                description: Organization is the organization to be used on the Certificate
+                type: array
+                items:
+                  type: string
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                type: object
+                properties:
+                  rotationPolicy:
+                    description: RotationPolicy controls how private keys should be
+                      regenerated when a re-issuance is being processed. If set to
+                      Never, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exists
+                      but it does not have the correct algorithm or size, a warning
+                      will be raised to await user intervention. If set to Always,
+                      a private key matching the specified requirements will be generated
+                      whenever a re-issuance occurs. Default is 'Never' for backward
+                      compatibility.
+                    type: string
+              renewBefore:
+                description: Certificate renew before expiration duration
+                type: string
+              secretName:
+                description: SecretName is the name of the secret resource to store
+                  this secret in
+                type: string
+              subject:
+                description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                type: object
+                properties:
+                  countries:
+                    description: Countries to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  localities:
+                    description: Cities to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizationalUnits:
+                    description: Organizational Units to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  postalCodes:
+                    description: Postal codes to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  provinces:
+                    description: State/Provinces to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  serialNumber:
+                    description: Serial number to be used on the Certificate.
+                    type: string
+                  streetAddresses:
+                    description: Street addresses to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+              uriSANs:
+                description: URISANs is a list of URI Subject Alternative Names to
+                  be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              usages:
+                description: Usages is the set of x509 actions that are enabled for
+                  a given key. Defaults are ('digital signature', 'key encipherment')
+                  if empty
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: CertificateStatus defines the observed state of Certificate
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  description: CertificateCondition contains condition information
+                    for an Certificate.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, currently ('Ready').
+                      type: string
+              lastFailureTime:
+                type: string
+                format: date-time
+              nextPrivateKeySecretName:
+                description: The name of the Secret resource containing the private
+                  key to be used for the next certificate iteration. The keymanager
+                  controller will automatically set this field if the `Issuing` condition
+                  is set to `True`. It will automatically unset this field when the
+                  Issuing condition is not set or False.
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                type: string
+                format: date-time
+              revision:
+                description: "The current 'revision' of the certificate as issued.
+                  \n When a CertificateRequest resource is created, it will have the
+                  `cert-manager.io/certificate-revision` set to one greater than the
+                  current value of this field. \n Upon issuance, this field will be
+                  set to the value of the annotation on the CertificateRequest resource
+                  used to issue the certificate. \n Persisting the value on the CertificateRequest
+                  resource allows the certificates controller to know whether a request
+                  is part of an old issuance or if it is part of the ongoing revision's
+                  issuance by checking if the revision value in the annotation is
+                  greater than this field."
+                type: integer
+  - name: v1alpha3
+    served: true
+    storage: false
+    "schema":
+      "openAPIV3Schema":
+        description: Certificate is a type to represent a Certificate from ACME
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateSpec defines the desired state of Certificate.
+              A valid Certificate requires at least one of a CommonName, DNSName,
+              or URISAN to be valid.
+            type: object
+            required:
+            - issuerRef
+            - secretName
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                type: array
+                items:
+                  type: string
+              duration:
+                description: Certificate default Duration
+                type: string
+              emailSANs:
+                description: EmailSANs is a list of Email Subject Alternative Names
+                  to be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses to be used on the
+                  Certificate
+                type: array
+                items:
+                  type: string
+              isCA:
+                description: IsCA will mark this Certificate as valid for signing.
+                  This implies that the 'cert sign' usage is set
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+              keyAlgorithm:
+                description: KeyAlgorithm is the private key algorithm of the corresponding
+                  private key for this certificate. If provided, allowed values are
+                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
+                  and key size of 2048 will be used for "rsa" key algorithm.
+                type: string
+                enum:
+                - rsa
+                - ecdsa
+              keyEncoding:
+                description: KeyEncoding is the private key cryptography standards
+                  (PKCS) for this certificate's private key to be encoded in. If provided,
+                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  be used by default.
+                type: string
+                enum:
+                - pkcs1
+                - pkcs8
+              keySize:
+                description: KeySize is the key bit size of the corresponding private
+                  key for this certificate. If provided, value must be between 2048
+                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                  to "ecdsa".
+                type: integer
+                maximum: 8192
+                minimum: 0
+              keystores:
+                description: Keystores configures additional keystore output formats
+                  stored in the `secretName` Secret resource.
+                type: object
+                properties:
+                  jks:
+                    description: JKS configures options for storing a JKS keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables JKS keystore creation for the
+                          Certificate. If true, a file named `keystore.jks` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the JKS keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                  pkcs12:
+                    description: PKCS12 configures options for storing a PKCS12 keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables PKCS12 keystore creation for the
+                          Certificate. If true, a file named `keystore.p12` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the PKCS12 keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                type: object
+                properties:
+                  rotationPolicy:
+                    description: RotationPolicy controls how private keys should be
+                      regenerated when a re-issuance is being processed. If set to
+                      Never, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exists
+                      but it does not have the correct algorithm or size, a warning
+                      will be raised to await user intervention. If set to Always,
+                      a private key matching the specified requirements will be generated
+                      whenever a re-issuance occurs. Default is 'Never' for backward
+                      compatibility.
+                    type: string
+              renewBefore:
+                description: Certificate renew before expiration duration
+                type: string
+              secretName:
+                description: SecretName is the name of the secret resource to store
+                  this secret in
+                type: string
+              subject:
+                description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                type: object
+                properties:
+                  countries:
+                    description: Countries to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  localities:
+                    description: Cities to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizationalUnits:
+                    description: Organizational Units to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizations:
+                    description: Organizations to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  postalCodes:
+                    description: Postal codes to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  provinces:
+                    description: State/Provinces to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  serialNumber:
+                    description: Serial number to be used on the Certificate.
+                    type: string
+                  streetAddresses:
+                    description: Street addresses to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+              uriSANs:
+                description: URISANs is a list of URI Subject Alternative Names to
+                  be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              usages:
+                description: Usages is the set of x509 actions that are enabled for
+                  a given key. Defaults are ('digital signature', 'key encipherment')
+                  if empty
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: CertificateStatus defines the observed state of Certificate
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  description: CertificateCondition contains condition information
+                    for an Certificate.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, currently ('Ready').
+                      type: string
+              lastFailureTime:
+                type: string
+                format: date-time
+              nextPrivateKeySecretName:
+                description: The name of the Secret resource containing the private
+                  key to be used for the next certificate iteration. The keymanager
+                  controller will automatically set this field if the `Issuing` condition
+                  is set to `True`. It will automatically unset this field when the
+                  Issuing condition is not set or False.
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                type: string
+                format: date-time
+              revision:
+                description: "The current 'revision' of the certificate as issued.
+                  \n When a CertificateRequest resource is created, it will have the
+                  `cert-manager.io/certificate-revision` set to one greater than the
+                  current value of this field. \n Upon issuance, this field will be
+                  set to the value of the annotation on the CertificateRequest resource
+                  used to issue the certificate. \n Persisting the value on the CertificateRequest
+                  resource allows the certificates controller to know whether a request
+                  is part of an old issuance or if it is part of the ongoing revision's
+                  issuance by checking if the revision value in the annotation is
+                  greater than this field."
+                type: integer
+---
+# Source: cert-manager/templates/templates.regular.out
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: challenges.acme.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.1'
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.dnsName
+    name: Domain
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: acme.cert-manager.io
+  preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
+  names:
+    kind: Challenge
+    listKind: ChallengeList
+    plural: challenges
+    singular: challenge
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
+      description: Challenge is a type to represent a Challenge request with an ACME
+        server
+      type: object
+      required:
+      - metadata
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          required:
+          - authzURL
+          - dnsName
+          - issuerRef
+          - key
+          - solver
+          - token
+          - type
+          - url
+          properties:
+            authzURL:
+              description: AuthzURL is the URL to the ACME Authorization resource
+                that this challenge is a part of.
+              type: string
+            dnsName:
+              description: DNSName is the identifier that this challenge is for, e.g.
+                example.com. If the requested DNSName is a 'wildcard', this field
+                MUST be set to the non-wildcard domain, e.g. for `*.example.com`,
+                it must be `example.com`.
+              type: string
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Challenge. If the Issuer does
+                not exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Challenge will be marked
+                as failed.
+              type: object
+              required:
+              - name
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+            key:
+              description: 'Key is the ACME challenge key for this challenge For HTTP01
+                challenges, this is the value that must be responded with to complete
+                the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key
+                from acme server for challenge>`. For DNS01 challenges, this is the
+                base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key
+                from acme server for challenge>` text that must be set as the TXT
+                record content.'
+              type: string
+            solver:
+              description: Solver contains the domain solving configuration that should
+                be used to solve this challenge resource.
+              type: object
+              properties:
+                dns01:
+                  type: object
+                  properties:
+                    acmedns:
+                      description: ACMEIssuerDNS01ProviderAcmeDNS is a structure containing
+                        the configuration for ACME-DNS servers
+                      type: object
+                      required:
+                      - accountSecretRef
+                      - host
+                      properties:
+                        accountSecretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        host:
+                          type: string
+                    akamai:
+                      description: ACMEIssuerDNS01ProviderAkamai is a structure containing
+                        the DNS configuration for Akamai DNS—Zone Record Management
+                        API
+                      type: object
+                      required:
+                      - accessTokenSecretRef
+                      - clientSecretSecretRef
+                      - clientTokenSecretRef
+                      - serviceConsumerDomain
+                      properties:
+                        accessTokenSecretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        clientSecretSecretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        clientTokenSecretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        serviceConsumerDomain:
+                          type: string
+                    azuredns:
+                      description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                        containing the configuration for Azure DNS
+                      type: object
+                      required:
+                      - resourceGroupName
+                      - subscriptionID
+                      properties:
+                        clientID:
+                          description: if both this and ClientSecret are left unset
+                            MSI will be used
+                          type: string
+                        clientSecretSecretRef:
+                          description: if both this and ClientID are left unset MSI
+                            will be used
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        environment:
+                          type: string
+                          enum:
+                          - AzurePublicCloud
+                          - AzureChinaCloud
+                          - AzureGermanCloud
+                          - AzureUSGovernmentCloud
+                        hostedZoneName:
+                          type: string
+                        resourceGroupName:
+                          type: string
+                        subscriptionID:
+                          type: string
+                        tenantID:
+                          description: when specifying ClientID and ClientSecret then
+                            this field is also needed
+                          type: string
+                    clouddns:
+                      description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                        containing the DNS configuration for Google Cloud DNS
+                      type: object
+                      required:
+                      - project
+                      properties:
+                        project:
+                          type: string
+                        serviceAccountSecretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    cloudflare:
+                      description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                        containing the DNS configuration for Cloudflare
+                      type: object
+                      required:
+                      - email
+                      properties:
+                        apiKeySecretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        apiTokenSecretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        email:
+                          type: string
+                    cnameStrategy:
+                      description: CNAMEStrategy configures how the DNS01 provider
+                        should handle CNAME records when found in DNS zones.
+                      type: string
+                      enum:
+                      - None
+                      - Follow
+                    digitalocean:
+                      description: ACMEIssuerDNS01ProviderDigitalOcean is a structure
+                        containing the DNS configuration for DigitalOcean Domains
+                      type: object
+                      required:
+                      - tokenSecretRef
+                      properties:
+                        tokenSecretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    rfc2136:
+                      description: ACMEIssuerDNS01ProviderRFC2136 is a structure containing
+                        the configuration for RFC2136 DNS
+                      type: object
+                      required:
+                      - nameserver
+                      properties:
+                        nameserver:
+                          description: The IP address or hostname of an authoritative
+                            DNS server supporting RFC2136 in the form host:port. If
+                            the host is an IPv6 address it must be enclosed in square
+                            brackets (e.g [2001:db8::1]) ; port is optional. This
+                            field is required.
+                          type: string
+                        tsigAlgorithm:
+                          description: 'The TSIG Algorithm configured in the DNS supporting
+                            RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName``
+                            are defined. Supported values are (case-insensitive):
+                            ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or
+                            ``HMACSHA512``.'
+                          type: string
+                        tsigKeyName:
+                          description: The TSIG Key name configured in the DNS. If
+                            ``tsigSecretSecretRef`` is defined, this field is required.
+                          type: string
+                        tsigSecretSecretRef:
+                          description: The name of the secret containing the TSIG
+                            value. If ``tsigKeyName`` is defined, this field is required.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    route53:
+                      description: ACMEIssuerDNS01ProviderRoute53 is a structure containing
+                        the Route 53 configuration for AWS
+                      type: object
+                      required:
+                      - region
+                      properties:
+                        accessKeyID:
+                          description: 'The AccessKeyID is used for authentication.
+                            If not set we fall-back to using env vars, shared credentials
+                            file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          type: string
+                        hostedZoneID:
+                          description: If set, the provider will manage only this
+                            zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName
+                            api call.
+                          type: string
+                        region:
+                          description: Always set the region when using AccessKeyID
+                            and SecretAccessKey
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the Route53 provider
+                            will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                            or the inferred credentials from environment variables,
+                            shared credentials file or AWS Instance metadata
+                          type: string
+                        secretAccessKeySecretRef:
+                          description: The SecretAccessKey is used for authentication.
+                            If not set we fall-back to using env vars, shared credentials
+                            file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    webhook:
+                      description: ACMEIssuerDNS01ProviderWebhook specifies configuration
+                        for a webhook DNS01 provider, including where to POST ChallengePayload
+                        resources.
+                      type: object
+                      required:
+                      - groupName
+                      - solverName
+                      properties:
+                        config:
+                          description: Additional configuration that should be passed
+                            to the webhook apiserver when challenges are processed.
+                            This can contain arbitrary JSON data. Secret values should
+                            not be specified in this stanza. If secret values are
+                            needed (e.g. credentials for a DNS service), you should
+                            use a SecretKeySelector to reference a Secret resource.
+                            For details on the schema of this field, consult the webhook
+                            provider implementation's documentation.
+                          x-kubernetes-preserve-unknown-fields: true
+                        groupName:
+                          description: The API group name that should be used when
+                            POSTing ChallengePayload resources to the webhook apiserver.
+                            This should be the same as the GroupName specified in
+                            the webhook provider implementation.
+                          type: string
+                        solverName:
+                          description: The name of the solver to use, as defined in
+                            the webhook provider implementation. This will typically
+                            be the name of the provider, e.g. 'cloudflare'.
+                          type: string
+                http01:
+                  description: ACMEChallengeSolverHTTP01 contains configuration detailing
+                    how to solve HTTP01 challenges within a Kubernetes cluster. Typically
+                    this is accomplished through creating 'routes' of some description
+                    that configure ingress controllers to direct traffic to 'solver
+                    pods', which are responsible for responding to the ACME server's
+                    HTTP requests.
+                  type: object
+                  properties:
+                    ingress:
+                      description: The ingress based HTTP01 challenge solver will
+                        solve challenges by creating or modifying Ingress resources
+                        in order to route requests for '/.well-known/acme-challenge/XYZ'
+                        to 'challenge solver' pods that are provisioned by cert-manager
+                        for each Challenge to be completed.
+                      type: object
+                      properties:
+                        class:
+                          description: The ingress class to use when creating Ingress
+                            resources to solve ACME challenges that use this challenge
+                            solver. Only one of 'class' or 'name' may be specified.
+                          type: string
+                        ingressTemplate:
+                          description: Optional ingress template used to configure
+                            the ACME challenge solver ingress used for HTTP01 challenges
+                          type: object
+                          properties:
+                            metadata:
+                              description: ObjectMeta overrides for the ingress used
+                                to solve HTTP01 challenges. Only the 'labels' and
+                                'annotations' fields may be set. If labels or annotations
+                                overlap with in-built values, the values here will
+                                override the in-built values.
+                              type: object
+                              properties:
+                                annotations:
+                                  description: Annotations that should be added to
+                                    the created ACME HTTP01 solver ingress.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                labels:
+                                  description: Labels that should be added to the
+                                    created ACME HTTP01 solver ingress.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                        name:
+                          description: The name of the ingress resource that should
+                            have ACME challenge solving routes inserted into it in
+                            order to solve HTTP01 challenges. This is typically used
+                            in conjunction with ingress controllers like ingress-gce,
+                            which maintains a 1:1 mapping between external IPs and
+                            ingress resources.
+                          type: string
+                        podTemplate:
+                          description: Optional pod template used to configure the
+                            ACME challenge solver pods used for HTTP01 challenges
+                          type: object
+                          properties:
+                            metadata:
+                              description: ObjectMeta overrides for the pod used to
+                                solve HTTP01 challenges. Only the 'labels' and 'annotations'
+                                fields may be set. If labels or annotations overlap
+                                with in-built values, the values here will override
+                                the in-built values.
+                              type: object
+                              properties:
+                                annotations:
+                                  description: Annotations that should be added to
+                                    the create ACME HTTP01 solver pods.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                labels:
+                                  description: Labels that should be added to the
+                                    created ACME HTTP01 solver pods.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            spec:
+                              description: PodSpec defines overrides for the HTTP01
+                                challenge solver pod. Only the 'nodeSelector', 'affinity'
+                                and 'tolerations' fields are supported currently.
+                                All other fields will be ignored.
+                              type: object
+                              properties:
+                                affinity:
+                                  description: If specified, the pod's scheduling
+                                    constraints
+                                  type: object
+                                  properties:
+                                    nodeAffinity:
+                                      description: Describes node affinity scheduling
+                                        rules for the pod.
+                                      type: object
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: The scheduler will prefer to
+                                            schedule pods to nodes that satisfy the
+                                            affinity expressions specified by this
+                                            field, but it may choose a node that violates
+                                            one or more of the expressions. The node
+                                            that is most preferred is the one with
+                                            the greatest sum of weights, i.e. for
+                                            each node that meets all of the scheduling
+                                            requirements (resource request, requiredDuringScheduling
+                                            affinity expressions, etc.), compute a
+                                            sum by iterating through the elements
+                                            of this field and adding "weight" to the
+                                            sum if the node matches the corresponding
+                                            matchExpressions; the node(s) with the
+                                            highest sum are the most preferred.
+                                          type: array
+                                          items:
+                                            description: An empty preferred scheduling
+                                              term matches all objects with implicit
+                                              weight 0 (i.e. it's a no-op). A null
+                                              preferred scheduling term matches no
+                                              objects (i.e. is also a no-op).
+                                            type: object
+                                            required:
+                                            - preference
+                                            - weight
+                                            properties:
+                                              preference:
+                                                description: A node selector term,
+                                                  associated with the corresponding
+                                                  weight.
+                                                type: object
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector
+                                                      requirements by node's labels.
+                                                    type: array
+                                                    items:
+                                                      description: A node selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      properties:
+                                                        key:
+                                                          description: The label key
+                                                            that the selector applies
+                                                            to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists, DoesNotExist.
+                                                            Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: An array of
+                                                            string values. If the
+                                                            operator is In or NotIn,
+                                                            the values array must
+                                                            be non-empty. If the operator
+                                                            is Exists or DoesNotExist,
+                                                            the values array must
+                                                            be empty. If the operator
+                                                            is Gt or Lt, the values
+                                                            array must have a single
+                                                            element, which will be
+                                                            interpreted as an integer.
+                                                            This array is replaced
+                                                            during a strategic merge
+                                                            patch.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                  matchFields:
+                                                    description: A list of node selector
+                                                      requirements by node's fields.
+                                                    type: array
+                                                    items:
+                                                      description: A node selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      properties:
+                                                        key:
+                                                          description: The label key
+                                                            that the selector applies
+                                                            to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists, DoesNotExist.
+                                                            Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: An array of
+                                                            string values. If the
+                                                            operator is In or NotIn,
+                                                            the values array must
+                                                            be non-empty. If the operator
+                                                            is Exists or DoesNotExist,
+                                                            the values array must
+                                                            be empty. If the operator
+                                                            is Gt or Lt, the values
+                                                            array must have a single
+                                                            element, which will be
+                                                            interpreted as an integer.
+                                                            This array is replaced
+                                                            during a strategic merge
+                                                            patch.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                              weight:
+                                                description: Weight associated with
+                                                  matching the corresponding nodeSelectorTerm,
+                                                  in the range 1-100.
+                                                type: integer
+                                                format: int32
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: If the affinity requirements
+                                            specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled
+                                            onto the node. If the affinity requirements
+                                            specified by this field cease to be met
+                                            at some point during pod execution (e.g.
+                                            due to an update), the system may or may
+                                            not try to eventually evict the pod from
+                                            its node.
+                                          type: object
+                                          required:
+                                          - nodeSelectorTerms
+                                          properties:
+                                            nodeSelectorTerms:
+                                              description: Required. A list of node
+                                                selector terms. The terms are ORed.
+                                              type: array
+                                              items:
+                                                description: A null or empty node
+                                                  selector term matches no objects.
+                                                  The requirements of them are ANDed.
+                                                  The TopologySelectorTerm type implements
+                                                  a subset of the NodeSelectorTerm.
+                                                type: object
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector
+                                                      requirements by node's labels.
+                                                    type: array
+                                                    items:
+                                                      description: A node selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      properties:
+                                                        key:
+                                                          description: The label key
+                                                            that the selector applies
+                                                            to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists, DoesNotExist.
+                                                            Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: An array of
+                                                            string values. If the
+                                                            operator is In or NotIn,
+                                                            the values array must
+                                                            be non-empty. If the operator
+                                                            is Exists or DoesNotExist,
+                                                            the values array must
+                                                            be empty. If the operator
+                                                            is Gt or Lt, the values
+                                                            array must have a single
+                                                            element, which will be
+                                                            interpreted as an integer.
+                                                            This array is replaced
+                                                            during a strategic merge
+                                                            patch.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                  matchFields:
+                                                    description: A list of node selector
+                                                      requirements by node's fields.
+                                                    type: array
+                                                    items:
+                                                      description: A node selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      properties:
+                                                        key:
+                                                          description: The label key
+                                                            that the selector applies
+                                                            to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists, DoesNotExist.
+                                                            Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: An array of
+                                                            string values. If the
+                                                            operator is In or NotIn,
+                                                            the values array must
+                                                            be non-empty. If the operator
+                                                            is Exists or DoesNotExist,
+                                                            the values array must
+                                                            be empty. If the operator
+                                                            is Gt or Lt, the values
+                                                            array must have a single
+                                                            element, which will be
+                                                            interpreted as an integer.
+                                                            This array is replaced
+                                                            during a strategic merge
+                                                            patch.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                    podAffinity:
+                                      description: Describes pod affinity scheduling
+                                        rules (e.g. co-locate this pod in the same
+                                        node, zone, etc. as some other pod(s)).
+                                      type: object
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: The scheduler will prefer to
+                                            schedule pods to nodes that satisfy the
+                                            affinity expressions specified by this
+                                            field, but it may choose a node that violates
+                                            one or more of the expressions. The node
+                                            that is most preferred is the one with
+                                            the greatest sum of weights, i.e. for
+                                            each node that meets all of the scheduling
+                                            requirements (resource request, requiredDuringScheduling
+                                            affinity expressions, etc.), compute a
+                                            sum by iterating through the elements
+                                            of this field and adding "weight" to the
+                                            sum if the node has pods which matches
+                                            the corresponding podAffinityTerm; the
+                                            node(s) with the highest sum are the most
+                                            preferred.
+                                          type: array
+                                          items:
+                                            description: The weights of all of the
+                                              matched WeightedPodAffinityTerm fields
+                                              are added per-node to find the most
+                                              preferred node(s)
+                                            type: object
+                                            required:
+                                            - podAffinityTerm
+                                            - weight
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity
+                                                  term, associated with the corresponding
+                                                  weight.
+                                                type: object
+                                                required:
+                                                - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over
+                                                      a set of resources, in this
+                                                      case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector
+                                                            requirement is a selector
+                                                            that contains values,
+                                                            a key, and an operator
+                                                            that relates the key and
+                                                            values.
+                                                          type: object
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is
+                                                                the label key that
+                                                                the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator
+                                                                represents a key's
+                                                                relationship to a
+                                                                set of values. Valid
+                                                                operators are In,
+                                                                NotIn, Exists and
+                                                                DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values
+                                                                is an array of string
+                                                                values. If the operator
+                                                                is In or NotIn, the
+                                                                values array must
+                                                                be non-empty. If the
+                                                                operator is Exists
+                                                                or DoesNotExist, the
+                                                                values array must
+                                                                be empty. This array
+                                                                is replaced during
+                                                                a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is
+                                                          a map of {key,value} pairs.
+                                                          A single {key,value} in
+                                                          the matchLabels map is equivalent
+                                                          to an element of matchExpressions,
+                                                          whose key field is "key",
+                                                          the operator is "In", and
+                                                          the values array contains
+                                                          only "value". The requirements
+                                                          are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies
+                                                      which namespaces the labelSelector
+                                                      applies to (matches against);
+                                                      null or empty list means "this
+                                                      pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be
+                                                      co-located (affinity) or not
+                                                      co-located (anti-affinity) with
+                                                      the pods matching the labelSelector
+                                                      in the specified namespaces,
+                                                      where co-located is defined
+                                                      as running on a node whose value
+                                                      of the label with key topologyKey
+                                                      matches that of any node on
+                                                      which any of the selected pods
+                                                      is running. Empty topologyKey
+                                                      is not allowed.
+                                                    type: string
+                                              weight:
+                                                description: weight associated with
+                                                  matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                type: integer
+                                                format: int32
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: If the affinity requirements
+                                            specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled
+                                            onto the node. If the affinity requirements
+                                            specified by this field cease to be met
+                                            at some point during pod execution (e.g.
+                                            due to a pod label update), the system
+                                            may or may not try to eventually evict
+                                            the pod from its node. When there are
+                                            multiple elements, the lists of nodes
+                                            corresponding to each podAffinityTerm
+                                            are intersected, i.e. all terms must be
+                                            satisfied.
+                                          type: array
+                                          items:
+                                            description: Defines a set of pods (namely
+                                              those matching the labelSelector relative
+                                              to the given namespace(s)) that this
+                                              pod should be co-located (affinity)
+                                              or not co-located (anti-affinity) with,
+                                              where co-located is defined as running
+                                              on a node whose value of the label with
+                                              key <topologyKey> matches that of any
+                                              node on which a pod of the set of pods
+                                              is running
+                                            type: object
+                                            required:
+                                            - topologyKey
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                type: object
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    type: array
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                  matchLabels:
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                    additionalProperties:
+                                                      type: string
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
+                                                type: array
+                                                items:
+                                                  type: string
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                    podAntiAffinity:
+                                      description: Describes pod anti-affinity scheduling
+                                        rules (e.g. avoid putting this pod in the
+                                        same node, zone, etc. as some other pod(s)).
+                                      type: object
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: The scheduler will prefer to
+                                            schedule pods to nodes that satisfy the
+                                            anti-affinity expressions specified by
+                                            this field, but it may choose a node that
+                                            violates one or more of the expressions.
+                                            The node that is most preferred is the
+                                            one with the greatest sum of weights,
+                                            i.e. for each node that meets all of the
+                                            scheduling requirements (resource request,
+                                            requiredDuringScheduling anti-affinity
+                                            expressions, etc.), compute a sum by iterating
+                                            through the elements of this field and
+                                            adding "weight" to the sum if the node
+                                            has pods which matches the corresponding
+                                            podAffinityTerm; the node(s) with the
+                                            highest sum are the most preferred.
+                                          type: array
+                                          items:
+                                            description: The weights of all of the
+                                              matched WeightedPodAffinityTerm fields
+                                              are added per-node to find the most
+                                              preferred node(s)
+                                            type: object
+                                            required:
+                                            - podAffinityTerm
+                                            - weight
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity
+                                                  term, associated with the corresponding
+                                                  weight.
+                                                type: object
+                                                required:
+                                                - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over
+                                                      a set of resources, in this
+                                                      case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector
+                                                            requirement is a selector
+                                                            that contains values,
+                                                            a key, and an operator
+                                                            that relates the key and
+                                                            values.
+                                                          type: object
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is
+                                                                the label key that
+                                                                the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator
+                                                                represents a key's
+                                                                relationship to a
+                                                                set of values. Valid
+                                                                operators are In,
+                                                                NotIn, Exists and
+                                                                DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values
+                                                                is an array of string
+                                                                values. If the operator
+                                                                is In or NotIn, the
+                                                                values array must
+                                                                be non-empty. If the
+                                                                operator is Exists
+                                                                or DoesNotExist, the
+                                                                values array must
+                                                                be empty. This array
+                                                                is replaced during
+                                                                a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is
+                                                          a map of {key,value} pairs.
+                                                          A single {key,value} in
+                                                          the matchLabels map is equivalent
+                                                          to an element of matchExpressions,
+                                                          whose key field is "key",
+                                                          the operator is "In", and
+                                                          the values array contains
+                                                          only "value". The requirements
+                                                          are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies
+                                                      which namespaces the labelSelector
+                                                      applies to (matches against);
+                                                      null or empty list means "this
+                                                      pod's namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be
+                                                      co-located (affinity) or not
+                                                      co-located (anti-affinity) with
+                                                      the pods matching the labelSelector
+                                                      in the specified namespaces,
+                                                      where co-located is defined
+                                                      as running on a node whose value
+                                                      of the label with key topologyKey
+                                                      matches that of any node on
+                                                      which any of the selected pods
+                                                      is running. Empty topologyKey
+                                                      is not allowed.
+                                                    type: string
+                                              weight:
+                                                description: weight associated with
+                                                  matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                type: integer
+                                                format: int32
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: If the anti-affinity requirements
+                                            specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled
+                                            onto the node. If the anti-affinity requirements
+                                            specified by this field cease to be met
+                                            at some point during pod execution (e.g.
+                                            due to a pod label update), the system
+                                            may or may not try to eventually evict
+                                            the pod from its node. When there are
+                                            multiple elements, the lists of nodes
+                                            corresponding to each podAffinityTerm
+                                            are intersected, i.e. all terms must be
+                                            satisfied.
+                                          type: array
+                                          items:
+                                            description: Defines a set of pods (namely
+                                              those matching the labelSelector relative
+                                              to the given namespace(s)) that this
+                                              pod should be co-located (affinity)
+                                              or not co-located (anti-affinity) with,
+                                              where co-located is defined as running
+                                              on a node whose value of the label with
+                                              key <topologyKey> matches that of any
+                                              node on which a pod of the set of pods
+                                              is running
+                                            type: object
+                                            required:
+                                            - topologyKey
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                type: object
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    type: array
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                  matchLabels:
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                    additionalProperties:
+                                                      type: string
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
+                                                type: array
+                                                items:
+                                                  type: string
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                nodeSelector:
+                                  description: 'NodeSelector is a selector which must
+                                    be true for the pod to fit on a node. Selector
+                                    which must match a node''s labels for the pod
+                                    to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                tolerations:
+                                  description: If specified, the pod's tolerations.
+                                  type: array
+                                  items:
+                                    description: The pod this Toleration is attached
+                                      to tolerates any taint that matches the triple
+                                      <key,value,effect> using the matching operator
+                                      <operator>.
+                                    type: object
+                                    properties:
+                                      effect:
+                                        description: Effect indicates the taint effect
+                                          to match. Empty means match all taint effects.
+                                          When specified, allowed values are NoSchedule,
+                                          PreferNoSchedule and NoExecute.
+                                        type: string
+                                      key:
+                                        description: Key is the taint key that the
+                                          toleration applies to. Empty means match
+                                          all taint keys. If the key is empty, operator
+                                          must be Exists; this combination means to
+                                          match all values and all keys.
+                                        type: string
+                                      operator:
+                                        description: Operator represents a key's relationship
+                                          to the value. Valid operators are Exists
+                                          and Equal. Defaults to Equal. Exists is
+                                          equivalent to wildcard for value, so that
+                                          a pod can tolerate all taints of a particular
+                                          category.
+                                        type: string
+                                      tolerationSeconds:
+                                        description: TolerationSeconds represents
+                                          the period of time the toleration (which
+                                          must be of effect NoExecute, otherwise this
+                                          field is ignored) tolerates the taint. By
+                                          default, it is not set, which means tolerate
+                                          the taint forever (do not evict). Zero and
+                                          negative values will be treated as 0 (evict
+                                          immediately) by the system.
+                                        type: integer
+                                        format: int64
+                                      value:
+                                        description: Value is the taint value the
+                                          toleration matches to. If the operator is
+                                          Exists, the value should be empty, otherwise
+                                          just a regular string.
+                                        type: string
+                        serviceType:
+                          description: Optional service type for Kubernetes solver
+                            service
+                          type: string
+                selector:
+                  description: Selector selects a set of DNSNames on the Certificate
+                    resource that should be solved using this challenge solver.
+                  type: object
+                  properties:
+                    dnsNames:
+                      description: List of DNSNames that this solver will be used
+                        to solve. If specified and a match is found, a dnsNames selector
+                        will take precedence over a dnsZones selector. If multiple
+                        solvers match with the same dnsNames value, the solver with
+                        the most matching labels in matchLabels will be selected.
+                        If neither has more matches, the solver defined earlier in
+                        the list will be selected.
+                      type: array
+                      items:
+                        type: string
+                    dnsZones:
+                      description: List of DNSZones that this solver will be used
+                        to solve. The most specific DNS zone match specified here
+                        will take precedence over other DNS zone matches, so a solver
+                        specifying sys.example.com will be selected over one specifying
+                        example.com for the domain www.sys.example.com. If multiple
+                        solvers match with the same dnsZones value, the solver with
+                        the most matching labels in matchLabels will be selected.
+                        If neither has more matches, the solver defined earlier in
+                        the list will be selected.
+                      type: array
+                      items:
+                        type: string
+                    matchLabels:
+                      description: A label selector that is used to refine the set
+                        of certificate's that this challenge solver will apply to.
+                      type: object
+                      additionalProperties:
+                        type: string
+            token:
+              description: Token is the ACME challenge token for this challenge. This
+                is the raw value returned from the ACME server.
+              type: string
+            type:
+              description: Type is the type of ACME challenge this resource represents,
+                e.g. "dns01" or "http01".
+              type: string
+            url:
+              description: URL is the URL of the ACME Challenge resource for this
+                challenge. This can be used to lookup details about the status of
+                this challenge.
+              type: string
+            wildcard:
+              description: Wildcard will be true if this challenge is for a wildcard
+                identifier, for example '*.example.com'.
+              type: boolean
+        status:
+          type: object
+          properties:
+            presented:
+              description: Presented will be set to true if the challenge values for
+                this challenge are currently 'presented'. This *does not* imply the
+                self check is passing. Only that the values have been 'submitted'
+                for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                has been presented, or the HTTP01 configuration has been configured).
+              type: boolean
+            processing:
+              description: Processing is used to denote whether this challenge should
+                be processed or not. This field will only be set to true by the 'scheduling'
+                component. It will only be set to false by the 'challenges' controller,
+                after the challenge has reached a final state or timed out. If this
+                field is set to false, the challenge controller will not take any
+                more action.
+              type: boolean
+            reason:
+              description: Reason contains human readable information on why the Challenge
+                is in the current state.
+              type: string
+            state:
+              description: State contains the current 'state' of the challenge. If
+                not set, the state of the challenge is unknown.
+              type: string
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
+---
+# Source: cert-manager/templates/templates.regular.out
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.1'
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
+  names:
+    kind: ClusterIssuer
+    listKind: ClusterIssuerList
+    plural: clusterissuers
+    singular: clusterissuer
+  scope: Cluster
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          type: object
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              type: object
+              required:
+              - privateKeySecretRef
+              - server
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                externalAccountBinding:
+                  description: ExternalAccountBinding is a reference to a CA external
+                    account of the ACME server.
+                  type: object
+                  required:
+                  - keyAlgorithm
+                  - keyID
+                  - keySecretRef
+                  properties:
+                    keyAlgorithm:
+                      description: keyAlgorithm is the MAC key algorithm that the
+                        key is used for. Valid values are "HS256", "HS384" and "HS512".
+                      type: string
+                      enum:
+                      - HS256
+                      - HS384
+                      - HS512
+                    keyID:
+                      description: keyID is the ID of the CA key that the External
+                        Account is bound to.
+                      type: string
+                    keySecretRef:
+                      description: keySecretRef is a Secret Key Selector referencing
+                        a data item in a Kubernetes Secret which holds the symmetric
+                        MAC key of the External Account Binding. The `key` is the
+                        index string that is paired with the key data in the Secret
+                        and should not be confused with the key data itself, or indeed
+                        with the External Account Binding keyID above. The secret
+                        key stored in the Secret **must** be un-padded, base64 URL
+                        encoded data.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      dns01:
+                        type: object
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            type: object
+                            required:
+                            - accountSecretRef
+                            - host
+                            properties:
+                              accountSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              host:
+                                type: string
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            type: object
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            properties:
+                              accessTokenSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              clientSecretSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              clientTokenSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              serviceConsumerDomain:
+                                type: string
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            type: object
+                            required:
+                            - resourceGroupName
+                            - subscriptionID
+                            properties:
+                              clientID:
+                                description: if both this and ClientSecret are left
+                                  unset MSI will be used
+                                type: string
+                              clientSecretSecretRef:
+                                description: if both this and ClientID are left unset
+                                  MSI will be used
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              environment:
+                                type: string
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                description: when specifying ClientID and ClientSecret
+                                  then this field is also needed
+                                type: string
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            type: object
+                            required:
+                            - project
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            type: object
+                            required:
+                            - email
+                            properties:
+                              apiKeySecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              apiTokenSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                              email:
+                                type: string
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            type: string
+                            enum:
+                            - None
+                            - Follow
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            type: object
+                            required:
+                            - tokenSecretRef
+                            properties:
+                              tokenSecretRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            type: object
+                            required:
+                            - nameserver
+                            properties:
+                              nameserver:
+                                description: The IP address or hostname of an authoritative
+                                  DNS server supporting RFC2136 in the form host:port.
+                                  If the host is an IPv6 address it must be enclosed
+                                  in square brackets (e.g [2001:db8::1]) ; port is
+                                  optional. This field is required.
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            type: object
+                            required:
+                            - region
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            type: object
+                            required:
+                            - groupName
+                            - solverName
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                x-kubernetes-preserve-unknown-fields: true
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                      http01:
+                        description: ACMEChallengeSolverHTTP01 contains configuration
+                          detailing how to solve HTTP01 challenges within a Kubernetes
+                          cluster. Typically this is accomplished through creating
+                          'routes' of some description that configure ingress controllers
+                          to direct traffic to 'solver pods', which are responsible
+                          for responding to the ACME server's HTTP requests.
+                        type: object
+                        properties:
+                          ingress:
+                            description: The ingress based HTTP01 challenge solver
+                              will solve challenges by creating or modifying Ingress
+                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                              to 'challenge solver' pods that are provisioned by cert-manager
+                              for each Challenge to be completed.
+                            type: object
+                            properties:
+                              class:
+                                description: The ingress class to use when creating
+                                  Ingress resources to solve ACME challenges that
+                                  use this challenge solver. Only one of 'class' or
+                                  'name' may be specified.
+                                type: string
+                              ingressTemplate:
+                                description: Optional ingress template used to configure
+                                  the ACME challenge solver ingress used for HTTP01
+                                  challenges
+                                type: object
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the ingress
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        description: Annotations that should be added
+                                          to the created ACME HTTP01 solver ingress.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      labels:
+                                        description: Labels that should be added to
+                                          the created ACME HTTP01 solver ingress.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                              name:
+                                description: The name of the ingress resource that
+                                  should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  is typically used in conjunction with ingress controllers
+                                  like ingress-gce, which maintains a 1:1 mapping
+                                  between external IPs and ingress resources.
+                                type: string
+                              podTemplate:
+                                description: Optional pod template used to configure
+                                  the ACME challenge solver pods used for HTTP01 challenges
+                                type: object
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the pod
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        description: Annotations that should be added
+                                          to the create ACME HTTP01 solver pods.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      labels:
+                                        description: Labels that should be added to
+                                          the created ACME HTTP01 solver pods.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                  spec:
+                                    description: PodSpec defines overrides for the
+                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                      'affinity' and 'tolerations' fields are supported
+                                      currently. All other fields will be ignored.
+                                    type: object
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling
+                                          constraints
+                                        type: object
+                                        properties:
+                                          nodeAffinity:
+                                            description: Describes node affinity scheduling
+                                              rules for the pod.
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node matches the
+                                                  corresponding matchExpressions;
+                                                  the node(s) with the highest sum
+                                                  are the most preferred.
+                                                type: array
+                                                items:
+                                                  description: An empty preferred
+                                                    scheduling term matches all objects
+                                                    with implicit weight 0 (i.e. it's
+                                                    a no-op). A null preferred scheduling
+                                                    term matches no objects (i.e.
+                                                    is also a no-op).
+                                                  type: object
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  properties:
+                                                    preference:
+                                                      description: A node selector
+                                                        term, associated with the
+                                                        corresponding weight.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          type: array
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          type: array
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                    weight:
+                                                      description: Weight associated
+                                                        with matching the corresponding
+                                                        nodeSelectorTerm, in the range
+                                                        1-100.
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to an update), the system
+                                                  may or may not try to eventually
+                                                  evict the pod from its node.
+                                                type: object
+                                                required:
+                                                - nodeSelectorTerms
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    description: Required. A list
+                                                      of node selector terms. The
+                                                      terms are ORed.
+                                                    type: array
+                                                    items:
+                                                      description: A null or empty
+                                                        node selector term matches
+                                                        no objects. The requirements
+                                                        of them are ANDed. The TopologySelectorTerm
+                                                        type implements a subset of
+                                                        the NodeSelectorTerm.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          type: array
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          type: array
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                          podAffinity:
+                                            description: Describes pod affinity scheduling
+                                              rules (e.g. co-locate this pod in the
+                                              same node, zone, etc. as some other
+                                              pod(s)).
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node has pods
+                                                  which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                type: array
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  type: object
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to a pod label update),
+                                                  the system may or may not try to
+                                                  eventually evict the pod from its
+                                                  node. When there are multiple elements,
+                                                  the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                type: array
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                          podAntiAffinity:
+                                            description: Describes pod anti-affinity
+                                              scheduling rules (e.g. avoid putting
+                                              this pod in the same node, zone, etc.
+                                              as some other pod(s)).
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the anti-affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  anti-affinity expressions, etc.),
+                                                  compute a sum by iterating through
+                                                  the elements of this field and adding
+                                                  "weight" to the sum if the node
+                                                  has pods which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                type: array
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  type: object
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the anti-affinity
+                                                  requirements specified by this field
+                                                  are not met at scheduling time,
+                                                  the pod will not be scheduled onto
+                                                  the node. If the anti-affinity requirements
+                                                  specified by this field cease to
+                                                  be met at some point during pod
+                                                  execution (e.g. due to a pod label
+                                                  update), the system may or may not
+                                                  try to eventually evict the pod
+                                                  from its node. When there are multiple
+                                                  elements, the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                type: array
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                      nodeSelector:
+                                        description: 'NodeSelector is a selector which
+                                          must be true for the pod to fit on a node.
+                                          Selector which must match a node''s labels
+                                          for the pod to be scheduled on that node.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      tolerations:
+                                        description: If specified, the pod's tolerations.
+                                        type: array
+                                        items:
+                                          description: The pod this Toleration is
+                                            attached to tolerates any taint that matches
+                                            the triple <key,value,effect> using the
+                                            matching operator <operator>.
+                                          type: object
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint
+                                                effect to match. Empty means match
+                                                all taint effects. When specified,
+                                                allowed values are NoSchedule, PreferNoSchedule
+                                                and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that
+                                                the toleration applies to. Empty means
+                                                match all taint keys. If the key is
+                                                empty, operator must be Exists; this
+                                                combination means to match all values
+                                                and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's
+                                                relationship to the value. Valid operators
+                                                are Exists and Equal. Defaults to
+                                                Equal. Exists is equivalent to wildcard
+                                                for value, so that a pod can tolerate
+                                                all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents
+                                                the period of time the toleration
+                                                (which must be of effect NoExecute,
+                                                otherwise this field is ignored) tolerates
+                                                the taint. By default, it is not set,
+                                                which means tolerate the taint forever
+                                                (do not evict). Zero and negative
+                                                values will be treated as 0 (evict
+                                                immediately) by the system.
+                                              type: integer
+                                              format: int64
+                                            value:
+                                              description: Value is the taint value
+                                                the toleration matches to. If the
+                                                operator is Exists, the value should
+                                                be empty, otherwise just a regular
+                                                string.
+                                              type: string
+                              serviceType:
+                                description: Optional service type for Kubernetes
+                                  solver service
+                                type: string
+                      selector:
+                        description: Selector selects a set of DNSNames on the Certificate
+                          resource that should be solved using this challenge solver.
+                        type: object
+                        properties:
+                          dnsNames:
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            type: array
+                            items:
+                              type: string
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            type: array
+                            items:
+                              type: string
+                          matchLabels:
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
+                            type: object
+                            additionalProperties:
+                              type: string
+            ca:
+              type: object
+              required:
+              - secretName
+              properties:
+                crlDistributionPoints:
+                  description: The CRL distribution points is an X.509 v3 certificate
+                    extension which identifies the location of the CRL from which
+                    the revocation of this certificate can be checked. If not set
+                    certificate will be issued without CDP. Values are strings.
+                  type: array
+                  items:
+                    type: string
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+            selfSigned:
+              type: object
+              properties:
+                crlDistributionPoints:
+                  description: The CRL distribution points is an X.509 v3 certificate
+                    extension which identifies the location of the CRL from which
+                    the revocation of this certificate can be checked. If not set
+                    certificate will be issued without CDP. Values are strings.
+                  type: array
+                  items:
+                    type: string
+            vault:
+              type: object
+              required:
+              - auth
+              - path
+              - server
+              properties:
+                auth:
+                  description: Vault authentication
+                  type: object
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    kubernetes:
+                      description: This contains a Role and Secret with a ServiceAccount
+                        token to authenticate with vault.
+                      type: object
+                      required:
+                      - role
+                      - secretRef
+                      properties:
+                        mountPath:
+                          description: The Vault mountPath here is the mount path
+                            to use when authenticating with Vault. For example, setting
+                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                            to authenticate with Vault. If unspecified, the default
+                            value "/v1/auth/kubernetes" will be used.
+                          type: string
+                        role:
+                          description: A required field containing the Vault Role
+                            to assume. A Role binds a Kubernetes ServiceAccount with
+                            a set of Vault policies.
+                          type: string
+                        secretRef:
+                          description: The required Secret field containing a Kubernetes
+                            ServiceAccount JWT used for authenticating with Vault.
+                            Use of 'ambient credentials' is not supported.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  type: string
+                  format: byte
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              type: object
+              required:
+              - zone
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  type: object
+                  required:
+                  - apiTokenSecretRef
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  type: object
+                  required:
+                  - credentialsRef
+                  - url
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certificate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      type: string
+                      format: byte
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          type: object
+          properties:
+            acme:
+              type: object
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+            conditions:
+              type: array
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                type: object
+                required:
+                - status
+                - type
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    type: string
+                    format: date-time
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+# Source: cert-manager/templates/cainjector-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-cainjector
+  namespace: "cert-manager"
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.1
+---
+# Source: cert-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager
+  namespace: "cert-manager"
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+---
+# Source: cert-manager/templates/webhook-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-webhook
+  namespace: "cert-manager"
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.1
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "create", "update", "patch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["auditregistration.k8s.io"]
+    resources: ["auditsinks"]
+    verbs: ["get", "list", "watch", "update"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Orders controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "orders/status"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "challenges"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["create", "delete"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Challenges controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+  # Use to update challenge resource status
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "challenges/status"]
+    verbs: ["update"]
+  # Used to watch challenge resources
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["get", "list", "watch"]
+  # Used to watch challenges, issuer and clusterissuer resources
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  # Need to be able to retrieve ACME account private key to complete challenges
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  # Used to create events
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # HTTP01 rules
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  # We require the ability to specify a custom hostname when we are creating
+  # new ingress resources.
+  # See: https://github.com/openshift/origin/blob/21f191775636f9acadb44fa42beeb4f75b255532/pkg/route/apiserver/admission/ingress_admission.go#L84-L148
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes/custom-host"]
+    verbs: ["create"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges/finalizers"]
+    verbs: ["update"]
+  # DNS01 rules (duplicated above)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-edit
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# ingress-shim controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests"]
+    verbs: ["create", "update", "delete"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["extensions"]
+    resources: ["ingresses/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-view
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Certificates controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/finalizers", "certificaterequests/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Issuer controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "issuers/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# ClusterIssuer controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "clusterissuers/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-cainjector
+subjects:
+  - name: cert-manager-cainjector
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-orders
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-clusterissuers
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-certificates
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-challenges
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-issuers
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-ingress-shim
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+# leader election rules
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+  # Used for leader election by the controller
+  # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
+  #   see cmd/cainjector/start.go#L113
+  # cert-manager-cainjector-leader-election-core is used by the SecretBased injector controller
+  #   see cmd/cainjector/start.go#L137
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+  # Used for leader election by the controller
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cert-manager-controller"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cert-manager-webhook:dynamic-serving
+  namespace: "cert-manager"
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.1
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames:
+  - 'cert-manager-webhook-ca'
+  verbs: ["get", "list", "watch", "update"]
+# It's not possible to grant CREATE permission on a single resourceName.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-cainjector:leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager-cainjector
+    namespace: cert-manager
+---
+# Source: cert-manager/templates/rbac.yaml
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager:leaderelection
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cert-manager-webhook:dynamic-serving
+  namespace: "cert-manager"
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-webhook:dynamic-serving
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cert-manager-webhook
+  namespace: cert-manager
+---
+# Source: cert-manager/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager
+  namespace: "cert-manager"
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 9402
+      targetPort: 9402
+  selector:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+---
+# Source: cert-manager/templates/webhook-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager-webhook
+  namespace: "cert-manager"
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.1
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+    targetPort: 10250
+  selector:
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+---
+# Source: cert-manager/templates/cainjector-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-manager-cainjector
+  namespace: "cert-manager"
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "cainjector"
+  template:
+    metadata:
+      labels:
+        app: cainjector
+        app.kubernetes.io/name: cainjector
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: "cainjector"
+        helm.sh/chart: cert-manager-v0.15.1
+    spec:
+      serviceAccountName: cert-manager-cainjector
+      containers:
+        - name: cert-manager
+          image: "quay.io/jetstack/cert-manager-cainjector:v0.15.1"
+          imagePullPolicy: IfNotPresent
+          args:
+          - --v=2
+          - --leader-election-namespace=kube-system
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          resources:
+            {}
+---
+# Source: cert-manager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-manager
+  namespace: "cert-manager"
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "controller"
+  template:
+    metadata:
+      labels:
+        app: cert-manager
+        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "controller"
+        app.kubernetes.io/managed-by: Helm
+        helm.sh/chart: cert-manager-v0.15.1
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9402'
+    spec:
+      serviceAccountName: cert-manager
+      containers:
+        - name: cert-manager
+          image: "quay.io/jetstack/cert-manager-controller:v0.15.1"
+          imagePullPolicy: IfNotPresent
+          args:
+          - --v=2
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
+          - --leader-election-namespace=kube-system
+          ports:
+          - containerPort: 9402
+            protocol: TCP
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          resources:
+            {}
+---
+# Source: cert-manager/templates/webhook-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-manager-webhook
+  namespace: "cert-manager"
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "webhook"
+  template:
+    metadata:
+      labels:
+        app: webhook
+        app.kubernetes.io/name: webhook
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: "webhook"
+        helm.sh/chart: cert-manager-v0.15.1
+    spec:
+      serviceAccountName: cert-manager-webhook
+      containers:
+        - name: cert-manager
+          image: "quay.io/jetstack/cert-manager-webhook:v0.15.1"
+          imagePullPolicy: IfNotPresent
+          args:
+          - --v=2
+          - --secure-port=10250
+          - --dynamic-serving-ca-secret-namespace=cert-manager
+          - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
+          - --dynamic-serving-dns-names=cert-manager-webhook,cert-manager-webhook.cert-manager,cert-manager-webhook.cert-manager.svc
+          ports:
+          - name: https
+            containerPort: 10250
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          resources:
+            {}
+---
+# Source: cert-manager/templates/webhook-mutating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: cert-manager-webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.1
+  annotations:
+    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
+webhooks:
+  - name: webhook.cert-manager.io
+    rules:
+      - apiGroups:
+          - "cert-manager.io"
+          - "acme.cert-manager.io"
+        apiVersions:
+          - v1alpha2
+          - v1alpha3
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - "*/*"
+    failurePolicy: Fail
+    # Only include 'sideEffects' field in Kubernetes 1.12+
+    sideEffects: None
+    clientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: "cert-manager"
+        path: /mutate
+---
+# Source: cert-manager/templates/webhook-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: cert-manager-webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.1
+  annotations:
+    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
+webhooks:
+  - name: webhook.cert-manager.io
+    namespaceSelector:
+      matchExpressions:
+      - key: "cert-manager.io/disable-validation"
+        operator: "NotIn"
+        values:
+        - "true"
+      - key: "name"
+        operator: "NotIn"
+        values:
+        - cert-manager
+    rules:
+      - apiGroups:
+          - "cert-manager.io"
+          - "acme.cert-manager.io"
+        apiVersions:
+          - v1alpha2
+          - v1alpha3
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - "*/*"
+    failurePolicy: Fail
+    # Only include 'sideEffects' field in Kubernetes 1.12+
+    sideEffects: None
+    clientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: "cert-manager"
+        path: /validate

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -1,0 +1,114 @@
+# Namespace where the Scylla Cluster will be created
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scylla
+
+---
+
+# Role for scylla members.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scylla-cluster-member
+  namespace: scylla
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - "apps"
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - scylla.scylladb.com
+    resources:
+      - clusters
+    verbs:
+      - get
+
+---
+
+# ServiceAccount for scylla members.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scylla-cluster-member
+  namespace: scylla
+
+---
+
+# RoleBinding for scylla members.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scylla-cluster-member
+  namespace: scylla
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scylla-cluster-member
+subjects:
+  - kind: ServiceAccount
+    name: scylla-cluster-member
+    namespace: scylla
+
+---
+
+# Scylla Cluster
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: Cluster
+metadata:
+  name: scylla-cluster
+  namespace: scylla
+spec:
+  version: 4.0.0
+  agentVersion: 2.0.2
+  cpuset: true
+  network:
+    hostNetworking: true
+  datacenter:
+    name: <eks_zone>
+    racks:
+      - name: <eks_region>
+        scyllaConfig: "scylla-config"
+        scyllaAgentConfig: "scylla-agent-config"
+        members: 3
+        storage:
+          storageClassName: local-raid-disks
+          capacity: 1800G
+        resources:
+          limits:
+            cpu: 5
+            memory: 58G
+        placement:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                  - key: failure-domain.beta.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - <eks_zone>
+          tolerations:
+            - key: role
+              operator: Equal
+              value: scylla-clusters
+              effect: NoSchedule

--- a/examples/eks/eks-cluster.yaml
+++ b/examples/eks/eks-cluster.yaml
@@ -7,7 +7,6 @@ metadata:
   region: <eks_region>
 
 nodeGroups:
-
   - name: scylla-pool
     instanceType: i3.2xlarge
     desiredCapacity: 3
@@ -17,13 +16,6 @@ nodeGroups:
       role: "scylla-clusters:NoSchedule"
     ssh:
       allow: true
-    preBootstrapCommands:
-      - cpupower frequency-set -g performance
-      - curl -o /etc/yum.repos.d/scylla.repo -L http://repositories.scylladb.com/scylla/repo/3e3ec6ec-92b2-46ec-b64f-5b2338bc47de/centos/scylladb-4.0.repo
-      - yum install -y scylla-server hwloc ethtool
-      - /opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-cpuscaling-setup
-      - /opt/scylladb/scripts/scylla_raid_setup --disks /dev/nvme0n1 --root /mnt/raid-disks/disk0 --update-fstab
-      - /opt/scylladb/scripts/perftune.py --nic eth0 --mode sq --tune net
     kubeletExtraConfig:
       cpuManagerPolicy: static
     availabilityZones:
@@ -49,9 +41,3 @@ nodeGroups:
       pool: "monitoring-pool"
     ssh:
       allow: true
-    preBootstrapCommands:
-      - blkdiscard /dev/nvme0n1
-      - mkfs.xfs -f /dev/nvme0n1
-      - mkdir -p /mnt/raid-disks/disk0
-      - mount -t xfs -o noatime /dev/nvme0n1 /mnt/raid-disks/disk0
-      - echo "/dev/nvme0n1 /mnt/raid-disks/disk0 xfs noatime,nofail 0 0\n" >> /etc/fstab

--- a/examples/eks/eks-cluster.yaml
+++ b/examples/eks/eks-cluster.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: <eks_cluster_name>
+  region: <eks_region>
+
+nodeGroups:
+
+  - name: scylla-pool
+    instanceType: i3.2xlarge
+    desiredCapacity: 3
+    labels:
+      pool: "scylla-pool"
+    taints:
+      role: "scylla-clusters:NoSchedule"
+    ssh:
+      allow: true
+    preBootstrapCommands:
+      - cpupower frequency-set -g performance
+      - curl -o /etc/yum.repos.d/scylla.repo -L http://repositories.scylladb.com/scylla/repo/3e3ec6ec-92b2-46ec-b64f-5b2338bc47de/centos/scylladb-4.0.repo
+      - yum install -y scylla-server hwloc ethtool
+      - /opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-cpuscaling-setup
+      - /opt/scylladb/scripts/scylla_raid_setup --disks /dev/nvme0n1 --root /mnt/raid-disks/disk0 --update-fstab
+      - /opt/scylladb/scripts/perftune.py --nic eth0 --mode sq --tune net
+    kubeletExtraConfig:
+      cpuManagerPolicy: static
+    availabilityZones:
+      - <eks_zone>
+
+  - name: cassandra-stress-pool
+    instanceType: c4.2xlarge
+    desiredCapacity: 4
+    labels:
+      pool: "cassandra-stress-pool"
+    taints:
+      role: "cassandra-stress:NoSchedule"
+    ssh:
+      allow: true
+    preBootstrapCommands:
+      - curl -o /etc/yum.repos.d/scylla.repo -L http://repositories.scylladb.com/scylla/repo/3e3ec6ec-92b2-46ec-b64f-5b2338bc47de/centos/scylladb-4.0.repo
+      - yum install -y scylla-tools
+
+  - name: monitoring-pool
+    instanceType: i3.large
+    desiredCapacity: 1
+    labels:
+      pool: "monitoring-pool"
+    ssh:
+      allow: true
+    preBootstrapCommands:
+      - blkdiscard /dev/nvme0n1
+      - mkfs.xfs -f /dev/nvme0n1
+      - mkdir -p /mnt/raid-disks/disk0
+      - mount -t xfs -o noatime /dev/nvme0n1 /mnt/raid-disks/disk0
+      - echo "/dev/nvme0n1 /mnt/raid-disks/disk0 xfs noatime,nofail 0 0\n" >> /etc/fstab

--- a/examples/eks/eks.sh
+++ b/examples/eks/eks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 #########
 # Start #
@@ -81,6 +81,10 @@ check_prerequisites
 # Create EKS cluster
 
 sed "s/<eks_region>/${EKS_REGION}/g;s/<eks_cluster_name>/${CLUSTER_NAME}/g;s/<eks_zone>/${EKS_ZONE}/g" eks-cluster.yaml | eksctl create cluster -f -
+
+# Configure node disks and network
+kubectl apply -f node-setup-daemonset.yaml
+sleep 60
 
 # Install local volume provisioner
 echo "Installing local volume provisioner..."

--- a/examples/eks/eks.sh
+++ b/examples/eks/eks.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -e
+
+#########
+# Start #
+#########
+
+display_usage() {
+	echo "End-to-end deployment script for scylla on EKS."
+	echo "usage: $0 -z|--eks-zone [EKS zone] -c|--k8s-cluster-name [cluster name (optional)]"
+}
+
+CLUSTER_NAME=scylla-demo
+
+while (( "$#" )); do
+  case "$1" in
+    -z|--eks-zone)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        EKS_ZONE=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -c|--k8s-cluster-name)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        CLUSTER_NAME=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -h|--help)
+      display_usage
+      exit 1
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$EKS_ZONE" ]
+then
+  display_usage
+  exit 1
+fi
+
+EKS_REGION=${EKS_ZONE:0:$((${#EKS_ZONE}-1))}
+
+check_prerequisites() {
+  echo "Checking if eksctl is present on the machine..."
+    if ! hash eksctl 2>/dev/null; then
+        echo "You need to install eksctl. See: https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html"
+        exit 1
+    fi
+
+    echo "Checking if kubectl is present on the machine..."
+    if ! hash kubectl 2>/dev/null; then
+        echo "You need to install kubectl. See: https://kubernetes.io/docs/tasks/tools/install-kubectl/"
+        exit 1
+    fi
+
+    echo "Checking if helm is present on the machine..."
+    if ! hash helm 2>/dev/null; then
+        echo "You need to install helm. See: https://docs.helm.sh/using_helm/#installing-helm"
+        exit 1
+    fi
+}
+
+# Check if the environment has the prerequisites installed
+check_prerequisites
+
+# Create EKS cluster
+
+sed "s/<eks_region>/${EKS_REGION}/g;s/<eks_cluster_name>/${CLUSTER_NAME}/g;s/<eks_zone>/${EKS_ZONE}/g" eks-cluster.yaml | eksctl create cluster -f -
+
+# Install local volume provisioner
+echo "Installing local volume provisioner..."
+helm install local-provisioner provisioner
+echo "Your disks are ready to use."
+
+echo "Starting the cert manger..."
+kubectl apply -f cert-manager.yaml
+kubectl -n cert-manager wait --for=condition=ready pod -l app=webhook --timeout=60s
+
+echo "Starting the scylla operator..."
+kubectl apply -f operator.yaml
+kubectl -n scylla-operator-system wait --for=condition=ready pod -l control-plane=controller-manager --timeout=60s
+
+echo "Starting the scylla cluster..."
+sed "s/<eks_region>/${EKS_REGION}/g;s/<eks_zone>/${EKS_ZONE}/g" cluster.yaml | kubectl apply -f -

--- a/examples/eks/grafana/dashboards/alternator.4.0.json
+++ b/examples/eks/grafana/dashboards/alternator.4.0.json
@@ -1,0 +1,4927 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "originalTitle": "Scylla Cluster Metrics",
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASMAAAEHCAYAAADlHSANAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nO2de5gcdZnv3+65dM89FyYhJGY4KywgMhAJoOuERM951nh5losyPkfxEMBnOSou8Q91MahRiS6wzxrl4oEjEB447HMGBdyzStgjmMscIQFMnIiCAc0guWcymfulb+f5Vlf1VP26uruqui6/qn4/z9PPTPdMV1X3zO/b7+33vrFcLkcMwzBBE+e/AMMwMsBixDCMFLAYMQwjBSxGDMNIAYsRwzBSwGLEMIwUsBgxDCMFLEYMw0gBixHDMFLAYsQwjBSwGDEMIwUsRgzDSAGLEcMwUsBixDCMFLAYMQwjBSxGDMNIAYsRwzBSwGLEMIwUsBgxDCMFLEYMw0gBixHDMFLAYsQwjBSwGDEMIwUsRgzDSAGLEcMwUsBixDCMFLAYMQwjBSxGDMNIAYsRwzBSwGLEMIwUsBgxDCMFLEYMw0gBixHDMFLAYsQwjBSwGDEMIwUsRgzDSAGLEcMwUsBixDCMFLAYMQwjBSxGDMNIQT3/Gfyjp7v3IiKap54QXy9ycPID6g2c6h/o2xu294FhzIjlcjl+Y1yip7tXExhNdNaoR17tw+l/C3Eior3q120Qrf6BvgMWnsswgcNi5JCe7t4zdcKzRv3aIenlbldFCrdtLFCMjLAYWUQVnzW6W1coLtycEdVywu1pFidGBliMyqDGeNapAnSh0+PUnbaA6jsXKN8nzjur8HhD11KKNzfZOtbMH94ofJ8aPEjZySnKTkxR6q2DTi8PDOqE6elqDsQwTmExElAFaD0RXWnX7YLQNCxfqggPhEYvQn6QPn6SMidOKiKF7yFQqcG3KTs5befssJqeZmFi/IbFaM4F0wTIkvsF0VHEp2spNXYtVb7KypwwHVQsK711VQFNmDZz1o7xmpoWo57u3nWqG1Yx2wUrp+niCyjxrrMUEbLrXskGBGnq5X3KV4suHrJ1m1WL6VSoXzwjJTUnRmr6fZ1qCZW1gmD9tFx+KSUvvsBXd8tvYDlBlKZf2UdTr+yrdPYRVZS2cOCbcZOaESNVhNart5KxoFoRoFIgIA6LaXLnbivu3CNEtJFFiXGDyIuRFRGKNycpeXE3ta1dLXXsx29gMUGUJnbsVgLjZWBRYqom0mLU090LAdpYSoQQB2q/ei01rbwg9DEgr4EgWbCWvqUGuzmmxNgmkmLU092LuqAtpWJCCEC3rl2tBKQZe0CMNGEqAWJK6/sH+rbwW8vYIVJipKboEVy9wuznECFYQvrCQ8YZcOFGn9xaTpSQfVvHJQGMVSIjRuVcMrhjC276FIuQB8BSgiiVcd/YdWMsEXoxUq2hLWa1QghMd1x7tZIdY7wFYnTy/sdLBbrZSmIqEmox6unuvVIVoiJrqPVDq6n942s5MO0zsJLGt24rtQXlW/0DfRuj/PoZ54RWjHq6exEbukV8HHVC8z5zFbtkAYJ40vADj5dy3dDO5Ep22xiR0ImRWje0zWwXPawhCBEjB+Nbt9Pok8+YWUmDqiCx28YUCJUYqTvqt4luGQeo5QVW0tD3HzTb/8YlAIyB0IiRuqn1YfFx1ArNv+lTHBuSnFOPPkXjz243u0iOIzEKoRCjUkKEmiHcmHCAYsmRx540c9se6R/oW8d/xtpGejEyC1QjZT//pk9zBXUIQU+l45vuZkFiipBajHq6exFPuE7/GISoc8MXeUNriEFngOO332MWR+JMWw0j7RBHMyFC2n7Rpq+wEIUcxPc6b7vZLOGwWk1QMDWIlJaRmWsGIcI/MAeqowWqtk32t7HLVoNIJ0ZmwWoWomjDgsSQbG4aC1Ftghqx5lVF+wevUy1kpkaQxjIyK2hkIaotjm+6x2wLyfVcGFkbSCFG6haPA3ohQtYMwWq/+lDrx/mIQxFxHxkg/bVAILXZaLKPKgoLZbJsK3jrSPSRRYz26vea+ZG+10/EmPnDfruDDk1BdkgZZ6TOU2PsA0E6+rW7xFYk2DpyJqf8o03gYmSWOZv/95/ypAeRNvkCGzirHAddEVhMeA2IhdTilJFqKFEYub1/oG9N6F4MY5lAxUjtR/SU/jEvtnhoLVKnXxlwbAG1tjbT+Piko+fCWkLPbd7Iax3Mb8MGWwHexxZhAhMjszgRFmvnhptdO4eFPs0FLlr5Ljr7nDPp7HPPpCVndCpfW9taSv7+/tcO0JFDx2n/6weU7/e89GpFseIe3PYosbmW40cRJUgxelrfOB9xotM3f9O1zFmFjoOKpbPqg5fQ5R+8VPnqBhClX/xsG+381UuKUJUCrhv6LnGWsDKIHwku9W/7B/oukvRymSoIRIzM3LOFX7rRlY2viDegiK5UTAgW0EeuWKPcvATC1PfYz+mZfzNtm8H9uS0C6/bYhjvFDxV21yKI72Jk5p651aER1hBuZkCEbvzcNbTikvOrPo8dDh86Tg/d11dSlLgfU2WQcDj12FPi77G7FjGCECND9gxZp8Xf/XJVixFZsuH7H1eCniJnndNFt3xlne8iJAJR+uEdWxQXTgTvwWlfupHLAcpgUhDJ2bWI4asYqWOF/qx/rFr3rFRbU8SEbvj8NdR77UedX7AHINC96ev3FcWUuEdTefB3PvKlb4u/c1X/QN/Tkl0q4xC/96YZyvq1IkGnID6EeIIoRLCG7n5oo3RCBGChbXniTvrw3xnHvCEmAlFFN0SmGNRqmZR88N61COGbGKnz7w0rEMWNTinVMRCL/J6HNiqpeVlBycCG279AX/vO54uuECN+WJDMQa0WXFodXeokYSYC+GkZGbIfCFo7rUyGyW4mRDd87hplkZerD5IJZPTufvCbikuphwXJHMQVTayjjWpShAk5voiRaBUhPoJpr05AsBrujChEsDIgRmEDbhtcSlGQ0Lge1h9jBKUQgnWErCxbRxHAlwB2T3fvNr0YVbPlw6zNBITI67qhUux8/iXa8fxuJVumgUru91xyvq1iStQlffGGjYYqbrcLQaMCrEZYjzoG+wf65PXLGUt4LkZqn6I92v1qFphZHdE/fOW6QALV42MTtOm2+0xT9Rqwdno/81HqvfYjllxHCNL1vV8xPOb2FpmocHj9t8Wd/dz3KOT44aYZTOjmVZc5EiK4LKIQIVgdVMaskhABWDkP/egJ+sSHvqBsE6kEgu5iUBtWYKlCzlrGxLJmVy3keCpGamDRMOEDGREnnBB2cCvFjF8NpkWytv/MKhCl7379Ptp0272KRVUOuJvXfPojht+AGHH8yIhJ7OhCNTbJhBSvLSODWqCmyEkGDYtRb5LD/dnwneCyZrB2nIAtITcjLlRBkCCyEFs9Jtshah6TfX3cwD/E+CpGzQ42hSKNj933elBZHVQdEQLW5XbkV+KN1wctCRLEVg/cNU73GynRxJ/T/CHFMzFSA9eFVrIwqZ1UW8Mq0qfxYTEEWVmNzFm1QJAQcyoHxFYsVeDYkRFY2Sb/U1cGfFmMQ7y0jIpcNLvAKhIbo2HTa5Dsefn3rpwdMadK7h6ycKef0Vm4D1eVrSMjJtY2i1FI8VKMDP8UTgLXZtmzIHffw7WqxkUTgRghnV8KxMTYOioPPuRQLqLjCnbVwoknYqS6aIUILOaf2Q1co9JatIpu+HyvexfpgHLC4ZQf3Fm+NAbZNdE6MmuVUsskL+4WXz1bRyHEK8vI8M/QtNK+izYpuCNojrZEtyijwt6Xf1+xBgnuWrn3ptYx+f9iMQohXomRod7DSbxIjI18UsJ2IG5RKXYE60i/dw2WESxHJo/J/xfXG4UQ18VI9dcNm2LtdjDUprtqwE1xq2m+jCAOhaZrpUDsSHz9mP/GzCEIUgcXQIYPLywjwz+BiT9fkWkhJrLqA9EVIo1KrhqmmOgR36Nax2T8E4tRyPBCjAxjZJzMCBN35V8eYatIA9XZ5QohYRmJrhozB4tR+PHcMmp00GQes+81sACDbqav4fV17HmpfA2TeH5RtGsZk1AAz1YLGV6IUVXxImwINVRcS9Y+Flk9r/hNmbgRKWJkPDeLkRHBOupQB0AwIcFVMRL/+A1dy2wfY1bYnf4eSawiDS+buO15ubwYoWmbHgT6mTlMXDW2jkKE25ZR1fEioWFW0QIMGrEI0U2wZ60copsmvle1Drtq4cZTMRL6zVhC7Nvj1cKvhu9t/rJn11Wpylt/XnbTjNQX/7+xGIUIt8XIYMY46V0kFvPJOHII12Q2+8wNKrUWkVGcZcHEMuKYUYjwVIycuGlhQZt99nCfu6J02OZGXI4bGRG7P0pwSYxFPHXTnKB3PcRuhzICKwmi9MTWe10RpUpdAcSAPseNjIjWOO/gDw9ui1GH9o0bVlFYhjECbOKFKJkNZWT8Ax0iBDhuFBJcEyP+BMoDS6m1PTwiGjXiLTxjLqzUu3jdhk8gk0+oyIPNruhP5GYDNqZqOIgdEtwUIwNOP6EQgNTiIHtdavHqNRChB3/0hC/Xe/jgMcN9njZrxCQ8wGIUEjwTI6cgABmWoKwXIrSiwnYTMdtmd7sNw8iKdGIkgrobGQPZP7hjCz3xv37h+3kr1SExTFhxM5tmiBk5dR/EWJMXfaerBZNhvRKiSkWe+i0jtRiXY6KLm2JkyKY5dR/EOpH9r8slRnDN0HvIC1BdXc4KFIWZM0dMlPB6oqxtRBGTzTKq1JGxGiptChaFOcoV7kztIb0YuTU00S0w3torxH5FIqIwc/CaiRJuitFe/R2nO8oRa9LHQlCzY3e/llfgOsbHJz07/qoPFk1HNYAptHrYMmKihJtidMqtA4mLbKcL8+3d4IhQ4+Mm2IdXbi4chFBfTAnB5hojJkpI56aRyVA+L+M0slCpg+QzwnvAVhETNTwTo+yE8yGDWGj6+elIZ8viqnkBNtZWEiNRkFsuL+/S1Som4YG9tf6ehAXXxKh/oM+wWvRDGJ0gzlvre/TnEXi7zen9zEfLpvRRTqB30bBlhoPXlnEtfMB4i5RuGmhba+wNBDclitXHsIrEWfoiDwrjr8X3hpmjGos8TKBLRk9378YovSa3xahQHpwafLuqA+GTXx8XQRar7zH/t1/oOX3pItePecPnr6loFYl735rZRSuJaJGLFnsUUNv14HV9s6e7d0tUXpfbYlQohNHPPnNK8yrjooOrFqR1VC7b5QTMYOu99qNlnylaRXhPOItW86zXtdS9rqe7NxLTc90WI4N/Xm1/ZgRp9T2NYR09eN8TZZ/jNW7N/Yd79k8/+HLZ3zGzitqvXhvUSw8FQgD7t7X+foQJt8XIkLlwoxXIgps+ZbiPDapBbhGpVCVtBQjR3Q9tLOuewQLc9PX7DI+1fmi1o4krNQwHr0OE1JYRqWl+saZm09fvrfq4Tql2oiyECL2yK+3OhwWoz6Ch1KH942wVlcMkrS9fywemJNJbRmD+3xutI9QdoZ9QEMCacToFRLOIVn2wvKsH90xsUdJ+9Yc5VlQBceYei1G48NQyEqfDOgWuiRgrwWL1ctNqOW756jrbE0AQrH74J3dVtIhQ3HnrLXcZHoNl2Mrp/IqY/L9xwWOIcFWM+gf6DH98k08qx0CMity12+4NJH4E60iJ+VgQJPQo+tp3Pk/3PLSxYjYOcaJbb7nTsBkX7ploGTLmmNQYccwoRHhR9FioNXJ7FjwWpX6bCBbtF2/YGIggwcKBpVMqu4bHIUI/2Xqv5TjTzTdsNHRyBPNv+jQHrS1iUvXPllGI8KIHNpShMAoW1pFbsQ4syoVf+iwd33RP4TFNkGCp+D2XH5bO99T0POI8pBZGOqlHgpUnChGswaaLLyj5HMaImDDpH+hjyyhEeGEZGT6N3IobacBVE92WIC0kjRWXnK/c7AoRXLN113y5qJUtihut1hTBAsXNTbc4jAgJE296A9cQPd2963q6e3PqzfNKdi8so6L0fuI8d0+g7VgffuDxwmOaIMFSWSHMo5eVfLD6ziKLCEIk1leVAlai3h2GWJvF16KOyYceW0VVACEioof9PKcXlpFBQb2agQZBMrWQbvwW9T0m/w5/uHXXf+LLVQkRmcTlcB8ChVstWUrp4v8zjhc5pIQQeS7uXoiRJ+l9M8wECfzwzkeUYLCsPZBQIwXRFFvY2hUiUtuJmAFROrL+W56+/zLBaX13KCFE2Fazzutzuy5GYnrfjSrsckCQFn7pRkOWjdTR2LA8ZLKSYA19Yu0XTGeuwbWyK0Sgc8PNyjYRM7cMm5WPb7q7Jiwkk/8zdtNsUkaI1viRDPCqn1Fhg2K1TdasgIxT54YvFg01hOUBKwkCEFSBJKmxIVhqsIaOCNYaRBRi6nQDLDKM8z5zlSJKZzzwPWr928uJYnM/hyANff/Bal+C9IjhgCi2DvGSoIWIPBxvXRTE9rpWBv2POm+7mUZ/upXGnzUmUiAAt66/SylAvOFz11S9v8wqsITQg0mc6qGhZQbdeG9g/Qzf/zhNvbKv6Gdati3KQW0hdjZY+jcZERmEiDwUI3wqFfYv4FPLj8I91DPBSkBD/5P3P170aQlR+u7X76Mf3rGFPnzFGkWU3K5NghWEaSYQIdEKmrvOpLLXzK0tHhM7dtPIY0+W7SE1+uRWxXqKIlb2pL3vA+u/StnsO/SPxWYmPyb+Xn0y2V7KY8im09Px1o7XY40J5R8rm8nMpMfHTryw/Yd+v7GiQDgWDFmECMRyuZzrBxVfIFyQIPrwYAGOb91WdpHCWlqx8l1KOQAmutoVJ4jPG68doN+89CrtefnVouyYCILUEEw3CkERtD312FMlK92bLrmQpl6aa+kDNy5qm21HnttFs2+8RVOvDOCfmSiToVgmnSXKZSmT9urDtiSxunqieDxH8bpMrKVtLJtOz1JLx7OZ6akxN0VL7fB4HRFd3z/Q52jXuExCRB6KEfygX2n3nWSJ3AKfmuNbt1cUJT3Y1ErquOm29uKeQ79Rq60hQlaHOmpFjG65ZKcefYomd5rPk0OGDe833DJ9HRIso7C6aief+A9K/eUwZY4PUfboUaJUStGbUNLQmI0lmydy9Y1HMxR/NtfQeP+Lv/znYv+6AlhnTmNjsgkReSVGlH+xhQNjAQTtImABT728TxEmP4LqpIoCsn0QIrdEqJKwilYofh/WE6l7+8Iw4gjWzvRvX6PUm39GFoIok5bgqjwmFidqTKRyyZY/ZeP1v/TS9ZNRiMhjMTLsUVv22GZPzuMEBNSnX9mnxFrcFiYIELJ7WPRujROyIkLlguGwonCMoKzTSkzs/SONP/8CpV77I9Fk9CbAOKa+MZtrad+frW98+IVfbb7DjUP2dPdeSURPCQ8HLkTksRgZgtinf/8bUu4+xyKFG4P4C75CqKxWjSMQ3dC1TCkp0KaZuPkarYiQ3iULE7B+xv/9OcqdPOmJ5RNraFDiN7FkE8WbWvPvVVsH1S9cbHz/2udTosvaeze5rzgrOjH4J0pP5V31+Mwk0Wz+7xRLz7rwKnTAckokJzLJlmdf2HHvx50eRh1v9E3dQ1IIEXmYTaOgMmp2QUAXloy4Ox5CUKp6GQLg5WuBIEKEJnfuKilCEMKOa68O1WRZWECj/+c5yvxxf/Xxnngd5RoTlG1qp1xTG2XaF1C2bQHFFi2jZUsWUjwes3AQezRfUNwuJnn+Snr78BCl0xnTY9Uf+TOydlR38gjFUjMUHztJsQziXTaNALxf05MtddOTVyMEkmtqPZFtbv/nKi0maYSIPLaMpMiohQlYZnAdSwWmSRWh1rVrlLKAsGTGEHye3PZrohEn//MxyiWSitBk2xZSZv4iSncuL/uM+fNaaX5H6WEHbjMxOUNHj9t/bQ2Dr1Ld2DDFR4coPnEKtQL2r6y+IZNpbv9/L/T/yFKdSE93L9LFWsp4r0xtVrwUI2kyajKjxa/Gtm4v6x6GVoSeeY5odsb6k+J1lG2ZR5n5iym97BzKtM23fV5YRcuXdnpiHZXi0NFhmp6u3jWDQNUfHcxbUHZcvViMMm0LdlgVJRnxTIxIwoyaLGiZPYiQWcW0nlhDPc27vjdU7tjs4RN07PZ7LFtCuWQLZRYupdkz30XZVnfc37bWJupc2O7KsawAN+2tgydcPWZ8epwa/vIa1R85QLHJUWtPqm9IZzo6b3Mr4O0nXouRtBk1v7EjQHoQHF/83fLDHmXi+I9/SjPbdla8IghQenEXzZ71HsrVN3ryCpYvPY3q6+t8e3eGT43T8Ih32cDE/pctC1O2uX3w1y/+2N/Wp1XidYWqQYz82KMmE9qeMIiQlRICVIOjd/a2X75Ix4/mXTa/aqLc4PB3fkSZ118vfSS4Ep3voJlz30tZNcPlJceHRmnJYvtunlMQqxqbmC4ZzK6WmbNXKjdYTI1v7KX6Q/tLBsLjk6Nd71953WhmXuf7nRRUBoHXYmTIqGFhRVWMtOybJkBWhxFgwgjmqF3+wUsL89T2v36gIEZh4dCt/0LZv7xlfrWxGKWXvJNmznuvZ1aQGVPTs0ocJ5n075xwDQ8fHfb0HNlkK02/u4fo3T2U/F1/SVGKzU611Q8d+g0MbE8vyCX8sIwKYLFGocE8Xgc6C+IrbrODB211tIQAYS9cXoQuKRpzrZ+vX6p5mkzANSslROnFZ9LMu3t8FSE9J4bHlFS/XzQlG6mlOaFk2PygIEp7nqP6Yyb7IjPp+r+59IZjv9790KJA/gA28FqMPG3OT7rtDloBIjJNWuWzWA+k/5mIWOyorzPSfmanINKMj1z5AVq1ZmXZibJo0K9HdksSwWrTGFEsRtMr/gulO99h9jTfmJ1N09j4lBLQ9ovOhR00NX2cslnv4rEi0yv+M9UNH6Wml7cWlQjEp8c737f6H+4JoLuALTwVI3R97OnuLdx3u+sjanK0fVcoDtRcIzsBYq+AEMYaGyh96GjhDBddfJ6F0da/N9wXG8bJxtCPnyi+oliMJt93hVIbJAMIKrc0J31L9eM88ztaaWh4zNdXj3KIyVUfp+adPy0WpPHhz2I0n68XZBOvOj3q8azrI9LdMmyDgFWmTeVA10ZsfVmy+RvU8Uljuxwr3SZ3PG8seHRrf5tXZP5cPB5q5oLV0ggRqWn3kTFr3RXcoqO9mRobfe9gosSTIEgisdRMwveLsYkf7xb+Wy/U7sD1cXOBYfFP7thdcKvyX9+23C7EKprLp7l62n18X6oIURRKdH6EGybGiDTQG0mcn4ZGcVIjFDTmGhKUWvJX0l3xyOgEdbQ1+1oIuXB+m+fBbDMgSJn5p1Pd8BHDT2V31fwQI8SNrtDuzLosRhCCUh0T4cZps9WamhL0rbvW06nhsZIdGJFah1igbzapVsniTc5rfLR9b5rbiN5HO55/qWTbW3Sg1IPnhq0ZGuqHZATxG7hNfhZCIpgNAfTbKgOZeYuKxKgcPd2984hofZWnPdU/0Oe4mNAPMdqm3yXs1Rw1M+DGodsjzjk1NUOvvfonpQd2ObQx1aSKSbUkdWIEHvrRE6YZNEwxEXtlu9WW1k/iEyPKNoagsmflQCAbe9b8LITM1x5N+RrMBvUn3i56LNeYNF18qhBt03swTunp7r2of6DP0VgjP2JGhqCC1fobt9BvzoUQVBqBjRofDTfECIKoT8/DKvuBzgKCJYb7mjWmgb18oezKmM1Q4g+7JLgQc1AI6SdwC+Gu+UnDwf3K3jaRXKK5lCWwzg0hUrlO3SRvG8/FqH+gD6t7RLuPeI6fiGKAKSFi+lyPPpvlljspditAXGjt36xTxhetff/1RXPUkEFDn+ywgiK85L7KW0KCQCuE9BOUFfhVeAkhSvzO3nuvulaPWPhVKzzitCe3H5YR6euNEFj2e6igvlvAEXWGmZkgKZM9dK6SWwWaZlk/xI/0xY0aWrO0sDfOhyA1//ppik+NS3A1Rk74nHIHizyOVcE1Tu75pW0h0lBdqw9Ue3PqopFPMSNSxWhuW8jgQV9dEC3tjvgRwAQPCNItX1mnVEKT6i5tuu3ewnMgCm5n/TBMsZybCvGbHwEh0oCr0Lyjj2bfuYJSZ54vTRwpiEJIxKkQr/JiIy2socbXdlXdXTLowZd+ilGBIAYKQoxQdKk1LoMgYcLrWed0KcFkcdKH224SBAYtVLTmaZooQfTwXshSM+UFjW/uUfr0pLrOl0aU/C6EJKX2qMXVjbSKCL25h2ISWp9O8EuMDFFjr+fvlwLuD2qDNAuJVFESQfDYqz10EJ0w9SayS66p1XRx4FMbCwe39BlnU2rpWZRZsCSw69QKIf3sCKkFs510hSwcY+ykIkL1B/eXtYRyjU3YKOv4PEHgixjB/NNvC/Fij5pVYCFBbCBIYntXtye91iKpM86mXEMjNb6xp+RiQTwJNwhXelEXpZaeHUjFdhCFkNhEa3cjLeJudccGS2bJRGCBZhYuoeRvfunehfuAn/Xqv9XSh0H36IF1BCsJN81dKreJlrGHshgWdSmCpLS3KAEsKLhvuMF1w3MyC05XLCY/+h2h9md4ZNz31DvOh6xeqdojiHjdycNKE3/sxLfqhuG9Q3wO7x+eHzb8FCPDtpAg4kZmRDVOEzQQk+kLVlH8rBUVRYnUBahZTKS6e5n5S/Li1L7QM8tpZHRSsY78LITEuXBOLZgNyyc+NqSID0TEivWjRy9CYcZPMTJsC0HcKHFeqN87xgJ6UVKazVeIdWjAGqif2m8QMSy6XLJNOabyfVObKxYUtoks7pzn+Z8zNztNqRPHKD10lBrGRqj58NsUGxlynAWTIfbmJn6KkWFbSJBxI8Z/IBoz516m3OB61B99S4mD2FmIsByI1P1Wb849DqsJcSqMMoK7B6tKE6ls+8KK2TvEb9zoCDl7KN9gDqIDwdE/ljpc3HzOSZFfetFyxZ1F/3AZt9xUg9+WUYEw9XZm3AVBa9yIVinCZDc2IqK5NXmxKg0Wb7bd3N0b6VxGmdak6c8gLNmZ4oBzdmyEMuMjps9xC30sLYoCpMc3McKwuJ7uXvzlOiiAPWqMnGjCBItJyRqpgVvEUOzGTiqRDwyXEHyqHJAAABErSURBVKyTR0iGKf9KrKxtgeJ6KYF8ifpCeY3f3Z8Mldi1Ni2EKQ9cq+zSs5VUP6nigWmrBXFSAr3hGlRQjrrWDpptbFIC9dn2/MRcP7KIsuK3GNXMtBCmehQXRbUQ9CjTVlMz+fn1EKyxIYqlZqUUKghOvK2D6tRb/cLFFGtMUuMZ+RHdfxo8WvEYtUIQllGBqEwLYfxFc11KZZG0Gpu8ZTUnUHXDxbU3+LnVIHrDkuIZ/w0Ql0S+oyvEJt6az8o1nLZIER3GOn6LUaC9jZjawCBSi7p0r3lFxdd/xuL5vs5ZY+bwq4WIAqaF6O8HtUeNYRj58FWMVAod59EO1u/eRgzDyEkQYuT5YEeGYcJH4GLEcSOGYSggMSqav88wDOO7GImtLWdZjBjGF2LpWan7GQdhGZF+5DUHsaNFtX2YGXcw+zvEpsalbtgVlBhxEDuiYMMrEzxme/ByjQmpa2lYjBhX0bo3MsGBPXzoGyWSS7SwGJlgECOOG0WLxGu7lH7NjP9o89PC6C4HIkZiEJsto+iBYYKYKssxJP9Q5tRhcGZIOxv4vTdNjzQN+hlvQMtYdHOcPfeyQlsQxn2UMVBv7Am9exykGO2VsUE/4y5YKLCSMC9NmSzLouQaWmwIIhQFCzRoMbpOu+P3yGvGI9AW1TytXBAlzFZLY1ZaDTcSqwath3i5iSu5unqKZdJheDkFghajAhzEjgapd5xLlM2UdBkgStpkWfQlgqWEHs8sTOWxM8RA6Ze97FxKDAQ6Ot820ogRB7GjQS5eR7N/vVKZYpH83c6yTfYRaEXmjV7bpQgT+hAp0y8iMnqnGvDe5PuBH6b6Y8WTRcxA/2zNFeYhjjZQG/SjQk7pfsVB7GgBQZm4vFdJ8cMKqjT5A4tPmSOvWlTK8Ea1NzSOFeWpGNoQR3SdRDdKO90nSRChMBOkZUSqdVRoxcdB7OiRUhvsK27Gwf2WP+Xz01Xnqoi1qRlK03o0r8cAx5BNztAPccSYo9TQUWo5fsRx8Flxx844OzJJARnEqDBlloPY0UUbSaSMIzo2SI3IANmYk5afMDtOJIiZNrBRmzSrH+Dot7unzVezOsQRxGyeA68vqgmAoMXIMGWWg9jRRxlH1HU+pbrOLwgTXDmnhXoQqTpF1MoPcIQVoUebPisycyRJmTJz9zVx0YDo5GaLBzy6iWIBKYMcoz1HTQbLqAAHsWsLvTDlByweVt2zw65XEYsbR0sNc5xRb0GSLQxxPD3y8TI9gYoRB7EZDSy4ubHXeQzTZSM2wFEjq8bBMsoQxwU1nUkM2jKiqAexJ3bsViy+eZ+5KtTnCAKzAY4QKG0emjK8Uf1e5gpks0GO2lce4jiHLGIUWBAbjd1OPfqUspDjze42wsNrGX7gceV7TM5tXbu64nOqOUdD11JqufxS188x+uRW5W8iw4dEQZwM89DyaJNm9cMbtYmzekrO27eBONBRmxBLys/y16aJD2MNGcTIURD7+KZ7lGm01S7w47ffo7iH6DjZueHmqo4lou9g6VU3y/SJOdclc8J9NwZCPf7sdoo3J+mMB/7J9eO7iSG4ayJWVuAhjsEhi2VUwEoQe3zrdsWdww3WQDWf2JpIeD2lJDvhjRh5HfTX4njZyWlPz8MwQTVXK4AgNhEVepXaDWJXKyJwnzS8nHAb1uB8avBtCa6CqQUCFyMVW7PUYA1puGkZeOHmhB3NIoKbxjBeIqUYVRKYutPmrJlqCyX1x+I6JyP6D4WGrmVyXBQTWWQRI1uz1PSuVbWjjvTHCuPIJC8FlEdIMX4SSssINCyfc9XcCj57GcT2KvbipWDo/w5ulz0wjIgUYuQkiK23aKqxDvRumlcZLwppNkof0NfH6RjGC2SxjKiaIHY1Fo1B1Hg7igEO6DN+IpMY2RpfZAw8u+cCcZxkDv37ym5a+ImPnZR6n5W0lpGdIDZcIKc1QqL7EbaAsJdxLr1radVNE7deMMEQxk3F0oiR3cGORSLi0MUSP/E9LXwMUemA02tFJ8co7q4PG+isKZJtW+DtNoMqkckyInWwo0IlcYGI6Avx3FroHCfJI1pxere4Esl9O3iSbIBgoKMbm4H9RjYxshnEXmb5d8uh39vmpWUUJsT3U+8WVyLsY5bDDIQIAxDCiNRiVNFVW67fFuJOEJstI3dAO1gIEhYH4z1oPtf00i9CK0Qkya59PbaC2PGWuXiPFsS28wleOI4ubhSmjaFeBq/1x66mKwIWR8Oh/Tza2iPgDjcceDUSI66lsozEIHalxSYuEqdBbH0w3MviRK/blNiJ61TCzQJQbbR1y46+yMyFDxq4wMl9O6l5e19+Lh3P2vcEBLEvJN2+s1I1LuLig1uHhmvVguOEseLYiVVYCr2w26kxyixaTvGT5rPAFFF6bZdyw7yv9OLlhp7XTHnsTFPB+1tuFr+MyChGezUxogptaMXF59TyEEWt1gsfxddvR5gzbQtp5tz3UuJ3O8pmdLBQcEMjfszahzDV0iQMq2hDCZCqt5IQQLfLmXMvU75nMaoeuGrXaUep1KAfP9NEyGm8RxS1Wh8mWW2ZBEYQTV3yEWUBwQoqN6wRFpQmTKQba62N6ak1CuOabI65Fkdc86x9d3Dc2wjxnnJunVXCYhl5VYZQTY2RHm30ENwKiI2V2pfCWOs31WuJ6CgfbdR1w+AbVKdOOnFSChGVOfskoxj1D/Tt7enuLdy3sy2EHFo1RYFwlwooRffGbfHwqgxBfP3VxqK0eftYbI0HXlXiHlY/8fEc3OoPzT2mjbCGBZVraFREKtfUJt24Z01wtHHXmbER5aafQptwclzVtU0tPStS1qOMlhHYTkTK2I9KQWxRSNyYu+aWZSRec1hqmLxqpQLRmL5gFRGtUly4+qNv2RImDW2ktZmlhYWabV+gnm9uhDUe08ejcg0J26OiNXHRkzo8t+1CG32dheiMj9g6dsVz62JrUQ36yypGezUxIlVgSmXJzDJqTsBxNLGo9Sb0YomEF/Gzuemxq5T4Bva0uTHWOj8mOy9STrZEjKo3GYBY5mfs10b8TGYxKlAuZS+6EE57YuM4mhjV+lgeL5vMmaGfHKvN3Efw1m4QN8xoFp0WvM+2L6y5zGIoxKjiHrXlSwuf5pXcOqtEbcy2HfSWkZuFlFbQZu7nhzCuUJ6Rn7M/VBhpHfa5+5hGq02bPRFvkzLeFQRSipEaxIbTrcwGruQ2warRLyCnQWyvK6Tdxotsmhgvc7OQ0ilZNWAtTomFKMWmxtSx1rP5+9Njys+C2rUea0woM/RBw8LFFEskFNGJt86jhtMWUazROPLpKM/aLyCrZUT6uFGlfWfIWk29sq9w3w2rxgvLKAzZtDD1XFIEClm1CvEUseZGEy8z2lqTVF9fV/54qrgUjpeYEyDGOTKL0TZ9EBuWTzkx0uNk0fvhjoQhmyZaRlFwVUWxKideCZ61HxiytRDRY4wb/b60C1XvQkbNra0lYYcHWTJBERoxKrcj360WtEyxVel3AJupXaQVo/6BvgP6WWpWMmp67Fo2ZsWTtYjoSsoQwGZqA5ktI7KzT81sW4iMuLnvTRRMN9qecNtdJihCJUblChrFheik+FF0Sdywjqq12EphJmpuzDYTLaNa7l7A+IvsYmS586MoRk4WfaNwjKmX95X8XauIFpsbxwSTO3Yb7rsR29GXR5AibsmSv8swbiO1GIltaCd37i7p5oif4PiErzZuJC5OJ4jHnH5lwBVXbUIQo8TZZ1Z9TFHgEudxz2rGP2S3jMDP9HfGt243/SW4KOLCP/XoU7ZOlBT2v0HQSp3PKrGEsWYFBZzVHhMiW5QxzOWqPqYovuL7wTBeEgYx2qy/M/rk1pIWT/OqSw33sWDx+1aBSyUK2uiTzzgOhiMYPPKvPyt6HNfk9Jiwqk7e/3jR45Mv7nEcj8IxReGGi9Zy+aUln1OKeJmujox/hPHvIL0Yqa6awZQY+v6PTRczFo8YMMbCF12acrRfvdbwU1gyxzfdbVs8IERD33+wZAcAJ8eEaBy//Z6Sldyl3hcrxxQtrfarP2zp+bnmNsN9J/2JGPcx7/XUYM9V8JkwWEZgHREVulVpAmEW01lw06eKHht+4HHFmrASq0EguG7BPMNj2vmsihqu69iGO8sWX2rHtOqyweo5+rW7Kh7z6Ia7qj5mrLHBehZtwWnG56ZnKfGHXdaey3iC0h9KaMafSzTP7n56Q/EAfomI5aqMNfhFT3fvlURUpOxYNK1rVxv6HUE0IEAicD2aV12Wt6BMsm94Xj7AXLqfESwvnA/n1WfKIHTIlCHIXsJdgpj+hYjeLf4AAgiLzOyYOBbExckx29auVuI+No9ZAG5v08oLlOvSlw3A6pt+ZR+Nbd1OqZmY0tZDBKNyZs67LHQ9ec7weW/an1zetY9NwE27f1FknaaW/vWDu565/bOunsxlQiNGlBckWEgPm/0MQqOfvZ8ZGaX0oWNmv1pAS4dXs4FV30upDBCNNUR0QC1XuLDSEyxg65h4f6ptGqfvhqkn29FJ8ZHjxY+rY3PC1KUwzGKEAZmYxiKSbemY+vUL/7PZtRN5RKjEiPKCdBERPU1EfjQCRgfSNwtdvpyBoZRr+gf6TqnXP08Nyl8n2TH/iLAbEdku44b1k0s0UXzCvO8zrKTZs1aEooFYGMUIbhlEyKzhXK6+IZd6x3mX7/7Zbf1Vn8hjQidGNLf41qu3Do9O8wgRbcQeOdVF3GxTALEyN/cP9G00+2EVx8Q1bTb7YbXXqb6vuN5bbDxfoZIgUUhEKUxiVGkEFIQoveyc/7rr377xv6u4RN8IpRhpqIvnSvW2xkSYBlUXZpu6tWSd+rulFuuganVtVjfqiufTnn9FmctC9HgLjqNZLhVeg5fHNHtP9MfEa90iHrOnu/dM3XtVyv0b0Z6v3l+Xa2i8NNfccZ6Zy6YHPZ7z4627pIspyS5GsH4UEULWskz6Hq5ZelHX34bBItIItRg5RV1sYsnyXisLXUN1Fw1pN7Fi3C6yHrOnu3eN8NABM7HWeO/aW5+qO/bWFbF0Klbp2OlFy9URPHIIk4xipE1PqSRAGunT/9P2F//jDvFvJj01KUaM91x65aauupETz9UNHXyn1ZPJMNpaBjGC9ZMfc50fdW21bivTuezPmdYF/y1M1pAeFiPGUy694vaeutGhLXZESUMTp2x7fsS1H7Emv8XowO/+QHWj+dHWKJFwMkgg7CKkwWLE+AIspfj0+Oa6k4c/FpuedNR7XZstpgmTF2OtvRIjTJvVxlxro67TQ+VLT8rS3JrNzFv8QibR8o9hFyENFiPGdy77u29/Mj42vCk+cuyvrMSVrKDN388l58QJlpWGVbfPrhhBWLIzM4XvITi5mRlKDeXdr9Tht9x7exsaKTt/8WAm0fKvu37+7VvdO7AcsBgxgQJhik2O/mN8YuSc+MRI9d3hLKJYVQ3FotPYUE/xeOldUnnBmfHtLYt1LEhlmuftzySavx2WFL1TWIwYaYArF0vN/PfYzORav8VJFmKnLZnJJVv/korV/STXkPgfsu8ncxMWI0ZqLvvYxvWx9Mzq2Mz0BbHU9ML46NC8KPzFMHk21r5gOtfcdjhb37g7naWnom75VILFiAkdyNDFMumVECnKZufHZibPiWXSydjkaIdbMSg3iLe056i5dTaWbJ7INSQOU2NycGZy6v+ilUctWTxWYTFiIofi7qVTVymvK5ddHEvNvK/wGrOZjvj0RMkevfWJRFM8His53zqXo1wum83ULVx8NH8/l87Mzo7XLVzUn02np2aGhw/u+veNptt1mPKwGDEMIwVhaa7GMEzEYTFiGEYKWIwYhpECFiOGYaSAxYhhGClgMWIYJniI6P8DS4M9PZB60rwAAAAASUVORK5CYII=\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel",
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
+                    "intervalFactor": 1,
+                    "legendFormat": "Total Nodes",
+                    "refId": "A",
+                    "step": 40
+                }
+            ],
+            "thresholds": "",
+            "title": "Total Nodes",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 2,
+                "y": 4
+            },
+            "id": 3,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Unreachable",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Unreachable",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "description": "Number of nodes that reported their status as Starting or Joining",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 4,
+                "y": 4
+            },
+            "id": 4,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Joining",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Joining",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 6,
+                "y": 4
+            },
+            "id": 5,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Leaving",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Leaving",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "percent_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Load",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percent",
+                    "logBase": 1,
+                    "max": 101,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "prometheus",
+            "description": "Nodes Information table",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 7,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the detailed node information",
+                    "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Time",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "__name__",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "exported_instance",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "job",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "version",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "type",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Version",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "${__cell_11}",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "svr",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "OS",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the OS node information",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "OS",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "OS",
+                            "value": "os"
+                        }
+                    ]
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "CQL",
+                    "type": "hidden"
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "Errors",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "Errors",
+                            "value": "errors"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "IO",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "IO",
+                            "value": "io"
+                        }
+                    ]
+                },
+                {
+                    "alias": "CPU",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the node CPU information",
+                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "CPU",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CPU",
+                            "value": "cpu"
+                        }
+                    ]
+                },
+                {
+                    "alias": "Status",
+                    "mappingType": 2,
+                    "pattern": "Value",
+                    "rangeMaps": [
+                        {
+                            "from": "1",
+                            "text": "Starting",
+                            "to": "1"
+                        },
+                        {
+                            "from": "2",
+                            "text": "Joining",
+                            "to": "2"
+                        },
+                        {
+                            "from": "3",
+                            "text": "Normal",
+                            "to": "3"
+                        },
+                        {
+                            "from": "4",
+                            "text": "Leaving",
+                            "to": "4"
+                        },
+                        {
+                            "from": "5",
+                            "text": "Decommissioned",
+                            "to": "5"
+                        },
+                        {
+                            "from": "6",
+                            "text": "Draining",
+                            "to": "6"
+                        },
+                        {
+                            "from": "7",
+                            "text": "Drained",
+                            "to": "7"
+                        },
+                        {
+                            "from": "8",
+                            "text": "Moving",
+                            "to": "8"
+                        }
+                    ],
+                    "type": "string"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                }
+            ],
+            "targets": [
+                {
+                    "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "title": "Nodes",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Alternator Actions",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_alternator_total_operations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Total Actions",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "alert_table",
+            "columns": [],
+            "datasource": "alertmanager",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 10,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "Time",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
+                    "pattern": "Time",
+                    "type": "date"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Instance",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                    "annotations": true,
+                    "expr": "job!=\"scylla_manager\"",
+                    "legendFormat": "{{description}}",
+                    "refId": "A",
+                    "target": "Query",
+                    "type": "table"
+                }
+            ],
+            "title": "Active Alerts",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Data Plane Actions</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 16
+            },
+            "id": 11,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "GetItem by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "PutItem by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "UpdateItem by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DeleteItem by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 16,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "BatchWriteItem by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 17,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"Query\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Query by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 30
+            },
+            "hiddenSeries": false,
+            "id": 18,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"Scan\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scan by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Data Plane Latencies</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 36
+            },
+            "id": 19,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 20,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed PutItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 21,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average PutItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 22,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile PutItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 23,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"PutItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile PutItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 24,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed GetItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 25,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average GetItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 26,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile GetItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 27,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile GetItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 50
+            },
+            "hiddenSeries": false,
+            "id": 28,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed UpdateItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 50
+            },
+            "hiddenSeries": false,
+            "id": 29,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average UpdateItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 50
+            },
+            "hiddenSeries": false,
+            "id": 30,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile UpdateItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 50
+            },
+            "hiddenSeries": false,
+            "id": 31,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"UpdateItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile UpdateItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 56
+            },
+            "hiddenSeries": false,
+            "id": 32,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Completed DeleteItem",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 56
+            },
+            "hiddenSeries": false,
+            "id": 33,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_op_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]])/($func(rate(scylla_alternator_op_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average DeleteItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 56
+            },
+            "hiddenSeries": false,
+            "id": 34,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile DeleteItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 56
+            },
+            "hiddenSeries": false,
+            "id": 35,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteItem\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile DeleteItem latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Control Plane Actions</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 62
+            },
+            "id": 36,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 37,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"CreateTable\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CreateTable by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 38,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DeleteTable\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DeleteTable by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 39,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DescribeTable\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DescribeTable by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 70
+            },
+            "hiddenSeries": false,
+            "id": 40,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"ListTables\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "ListTables by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 70
+            },
+            "hiddenSeries": false,
+            "id": 41,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"DescribeEndpoints\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DescribeEndpoints by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "##  ",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 70
+            },
+            "id": 42,
+            "isNew": true,
+            "links": [],
+            "mode": "markdown",
+            "options": {},
+            "span": 4,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 0,
+                "y": 76
+            },
+            "id": 43,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 12,
+                "y": 76
+            },
+            "id": 44,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of rows that were read from the cache, without needing to be fetched from storage.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 78
+            },
+            "hiddenSeries": false,
+            "id": 45,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Cache Hits",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of rows that were not present in the cache, and had to be fetched from storage.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 78
+            },
+            "hiddenSeries": false,
+            "id": 46,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Cache Misses",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wpm_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 78
+            },
+            "hiddenSeries": false,
+            "id": 47,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(delta(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Write Timeouts/Minutes by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "decimals": 0,
+                    "format": "wpm",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rpm_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 78
+            },
+            "hiddenSeries": false,
+            "id": 48,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(delta(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Read Timeouts/Minutes by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "decimals": 0,
+                    "format": "rpm",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 84
+            },
+            "id": 49,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 86
+            },
+            "hiddenSeries": false,
+            "id": 50,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 86
+            },
+            "hiddenSeries": false,
+            "id": 51,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h4 style=\"color:#5881c2; border-bottom: 0px solid #5881c2;\">Scylla Monitoring version - 3.3</h4>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 92
+            },
+            "id": 52,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mount path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "aggregation_function",
+                "current": {
+                    "tags": [],
+                    "text": "sum",
+                    "value": "sum"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Function",
+                "multi": false,
+                "name": "func",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "sum",
+                        "value": "sum"
+                    },
+                    {
+                        "selected": false,
+                        "text": "avg",
+                        "value": "avg"
+                    },
+                    {
+                        "selected": false,
+                        "text": "max",
+                        "value": "max"
+                    },
+                    {
+                        "selected": false,
+                        "text": "min",
+                        "value": "min"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stddev",
+                        "value": "stddev"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stdvar",
+                        "value": "stdvar"
+                    }
+                ],
+                "query": "sum,avg,max,min,stddev,stdvar",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "GetItem",
+                    "value": "GetItem"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "alternator_latency_ops",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "GetItem",
+                        "value": "GetItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "PutItem",
+                        "value": "PutItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "UpdateItem",
+                        "value": "UpdateItem"
+                    },
+                    {
+                        "selected": true,
+                        "text": "DeleteItem",
+                        "value": "DeleteItem"
+                    }
+                ],
+                "query": "GetItem,PutItem,UpdateItem,DeleteItem",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Alternator",
+    "uid": "alternator-4-0",
+    "version": 1
+}

--- a/examples/eks/grafana/dashboards/scylla-cpu.4.0.json
+++ b/examples/eks/grafana/dashboards/scylla-cpu.4.0.json
@@ -1,0 +1,700 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Information by Task Group</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "group",
+            "title": "$group",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. This graph shows how much time was spent in $group group",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time used by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ms_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Scylla employs an event-loop like reactor that alternates between the execution of different groups of tasks periodically. The maximum amount of time during which a task group can run is called the \"task quota\". Some task groups may disrespect that and run for longer. This may cause latency issues",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_scheduler_time_spent_on_task_quota_violations_ms{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Time spent in task quota violations by [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Shares assigned to the $group. Shares determine how Scylla reactor distributes the task quotas between groups (Higher share gets more quotas)",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_scheduler_shares{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\",group=~\"$group\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler shares [[by]] - $group",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 2,
+                "includeAll": true,
+                "label": "group",
+                "multi": true,
+                "name": "group",
+                "options": [],
+                "query": "label_values(scylla_scheduler_time_spent_on_task_quota_violations_ms,group)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "3.3",
+                    "value": "3.3"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "3.3",
+                        "value": "3.3"
+                    }
+                ],
+                "query": "3.3",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "CPU Metrics",
+    "uid": "cpu-4-0",
+    "version": 5
+}

--- a/examples/eks/grafana/dashboards/scylla-cql.4.0.json
+++ b/examples/eks/grafana/dashboards/scylla-cql.4.0.json
@@ -1,0 +1,3832 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "originalTitle": "CQL",
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL By User - Coordinator</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL INSERT commands generated by the user",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 6
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]]) - sum(irate(scylla_cql_inserts_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Insert",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL SELECT commands generated by the user",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 6
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]]) - sum(irate(scylla_cql_reads_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL DELETE commands generated by the user",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 6
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])-sum(irate(scylla_cql_deletes_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Deletes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL UPDATE commands generated by the user",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 6
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])-sum(irate(scylla_cql_updates_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "amount of CQL connections currently established",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(scylla_transport_current_connections{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Client CQL connections by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL batches command, each batched command is counted once",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL command batched. Each batch would add the number of commands inside the batch",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_statements_in_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Command In Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Counts the number of SELECT statements with BYPASS CACHE option",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(delta(scylla_cql_select_bypass_caches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "BYPASS CACHE",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL Internal - Coordinator</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 18
+            },
+            "id": 11,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL INSERT commands generated by intenal operations",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_inserts_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Internal Insert",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL SELECT commands generated by intenal operations",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_reads_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Internal Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL DELETE commands generated by intenal operations",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_deletes_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Deletes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL UPDATE commands generated by intenal operations",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_updates_per_ks{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", who=\"internal\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">LWT</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "id": 16,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 17,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Insert",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 18,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Deletes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 19,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of CQL batches command, each batched command is counted once",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 20,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 1,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_batches{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", conditional=\"yes\"}[300s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Batches by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Optimization</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 34
+            },
+            "id": 21,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "All of the requests should be prepared\n\nPrepared statements remove the overhead of parsing the query every time and allow optimal routing of requests from client to server",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 0,
+                "y": 36
+            },
+            "id": 22,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "floor(100 *sum(rate(scylla_query_processor_statements_prepared{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) /(sum(rate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) + sum(rate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) + sum(rate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) + sum(rate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])))) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "CQL Non-Prepared Statements",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "All of the requests should be prepared\n",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 2,
+                "y": 36
+            },
+            "hiddenSeries": false,
+            "id": 23,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_query_processor_statements_prepared{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL Non-Prepared Statements",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "All requests should be paged\n\nNon Paged request sources:\n- Client modifying the fetch size\n\nNon Paged requests require reading all the results and returning them in a single request.",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 8,
+                "y": 36
+            },
+            "id": 24,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "100 * (sum(rate(scylla_cql_unpaged_select_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]))/sum(rate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]))) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "Non-Paged CQL Reads",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Non-Paged requests require reading all the results and returning them in a single request",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 10,
+                "y": 36
+            },
+            "hiddenSeries": false,
+            "id": 25,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_unpaged_select_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Non-Paged CQL Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "All of the requests should be Token Aware\n\nNon Token Aware requests sources:\n* Non-Prepared Stamements\n* Client not using a Token Aware load balancing policy\n\nTokenAware requests are sent to a Scylla node that is also a replica. Token Un-Aware requests require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 16,
+                "y": 36
+            },
+            "id": 26,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "100 - floor(100*(sum(rate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) +sum(rate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])))/(sum(rate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) + rate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) + rate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) + rate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])))) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "Non-Token Aware",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that are not token aware indicates that requests are not routed to the right node, which require extra hop and additional processing.\n\nNote that the metric shows incorrect values when batches are used.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 36
+            },
+            "hiddenSeries": false,
+            "id": 27,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) - sum(irate(scylla_storage_proxy_coordinator_reads_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + sum(irate(scylla_cql_inserts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) + irate(scylla_cql_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) + irate(scylla_cql_deletes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) - sum(irate(scylla_storage_proxy_coordinator_total_write_attempts_local_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])\n",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Non-Token Aware Queries",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "Reversed CQL Reads entail additional processing on server side\n\nSources: CQL Read requests with ORDER BY that is different from the \"CLUSTERING ORDER BY\" of the table\nAlternatives:\n\n* Denormalize your data (use a Materialized View)",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 0,
+                "y": 42
+            },
+            "id": 28,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "100 * sum(rate(scylla_cql_reverse_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) / sum(rate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "Reversed CQL Reads",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Reversed CQL Reads entail additional processing on server side and should be avoided",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 2,
+                "y": 42
+            },
+            "hiddenSeries": false,
+            "id": 29,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_reverse_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reversed CQL Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "ALLOW FILTERING CQL Reads, the percentage of read requests with 'ALLOW FILTERING'\n\nALLOW FILTERING CQL Reads entail additional processing on server side\n\nSources: CQL Read requests with \"ALLOW FILTERING\"\n\nALLOW FILTERING should be used when large parts of the filtered data is returned - check \n\"ALLOW FILTERING CQL Read Filtered Rows to check what percentage of the data is used\"\n\nAlternatives:\n- Use a Secondary Index\n- Denormalize your data (use a Materialized View)",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 8,
+                "y": 42
+            },
+            "id": 30,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "100 * sum(rate(scylla_cql_filtered_read_requests{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) / sum(rate(scylla_cql_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "ALLOW FILTERING CQL Reads",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Read requests with ALLOW FILTERING\n\nALLOW FILTERING CQL Reads entail additional processing on server side and should be avoided",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 10,
+                "y": 42
+            },
+            "hiddenSeries": false,
+            "id": 31,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_filtered_read_requests{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "ALLOW FILTERING CQL Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "ALLOW FILTERING Filtered rows, the percentage of rows that were read and then filtered.\n\nALLOW FILTERING CQL Reads entail additional processing on server side. \nReading a row and then filter it is a waste of resources.\n\nSources: CQL Read requests with \"ALLOW FILTERING\"\n\nALLOW FILTERING should be used when large parts of the filtered data is returned\n\nAlternatives:\n- Use a Secondary Index\n- Denormalize your data (use a Materialized View)",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 16,
+                "y": 42
+            },
+            "id": 32,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "100 * sum(rate(scylla_cql_filtered_rows_dropped_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]))  /sum(rate(scylla_cql_filtered_rows_read_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "ALLOW FILTERING Filtered Rows",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "CQL Queries with ALLOW FILTERING should be avoided.\nDropped rows are rows that were read but were filtered by the server.\nWhen dropped rows is relatively high you should consider the alternatives",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 42
+            },
+            "hiddenSeries": false,
+            "id": 33,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_cql_filtered_rows_read_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "rows read $node $shard",
+                    "refId": "A"
+                },
+                {
+                    "expr": "sum(irate(scylla_cql_filtered_rows_matched_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 2,
+                    "legendFormat": "rows matched $node $shard",
+                    "refId": "B"
+                },
+                {
+                    "expr": "sum(irate(scylla_cql_filtered_rows_dropped_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "rows dropped $node $shard",
+                    "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "ALLOW FILTERING CQL Read Filtering",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "Using consistency level ANY in a query may hurt persistency, if the node receiving the request will fail the data may be lost",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 0,
+                "y": 48
+            },
+            "id": 34,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "floor(100 *sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", consistency_level=\"ANY\"}[60s]))/sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]))) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "CQL ANY Queries",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Using consistency level ANY in a query may hurt persistency, if the node receiving the request will fail the data may be lost",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 2,
+                "y": 48
+            },
+            "hiddenSeries": false,
+            "id": 35,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\",  consistency_level=\"ANY\"}[1m])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL ANY CL Queries",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "Using consistency level ALL in a query may hurt availability, if a node is unavailable operations will fail",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 8,
+                "y": 48
+            },
+            "id": 36,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "floor(100 *sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", consistency_level=\"ALL\"}[60s]))/sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]))) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "CQL ALL CL Queries",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Using consistency level ALL in a query may hurt availability, if a node is unavailable operations will fail",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 10,
+                "y": 48
+            },
+            "hiddenSeries": false,
+            "id": 37,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\",  consistency_level=\"ALL\"}[1m])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL ALL CL Queries",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cross DC Information</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 54
+            },
+            "id": 38,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "Using consistency level ONE in a query when there is more than one DC may hurt performance, queries may end in the non-local DC. Use LOCAL_ONE instead",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 0,
+                "y": 56
+            },
+            "id": 39,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "floor(100 *sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", consistency_level=\"ONE\"}[60s]))/sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]))) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "CQL ONE Queries",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Using consistency level ONE in a query when there is more than one DC may hurt performance, queries may end in the non-local DC. Use LOCAL_ONE instead",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 2,
+                "y": 56
+            },
+            "hiddenSeries": false,
+            "id": 40,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\",  consistency_level=\"ONE\"}[1m])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL ONE CL Queries",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "Using consistency level QUORUM in a query when there is more than one DC may hurt performance, queries may end in the non-local DC. Use LOCAL_QUORUM instead",
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 8,
+                "y": 56
+            },
+            "id": 41,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "span": 1,
+            "targets": [
+                {
+                    "expr": "floor(100 *sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", consistency_level=\"QUORUM\"}[60s]))/sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]))) OR vector(0)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "aaa",
+                    "refId": "A"
+                }
+            ],
+            "title": "CQL QUORUM CL Queries",
+            "transparent": true,
+            "type": "gauge"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Using consistency level QUORUM in a query when there is more than one DC may hurt performance, queries may end in the non-local DC. Use LOCAL_QUORUM instead",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 10,
+                "y": 56
+            },
+            "hiddenSeries": false,
+            "id": 42,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(delta(scylla_query_processor_queries{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\",  consistency_level=\"QUORUM\"}[1m])) by ([[by]])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CQL QUORUM CL Queries",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "cacheTimeout": null,
+            "class": "gauge_errors_panel",
+            "datasource": "prometheus",
+            "description": "Cross DC traffic may cause additional latencies and network loads and in most cases, should be avoided.\n\nCross DC Read requests sources:\n- Consistency Level that is not LOCAL_XXX\n- Tables with read_repair_chance > 0\n\nNote:\n- If requests are supposed to be  DC local - verify client is using a DCAware policy and a LOCAL_XX consistency level",
+            "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 0,
+                "y": 62
+            },
+            "id": 43,
+            "links": [],
+            "options": {
+                "fieldOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "defaults": {
+                        "mappings": [
+                            {
+                                "id": 0,
+                                "op": "=",
+                                "text": "N/A",
+                                "type": 1,
+                                "value": "null"
+                            }
+                        ],
+                        "max": 100,
+                        "min": 0,
+                        "nullValueMode": "connected",
+                        "thresholds": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 4
+                            },
+                            {
+                                "color": "#d44a3a",
+                                "value": 10
+                            }
+                        ],
+                        "unit": "percent"
+                    },
+                    "override": {},
+                    "values": false
+                },
+                "orientation": "horizontal",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "6.5.1",
+            "repeat": "dc",
+            "span": 2,
+            "targets": [
+                {
+                    "expr": "100*(sum(rate(scylla_storage_proxy_coordinator_reads_remote_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) - sum(rate(scylla_storage_proxy_coordinator_reads_remote_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", datacenter=~\"$dc\", shard=~\"[[shard]]\"}[60s])))/sum(rate(scylla_storage_proxy_coordinator_reads_remote_node{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) OR vector(0)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "title": "Cross DC read requests $dc",
+            "transparent": true,
+            "type": "gauge"
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "3.3",
+                    "value": "3.3"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "3.3",
+                        "value": "3.3"
+                    }
+                ],
+                "query": "3.3",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-5m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Scylla CQL",
+    "uid": "cql-4-0",
+    "version": 0
+}

--- a/examples/eks/grafana/dashboards/scylla-detailed.4.0.json
+++ b/examples/eks/grafana/dashboards/scylla-detailed.4.0.json
@@ -1,0 +1,8077 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "percent_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Load",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percent",
+                    "logBase": 1,
+                    "max": 101,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the connection level, not your data model.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Requests Served per [[by]] - Coordinator",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reads per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Writes per [[by]] - Replica",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_header_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes - Coordinator</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 0,
+                "y": 10
+            },
+            "id": 6,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "text_header_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts and Errors - Coordinator</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 12,
+                "y": 10
+            },
+            "id": 7,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Foreground writes are writes that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased write latencies.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_storage_proxy_coordinator_foreground_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Foreground Writes per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Foreground reads are reads that weren't acknowledged yet to the application. For instance, if a single replica responded and two are needed due to the consistency level. This metric represents a queue size, not a rate. High values here correlate with increased read latencies.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_storage_proxy_coordinator_foreground_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Foreground Reads per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Write Timeouts/Seconds per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla did not even try to write because replicas that were needed to execute this write were unavailable. Unavailable writes are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 11,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Write Unavailable/Seconds per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Background writes are writes that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased write latencies.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_storage_proxy_coordinator_background_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Background Writes per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Background reads are reads that are already acknowledged to the application but have additional work to be done. For instance, if a replica responded and only one is needed, this request is still listed as a background request until all replicas respond. This metric represents a queue size, not a rate. High values here correlate with increased read latencies.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_storage_proxy_coordinator_background_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Background Reads per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m]) + rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Read Timeouts/Seconds per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla did not even try to read because replicas that were needed to execute this write were unavailable. Unavailable reads are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Read Unavailable/Seconds per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 16,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_hints_manager_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Hints Written per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 17,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_hints_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[30s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Hints sent per [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of times a digest read was done on behalf of a speculative retry.\n\nSpeculative retry is a mechanism that causes the client or server to speculate that a request may fail, and send a new request.\n\nspeculative retry may reduce latency in exchange for system load, but only if there is little activity.\n\nA lot of speculative retries increases load and can harm latency more than helping.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 18,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_speculative_digest_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Speculative Digest Reads By [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of times a read was done on behalf of a speculative retry.\n\nSpeculative retry is a mechanism that causes the client or server to speculate that a request may fail, and send a new request.\n\nspeculative retry may reduce latency in exchange for system load, but only if there is little activity.\n\nA lot of speculative retries increases load and can harm latency more than helping.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 19,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_speculative_data_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Speculative Data Reads By [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Replica</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 30
+            },
+            "id": 20,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 21,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_database_active_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Active sstable reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 22,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_database_queued_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Queued sstable reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 23,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_database_requests_blocked_memory_current{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Writes currently blocked on dirty",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 24,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_commitlog_pending_allocations{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Writes currently blocked on commitlog",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 38
+            },
+            "id": 25,
+            "isNew": true,
+            "links": [],
+            "mode": "markdown",
+            "options": {},
+            "span": 3,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 26,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_reads_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reads failed",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 27,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_requests_blocked_memory{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Writes blocked on dirty",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 38
+            },
+            "hiddenSeries": false,
+            "id": 28,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_commitlog_requests_blocked_memory{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Writes blocked on commitlog",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 44
+            },
+            "id": 29,
+            "isNew": true,
+            "links": [],
+            "mode": "markdown",
+            "options": {},
+            "span": 3,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "text_panel",
+            "content": "",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 44
+            },
+            "id": 30,
+            "isNew": true,
+            "links": [],
+            "mode": "markdown",
+            "options": {},
+            "span": 3,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 31,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_writes_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Writes failed",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 44
+            },
+            "hiddenSeries": false,
+            "id": 32,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_total_writes_timedout{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Writes timed out",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache - Replica</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 50
+            },
+            "id": 33,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 52
+            },
+            "hiddenSeries": false,
+            "id": 34,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_reads{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s]) - irate(scylla_cache_reads_with_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reads with no misses",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 52
+            },
+            "hiddenSeries": false,
+            "id": 35,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_reads_with_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reads with misses",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 58
+            },
+            "hiddenSeries": false,
+            "id": 36,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Row Hits",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 58
+            },
+            "hiddenSeries": false,
+            "id": 37,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_partition_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Partition Hits",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 58
+            },
+            "hiddenSeries": false,
+            "id": 38,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Row Misses",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 58
+            },
+            "hiddenSeries": false,
+            "id": 39,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_partition_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Partition Misses",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 40,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Row Insertions",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 41,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_partition_insertions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Partition Insertions",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 42,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Row Evictions",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 64
+            },
+            "hiddenSeries": false,
+            "id": 43,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_partition_evictions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Partition Evictions",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 70
+            },
+            "hiddenSeries": false,
+            "id": 44,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_rows_merged_from_memtable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Row Merges",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 70
+            },
+            "hiddenSeries": false,
+            "id": 45,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_partition_merges{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Partition Merges",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 70
+            },
+            "hiddenSeries": false,
+            "id": 46,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_removals{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Row Removals",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 70
+            },
+            "hiddenSeries": false,
+            "id": 47,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_partition_removals{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Partition Removals",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 76
+            },
+            "hiddenSeries": false,
+            "id": 48,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_cache_rows{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Rows",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 76
+            },
+            "hiddenSeries": false,
+            "id": 49,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_cache_partitions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Partitions",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 76
+            },
+            "hiddenSeries": false,
+            "id": 50,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_cache_bytes_used{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Used Bytes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 76
+            },
+            "hiddenSeries": false,
+            "id": 51,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_cache_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Total Bytes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized Views - Replica</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 82
+            },
+            "id": 52,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of view update locally",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 84
+            },
+            "hiddenSeries": false,
+            "id": 53,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_database_total_view_updates_pushed_local{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "View Local Update",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of view update remotely",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 84
+            },
+            "hiddenSeries": false,
+            "id": 54,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_database_total_view_updates_pushed_remote{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "View Remote Update",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Size in bytes of the view update backlog at each base replica.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 84
+            },
+            "hiddenSeries": false,
+            "id": 55,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_database_view_update_backlog{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "View Update Backlog",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of dropped view updates due to an excessive view update backlog.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 84
+            },
+            "hiddenSeries": false,
+            "id": 56,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_database_dropped_view_updates{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Dropped View Updates",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of hints sent for view.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 90
+            },
+            "hiddenSeries": false,
+            "id": 57,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_hints_for_views_manager_sent{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[30s]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Hints for view",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Currently throttled base writes, as a consequence of the respective view update backlog.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 90
+            },
+            "hiddenSeries": false,
+            "id": 58,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_storage_proxy_coordinator_current_throttled_base_writes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"})  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Throttled Base Writes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">LWT - Coordinator</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 96
+            },
+            "id": 59,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "LWT read rate.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 98
+            },
+            "hiddenSeries": false,
+            "id": 60,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "LWT Avrage Read latency.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 98
+            },
+            "hiddenSeries": false,
+            "id": 61,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_cas_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Avrage Read latency",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "LWT 95% Read latency.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 98
+            },
+            "hiddenSeries": false,
+            "id": 62,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95% latency",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "LWT Read Timeouts",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 98
+            },
+            "hiddenSeries": false,
+            "id": 63,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Read Timeouts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "LWT write rate.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 104
+            },
+            "hiddenSeries": false,
+            "id": 64,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Writes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "LWT Avrage Write latency.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 104
+            },
+            "hiddenSeries": false,
+            "id": 65,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_cas_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Avrage Write latency",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "LWT 95% write latency.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 104
+            },
+            "hiddenSeries": false,
+            "id": 66,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95% latency",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "LWT Write Timeouts",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 104
+            },
+            "hiddenSeries": false,
+            "id": 67,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Write Timeouts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "An LWT INSERT, UPDATE or DELETE command that involves a condition will be rejected if the condition is not met.\n\nWhile it is ok, a high value may indicate that there is a potential problem with data distribution",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 110
+            },
+            "hiddenSeries": false,
+            "id": 68,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_write_condition_not_met{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Condition-Not-Met",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of times some INSERT, UPDATE or DELETE request with conditions had to retry because there was a concurrent conditional statement against the same key. Each retry is performed after a randomized sleep interval, so it can lead to statement timing out completely.\n\nIt can indicates contention over a hot row or key",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 110
+            },
+            "hiddenSeries": false,
+            "id": 69,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_write_contention_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Write Contention",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of times some SELECT with SERIAL consistency had to retry because there was a concurrent conditional statement against the same key. Each retry is performed after a randomized sleep interval, so it can lead to statement timing out completely.\n\nIt can indicates contention over a hot row or key",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 110
+            },
+            "hiddenSeries": false,
+            "id": 70,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_read_contention_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]]) - $func(rate(scylla_storage_proxy_coordinator_cas_read_contention_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", le=\"1.000000\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Read Contention",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of partially succeeded conditional statements. These statements were not committed by the coordinator, due to some replicas responding with errors or timing out. The coordinator had to propagate the error to the client. However, the statement succeeded on a minority of replicas, so may later be propagated to the rest during repair.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 110
+            },
+            "hiddenSeries": false,
+            "id": 71,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_write_timeout_due_to_uncertainty{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Write Timeout Due to Uncertainty",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of times a INSERT, UPDATE, or DELETE with conditions failed after being unable to contact enough replicas to match the consistency level",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 116
+            },
+            "hiddenSeries": false,
+            "id": 72,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_write_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Write Unavailable",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of times a SELECT with SERIAL consistency failed after being unable to contact enough replicas to match the consistency level",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 116
+            },
+            "hiddenSeries": false,
+            "id": 73,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_read_unavailable{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Read Unavailable",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Paxos-repairs of INSERT, UPDATE, or DELETE with conditions.\n\nA repair is necessary when a previous Paxos statement was partialy successful. A subsequent statement then may not proceed before completing the work of its predecessor. A repair is not guaranteed to succeed, the metric indicates the number of repair attempts made",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 116
+            },
+            "hiddenSeries": false,
+            "id": 74,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_write_unfinished_commit{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Write Unfinished - Repair Attempts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Paxos-repairs of SELECT statement with SERIAL consistency.\n\nA repair is necessary when a previous Paxos statement was partialy successful. A subsequent statement then may not proceed before completing the work of its predecessor. A repair is not guaranteed to succeed, the metric indicates the number of repair attempts made",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 116
+            },
+            "hiddenSeries": false,
+            "id": 75,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_read_unfinished_commit{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Read Unfinished - Repair Attempts",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Normally, a PREPARE Paxos-round piggy-backs the previous value along with the PREPARE response. When the coordinator is unable to obtain the previous value (or its digest) from some of the participants, or when the digests did not match, a separate repair round has to be performed.\n\nThis indicates that some Paxos queries did not run successfully to completion, e.g. because some node is overloaded, down, or there was contention around a key.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 122
+            },
+            "hiddenSeries": false,
+            "id": 76,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_failed_read_round_optimization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Failed Read-Round Optimization",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of pruning requests.\n\nA successful conditional statement deletes the intermediate state from system.paxos table using PRUNE command.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 122
+            },
+            "hiddenSeries": false,
+            "id": 77,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_prune{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Prune",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Dropped pruning requests.\n\nA successful conditional statement deletes the intermediate state from system.paxos table using PRUNE command. If the system is busy it may not keep up with the PRUNE requests, so such requests are dropped.\n\nHigh value suggests the system is overloaded and also that system.paxos table is taking up space. If a prune is dropped, system.paxos table key and value for respective LWT transaction  will stay around until next transaction against the same key or until the gc_grace_period, when it's removed by compaction.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 122
+            },
+            "hiddenSeries": false,
+            "id": 78,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_cas_dropped_prune{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m]))  by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LWT Dropped Prune",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CDC - Replica</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 128
+            },
+            "id": 79,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "The rate of CDC operations.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 130
+            },
+            "hiddenSeries": false,
+            "id": 80,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cdc_operations_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CDC Operations",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "The rate of failed CDC operations.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 130
+            },
+            "hiddenSeries": false,
+            "id": 81,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cdc_operations_failed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_cas_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Failed CDC operations",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory - Replica</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 136
+            },
+            "id": 82,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 138
+            },
+            "hiddenSeries": false,
+            "id": 83,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_lsa_total_space_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LSA total memory",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 138
+            },
+            "hiddenSeries": false,
+            "id": 84,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_lsa_non_lsa_used_space_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Non-LSA used memory",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Compaction - Replica</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 144
+            },
+            "id": 85,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel_int",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 146
+            },
+            "hiddenSeries": false,
+            "id": 86,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(scylla_compaction_manager_compactions{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Running Compactions",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "decimals": 0,
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "percent_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Percentage of CPU time used by compaction",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 146
+            },
+            "hiddenSeries": false,
+            "id": 87,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "($func(rate(scylla_scheduler_runtime_ms{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\", group=\"compaction\"}[60s])) by ([[by]]))/10",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Compactions CPU Runtime",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "decimals": 0,
+                    "format": "percent",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "graph_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Shares assigned to the compaction",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 146
+            },
+            "hiddenSeries": false,
+            "id": 88,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_scheduler_shares{group=\"compaction\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]])",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Compactions Shares",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 152
+            },
+            "id": 89,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 154
+            },
+            "hiddenSeries": false,
+            "id": 90,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 154
+            },
+            "hiddenSeries": false,
+            "id": 91,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "aggregation_function",
+                "current": {
+                    "tags": [],
+                    "text": "sum",
+                    "value": "sum"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Function",
+                "multi": false,
+                "name": "func",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "sum",
+                        "value": "sum"
+                    },
+                    {
+                        "selected": false,
+                        "text": "avg",
+                        "value": "avg"
+                    },
+                    {
+                        "selected": false,
+                        "text": "max",
+                        "value": "max"
+                    },
+                    {
+                        "selected": false,
+                        "text": "min",
+                        "value": "min"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stddev",
+                        "value": "stddev"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stdvar",
+                        "value": "stdvar"
+                    }
+                ],
+                "query": "sum,avg,max,min,stddev,stdvar",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "3.3",
+                    "value": "3.3"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "3.3",
+                        "value": "3.3"
+                    }
+                ],
+                "query": "3.3",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Detailed",
+    "uid": "detailed-4-0",
+    "version": 5
+}

--- a/examples/eks/grafana/dashboards/scylla-errors.4.0.json
+++ b/examples/eks/grafana/dashboards/scylla-errors.4.0.json
@@ -1,0 +1,1148 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Read requests that failed due to an 'unavailable' error",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_read_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Local Reads Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of write requests that failed due to an 'unavailable' error",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_write_errors_local_node{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Local Write Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "##  ",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 4,
+            "isNew": true,
+            "links": [],
+            "mode": "markdown",
+            "options": {},
+            "span": 4,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of Read requests that failed due to an 'unavailable' error",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_read_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reads Unavailable Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of write requests that failed on a local Node",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_write_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Write Unavailable Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of write requests that failed on a local Node",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_storage_proxy_coordinator_range_unavailable{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Range Unavailable Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of AIO Errors",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(irate(scylla_reactor_aio_errors{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "AIO Error by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Total number of abandoned failed futures, futures destroyed while still containing an exception.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_reactor_abandoned_failed_futures{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Ignored Future By [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of C++ exceptions thrown.\n\n A peak in the number of exceptions is an indication of a potential problem.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_reactor_cpp_exceptions{instance=~\"[[node]]\" ,cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "C++ Exceptions [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "Shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "3.3",
+                    "value": "3.3"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "3.3",
+                        "value": "3.3"
+                    }
+                ],
+                "query": "3.3",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Scylla Errors Monitoring",
+    "uid": "error-4-0",
+    "version": 5
+}

--- a/examples/eks/grafana/dashboards/scylla-io.4.0.json
+++ b/examples/eks/grafana/dashboards/scylla-io.4.0.json
@@ -1,0 +1,699 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">I/O Queue Information</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 3,
+            "panels": [],
+            "repeat": "classes",
+            "title": "$classes",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "1000000*max(scylla_io_queue_delay{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "seastar_io_queue_delay",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$classes I/O Queue delay by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_io_queue_total_bytes{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "seastar_io_queue_delay",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$classes I/O Queue bandwidth by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "iops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 7
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(scylla_io_queue_total_operations{class=\"$classes\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "seastar_io_queue_delay",
+                    "refId": "A",
+                    "step": 30
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$classes I/O Queue IOPS by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "iops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 2,
+                "includeAll": true,
+                "label": "classes",
+                "multi": true,
+                "name": "classes",
+                "options": [],
+                "query": "label_values(scylla_io_queue_delay,class)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "3.3",
+                    "value": "3.3"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "3.3",
+                        "value": "3.3"
+                    }
+                ],
+                "query": "3.3",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-3h",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "I/O",
+    "uid": "io-4-0",
+    "version": 0
+}

--- a/examples/eks/grafana/dashboards/scylla-os.4.0.json
+++ b/examples/eks/grafana/dashboards/scylla-os.4.0.json
@@ -1,0 +1,1441 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "cacheTimeout": null,
+            "class": "pie_chart_panel",
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fontSize": "80%",
+            "format": "bytes",
+            "gridPos": {
+                "h": 8,
+                "w": 4,
+                "x": 0,
+                "y": 4
+            },
+            "height": "250px",
+            "id": 2,
+            "interval": null,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "legendType": "On graph",
+            "links": [],
+            "maxDataPoints": 3,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "pieType": "pie",
+            "repeat": "node",
+            "span": 2,
+            "strokeWidth": 1,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Free",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 7200
+                },
+                {
+                    "expr": "(sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"})-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}))",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "legendFormat": "Used",
+                    "refId": "B",
+                    "step": 7200
+                }
+            ],
+            "title": "Total Storage $node",
+            "type": "grafana-piechart-panel",
+            "valueName": "current"
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Disk $monitor_disk</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 12
+            },
+            "id": 3,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_writes_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_writes_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Writes per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_reads_completed_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_reads_completed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Reads per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 20
+            },
+            "id": 7,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 3,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_bytes_written{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Writes Bps per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 20
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_disk_bytes_read{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_disk\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Read Bps per $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "text_panel",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Network $monitor_network_interface</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "id": 10,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "pps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 11,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_receive_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_receive_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Rx Packets",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "pps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "pps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 28
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_transmit_packets_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Tx Packets",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "pps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 34
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Rx Bps",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 34
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(irate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", device=\"$monitor_network_interface\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Interface Tx Bps",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "Bps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(node_filesystem_avail_bytes, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(node_filesystem_avail_bytes{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(node_filesystem_avail_bytes{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    }
+                ],
+                "query": "Cluster,DC,Instance",
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "isNone": true,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitor_disk",
+                "options": [],
+                "query": "node_disk_read_bytes_total",
+                "refresh": 2,
+                "regex": "/.*device=\"([^\\\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "isNone": true,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitor_network_interface",
+                "options": [],
+                "query": "node_network_receive_packets_total",
+                "refresh": 2,
+                "regex": "/.*device=\"([^\\\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mount path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "3.3",
+                    "value": "3.3"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "3.3",
+                        "value": "3.3"
+                    }
+                ],
+                "query": "3.3",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "OS Metrics",
+    "uid": "OS-4-0",
+    "version": 5
+}

--- a/examples/eks/grafana/dashboards/scylla-overview.4.0.json
+++ b/examples/eks/grafana/dashboards/scylla-overview.4.0.json
@@ -1,0 +1,2949 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            },
+            {
+                "class": "annotation_restart",
+                "datasource": "prometheus",
+                "enable": true,
+                "expr": "resets(scylla_gossip_heart_beat[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "node_restart",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "restart",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_stall",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_stall_detector_reported[1m])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "stall detector",
+                "showIn": 0,
+                "tagKeys": "dc,instance,shard",
+                "tags": [],
+                "titleFormat": "Stall found",
+                "type": "tags"
+            },
+            {
+                "class": "annotation_schema_changed",
+                "datasource": "prometheus",
+                "enable": false,
+                "expr": "changes(scylla_database_schema_changed[30s])>0",
+                "hide": false,
+                "iconColor": "rgba(255, 96, 96, 1)",
+                "limit": 100,
+                "name": "Schema Changed",
+                "showIn": 0,
+                "tagKeys": "instance,dc,cluster",
+                "tags": [],
+                "titleFormat": "schema changed",
+                "type": "tags"
+            }
+        ]
+    },
+    "class": "dashboard",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "originalTitle": "Scylla Cluster Metrics",
+    "overwrite": true,
+    "panels": [
+        {
+            "class": "text_panel",
+            "content": "<div id=\"amnon\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAA6CAYAAACZBESJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGm9JREFUeNrsXQd8VFXWP+9NTe+NEOmgSIdFiuxSIqB0krCssrCI0sKGLnVZV/qCCqx0ERdQ+ehFCKEtCAuCCAkdQkkhlPQ2yfT5znkzwWTyJslMJqDfd//8zo+ZVydz5//+55x777kADAwMDAwMDL99cC/yZjKpUtqxWUQbvUFbD982Q9OjKdE6oz1Gu4HGo6VzHPdzsabw+uU7h4tYMzEw/IqJLpUouE7NIwL1Bl0kvh1gIbQr8DzIgvyA9/EGMJnKnGPSG0CXnAYmjQY/HWfATTeR9HuL1Pknr9w9cpo1GQPDr4ToUomc79g88jWDQTcf3w7ipFJwad8SFE0agLxuKMgb1wcwGGxfAMlvKCgE3b1kKLp0DTR37oP+cboBJPx1juPXFKnzNiHpDaz5GBheAtGlEhnXsVnkqwajfgGq8WBZaBB4Rb4DyhavAaeQl1PvKgPP0yY9grxdh0FzIxEdfsP9Ik3eR1fuxu1hTcjA8AKJLpHIZJ2aRY4zmAxLkeBKIrhrh9aCK+5M6NMzIe+7g6A6+5OeVypjVcU5Y+ITjz5hTcnAUMNER5K7IMm3GnlThHuPzuD1p/7AyWSOK3iFn5gjRQd1wk3I+moHmLLzbqi0+SOQ7D+z5mRgsMHRal+Alyo7NY/aZpRyEX7Rw8Gzbw8zGWsSPAfSkEBwaf066J88C+TS8/v5+YRdepp9P5k1KQODk4lOJO/YPHKLScpH+o4bBm4d2oDJ8OJyZBIvD1A2awLa1DQPPr2gB5L9FJL9KWtWBgYnue5IchmSfIZJws33Hf9nJDnG4wajeSf+r752G1RnLoLm7gMwZOc9V3lOKgEFktO1fStw7dSm+i4+z+P1cyFr9RbQXL3zs8pQ0Dsh8Vgma1oGhmoSHUnOd2wW2dEkgbNeUX3Bc0C4OemGhNU9fgZZa78BQ1IqNG3RGP7Qoz00a9UEDKj0RqMRUpOfwMXzV+H44bPgEhoM5AkomzasXtIOHyLahymQuWyjIf/xw+0JD04OY03LwFBNovMUl7eIOi1t+Er74E+mgkmnE0iuufMAMpeshXp1Q2DuognQ+NV6Nq/x9EkGfLpwE5z+4TL49Q8H7+ERYFJrHCY69csX/XgFMv+5Ia1IqnkXVf0H1rwMDA7G6Dwv4Ts1i+ppkvDT/SeMAImPF6BUo4v+ELKWroMWLRrB+q0LICDQt9y5pOp3bj2EtNRn4O3jCX0GdgM3pRxObN4HMpkUlM2bVDyQpiJgSMC7uYLhyTNPVVJyg2d5SV+z5mVgcJDoHMfLw4Kbfa1o1jjUa2BPgZgmrRYyl2+EZvVDYeWmeSCVSsudp9XqYOc3h2F69BKI+/4H+H7vSUHx3xnYFVzlMjjx9T5wf60hSAP9hQeH/TABr1QC5+4GutOXpX7+dX56lv0ghTUxA4N5Aok9as6hmtc3cdDerUt7MBEhDUYoPH0BJJnZMHthtCjJCepiDez69gjIkNQcutoF+Sr4eOZKuHguASLfewfaNm8AGVv3AIcK7xBM+BCS8CAPq0WeQZBJp/+QNS8DgwNEFzwADgbyHm7g1uV3AslNej0UHTwBfSPDIbR2kM0T9XoD3LubDBIJb/EMiOxFsGr5FnBxVcL4Se9BQWIKqBNuAWfjYVEp142o6vjZlG+0lLpLPVq2bBjOWpiBwQGi88jQPyjQxQYklZBlz8gCyM2HLt1+V4nLz4E7ktBUpivNBFkZOXABVb1+wzCoGxYEhZeuCvG2Y0w3AeeiBEWjepTF98QtLVkTMzA4RvSW8jqh5r5vInpyGkjlUmjXoXmFJ8oVMniza1tB2cvE7hodxP98S3gIdO7SCoofZwDH8w7/QRzPgcTbE6ShQW4mg/F11sQMDPYS3US5OD5Y8WpD5LhRcJX1KY8hJDSw0lPd3Fxg/rLJMHrCUPDx8QQjnsvhP8rEU1cbZxnDrk99LAyCcRgUq6PrL/UVbtKxJr60Pn36yNEzaYc2FW0r2lm002ixaCvRInbt2uVRE/eOiYlxweu/iTYRbTPaf9FOoR1H24Q2asmSJbXtve6iRYvq47k90bqWsu50rylTpvhXdv66deukeGwLtHCra7yF1mD48OGVumn4ncnw2NZoPazOr9uvXz/emd/jhQsXAvG6ndC6lbpXz1atWrm/aBKmp6d3tvrOG3p7ezv1761yMMxzEq5T86i6RqNB1CWvqtq6e7haue+lY2wjGIuKqzVWnq7Nofcgqx0MpnjnDsft3bu3JDY2tivxAq29rcOIjxEREQVExJ07dy4fMmRIanXvHR0dXfeLL76Yji/fRfOu4ND3Z8yYoUOLXbx48d9nz54dX8VbvIn2BVq5B9Snn366xGg0zlqxYkVF51NRkbVor4nsm4S2sgqfwQftX5ZrlcYnaEvQip3YnN3R6A+yTiy1Rot/gSRvGRAQcAhfepXajPEw1EfLfxmKTuyrSySUBPiYlZPc5LAQSLz9sNKTi4vUsOTjdfDpok2Qm1uAos3hJUyCm+7h7mq+gVwG8iYNHO9Lr0H07NnTH0n+Ob48XgHJS4MIExMVFfWf7du393T0vuPGjePwgfEXJPlP+HZ8JSQvgQyt/6xZsy7guZMWLFhQlVttQfvWxr7h9BXYOnHNmjUwZsyYsTZIfnDEiBH7t2zZwvxncfwVqOpSWfjl5OQM8vT0lL4Mootl2EDq7wtGdLkfpVY8l0St1sKRg2eEgTFlYnckd6u2TaGwQAX/PRMPLrUCzN12vy6Su8TFxY21NIq9KERzaL48kkeGJCI124zm78AlqK9y6Zw5cyZ98sknFR6Iyg/oAWy2oWa1Pv/888hJkybZcmvHofUT2Z41cuTIVUjyJMbn8nj69KkXqvkgy4O5XJSGpngZRDcKPwIq85SRY9Z3JLq8bm0wenrAzm2HK3WpicxcGbecg4AgX+jeqyPcT0yBpJQn4Nq00a9R0duizXfgvPvous8YOnToNXtP/PDDD2UY987Fl3Or+dnvL1y48Mq8efMqPRDJfmHp0qUbwVy00xpRFnfXWs3D0OugmoBi8Ru58qcYpW1igoial6BNXl5eW1R1/oUS3WgywLlrO3N53iqnIpGAokNrOLTnBOTlFdpOBkgl0LBxHeSw8Tnx3d1d4P2xUaDVaGHLl/vAo1EdcO3YBkw6fTWcDAwJNDrQPXqq5ySSasc44eHhfqjm79rYnYu23aJoRIStaKqS8AtJPh/j8zgHSA4bNmygiTkVsZPm3q+zxOwRxDm0O9ZuM5K8/9y5c+0pqrnR8jdZwxtV/f2YmJjniT4MJyi0iBZ7ABDBUc23ff3113rGZ1E1h6CgoBFgroJsC05TdfueFhwl241PNbfvUfrdvAkJ7PF2V9AplTBn0jLbPiS66F26tQO9Xi+Q3MVFCcM/HAQ9UM3/Z8v3cPr8VQgQJrZoq/1HCUm9YnURfsgbTviO/NDEBgncO3jw4AB8sPwJbR3aLrThgwcPpn7GNbt3716MJP+3g/ekWHeEjX15aDNXrFhRH+83Du07tD1o0dOnT2+F+/4GQgYFNqErHoUkv2fPjWfOnKlDVV+NLxNEdg9YuXJlXyR7yfsuNlx2zQcffPAZkvwOo7RN9BNJBFojAlU9wMOj+h049gb79ANKMhYVB5cRdR8v8P3rSLi+fD2sWLIZoqcME4a6lobSRSFsr1MvFFSqYug3uDt4eLjBvh3HYMPGveDfpxsoXm8M+vQs0D9JB3n9MOAUCvvnqpOiF6tBm/hQz8klzshakmsVar3x0KFDd/r3719uhtzevXsfEukcvdmoUaNIzbviyz+I7H60atWqmIkTJ+4VO3f58uVqiUSybMmSJWuR5Cp0xR2aDohk/xGv8+W0adM+F/mNDEtLSzv98ccf34qOjh6D75uKXOJTtFjG5QpBIVlVGDwRbRaa9kUS3YjES9Amp3Wgck5g+IVcikZ1weMvkbDnq51w9/ZDmLMgutyQWLlCDoOH9hJeZyChVyzdDNu/iwP/gW+Bz4hIMOQVgOrUecjdtg+ULV4F/4/GAO/iYtckF4ua02eihR+u11Qr9enTx+fAgQNuSHaVky9dC62rjX0UGuyt6GRUYw2ZEz7HerSOltCgNDrv2rXr92DujhNT89Oo5ls3bdrEXHYbePz4cXN02xtB+WniFI6FWXnawy0hXLWIbn+gbzLlGTKzy39GCQ9undqB/4yxcD0tE97tNxH+MWsVnDhyDpIeppkD2px8OH/2CiyatwaGvDMR9sddgOBRQ8B72CAwqtXCQBlpcABIawWC9n4KFHx/EniFHZNcSM21WozPn1DugAiY5IR20YF4f2anfv36HUeyt3Xy74AaWmyY4X9Xr179b1TzF/JjxDBAhx4C9atfFRN9MPdte1q77KNHj/4MSX6b0blCzBFR82MWlbceK+Cfn58/Et33anW12XuyAYl+Sp+R/ZFoyQpUeXmT+hCydCYq84/ww6VrEDf1U+AkkjLHyEICwbVfD3AL7wwSL0+h4ITm9n3I2xUrlJ5yfaM1uPfoBOqbiTYH19gkukYL+rR0KNTk6K+lnXVK3gTtJFoTkX0dkOzn8TNewtf70W2Pwxi9uoMtPG3EbrdFkm01jfNo+9BaWG2va+N4cvUPMx5XqOaeISEh3UW49x3aTssDtJ5IUu4rEO8NqakYnUuiCS2aW/dBju66mFtNQ1Ddw98UjPbrktLMii2VgLxObeCU5kQikbLg8ElQnbmEx6SConkTCF4yQziGikwqmjayu+oMlaQyZudo0Ds454yGOX78eFavXr3+HRcX92d8K9aPLLO4uB0HDRq0GEl/H19/sXv37nWRkZGOuNCvoFlX7dCjmt+aMGHCC/1Roqrj18h/PmXKFCL6wEoOv4Rq/j8bN25kLrv9ag4BAQH7MzMzNVlZWft9fX2joWzfeiNU9e7u7u6HVSqVQ4NM7HLdjUaD6dy1nUk8x4Oe3PeqjFSlddbqhwmklTeoIyyvlL//GGQsXgNpY2ZD0Y5D0NQX+ePtBcELp4OsdojDlWQ5i6JrU59q0ItIdWLjXEabXIUnKn0jDdFWRERE3NuxY0eEk+6PT0lQvYxf5dSpU3M/++wzysInVnIodfXFMx7bxqNHjwDVnNYgtO5S22JpY8K/Sr0Gq1hd9qIUnX7KlJC7qEtJa891bgumX54CUHzlBmT8cz3IwoJB4uvzPGNOxNWiB0BxPLnxktBgkOblw3vD3hG62LZ+uQ8up6YDVHe9B87sJWCMXoT3uemsBjp69KgOVf1LVHVy0Smj3L0Kp9WOiopajWR3r0Y3268FNOyX+tb/ZmP/2rFjx25HNWdsrhiU2Kwlsv2Lktjcz8/vQU5OzmVvb+8uVkIcVVhY+A9U9Zuo6nYzxZFRN0aT0RivTU4rO/kElduldTNBlWkxRcBYe1TvN2BEj3ZQePsBeEW9AyHL50DYthUQNPevwDd4BX46ewV+PBsP33wbC96d2ghFLKoDmk1nVBWRu1+EpHdqxh3JTh5D/Ntvv90DzF1KpHLPKjktCMn+wfbt2wOqeXsKGQJf1q8TVR1WrFjxGb48IJY7GD9+/Lb169erGI8rRbRI+JcQGBh4F9320uRdZUPVRzgkzg4S3YRKnawTiM6XT8Y1rAOeA3uBEfcl3X8Ebdu/jq85cPldC5ojLqg7r5SDW3gXuJOYAvNmrBQSeN5/7CeoseNqXibjTl1rSTXRUkeOHCHC30Kb0L9/f8qQv4G2Ac3WOu60DnyUHbegOnfZ5X4h0dGNaSTay8LkyZNzkewPRHZlgHkQD0PFbnvn0NDQ16B8wLtVhNQHLN+rNWJQ1QNcqMv5RSg6Uj2BlFOflS06pVTq5wM+00dD7PdnYMyIeeDVvDEohKWSjc/Vnyq+hq5dAMGLPoKAGeOeF7KoFtGLNaC7lwIqXd7DhHvHa7zxDh48qEPCX0QbM3DgwMZgzpqKqXGIHZfFGAbECEWj3rowyvyfUnMC9WqUSdr6+Pjoc3NzabvO6ljKYlNSVFLjRDcaDcZz13ee4jkJGDLEiU7KTuWmQlZ/AoFzJoD/5FFgtM6e43m8hzvG8yEOVn0Vic/R9TdQxp3jU190K+7fvz9t8ODBS/HlfZE8SCM7LkWfXWwSzOuo6sNWrlzJKPMbQ2pqqjuqeXeRZNpBdNvTMzLExFtIyom5uH93JCnn4MwYDoNhYzp1sXG2ikTQvHUksuLVBsA7MpTVbp6T666jjHsBJ+XPO/v6NFXVZDL9MTY2drIDp1d5muqmTZuyR48efcTG7pExMTGzKiL7jBkz6uLnPIa2b9GiRT6MZr8KzIayhSVKu+2ixTRQ1e/n5+f/DOZZo6URWFRU1A3dd7u46+hoGwP+kOK1KWk9ywyFfZmwxOj6R09UoJBcdzLJIS4ujgovbO/du3cx/u21Dh06NLtv377PXasBAwYE7NmzhwpDNLA6vQjsn49OI312oA2x2k5P8oVI9oZGo3EGxs3P15ibNm0aLFu2rBO+XA7mfn2YNWvWCTxu7Ny5cy/+xolS58CBA7+3kMLWD1zRo0ePiydPnsypzo2uXLnSDsxTbmW2fUcoatKkSfzdu3crHSeBag61a9cWm6WWFxwc/B9U84oy0JSUowlV1kE5DY88AXYMi3WU6EYwmhJ0RPSaXiK5iiSnATm0WgxIpUgsvdOIHh4eTiSnutElJVLoS5/Wp0+fcUj4HyxudlNL/Cz21E62ELfK2Lhx42P876sNGzbQfX1FfmjvT5o06U9o1N13BsxVZ94C84iq0m3aes6cOUfRPpo/f/6GqsxJ/5ViBNiezVca1CNyspr3qkofIY0p6IaWVoVjqWCJ2OSVbVB5aSxKytHDPMxqey9U9Qao6rfVanWVXGWHXHfOPBT2tB5jdGECyUsnOghz0Gnoq0qbm5GQeEzvLJIfO3aMfjy7ofy4bnrqv432EVpfGyQn0GAbR0bp0Tx2Gvpo6wt2sTxcyC0cb8kDiD246XNRzbbfMw/6pYDqCogl4baA7Z4ac8N5eenQfaeknN5GrF71mo8OKzqNgqLhrdTNxvMvnekWt10DvFPddpqO+xcRklcVF3fu3Dlv6NCh9svKxo0wduzYb/Dl6ArIXhWQe0fdf2zRyReM5OTk3ui2N4XyXWpn0W2/8+zZs6qo8SobLvqA4uJiX6VSWXNENxj1cO76rhwe+AwhIce/XPddGPpKiTgaESflnUb048ePP33rrbcmWb5se/EfJPl7Q4YMeeDo/devXw/jx4+nhA3lBy45cInbCxcu7Infz4rfsNv+W8Z7NtS8Km57iarfKygouAzlk3JKiwhJaozov8TpxiRtisjAmZfhupOipz4pBonkhjMvbZnUQskPGviyq5LD6QlN3Wvjdu/e3R1Jfq+691+7di09yM5MmDCBEm00//tYZS6fJXactXjx4q52lpFicJ6a13rllVcox2Kd1MuvVavWHlRze0aH2VL1iVV13x2WYp6Xyjq3iFrM1wqYGvLZ34Shp4UnzoFnn27CDLKSSi852/aC3/jhAhEt8gvG/ELIXLUZ/Ea/C5KgUqunGoygvnkXVGcvQcCUD36J/zE0MGTlQP7+o+A37s/m7UgpmlijfZgCrh1aQ+Gxs5D9xdZ7RRJ1B4zRs2qqAXv37u0WGxtLo+FozjgNbTVYLG3v3r1nBg8efLemf0QxMTG+K1eupPu/ZknUUPafJu5T4u/k0qVLH86cOZPNImN4Docns3PCmHdT/POEHJK78MgpcGnVFKQhAQIRTTodFJ39CfxjRiLRrbXPJCzWIKUHQokq0zZVsfCAKJPNNxhAl/YU1Am38fmIH1nNCdemOezqhJvC/HVzIi6v6OqjH7Jq8gs7cuSIChWWMrsnX1ajrVq1KhuNlJqpNUPNxegl9ENynn6ekJPwIPH1Bm3yo+eFI4msnFwOmlv3hP2V+98iK7XQgwCJbswrABmt+UbDaOlQtQZ0D5KFijQmjUZIxHESyTnWpAwMTiQ6JeTOX9uVTQk5LSorFZugVUw1NxJ/ITXNRQ8LEdx6rgpRArn8tJabdRafyj9rU5+UelhYJrA8yQBZoL8wvJYScbj/OmtSBgbnKrpZ1UumrCI5qXJM2emrpMbiXXBUxFGPcTdUJWNPMTwSm1aFodclWXZ9eibI6tYWJrPoU58UMkVnYKgZolMRiqu6lDShvjupty7p0fNlj6nbTervAwZUdCi7QItAWKHIZGUj6yxVYzT3U0AW5C/E8bSSqyG/UDDew02I1c0j4oApOgNDTSi6ySgUiwQjkpFiaIqndSWqjoSnmu9aJw+qMWn1oEt9DLyLEqTouuuSH1MiLiM+8aiONSkDQ0247hwkmCwJOYm7m1CemfrWS1S9RLk5R8fEW8pDaR+goterTbl+cyLuYSq+DxPGuOvThEQcU3MGhpog+vOEnInP1JrdZ5DWDgEtuu8Ue5M7TwUn9M8yqxaL6ynp9hg4kQw9PTiExRyowA3G5yWJOCK9FuNzkPAsPmdgqCFFN6u60XhafesecDIJyGsHC/XYy7jqQkKuVDadut1kMlDT8NmSmu+cOXFHq7XIKQSgBBxtQyJT0UlK9En8zQUnhVFw6Zl4XC0wZOWC/tHTYqboDAw1S3S9QPTrd6DoQjy4tGsB2jsPoGD/MYGcitcbAeeigKyN35qXQ0aiEkkpaae+ehsKT54DTi4TBskUxJ4SYm81egeGXPPiKOQd0Hb5K7WEElX6zBzI3mRe7JNG1eVuP4DXV9KQzyusORkYbEbA1YdEInPp1CxyK0p7hJB5x/iZFmsQusNQpfUl2XVUb1loEJHcgOpOc3qpRE0f3s1ViO31GdmF6OLvQe/8j5xCppBjDK6+kSiEAEKZaF8vMOSrBEXnXV2Ea6Pi31apc6PjE4+eZM3JwFCDRLeQXYJkD8e4nRbfo8obNLmkDZinWFKlRprFNQpNgY77LbVOdeDKnSOGN1sO7aU3aDtxHJdXrCncnZB49B5uC9PpNVSwnvx6KuxAJKbVRTug0SLstExSXY7jk1TFOfuR5FmsKRkYGBgY/l/jfwUYAPw0FqsWp2FrAAAAAElFTkSuQmCC\" style=\"margin-top:-20px\" height=\"55\">\n<span style=\"font-size:40px\">  [[cluster]]</span><span style=\"padding-top: 25px;float:right\"><a href=\"https://github.com/scylladb/scylla-monitoring/issues/new?body=scylla-version%3D[[scylla_dash_version]]%0Amonitoring-version%3D[[monitoring_version]]\" target=\"_blank\"><input title=\"Report an issue with Scylla Monitoring\" type=\"button\" style=\"background-color:#57d1e5;color:black;font-size:20px\" value=\"Report an issue\"></a></span><hr style=\"border-top: 3px solid #5780c1;\"></div>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 4,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel",
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 0,
+                "y": 4
+            },
+            "id": 2,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
+                    "intervalFactor": 1,
+                    "legendFormat": "Total Nodes",
+                    "refId": "A",
+                    "step": 40
+                }
+            ],
+            "thresholds": "",
+            "title": "Total Nodes",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 2,
+                "y": 4
+            },
+            "id": 3,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Unreachable",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Unreachable",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "description": "Number of nodes that reported their status as Starting or Joining",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 4,
+                "y": 4
+            },
+            "id": 4,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scylla_node_operation_mode==1) +  count(scylla_node_operation_mode==2)OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Joining",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Joining",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "cacheTimeout": null,
+            "class": "single_stat_panel_fail",
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(250, 113, 0, 0.89)",
+                "rgba(255, 0, 0, 0.9)"
+            ],
+            "datasource": "prometheus",
+            "description": "Number of nodes that reported their status as  Leaving, Decommissioned, Draining or Drained",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": false
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 6,
+                "y": 4
+            },
+            "id": 5,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+                {
+                    "name": "value to text",
+                    "value": 1
+                },
+                {
+                    "name": "range to text",
+                    "value": 2
+                }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+                {
+                    "from": "null",
+                    "text": "N/A",
+                    "to": "null"
+                }
+            ],
+            "span": 1,
+            "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+                {
+                    "expr": "count(scylla_node_operation_mode>3)OR vector(0)",
+                    "intervalFactor": 1,
+                    "legendFormat": "Leaving",
+                    "refId": "A",
+                    "step": 20
+                }
+            ],
+            "thresholds": "1,2",
+            "title": "Leaving",
+            "transparent": true,
+            "type": "singlestat",
+            "valueFontSize": "150%",
+            "valueMaps": [
+                {
+                    "op": "=",
+                    "text": "N/A",
+                    "value": "null"
+                }
+            ],
+            "valueName": "current"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "percent_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "The percentage of the time during which Scylla utilized the CPU. Note that because Scylla does busy polling for some time before going idle, CPU utilization as seen by the operating system may be much higher. Your system is not yet CPU-bottlenecked until this metric is high.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "avg(scylla_reactor_utilization{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"} ) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Load",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percent",
+                    "logBase": 1,
+                    "max": 101,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "single_value_table",
+            "columns": [
+                {
+                    "text": "Avg",
+                    "value": "avg"
+                }
+            ],
+            "datasource": "prometheus",
+            "description": "Nodes Information table",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 4
+            },
+            "id": 7,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the detailed node information",
+                    "linkUrl": "/d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "Time",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "__name__",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "exported_instance",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "job",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "version",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "type",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Version",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "${__cell_11}",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "svr",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "OS",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the OS node information",
+                    "linkUrl": "/d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "OS",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "OS",
+                            "value": "os"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the CQL information",
+                    "linkUrl": "/d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "CQL",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CQL",
+                            "value": "cql"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "Errors",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "Errors",
+                            "value": "errors"
+                        }
+                    ]
+                },
+                {
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the Errors metrics information",
+                    "linkUrl": "/d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "IO",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "IO",
+                            "value": "io"
+                        }
+                    ]
+                },
+                {
+                    "alias": "CPU",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the node CPU information",
+                    "linkUrl": "/d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+                    "mappingType": 1,
+                    "pattern": "CPU",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short",
+                    "valueMaps": [
+                        {
+                            "text": "CPU",
+                            "value": "cpu"
+                        }
+                    ]
+                },
+                {
+                    "alias": "Status",
+                    "mappingType": 2,
+                    "pattern": "Value",
+                    "rangeMaps": [
+                        {
+                            "from": "1",
+                            "text": "Starting",
+                            "to": "1"
+                        },
+                        {
+                            "from": "2",
+                            "text": "Joining",
+                            "to": "2"
+                        },
+                        {
+                            "from": "3",
+                            "text": "Normal",
+                            "to": "3"
+                        },
+                        {
+                            "from": "4",
+                            "text": "Leaving",
+                            "to": "4"
+                        },
+                        {
+                            "from": "5",
+                            "text": "Decommissioned",
+                            "to": "5"
+                        },
+                        {
+                            "from": "6",
+                            "text": "Draining",
+                            "to": "6"
+                        },
+                        {
+                            "from": "7",
+                            "text": "Drained",
+                            "to": "7"
+                        },
+                        {
+                            "from": "8",
+                            "text": "Moving",
+                            "to": "8"
+                        }
+                    ],
+                    "type": "string"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                }
+            ],
+            "targets": [
+                {
+                    "expr": "0*scylla_scylladb_current_version{cluster=~\"$cluster|$^\", dc=~\"$dc\"} + on (instance) group_left() scylla_node_operation_mode{cluster=~\"$cluster|$^\", dc=~\"$dc\"}",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                }
+            ],
+            "title": "Nodes",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "bytes_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(node_filesystem_size_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail_bytes{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                },
+                {
+                    "expr": "sum(node_filesystem_size{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])-sum(node_filesystem_avail{mountpoint=\"$mount_point\", instance=~\"$node\"}) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "B",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Disk Size by $by",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Amount of requests served as the coordinator. Imbalances here represent dispersion at the client-side level or connection balancing level, not your data model.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_transport_requests_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]]) + $func(irate(scylla_thrift_served{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 4
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Requests Served - Coordinator",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "alert_table",
+            "columns": [],
+            "datasource": "alertmanager",
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 10,
+            "links": [],
+            "options": {},
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "span": 4,
+            "styles": [
+                {
+                    "alias": "Time",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_4}&from=${__cell_0}",
+                    "pattern": "Time",
+                    "type": "date"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "severity",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "alertname",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "cluster",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "monitor",
+                    "type": "hidden"
+                },
+                {
+                    "class": "hidden_column",
+                    "pattern": "summary",
+                    "type": "hidden"
+                },
+                {
+                    "alias": "Instance",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Jump to the see the node",
+                    "linkUrl": "/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}",
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                },
+                {
+                    "alias": "",
+                    "colorMode": null,
+                    "colors": [
+                        "rgba(245, 54, 54, 0.9)",
+                        "rgba(237, 129, 40, 0.89)",
+                        "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                    "annotations": true,
+                    "expr": "job!=\"scylla_manager\"",
+                    "legendFormat": "{{description}}",
+                    "refId": "A",
+                    "target": "Query",
+                    "type": "table"
+                }
+            ],
+            "title": "Active Alerts",
+            "transform": "table",
+            "type": "table"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Latencies - Coordinator</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 16
+            },
+            "id": 11,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Writes",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_write_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average write latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile write latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile write latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 16,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reads",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 17,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_read_latency_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]]) + 1)",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Average read latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 18,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "95th percentile read latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "us_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 24
+            },
+            "hiddenSeries": false,
+            "id": 19,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[60s])) by ([[by]], le))",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "metric": "",
+                    "refId": "A",
+                    "step": 1
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "99th percentile read latency by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "\u00b5s",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache - Replica</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 0,
+                "y": 30
+            },
+            "id": 20,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 12,
+                "x": 12,
+                "y": 30
+            },
+            "id": 21,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 6,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of rows that were read from the cache, without needing to be fetched from storage.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 0,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 22,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_hits{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Cache Hits",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "ops_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Number of rows that were not present in the cache, and had to be fetched from storage.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 6,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 23,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(irate(scylla_cache_row_misses{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[60s])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Cache Misses",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "wps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 12,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 24,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_write_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Write Timeouts/Seconds by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "wps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "rps_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 18,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 25,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "$func(rate(scylla_storage_proxy_coordinator_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])+rate(scylla_storage_proxy_coordinator_cas_read_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])+rate(scylla_storage_proxy_coordinator_range_timeouts{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[1m])) by ([[by]])",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Read Timeouts/Seconds by [[by]]",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "rps",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Your Panels</h1>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 38
+            },
+            "id": 26,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 40
+            },
+            "hiddenSeries": false,
+            "id": 27,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "class": "user_panel",
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "description": "This graph panel was left empty on purpose for ad-hoc usage. Change it when needed. Pay attention that changes to the panel will not be saved.\n\nIf you do need a panel that can be saved, create a new dashboard, or edit the panel inside the json file",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 40
+            },
+            "hiddenSeries": false,
+            "id": 28,
+            "isNew": true,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {}
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Your Graph here",
+            "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "class": "plain_text",
+            "content": "<h4 style=\"color:#5881c2; border-bottom: 0px solid #5881c2;\">Scylla Monitoring version - 3.3</h4>",
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 46
+            },
+            "id": 29,
+            "isNew": true,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [
+        "4.0"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "class": "by_template_var",
+                "current": {
+                    "tags": [],
+                    "text": "Instance",
+                    "value": "instance"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "by",
+                "multi": false,
+                "name": "by",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "Cluster",
+                        "value": "cluster"
+                    },
+                    {
+                        "selected": false,
+                        "text": "DC",
+                        "value": "dc"
+                    },
+                    {
+                        "selected": true,
+                        "text": "Instance",
+                        "value": "instance"
+                    },
+                    {
+                        "selected": false,
+                        "text": "instance,shard",
+                        "value": "instance,shard"
+                    }
+                ],
+                "query": "Cluster,DC,Instance,Shard",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "dc",
+                "multi": true,
+                "name": "dc",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster\"}, dc)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "node",
+                "multi": true,
+                "name": "node",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization{cluster=~\"$cluster|$^\", dc=~\"$dc\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_all",
+                "current": {
+                    "text": "All",
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "shard",
+                "multi": true,
+                "name": "shard",
+                "options": [],
+                "query": "label_values(scylla_reactor_utilization,shard)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 3,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_single",
+                "current": {
+                    "text": "/var/lib/scylla",
+                    "value": "/var/lib/scylla"
+                },
+                "datasource": "prometheus",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Mount path",
+                "multi": false,
+                "name": "mount_point",
+                "options": [],
+                "query": "node_filesystem_avail_bytes",
+                "refresh": 2,
+                "regex": "/mountpoint=\"([^\"]*)\".*/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "class": "aggregation_function",
+                "current": {
+                    "tags": [],
+                    "text": "sum",
+                    "value": "sum"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Function",
+                "multi": false,
+                "name": "func",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "sum",
+                        "value": "sum"
+                    },
+                    {
+                        "selected": false,
+                        "text": "avg",
+                        "value": "avg"
+                    },
+                    {
+                        "selected": false,
+                        "text": "max",
+                        "value": "max"
+                    },
+                    {
+                        "selected": false,
+                        "text": "min",
+                        "value": "min"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stddev",
+                        "value": "stddev"
+                    },
+                    {
+                        "selected": false,
+                        "text": "stdvar",
+                        "value": "stdvar"
+                    }
+                ],
+                "query": "sum,avg,max,min,stddev,stdvar",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "class": "adhoc_filter",
+                "datasource": "prometheus",
+                "filters": [],
+                "hide": 0,
+                "label": "ad hoc",
+                "name": "adhoc",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "template_variable_custom",
+                "current": {
+                    "text": "4.0",
+                    "value": "4.0"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "scylla_dash_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "4.0",
+                        "value": "4.0"
+                    }
+                ],
+                "query": "4.0",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "allValue": null,
+                "class": "monitor_version_var",
+                "current": {
+                    "text": "3.3",
+                    "value": "3.3"
+                },
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "monitoring_version",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "3.3",
+                        "value": "3.3"
+                    }
+                ],
+                "query": "3.3",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "now": true,
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Overview",
+    "uid": "overview-4-0",
+    "version": 1
+}

--- a/examples/eks/grafana/values.yaml.in
+++ b/examples/eks/grafana/values.yaml.in
@@ -1,0 +1,451 @@
+rbac:
+  create: true
+  pspEnabled: true
+  pspUseAppArmor: true
+  namespaced: false
+serviceAccount:
+  create: true
+  name:
+
+replicas: 1
+
+deploymentStrategy: 
+  type: RollingUpdate
+
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+  initialDelaySeconds: 60
+  timeoutSeconds: 30
+  failureThreshold: 10
+
+image:
+  repository: grafana/grafana
+  tag: 5.4.2
+  pullPolicy: IfNotPresent
+
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+testFramework:
+  image: "dduportal/bats"
+  tag: "0.4.0"
+
+securityContext:
+  runAsUser: 472
+  fsGroup: 472
+
+
+extraConfigmapMounts: []
+  # - name: certs-configmap
+  #   mountPath: /etc/grafana/ssl/
+  #   configMap: certs-configmap
+  #   readOnly: true
+
+
+extraEmptyDirMounts: []
+  # - name: provisioning-notifiers
+  #   mountPath: /etc/grafana/provisioning/notifiers
+
+
+## Assign a PriorityClassName to pods if set
+# priorityClassName:
+
+downloadDashboardsImage:
+  repository: appropriate/curl
+  tag: latest
+  pullPolicy: IfNotPresent
+
+## Pod Annotations
+# podAnnotations: {}
+
+## Deployment annotations
+# annotations: {}
+
+## Expose the grafana service to be accessed from outside the cluster (LoadBalancer service).
+## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+    # targetPort: 4181 To be used with a proxy extraContainer
+  annotations: {}
+  labels: {}
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+#  limits:
+#    cpu: 100m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+#
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+extraInitContainers: []
+
+## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
+extraContainers: |
+# - name: proxy
+#   image: quay.io/gambol99/keycloak-proxy:latest
+#   args:
+#   - -provider=github
+#   - -client-id=
+#   - -client-secret=
+#   - -github-org=<ORG_NAME>
+#   - -email-domain=*
+#   - -cookie-secret=
+#   - -http-address=http://0.0.0.0:4181
+#   - -upstream-url=http://127.0.0.1:3000
+#   ports:
+#     - name: proxy-web
+#       containerPort: 4181
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: false
+  # storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  # annotations: {}
+  # subPath: ""
+  # existingClaim:
+
+initChownData:
+  ## If false, data ownership will not be reset at startup
+  ## This allows the prometheus-server to be run with an arbitrary user
+  ##
+  enabled: true
+
+  ## initChownData container image
+  ##
+  image:
+    repository: busybox
+    tag: "1.30"
+    pullPolicy: IfNotPresent
+
+  ## initChownData resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+
+
+# Administrator credentials when not using an existing secret (see below)
+adminUser: admin
+adminPassword: admin
+
+# Use an existing secret for the admin user.
+admin:
+  existingSecret: ""
+  userKey: admin-user
+  passwordKey: admin-password
+
+## Define command to be executed at startup by grafana container
+## Needed if using `vault-env` to manage secrets (ref: https://banzaicloud.com/blog/inject-secrets-into-pods-vault/)
+## Default is "run.sh" as defined in grafana's Dockerfile
+# command:
+# - "sh"
+# - "/run.sh"
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## Extra environment variables that will be pass onto deployment pods
+env: {}
+
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for auth tokens, etc
+envFromSecret: ""
+
+## Additional grafana server secret mounts
+# Defines additional mounts with secrets. Secrets must be manually created in the namespace.
+extraSecretMounts: []
+  # - name: secret-files
+  #   mountPath: /etc/secrets
+  #   secretName: grafana-secret-files
+  #   readOnly: true
+
+## Additional grafana server volume mounts
+# Defines additional volume mounts.
+extraVolumeMounts: []
+  # - name: extra-volume
+  #   mountPath: /mnt/volume
+  #   readOnly: true
+  #   existingClaim: volume-claim
+
+## Pass the plugins you want installed as a list.
+##
+plugins: "camptocamp-prometheus-alertmanager-datasource,grafana-piechart-panel"
+
+## Configure grafana datasources
+## ref: http://docs.grafana.org/administration/provisioning/#datasources
+##
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+    - name: prometheus
+      type: prometheus
+      url: http://scylla-prom-prometheus-server.monitoring.svc.cluster.local
+      access: proxy
+      isDefault: true
+    - name: alertmanager
+      type: camptocamp-prometheus-alertmanager-datasource
+      orgId: 1
+      typeLogoUrl: public/img/icn-datasource.svg
+      access: proxy
+      url: http://scylla-prom-prometheus-alertmanager.monitoring.svc.cluster.local
+      jsonData:
+        severity_critical: '4'
+        severity_high: '3'
+        severity_warning: '2'
+        severity_info: '1'
+
+
+#  datasources.yaml:
+#    apiVersion: 1
+#    datasources:
+#    - name: Prometheus
+#      type: prometheus
+#      url: http://prometheus-prometheus-server
+#      access: proxy
+#      isDefault: true
+
+## Configure notifiers
+## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
+##
+notifiers: {}
+#  notifiers.yaml:
+#    notifiers:
+#    - name: email-notifier
+#      type: email
+#      uid: email1
+#      # either:
+#      org_id: 1
+#      # or
+#      org_name: Main Org.
+#      is_default: true
+#      settings:
+#        addresses: an_email_address@example.com
+#    delete_notifiers:
+
+## Configure grafana dashboard providers
+## ref: http://docs.grafana.org/administration/provisioning/#dashboards
+##
+## `path` must be /var/lib/grafana/dashboards/<provider_name>
+##
+dashboardProviders:
+  dashboardproviders.yaml:
+    apiVersion: 1
+    providers:
+    - name: 'scylla'
+      orgId: 1
+      folder: 'scylla'
+      type: file
+      disableDeletion: false
+      updateIntervalSeconds: 10 #how often Grafana will scan for changed dashboards
+      options:
+        path: /var/lib/grafana/dashboards/scylla
+#  dashboardproviders.yaml:
+#    apiVersion: 1
+#    providers:
+#    - name: 'default'
+#      orgId: 1
+#      folder: ''
+#      type: file
+#      disableDeletion: false
+#      editable: true
+#      options:
+#        path: /var/lib/grafana/dashboards/default
+
+## Configure grafana dashboard to import
+## NOTE: To use dashboards you must also enable/configure dashboardProviders
+## ref: https://grafana.com/dashboards
+##
+## dashboards per provider, use provider name as key.
+##
+dashboards:
+  scylla:
+    alternator-4.0:
+
+    scylla-cpu-4.0:
+
+    scylla-cql-4.0:
+
+    scylla-detailed-4.0:
+
+    scylla-errors-4.0:
+
+    scylla-io-4.0:
+
+    scylla-os-4.0:
+
+    scylla-overview-4.0:
+
+  # default:
+  #   some-dashboard:
+  #     json: |
+  #       $RAW_JSON
+  #   custom-dashboard:
+  #     file: dashboards/custom-dashboard.json
+  #   prometheus-stats:
+  #     gnetId: 2
+  #     revision: 2
+  #     datasource: Prometheus
+  #   local-dashboard:
+  #     url: https://example.com/repository/test.json
+  #   local-dashboard-base64:
+  #     url: https://example.com/repository/test-b64.json
+  #     b64content: true
+
+## Reference to external ConfigMap per provider. Use provider name as key and ConfiMap name as value.
+## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.
+## ConfigMap data example:
+##
+## data:
+##   example-dashboard.json: |
+##     RAW_JSON
+##
+dashboardsConfigMaps: {}
+#  default: ""
+
+## Grafana's primary configuration
+## NOTE: values in map will be converted to ini format
+## ref: http://docs.grafana.org/installation/configuration/
+##
+grafana.ini:
+  paths:
+    data: /var/lib/grafana/data
+    logs: /var/log/grafana
+    plugins: /var/lib/grafana/plugins
+    provisioning: /etc/grafana/provisioning
+  analytics:
+    check_for_updates: true
+  log:
+    mode: console
+  grafana_net:
+    url: https://grafana.net
+## LDAP Authentication can be enabled with the following values on grafana.ini
+## NOTE: Grafana will fail to start if the value for ldap.toml is invalid
+  # auth.ldap:
+  #   enabled: true
+  #   allow_sign_up: true
+  #   config_file: /etc/grafana/ldap.toml
+
+## Grafana's LDAP configuration
+## Templated by the template in _helpers.tpl
+## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
+## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
+## ref: http://docs.grafana.org/installation/ldap/#configuration
+ldap:
+  # `existingSecret` is a reference to an existing secret containing the ldap configuration
+  # for Grafana in a key `ldap-toml`.
+  existingSecret: ""
+  # `config` is the content of `ldap.toml` that will be stored in the created secret
+  config: ""
+  # config: |-
+  #   verbose_logging = true
+
+  #   [[servers]]
+  #   host = "my-ldap-server"
+  #   port = 636
+  #   use_ssl = true
+  #   start_tls = false
+  #   ssl_skip_verify = false
+  #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
+
+## Grafana's SMTP configuration
+## NOTE: To enable, grafana.ini must be configured with smtp.enabled
+## ref: http://docs.grafana.org/installation/configuration/#smtp
+smtp:
+  # `existingSecret` is a reference to an existing secret containing the smtp configuration
+  # for Grafana.
+  existingSecret: ""
+  userKey: "user"
+  passwordKey: "password"
+
+## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
+## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
+sidecar:
+  image: kiwigrid/k8s-sidecar:0.0.16
+  imagePullPolicy: IfNotPresent
+  resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 100Mi
+#   requests:
+#     cpu: 50m
+#     memory: 50Mi
+  # skipTlsVerify Set to true to skip tls verification for kube api calls
+  # skipTlsVerify: true
+#  dashboards:
+#    enabled: false
+    # label that the configmaps with dashboards are marked with
+#    label: grafana_dashboard
+    # folder in the pod that should hold the collected dashboards (unless `defaultFolderName` is set)
+#    folder: /tmp/dashboards
+    # The default folder name, it will create a subfolder under the `folder` and put dashboards in there instead
+#    defaultFolderName: null
+    # If specified, the sidecar will search for dashboard config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+#    searchNamespace: null
+  datasources:
+    enabled: false
+    # label that the configmaps with datasources are marked with
+    label: grafana_datasource
+    # If specified, the sidecar will search for datasource config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+

--- a/examples/eks/node-setup-daemonset.yaml
+++ b/examples/eks/node-setup-daemonset.yaml
@@ -1,0 +1,175 @@
+# ClusterRole for node-setup-daemonset.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-setup-daemonset
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+
+
+---
+
+# ServiceAccount for node-setup daemonset.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-setup-daemonset
+  namespace: default
+---
+# Bind node-setup daemonset ServiceAccount with ClusterRole.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node-setup-daemonset
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-setup-daemonset
+subjects:
+- kind: ServiceAccount
+  name: node-setup-daemonset
+  namespace: default
+---
+# Daemonset that will configure disks and networking interfaces on node.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-setup
+spec:
+  selector:
+    matchLabels:
+      name: node-setup
+  template:
+    metadata:
+      labels:
+        name: node-setup
+    spec:
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: pool
+                  operator: In
+                  values:
+                   - scylla-pool
+      tolerations:
+        - key: role
+          operator: Equal
+          value: scylla-clusters
+          effect: NoSchedule
+        - key: role
+          operator: Equal
+          value: cassandra-stress
+          effect: NoSchedule
+      serviceAccountName: node-setup-daemonset
+      containers:
+      - name: node-setup
+        image: scyllazimnx/scylla-machine-image-k8s-aws:666.development-20201001.eea319c
+        imagePullPolicy: Always
+        args:
+          - --all
+        env:
+          - name: ROOT_DISK
+            value: /mnt/hostfs/mnt/raid-disks/disk0
+          - name: SCYLLAD_CONF_MOUNT
+            value: /mnt/scylla.d/
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: hostfs
+            mountPath: /mnt/hostfs
+            mountPropagation: Bidirectional
+          - name: hostetcscyllad
+            mountPath: /mnt/scylla.d
+            mountPropagation: Bidirectional
+          - name: hostirqbalanceconfig
+            mountPath: /etc/conf.d/irqbalance
+            mountPropagation: Bidirectional
+      volumes:
+        - name: hostfs
+          hostPath:
+            path: /
+        - name: hostetcscyllad
+          hostPath:
+            path: /etc/scylla.d/
+        - name: hostirqbalanceconfig
+          hostPath:
+            path: /etc/sysconfig/irqbalance
+
+---
+# Daemonset that will disks on monitoring node.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: monitoring-node-setup
+spec:
+  selector:
+    matchLabels:
+      name: monitoring-node-setup
+  template:
+    metadata:
+      labels:
+        name: monitoring-node-setup
+    spec:
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: pool
+                    operator: In
+                    values:
+                      - monitoring-pool
+      serviceAccountName: node-setup-daemonset
+      containers:
+        - name: node-setup
+          image: scyllazimnx/scylla-machine-image-k8s-aws:666.development-20201001.eea319c
+          imagePullPolicy: Always
+          args:
+            - --setup-disks
+          env:
+            - name: ROOT_DISK
+              value: /mnt/hostfs/mnt/raid-disks/disk0
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: hostfs
+              mountPath: /mnt/hostfs
+              mountPropagation: Bidirectional
+      volumes:
+        - name: hostfs
+          hostPath:
+            path: /
+

--- a/examples/eks/operator.yaml
+++ b/examples/eks/operator.yaml
@@ -1,0 +1,1174 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: scylla-operator-system
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: scylla-operator-system/scylla-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: clusters.scylla.scylladb.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      caBundle: Cg==
+      service:
+        name: scylla-operator-webhook-service
+        namespace: scylla-operator-system
+        path: /convert
+  group: scylla.scylladb.com
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Cluster is the Schema for the clusters API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ClusterSpec defines the desired state of Cluster
+          properties:
+            agentRepository:
+              description: Repository to pull the agent image from. Defaults to "scylladb/scylla-manager-agent".
+              type: string
+            agentVersion:
+              description: Version of Scylla Manager Agent to use. Defaults to "latest".
+              type: string
+            alternator:
+              description: Alternator designates this cluster an Alternator cluster
+              properties:
+                port:
+                  description: Port on which to bind the Alternator API
+                  format: int32
+                  type: integer
+              type: object
+            cpuset:
+              description: CpuSet determines if the cluster will use cpu-pinning for
+                max performance.
+              type: boolean
+            datacenter:
+              description: Datacenter that will make up this cluster.
+              properties:
+                name:
+                  description: Name of the Scylla Datacenter. Used in the cassandra-rackdc.properties
+                    file.
+                  type: string
+                racks:
+                  description: Racks of the specific Datacenter.
+                  items:
+                    description: RackSpec is the desired state for a Scylla Rack.
+                    properties:
+                      members:
+                        description: Members is the number of Scylla instances in
+                          this rack.
+                        format: int32
+                        type: integer
+                      name:
+                        description: Name of the Scylla Rack. Used in the cassandra-rackdc.properties
+                          file.
+                        type: string
+                      placement:
+                        description: Placement describes restrictions for the nodes
+                          Scylla is scheduled on.
+                        properties:
+                          nodeAffinity:
+                            description: Node affinity is a group of node affinity
+                              scheduling rules.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Pod affinity is a group of inter pod affinity
+                              scheduling rules.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Pod anti affinity is a group of inter pod
+                              anti affinity scheduling rules.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          tolerations:
+                            items:
+                              description: The pod this Toleration is attached to
+                                tolerates any taint that matches the triple <key,value,effect>
+                                using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: Effect indicates the taint effect to
+                                    match. Empty means match all taint effects. When
+                                    specified, allowed values are NoSchedule, PreferNoSchedule
+                                    and NoExecute.
+                                  type: string
+                                key:
+                                  description: Key is the taint key that the toleration
+                                    applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists;
+                                    this combination means to match all values and
+                                    all keys.
+                                  type: string
+                                operator:
+                                  description: Operator represents a key's relationship
+                                    to the value. Valid operators are Exists and Equal.
+                                    Defaults to Equal. Exists is equivalent to wildcard
+                                    for value, so that a pod can tolerate all taints
+                                    of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: TolerationSeconds represents the period
+                                    of time the toleration (which must be of effect
+                                    NoExecute, otherwise this field is ignored) tolerates
+                                    the taint. By default, it is not set, which means
+                                    tolerate the taint forever (do not evict). Zero
+                                    and negative values will be treated as 0 (evict
+                                    immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: Value is the taint value the toleration
+                                    matches to. If the operator is Exists, the value
+                                    should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      resources:
+                        description: Resources the Scylla Pods will use.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      scyllaAgentConfig:
+                        description: Scylla config map name to customize scylla manager
+                          agent
+                        type: string
+                      scyllaConfig:
+                        description: Scylla config map name to customize scylla.yaml
+                        type: string
+                      storage:
+                        description: Storage describes the underlying storage that
+                          Scylla will consume.
+                        properties:
+                          capacity:
+                            description: Capacity of each member's volume
+                            type: string
+                          storageClassName:
+                            description: Name of storageClass to request
+                            type: string
+                        required:
+                        - capacity
+                        type: object
+                    required:
+                    - members
+                    - name
+                    - resources
+                    - scyllaAgentConfig
+                    - scyllaConfig
+                    - storage
+                    type: object
+                  type: array
+              required:
+              - name
+              - racks
+              type: object
+            developerMode:
+              description: DeveloperMode determines if the cluster runs in developer-mode.
+              type: boolean
+            network:
+              description: Networking config
+              properties:
+                dnsPolicy:
+                  description: DNSPolicy defines how a pod's DNS will be configured.
+                  type: string
+                hostNetworking:
+                  type: boolean
+              type: object
+            repository:
+              description: Repository to pull the image from.
+              type: string
+            sidecarImage:
+              description: User-provided image for the sidecar that replaces default.
+              properties:
+                repository:
+                  description: Repository to pull the image from.
+                  type: string
+                version:
+                  description: Version of the image.
+                  type: string
+              required:
+              - repository
+              - version
+              type: object
+            sysctls:
+              description: 'Sysctl properties to be applied during initialization
+                given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
+              items:
+                type: string
+              type: array
+            version:
+              description: Version of Scylla to use.
+              type: string
+          required:
+          - agentVersion
+          - datacenter
+          - version
+          type: object
+        status:
+          description: ClusterStatus defines the observed state of Cluster
+          properties:
+            racks:
+              additionalProperties:
+                description: RackStatus is the status of a Scylla Rack
+                properties:
+                  conditions:
+                    description: Conditions are the latest available observations
+                      of a rack's state.
+                    items:
+                      description: RackCondition is an observation about the state
+                        of a rack.
+                      properties:
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  members:
+                    description: Members is the current number of members requested
+                      in the specific Rack
+                    format: int32
+                    type: integer
+                  readyMembers:
+                    description: ReadyMembers is the number of ready members in the
+                      specific Rack
+                    format: int32
+                    type: integer
+                  version:
+                    description: Version is the current version of Scylla in use.
+                    type: string
+                required:
+                - members
+                - readyMembers
+                - version
+                type: object
+              type: object
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: scylla-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - scylla.scylladb.com
+  resources:
+  - clusters/status
+  verbs:
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scylla-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scylla-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: scylla-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: scylla-operator-webhook-service
+  namespace: scylla-operator-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: scylla-operator-controller-manager
+  namespace: scylla-operator-system
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  serviceName: controller-manager-service
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - operator
+        - --log-level=debug
+        command:
+        - /scylla-operator
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: scylladb/scylla-operator:v0.2.3
+        imagePullPolicy: IfNotPresent
+        name: manager
+        ports:
+        - containerPort: 443
+          name: webhook-server
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: scylla-operator-serving-cert
+  namespace: scylla-operator-system
+spec:
+  dnsNames:
+  - scylla-operator-webhook-service.scylla-operator-system.svc
+  - scylla-operator-webhook-service.scylla-operator-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: scylla-operator-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: scylla-operator-selfsigned-issuer
+  namespace: scylla-operator-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: scylla-operator-system/scylla-operator-serving-cert
+  creationTimestamp: null
+  name: scylla-operator-validating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: scylla-operator-webhook-service
+      namespace: scylla-operator-system
+      path: /validate-scylla-scylladb-com-v1alpha1-cluster
+  failurePolicy: Fail
+  name: vcluster.kb.io
+  rules:
+  - apiGroups:
+    - scylla.scylladb.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters

--- a/examples/eks/provisioner/Chart.yaml
+++ b/examples/eks/provisioner/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+version: 2.3.0
+description: local provisioner chart 
+name: provisioner
+keywords:
+  - storage
+  - local
+engine: gotpl

--- a/examples/eks/provisioner/templates/namespace.yaml
+++ b/examples/eks/provisioner/templates/namespace.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.common.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.common.namespace | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+{{- end }}

--- a/examples/eks/provisioner/templates/provisioner-cluster-role-binding.yaml
+++ b/examples/eks/provisioner/templates/provisioner-cluster-role-binding.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.common.rbac }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.daemonset.serviceAccount }}
+  namespace: {{ .Values.common.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.daemonset.serviceAccount }}
+  namespace: {{ .Values.common.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+{{- if .Values.common.useJobForCleaning }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-storage-provisioner-jobs-role
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+rules:
+- apiGroups:
+    - 'batch'
+  resources:
+    - jobs
+  verbs:
+    - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-storage-provisioner-jobs-rolebinding
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.daemonset.serviceAccount }}
+  namespace: {{ .Values.common.namespace }}
+roleRef:
+  kind: Role
+  name: local-storage-provisioner-jobs-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/examples/eks/provisioner/templates/provisioner-service-account.yaml
+++ b/examples/eks/provisioner/templates/provisioner-service-account.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.common.rbac }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.daemonset.serviceAccount }}
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+{{- end }}

--- a/examples/eks/provisioner/templates/provisioner.yaml
+++ b/examples/eks/provisioner/templates/provisioner.yaml
@@ -1,0 +1,196 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.common.configMapName }}
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+data:
+{{- if .Values.daemonset.nodeLabels }}
+  nodeLabelsForPV: |
+   {{- range $label := .Values.daemonset.nodeLabels }}
+    - {{$label}}
+   {{- end }}
+{{- end }}
+{{- if .Values.common.useAlphaAPI }}
+  useAlphaAPI: "true"
+{{- end }}
+{{- if .Values.common.useJobForCleaning }}
+  useJobForCleaning: "yes"
+{{- end}}
+{{- if .Values.common.useNodeNameOnly }}
+  useNodeNameOnly: "true"
+{{- end }}
+{{- if .Values.common.minResyncPeriod }}
+  minResyncPeriod: {{ .Values.common.minResyncPeriod | quote }}
+{{- end}}
+  storageClassMap: |
+    {{- range $classConfig := .Values.classes }}
+    {{ $classConfig.name }}:
+       hostDir: {{ $classConfig.hostDir }}
+       mountDir: {{ if $classConfig.mountDir }} {{- $classConfig.mountDir -}} {{ else }} {{- $classConfig.hostDir -}} {{ end }}
+       {{- if $classConfig.blockCleanerCommand }}
+       blockCleanerCommand:
+       {{- range $val := $classConfig.blockCleanerCommand }}
+         - "{{ $val -}}"{{- end}}
+       {{- end }}
+       {{- if $classConfig.volumeMode }}
+       volumeMode: {{ $classConfig.volumeMode }}
+       {{- end }}
+       {{- if $classConfig.fsType }}
+       fsType: {{ $classConfig.fsType }}
+       {{- end }}
+    {{- end }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Values.daemonset.name }}
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    app: local-volume-provisioner
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: {{.Values.daemonset.serviceAccount}}
+{{- if .Values.daemonset.nodeSelector }}
+      nodeSelector:
+{{ .Values.daemonset.nodeSelector | toYaml | trim | indent 8 }}
+{{- end }}
+{{- if .Values.daemonset.tolerations }}
+      tolerations:
+{{ .Values.daemonset.tolerations | toYaml | trim | indent 8 }}
+{{- end }}
+      containers:
+        - image: "{{ .Values.daemonset.image }}"
+          {{- if .Values.daemonset.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.daemonset.imagePullPolicy | quote }}
+          {{- end }}
+          name: provisioner
+          securityContext:
+            privileged: true
+{{- if .Values.daemonset.resources }}
+          resources:
+{{ .Values.daemonset.resources | toYaml | trim | indent 12 }}
+{{- end }}
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "{{ .Values.daemonset.image }}"
+          {{- if .Values.daemonset.kubeConfigEnv }}
+            - name: KUBECONFIG
+              value: {{.Values.daemonset.kubeConfigEnv}}
+          {{- end }}
+          {{- if .Values.prometheus.operator.enabled }}
+          ports:
+          - containerPort: 8080
+            name: http
+          {{- end }}
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /dev
+              name: provisioner-dev
+            {{- range $classConfig := .Values.classes }}
+            - mountPath: {{ if $classConfig.mountDir }} {{- $classConfig.mountDir -}} {{ else }} {{- $classConfig.hostDir -}} {{ end }}
+              name: {{ $classConfig.name }}
+              mountPropagation: "HostToContainer"
+            {{- end }}
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: {{ .Values.common.configMapName }}
+        - name: provisioner-dev
+          hostPath:
+            path: /dev
+        {{- range $classConfig := .Values.classes }}
+        - name: {{ $classConfig.name }}
+          hostPath:
+            path: {{ $classConfig.hostDir }}
+        {{- end }}
+{{- $release := .Release }}
+{{- $chart := .Chart }}
+{{- range $val := .Values.classes }}
+{{- if $val.storageClass }}
+{{- $reclaimPolicy := $val.reclaimPolicy | default "Delete" }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $val.name }}
+  labels:
+    heritage: {{ $release.Service | quote }}
+    release: {{ $release.Name | quote }}
+    chart: {{ replace "+" "_" $chart.Version | printf "%s-%s" $chart.Name }}
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: {{ $reclaimPolicy }}
+{{- end }}
+{{- end }}
+{{- if .Values.prometheus.operator.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.daemonset.name }}
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    app: local-volume-provisioner
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+  selector:
+    app: local-volume-provisioner
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.daemonset.name }}
+  namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
+  labels:
+    app: local-volume-provisioner
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+    {{- if .Values.prometheus.operator.serviceMonitor.selector }}
+    {{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+    {{- end }}
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+      release: {{ .Release.Name | quote }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.common.namespace }}
+  endpoints:
+    - port: http
+      interval: {{ .Values.prometheus.operator.serviceMonitor.interval }}
+      scheme: http
+{{- end }}

--- a/examples/eks/provisioner/values.yaml
+++ b/examples/eks/provisioner/values.yaml
@@ -1,0 +1,146 @@
+#
+# Common options.
+#
+common:
+  #
+  # Defines whether to generate service account and role bindings.
+  #
+  rbac: true
+  #
+  # Defines the namespace where provisioner runs
+  #
+  namespace: default
+  #
+  # Defines whether to create provisioner namespace
+  # 
+  createNamespace: false
+  # Beta PV.NodeAffinity field is used by default. If running against pre-1.10
+  # k8s version, the `useAlphaAPI` flag must be enabled in the configMap.
+  #
+  useAlphaAPI: false
+  #
+  # Provisioner clean volumes in process by default. If set to true, provisioner
+  # will use Jobs to clean.
+  #
+  useJobForCleaning: false
+  #
+  # Provisioner name contains Node.UID by default. If set to true, the provisioner
+  # name will only use Node.Name.
+  #
+  useNodeNameOnly: false
+  #
+  # Resync period in reflectors will be random between minResyncPeriod and
+  # 2*minResyncPeriod. Default: 5m0s.
+  #
+  #minResyncPeriod: 5m0s
+  #
+  # Defines the name of configmap used by Provisioner
+  #
+  configMapName: "local-provisioner-config"
+#
+# Configure storage classes.
+#
+classes:
+- name: local-raid-disks # Defines name of storage classes.
+  # Path on the host where local volumes of this storage class are mounted
+  # under.
+  hostDir: /mnt/raid-disks
+  # Optionally specify mount path of local volumes. By default, we use same
+  # path as hostDir in container.
+  # mountDir: /mnt/fast-disks
+  # The volume mode of created PersistentVolume object. Default to Filesystem
+  # if not specified.
+  volumeMode: Filesystem
+  # Filesystem type to mount.
+  # It applies only when the source path is a block device,
+  # and desire volume mode is Filesystem.
+  # Must be a filesystem type supported by the host operating system.
+  fsType: xfs
+  blockCleanerCommand:
+  #  Do a quick reset of the block device during its cleanup.
+  #  - "/scripts/quick_reset.sh"
+  #  or use dd to zero out block dev in two iterations by uncommenting these lines
+  #  - "/scripts/dd_zero.sh"
+  #  - "2"
+  # or run shred utility for 2 iteration.s
+     - "/scripts/shred.sh"
+     - "2"
+  # or blkdiscard utility by uncommenting the line below.
+  #  - "/scripts/blkdiscard.sh"
+  # Uncomment to create storage class object with default configuration.
+  storageClass: true
+  # Uncomment to create storage class object and configure it.
+  # storageClass:
+  #   reclaimPolicy: Delete # Avaiable reclaim policies: Delete/Retain, defaults: Delete.
+#
+# Configure DaemonSet for provisioner.
+# 
+daemonset:
+  #
+  # Defines the name of a Provisioner
+  #
+  name: "local-volume-provisioner"
+  #
+  # Defines Provisioner's image name including container registry.
+  #
+  image: quay.io/external_storage/local-volume-provisioner:v2.3.4
+  #
+  # Defines Image download policy, see kubernetes documentation for available values.
+  #
+  #imagePullPolicy: Always
+  #
+  # Defines a name of the service account which Provisioner will use to communicate with API server.
+  #
+  serviceAccount: local-storage-admin
+  # If configured, nodeSelector will add a nodeSelector field to the DaemonSet PodSpec.
+  #
+  # NodeSelector constraint for local-volume-provisioner scheduling to nodes.
+  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # nodeSelector:
+  #
+  # If configured KubeConfigEnv will (optionally) specify the location of kubeconfig file on the node.
+  #  kubeConfigEnv: KUBECONFIG
+  #
+  # List of node labels to be copied to the PVs created by the provisioner in a format:
+  #
+  #  nodeLabels:
+  #    - failure-domain.beta.kubernetes.io/zone
+  #    - failure-domain.beta.kubernetes.io/region
+  #
+  # If configured, tolerations will add a toleration field to the DaemonSet PodSpec.
+  #
+  # Node tolerations for local-volume-provisioner scheduling to nodes with taints.
+  # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations:
+    - key: role
+      operator: Equal
+      value: scylla-clusters
+      effect: NoSchedule
+    - key: role
+      operator: Equal
+      value: cassandra-stress
+      effect: NoSchedule
+  #
+  # If configured, resources will set the requests/limits field to the Daemonset PodSpec.
+  # Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  resources: {}
+#
+# Configure Prometheus monitoring
+#
+prometheus:
+  operator:
+    ## Are you using Prometheus Operator?
+    enabled: false
+
+    serviceMonitor:
+      ## Interval at which Prometheus scrapes the provisioner
+      interval: 10s
+
+      # Namespace Prometheus is installed in
+      namespace: monitoring
+
+      ## Defaults to whats used if you follow CoreOS [Prometheus Install Instructions](https://github.com/coreos/prometheus-operator/tree/master/helm#tldr)
+      ## [Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus/templates/prometheus.yaml#L65)
+      ## [Kube Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/kube-prometheus/values.yaml#L298)
+      selector:
+        prometheus: kube-prometheus


### PR DESCRIPTION
**Description of your changes:**

Added eks.sh script which spawns EKS cluster using single zone with 3 node groups:

```
- scylla-pool           - 3 x i3.2xlarge - where Scylla Nodes are being scheduled
- cassandra-stress-pool - 4 x c4.2xlarge - used by the workload generators
- monitoring-pool       - 1 x i3.large   - used by the monitoring
```

Sciprt additionally deploys Scylla Operator and Scylla nodes.
User is also able to use provided write workload generator.

Script usage:
```
usage: ./eks.sh -z|--eks-zone [EKS zone] -c|--k8s-cluster-name [cluster name (optional)]
```
Fixes #44



**Checklist:**
- [x] Documentation has been updated, if necessary.
