### PR TITLE
Make io setup optional when starting scyllaDB container

### DIFF
--- a/config/crd/bases/scylla.scylladb.com_clusters.yaml
+++ b/config/crd/bases/scylla.scylladb.com_clusters.yaml
@@ -486,6 +486,9 @@ spec:
             developerMode:
               description: DeveloperMode determines if the cluster runs in developer-mode.
               type: boolean
+            ioSetup:
+              description: ioSetup determines if scylladb container should do io setup at startup
+              type: boolean
             network:
               description: Networking config
               properties:

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -84,6 +84,7 @@ spec:
   version: 4.0.0
   agentVersion: 2.0.2
   developerMode: true
+  ioSetup: true
   datacenter:
     name: us-east-1
     racks:

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -84,6 +84,7 @@ spec:
   version: 4.0.0
   agentVersion: 2.0.2
   cpuset: true
+  ioSetup: true
   sysctls:
     - "fs.aio-max-nr=2097152"
   network:

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -44,6 +44,8 @@ type ClusterSpec struct {
 	DeveloperMode bool `json:"developerMode,omitempty"`
 	// CpuSet determines if the cluster will use cpu-pinning for max performance.
 	CpuSet bool `json:"cpuset,omitempty"`
+	// IoSetup determines if scylla should run io-setup at startup
+	IoSetup bool `json:"ioSetup,omitempty"`
 	// Datacenter that will make up this cluster.
 	Datacenter DatacenterSpec `json:"datacenter"`
 	// User-provided image for the sidecar that replaces default.

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -166,6 +166,8 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 
 	// Check if we need to run in developer mode
 	devMode := "0"
+	// Check if we need to run io-setup
+	ioSetup := "0"
 	cluster := &v1alpha1.Cluster{}
 	err = s.Get(ctx, naming.NamespacedName(s.member.Cluster, s.member.Namespace), cluster)
 	if err != nil {
@@ -173,6 +175,9 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 	}
 	if cluster.Spec.DeveloperMode {
 		devMode = "1"
+	}
+	if cluster.Spec.IoSetup {
+		ioSetup = "1"
 	}
 	shards, err := strconv.Atoi(options.GetSidecarOptions().CPU)
 	if err != nil {
@@ -184,6 +189,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		fmt.Sprintf("--broadcast-rpc-address=%s", m.StaticIP),
 		fmt.Sprintf("--seeds=%s", strings.Join(seeds, ",")),
 		fmt.Sprintf("--developer-mode=%s", devMode),
+		fmt.Sprintf("--io-setup=%s", ioSetup),
 		fmt.Sprintf("--overprovisioned=%d", 0),
 		fmt.Sprintf("--smp=%d", shards),
 	}


### PR DESCRIPTION
  + Related to #146 to avoid long startup time

When we provision our machines, we pre-configure them in order to get the correct configuration for scyllaDB. 
Thus running io-setup at startup takes a long time and duplicate effort in our case.

Scylla container support this option https://github.com/scylladb/scylla/issues/6587
https://github.com/scylladb/scylla/commit/fc1851cdc16f24623dcc452ef87ecfc7b97c8d0d#diff-b2c8ee866cc696977a318d279ed1d681

**It is not yet supported by latest 4.1.x docker image**, let me know how/if you want to support backward compatibility

=====

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.