### PR TITLE
makefile: use nightly version on master branch

### DIFF
--- a/config/operator/operator/kustomization.yaml
+++ b/config/operator/operator/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: scylladb/scylla-operator
-  newTag: v0.3.0
+  newTag: nightly

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -1832,7 +1832,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: scylladb/scylla-operator:v0.3.0
+        image: scylladb/scylla-operator:nightly
         imagePullPolicy: IfNotPresent
         name: manager
         ports:

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "master" ]]; then
+  echo $(git describe --tags --always --abbrev=0)
+  exit 0
+fi
+
+echo 'nightly'


### PR DESCRIPTION
It makes development and testing on cloud providers easier.
And 0.3.0 isn't compatible with master.

