### PR TITLE
fix(sidecar): make it respect node status on sync

### DIFF
--- a/pkg/controllers/sidecar/sidecar_controller.go
+++ b/pkg/controllers/sidecar/sidecar_controller.go
@@ -74,12 +74,13 @@ func (mc *MemberReconciler) Reconcile(request reconcile.Request) (reconcile.Resu
 	}
 
 	mc.logger.Info(ctx, "Starting reconciliation...")
-	if err := mc.sync(ctx, memberService); err != nil {
-		mc.logger.Error(ctx, "An error occurred during reconciliation", "error", err)
-		return reconcile.Result{Requeue: true}, errors.WithStack(err)
-	}
 
-	return reconcile.Result{}, nil
+	requeue, err := mc.sync(ctx, memberService)
+	if err != nil {
+		mc.logger.Error(ctx, "An error occurred during reconciliation", "error", err)
+		return reconcile.Result{Requeue: requeue}, errors.WithStack(err)
+	}
+	return reconcile.Result{Requeue: requeue}, nil
 }
 
 // newReconciler returns a new reconcile.Reconciler

--- a/pkg/controllers/sidecar/sync.go
+++ b/pkg/controllers/sidecar/sync.go
@@ -2,41 +2,83 @@ package sidecar
 
 import (
 	"context"
+	"os/exec"
 
-	"github.com/scylladb/scylla-operator/pkg/util/network"
+	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 
 	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/util"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/util/network"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (mc *MemberReconciler) sync(ctx context.Context, memberService *corev1.Service) error {
+func (mc *MemberReconciler) sync(ctx context.Context, memberService *corev1.Service) (bool, error) {
 	// Check if member must decommission
 	if decommission, ok := memberService.Labels[naming.DecommissionLabel]; ok {
 		host, err := network.FindFirstNonLocalIP()
 		if err != nil {
-			return errors.Wrapf(err, "error during decommission")
+			return true, errors.Wrapf(err, "Can't get node ip")
 		}
 		// Check if member has already decommissioned
 		if decommission == naming.LabelValueTrue {
-			return nil
+			mc.logger.Debug(ctx, "Node is already decommissioned")
+			return false, nil
 		}
-		// Else, decommission member
-		if err := mc.scyllaClient.Decommission(ctx, host.String()); err != nil {
-			mc.logger.Error(ctx, "Error during decommission", "error", errors.WithStack(err))
+		opMode, err := mc.scyllaClient.OperationMode(ctx, host.String())
+		if err != nil {
+			return true, errors.Wrapf(err, "error on getting node operation mode: %s", errors.WithStack(err))
 		}
-		// Confirm memberService has been decommissioned
-		if opMode, err := mc.scyllaClient.OperationMode(ctx, host.String()); err != nil || !opMode.IsDecommisioned() {
-			return errors.Wrapf(err, "error during decommission, operation mode: %s", opMode)
+		switch opMode {
+		case scyllaclient.OperationalModeLeaving, scyllaclient.OperationalModeDecommissioning, scyllaclient.OperationalModeDraining:
+			// If node is leaving/draining/decommissioning, keep retrying
+			return true, nil
+		case scyllaclient.OperationalModeDrained:
+			mc.logger.Info(ctx, "Node is in DRAINED state, restarting scylla to make it decommissionable")
+			// TBD: Label pod/service that it is in restarting state to avoid livenes probe race
+			_, err := exec.Command("supervisorctl", "restart", "scylla").Output()
+			if err != nil {
+				return true, errors.Wrapf(err, "restarting node has failed: %s", err)
+			}
+			mc.logger.Info(ctx, "Scylla successfully restarted")
+			return true, nil
+		case scyllaclient.OperationalModeNormal:
+			// Node can be in NORMAL mode while still starting up
+			// Last thing that scylla is doing as part of startup process is brining native transport up
+			// So we check if native port is up as sign that it is not loading
+			nativeUp, err := mc.scyllaClient.IsNativeTransportEnabled(ctx, host.String())
+			if err != nil {
+				return true, errors.Wrapf(err, "failed to get native transport status: %s", errors.WithStack(err))
+			}
+			if !nativeUp {
+				mc.logger.Info(ctx, "Node native transport is down, it is sign that node is starting up")
+				return true, nil
+			}
+			// Decommission node only if it is in normal mode and native transport is up
+			if decommissionErr := mc.scyllaClient.Decommission(ctx, host.String()); decommissionErr != nil {
+				// Decommission is long running task, so request fails due to the timeout in most cases
+				// To do not raise error when it is happening we check opMode
+				opMode, err = mc.scyllaClient.OperationMode(ctx, host.String())
+				if err == nil && (opMode.IsDecommissioned() || opMode.IsLeaving() || opMode.IsDecommissioning()) {
+					return true, nil
+				}
+				return true, errors.Wrapf(decommissionErr, "error during decommission: %s", errors.WithStack(decommissionErr))
+			}
+		case scyllaclient.OperationalModeJoining:
+			// If node is joining we need to wait till it reaches Normal state and then decommission it
+			mc.logger.Info(ctx, "Can't decommission joining node")
+			return true, nil
+		case scyllaclient.OperationalModeDecommissioned:
+			mc.logger.Info(ctx, "Node is decommissioned. Skip decommission")
+		default:
+			return true, errors.Errorf("Unexpected node operation mode: %s", opMode)
 		}
 		// Update Label to signal that decommission has completed
 		old := memberService.DeepCopy()
 		memberService.Labels[naming.DecommissionLabel] = naming.LabelValueTrue
 		if err := util.PatchService(ctx, old, memberService, mc.kubeClient); err != nil {
-			return errors.Wrap(err, "error patching MemberService")
+			return true, errors.Wrap(err, "error patching MemberService")
 		}
 	}
-
-	return nil
+	return false, nil
 }

--- a/pkg/scyllaclient/model.go
+++ b/pkg/scyllaclient/model.go
@@ -52,35 +52,65 @@ func (s NodeState) String() string {
 type OperationalMode string
 
 const (
-	OperationalModeClient         OperationalMode = "CLIENT"
-	OperationalModeDecommissioned OperationalMode = "DECOMMISSIONED"
-	OperationalModeJoining        OperationalMode = "JOINING"
-	OperationalModeLeaving        OperationalMode = "LEAVING"
-	OperationalModeNormal         OperationalMode = "NORMAL"
-	OperationalModeUnknown        OperationalMode = "UNKNOWN"
+	OperationalModeClient          OperationalMode = "CLIENT"
+	OperationalModeDecommissioned  OperationalMode = "DECOMMISSIONED"
+	OperationalModeDecommissioning OperationalMode = "DECOMMISSIONING"
+	OperationalModeJoining         OperationalMode = "JOINING"
+	OperationalModeLeaving         OperationalMode = "LEAVING"
+	OperationalModeNormal          OperationalMode = "NORMAL"
+	OperationalModeDrained         OperationalMode = "DRAINED"
+	OperationalModeDraining        OperationalMode = "DRAINING"
+	OperationalModeUnknown         OperationalMode = "UNKNOWN"
 )
 
 var (
 	operationalModeMap = map[string]OperationalMode{
-		"CLIENT":         OperationalModeClient,
-		"DECOMMISSIONED": OperationalModeDecommissioned,
-		"JOINING":        OperationalModeJoining,
-		"LEAVING":        OperationalModeLeaving,
-		"NORMAL":         OperationalModeNormal,
+		"CLIENT":          OperationalModeClient,
+		"DECOMMISSIONED":  OperationalModeDecommissioned,
+		"DECOMMISSIONING": OperationalModeDecommissioning,
+		"JOINING":         OperationalModeJoining,
+		"LEAVING":         OperationalModeLeaving,
+		"DRAINED":         OperationalModeDrained,
+		"DRAINING":        OperationalModeDraining,
+		"NORMAL":          OperationalModeNormal,
 	}
 )
 
 func (o OperationalMode) String() string {
 	switch o {
-	case "CLIENT", "DECOMMISSIONED", "JOINING", "LEAVING", "NORMAL":
+	case "CLIENT", "DECOMMISSIONED", "DECOMMISSIONING", "JOINING", "LEAVING", "NORMAL", "DRAINED", "DRAINING":
 		return string(o)
 	default:
 		return "UNKNOWN"
 	}
 }
 
-func (o OperationalMode) IsDecommisioned() bool {
+func (o OperationalMode) IsDecommissioned() bool {
 	return o == OperationalModeDecommissioned
+}
+
+func (o OperationalMode) IsDecommissioning() bool {
+	return o == OperationalModeDecommissioned
+}
+
+func (o OperationalMode) IsLeaving() bool {
+	return o == OperationalModeLeaving
+}
+
+func (o OperationalMode) IsNormal() bool {
+	return o == OperationalModeNormal
+}
+
+func (o OperationalMode) IsJoining() bool {
+	return o == OperationalModeJoining
+}
+
+func (o OperationalMode) IsDrained() bool {
+	return o == OperationalModeDrained
+}
+
+func (o OperationalMode) IsDraining() bool {
+	return o == OperationalModeDraining
 }
 
 func operationalModeFromString(str string) OperationalMode {


### PR DESCRIPTION
**Description of your changes:**
Make sidecar controller respect scylla state on decommission

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/223
Resolves https://github.com/scylladb/scylla-operator/issues/243

**Checklist:**
- [ ] ~~Documentation has been updated, if necessary.~~
- [x] Image has been built (`make docker-build`) on the last commit.
