### PR TITLE
Callout lack of persistence

### DIFF
--- a/docs/gke.md
+++ b/docs/gke.md
@@ -1,6 +1,6 @@
 # Deploying Scylla on GKE
 
-This guide is focused on deploying Scylla on GKE with maximum performance.
+This guide is focused on deploying Scylla on GKE with maximum performance (without any persistence guarantees).
 It sets up the kubelets on GKE nodes to run with [static cpu policy](https://kubernetes.io/blog/2018/07/24/feature-highlight-cpu-manager/) and uses [local sdd disks](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/local-ssd) in RAID0 for maximum performance.
 
 Most of the commands used to setup the Scylla cluster are the same for all environments
@@ -48,7 +48,7 @@ CLUSTER_NAME=scylla-demo
 
 For this guide, we'll create a GKE cluster with the following:
 
-1. A NodePool of 3 `n1-standard-32` Nodes, where the Scylla Pods will be deployed. Each of these Nodes has 8 local SSDs attached, which will later be combined into a RAID0 array. It is important to disable `autoupgrade` and `autorepair`, since they cause loss of data on local SSDs. 
+1. A NodePool of 3 `n1-standard-32` Nodes, where the Scylla Pods will be deployed. Each of these Nodes has 8 local SSDs attached, which will later be combined into a RAID0 array. It is important to disable `autoupgrade` and `autorepair`, since they increase the frequency of loss of data on local SSDs. 
 
 ```
 gcloud beta container --project "${GCP_PROJECT}" \


### PR DESCRIPTION
**Description of your changes:**

This document may imply to individuals unfamiliar with GCE's Local SSDs that this configuration will persist their data in a durable way.  From their [marketing page](https://cloud.google.com/local-ssd), "Local SSDs are designed for temporary storage use cases such as caches or scratch processing space."

The additions in this PR give readers two opportunities to understand they're deploying an ephemeral data cluster.

**Which issue is resolved by this Pull Request:**
N/A

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.