### PR TITLE
[stress script] remove comma in generated yaml file

### DIFF
--- a/scripts/cass-stress-gen.py
+++ b/scripts/cass-stress-gen.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
       args.limit = 'throttle={}/s'.format(args.limit)
     if args.nodeselector:
       parts = args.nodeselector.split("=")
-      args.nodeselector = "{}: {},".format(parts[0], parts[1])
+      args.nodeselector = "{}: {}".format(parts[0], parts[1])
 
     # Create manifests
     manifests = create_job_list(args)


### PR DESCRIPTION
**Description of your changes:**

My change fix an issue related to nodeselector option of script cass-stress-gen.py.


**Which issue is resolved by this Pull Request:**
Resolves #

My change fix an issue in generated yam file to stress scylla DB.
A comma is added at the end of the line in the generated yaml file.
This comma create an error during K8S ingestion.
The fix just remove this comma in python script.

