### PR TITLE
alternator: Add write-isolation parameter with default 'always'

### DIFF
--- a/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
+++ b/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
@@ -45,6 +45,8 @@ spec:
                   description: Port on which to bind the Alternator API
                   format: int32
                   type: integer
+                write_isolation:
+                  type: string
               type: object
             automaticOrphanedNodeCleanup:
               description: AutomaticOrphanedNodeCleanup controls if automatic orphan node cleanup should be performed.

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -60,6 +60,8 @@ spec:
                   description: Port on which to bind the Alternator API
                   format: int32
                   type: integer
+                write_isolation:
+                  type: string
               type: object
             automaticOrphanedNodeCleanup:
               description: AutomaticOrphanedNodeCleanup controls if automatic orphan node cleanup should be performed.

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -199,7 +199,8 @@ type StorageSpec struct {
 
 type AlternatorSpec struct {
 	// Port on which to bind the Alternator API
-	Port int32 `json:"port,omitempty"`
+	Port           int32  `json:"port,omitempty"`
+	WriteIsolation string `json:"write_isolation,omitempty"`
 }
 
 func (a *AlternatorSpec) Enabled() bool {

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -40,6 +40,12 @@ var _ webhook.Defaulter = &ScyllaCluster{}
 var _ webhook.Validator = &ScyllaCluster{}
 
 func (c *ScyllaCluster) Default() {
+	if c.Spec.Alternator != nil {
+		if c.Spec.Alternator.WriteIsolation == "" {
+			c.Spec.Alternator.WriteIsolation = "always"
+		}
+	}
+
 	for i, repairTask := range c.Spec.Repairs {
 		if repairTask.StartDate == nil {
 			c.Spec.Repairs[i].StartDate = pointer.StringPtr("now")

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -220,6 +220,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 	}
 	if cluster.Spec.Alternator.Enabled() {
 		args["alternator-port"] = pointer.StringPtr(strconv.Itoa(int(cluster.Spec.Alternator.Port)))
+		args["alternator-write-isolation"] = pointer.StringPtr(cluster.Spec.Alternator.WriteIsolation)
 	}
 	// If node is being replaced
 	if addr, ok := m.ServiceLabels[naming.ReplaceLabel]; ok {


### PR DESCRIPTION
Alternator since 4.0+ requires additional parameter. Unfortunately it refuses to start even when mounted scylla.yaml contain desired value. 

**Checklist:**
- [x] Image has been built (`make docker-build`) on the last commit.