### PR TITLE
Update cluster.yaml with scylla manager agent to 2.2 to support GCP backup

### DIFF
--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -82,7 +82,7 @@ metadata:
   namespace: scylla
 spec:
   version: 4.0.0
-  agentVersion: 2.0.2
+  agentVersion: 2.2
   cpuset: true
   sysctls:
     - "fs.aio-max-nr=2097152"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.