### PR TITLE
Update manager version to 2.2 to support GCP backup

### DIFF
--- a/config/manager/manager/kustomization.yaml
+++ b/config/manager/manager/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 images:
 - name: manager
   newName: scylladb/scylla-manager
-  newTag: 2.1.2
+  newTag: 2.2.0
 - name: operator
   newName: scylladb/scylla-operator
   newTag: v0.3.0


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.