### PR TITLE
alternator: change default write isolation to only_rmw_uses_lwt

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -39,10 +39,16 @@ func (r *ScyllaCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &ScyllaCluster{}
 var _ webhook.Validator = &ScyllaCluster{}
 
+const (
+	AlternatorWriteIsolationAlways         = "always"
+	AlternatorWriteIsolationForbidRMW      = "forbid_rmw"
+	AlternatorWriteIsolationOnlyRMWUsesLWT = "only_rmw_uses_lwt"
+)
+
 func (c *ScyllaCluster) Default() {
 	if c.Spec.Alternator != nil {
 		if c.Spec.Alternator.WriteIsolation == "" {
-			c.Spec.Alternator.WriteIsolation = "always"
+			c.Spec.Alternator.WriteIsolation = AlternatorWriteIsolationOnlyRMWUsesLWT
 		}
 	}
 


### PR DESCRIPTION
"always" is too restrictive and too slow to be a good default.
