### PR TITLE
Issue 193 - Configuration by the user is ignored

### DIFF
--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -98,16 +98,16 @@ func (s *ScyllaConfig) setupScyllaYAML() error {
 	cfg["rpc_address"] = "0.0.0.0"
 	cfg["endpoint_snitch"] = "GossipingPropertyFileSnitch"
 
-	overrideYAMLBytes, err := yaml.Marshal(cfg)
+	defaultYAMLBytes, err := yaml.Marshal(cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse override options for scylla.yaml")
 	}
-	scyllaYAMLConfigMapFilteredBytes, err := mergeYAMLs(scyllaYAMLConfigMapBytes, overrideYAMLBytes)
+	scyllaYAMLConfigMapFilteredBytes, err := mergeYAMLs(defaultYAMLBytes, scyllaYAMLConfigMapBytes)
 	if err != nil {
 		return errors.Wrap(err, "failed to merged config map YAML with default yaml values")
 	}
 
-	customScyllaYAMLBytes, err := mergeYAMLs(scyllaYAMLBytes, scyllaYAMLConfigMapFilteredBytes)
+	customScyllaYAMLBytes, err := mergeYAMLs(scyllaYAMLConfigMapFilteredBytes, scyllaYAMLBytes)
 	if err != nil {
 		return errors.Wrap(err, "failed to merged YAMLs")
 	}

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -107,13 +107,13 @@ func (s *ScyllaConfig) setupScyllaYAML() error {
 		return errors.Wrap(err, "failed to merged config map YAML with default yaml values")
 	}
 
-	customScyllaYAMLBytes, err := mergeYAMLs(customScyllaYAMLBytes, scyllaYAMLConfigMapBytes)
+	finalScyllaYaml, err := mergeYAMLs(customScyllaYAMLBytes, scyllaYAMLConfigMapBytes)
 	if err != nil {
 		return errors.Wrap(err, "failed to merged YAMLs")
 	}
 
 	// Write result to file
-	if err = ioutil.WriteFile(scyllaYAMLPath, customScyllaYAMLBytes, os.ModePerm); err != nil {
+	if err = ioutil.WriteFile(scyllaYAMLPath, finalScyllaYaml, os.ModePerm); err != nil {
 		return errors.Wrap(err, "error trying to write scylla.yaml")
 	}
 

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -102,12 +102,12 @@ func (s *ScyllaConfig) setupScyllaYAML() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to parse override options for scylla.yaml")
 	}
-	scyllaYAMLConfigMapFilteredBytes, err := mergeYAMLs(defaultYAMLBytes, scyllaYAMLConfigMapBytes)
+	scyllaYAMLConfigMapFilteredBytes, err := mergeYAMLs(defaultYAMLBytes, scyllaYAMLBytes)
 	if err != nil {
 		return errors.Wrap(err, "failed to merged config map YAML with default yaml values")
 	}
 
-	customScyllaYAMLBytes, err := mergeYAMLs(scyllaYAMLConfigMapFilteredBytes, scyllaYAMLBytes)
+	customScyllaYAMLBytes, err := mergeYAMLs(customScyllaYAMLBytes, scyllaYAMLConfigMapBytes)
 	if err != nil {
 		return errors.Wrap(err, "failed to merged YAMLs")
 	}

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -102,7 +102,7 @@ func (s *ScyllaConfig) setupScyllaYAML() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to parse override options for scylla.yaml")
 	}
-	scyllaYAMLConfigMapFilteredBytes, err := mergeYAMLs(defaultYAMLBytes, scyllaYAMLBytes)
+	customScyllaYAMLBytes, err := mergeYAMLs(defaultYAMLBytes, scyllaYAMLBytes)
 	if err != nil {
 		return errors.Wrap(err, "failed to merged config map YAML with default yaml values")
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
func (s *ScyllaConfig) setupScyllaYAML() file was merging YAML's in the wrong order.
The PR changes the order to:
Default Values <- Existing Values <- User Values

**Which issue is resolved by this Pull Request:**
Resolves #193 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.