### PR TITLE
fix(cluster_controller): shift log error on cluster update to info level

### DIFF
--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -121,7 +121,11 @@ func (cc *ClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error
 	if !reflect.DeepEqual(c.Status, copy.Status) {
 		logger.Info(ctx, "Writing cluster status.")
 		if err := cc.Status().Update(ctx, copy); err != nil {
-			logger.Error(ctx, "Failed to update cluster status", "error", err)
+			if apierrors.IsConflict(err) {
+				logger.Info(ctx, "Failed to update cluster status", "error", err)
+			} else {
+				logger.Error(ctx, "Failed to update cluster status", "error", err)
+			}
 			return reconcile.Result{}, errors.WithStack(err)
 		}
 	}


### PR DESCRIPTION
**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/217

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.