### PR TITLE
Make it possible to control timezone on scylla nodes

### DIFF
--- a/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
+++ b/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
@@ -1449,6 +1449,9 @@ spec:
               items:
                 type: string
               type: array
+            timeZone:
+              description: Timezone property links /etc/localtime on scylla containers to the host timezone file. Host timezone file path is calculated of Timezone value,   if Timezone starts with '/' it is assumed to be full path the the timezone file. Otherwise host file path is calculated by prepending Timezone with '/usr/share/zoneinfo/'.
+              type: string
             version:
               description: Version of Scylla to use.
               type: string

--- a/examples/eks/operator.yaml
+++ b/examples/eks/operator.yaml
@@ -1464,6 +1464,9 @@ spec:
               items:
                 type: string
               type: array
+            timeZone:
+              description: Timezone property links /etc/localtime on scylla containers to the host timezone file. Host timezone file path is calculated of Timezone value,   if Timezone starts with '/' it is assumed to be full path the the timezone file. Otherwise host file path is calculated by prepending Timezone with '/usr/share/zoneinfo/'.
+              type: string
             version:
               description: Version of Scylla to use.
               type: string

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -83,6 +83,7 @@ metadata:
 spec:
   version: 4.0.0
   agentVersion: 2.0.2
+  timeZone: GMT
   developerMode: true
   datacenter:
     name: us-east-1
@@ -90,7 +91,7 @@ spec:
       - name: us-east-1a
         scyllaConfig: "scylla-config"
         scyllaAgentConfig: "scylla-agent-config"
-        members: 3
+        members: 1
         storage:
           capacity: 5Gi
         resources:

--- a/examples/generic/operator.yaml
+++ b/examples/generic/operator.yaml
@@ -1464,6 +1464,9 @@ spec:
               items:
                 type: string
               type: array
+            timeZone:
+              description: Timezone property links /etc/localtime on scylla containers to the host timezone file. Host timezone file path is calculated of Timezone value,   if Timezone starts with '/' it is assumed to be full path the the timezone file. Otherwise host file path is calculated by prepending Timezone with '/usr/share/zoneinfo/'.
+              type: string
             version:
               description: Version of Scylla to use.
               type: string

--- a/examples/gke/operator.yaml
+++ b/examples/gke/operator.yaml
@@ -1464,6 +1464,9 @@ spec:
               items:
                 type: string
               type: array
+            timeZone:
+              description: Timezone property links /etc/localtime on scylla containers to the host timezone file. Host timezone file path is calculated of Timezone value,   if Timezone starts with '/' it is assumed to be full path the the timezone file. Otherwise host file path is calculated by prepending Timezone with '/usr/share/zoneinfo/'.
+              type: string
             version:
               description: Version of Scylla to use.
               type: string

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -54,6 +54,13 @@ type ClusterSpec struct {
 	// Example: fs.aio-max-nr=232323
 	Sysctls    []string `json:"sysctls,omitempty"`
 	ScyllaArgs string   `json:"scyllaArgs,omitempty"`
+
+	// Timezone property links /etc/localtime on scylla containers to the host timezone file.
+	// Host timezone file path is calculated of Timezone value,
+	//   if Timezone starts with '/' it is assumed to be full path the the timezone file.
+	// Otherwise host file path is calculated by prepending Timezone with '/usr/share/zoneinfo/'.
+	Timezone string `json:"timeZone,omitempty"`
+
 	// Networking config
 	Network Network `json:"network,omitempty"`
 	// Repairs specifies repair task in Scylla Manager.


### PR DESCRIPTION
**Description of your changes:**
Add timezone option to the cluster specification that links /etc/localtime on container to the particular timezone file on the host

**Which issue is resolved by this Pull Request:**
Resolves #239

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.