### PR TITLE
config: Add readiness probe on webhook container

### DIFF
--- a/config/operator/default/manager_webhook_patch.yaml
+++ b/config/operator/default/manager_webhook_patch.yaml
@@ -12,6 +12,11 @@ spec:
         - containerPort: 443
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 443
+          initialDelaySeconds: 5
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -1839,6 +1839,11 @@ spec:
         - containerPort: 443
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 443
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
**Description of your changes:**
No readiness probe leads to have no way to make sure that s-o is deployed and ready to accept requests.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/274

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.