### PR TITLE
version: use tagged version only on release branches

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -19,7 +19,7 @@
 set -euo pipefail
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$BRANCH" != "master" ]]; then
+if [[ $BRANCH == branch-* ]]; then
   echo $(git describe --tags --always --abbrev=0)
   exit 0
 fi


### PR DESCRIPTION
Feature branches are usually developed on master, so nightly
is better choice.

