### PR TITLE
fix(preStop hook): to run supervisorctl stop scylla instead of nodetool drain

### DIFF
--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -310,8 +310,7 @@ func StatefulSetForRack(r scyllav1alpha1.RackSpec, c *scyllav1alpha1.ScyllaClust
 								PreStop: &corev1.Handler{
 									Exec: &corev1.ExecAction{
 										Command: []string{
-											"nodetool",
-											"drain",
+											"/bin/sh", "-c", "PID=$(pgrep -x scylla);supervisorctl stop scylla; while kill -0 $PID; do sleep 1; done;",
 										},
 									},
 								},


### PR DESCRIPTION
**Description of your changes:**
Fixing preStop hook to run supervisorctl stop scylla instead of nodetool drain

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/240

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.
