### PR TITLE
alternator: make write-isolation optional w/o default value

### DIFF
--- a/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
+++ b/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
@@ -45,7 +45,7 @@ spec:
                   description: Port on which to bind the Alternator API
                   format: int32
                   type: integer
-                write_isolation:
+                writeIsolation:
                   type: string
               type: object
             automaticOrphanedNodeCleanup:

--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -185,12 +185,17 @@ spec:
   version: 4.0.0
   alternator:
     port: 8000
+    writeIsolation: only_rmw_uses_lwt
   agentVersion: 2.0.2
   developerMode: true
   datacenter:
     name: us-east-1
 ```
 You can specify whichever port you want.
+
+You must provide desired write isolation, supported values are: "always", "forbid_rmw", "only_rmw_uses_lwt".
+Difference between those isolation levels can be found in Scylla Alternator documentation.
+
 Once this is done the regular CQL ports will no longer be available, the cluster is a pure Alienator cluster.
 
 ## Accessing the Database

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -60,7 +60,7 @@ spec:
                   description: Port on which to bind the Alternator API
                   format: int32
                   type: integer
-                write_isolation:
+                writeIsolation:
                   type: string
               type: object
             automaticOrphanedNodeCleanup:

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -200,7 +200,7 @@ type StorageSpec struct {
 type AlternatorSpec struct {
 	// Port on which to bind the Alternator API
 	Port           int32  `json:"port,omitempty"`
-	WriteIsolation string `json:"write_isolation,omitempty"`
+	WriteIsolation string `json:"writeIsolation,omitempty"`
 }
 
 func (a *AlternatorSpec) Enabled() bool {

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -39,19 +39,7 @@ func (r *ScyllaCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &ScyllaCluster{}
 var _ webhook.Validator = &ScyllaCluster{}
 
-const (
-	AlternatorWriteIsolationAlways         = "always"
-	AlternatorWriteIsolationForbidRMW      = "forbid_rmw"
-	AlternatorWriteIsolationOnlyRMWUsesLWT = "only_rmw_uses_lwt"
-)
-
 func (c *ScyllaCluster) Default() {
-	if c.Spec.Alternator != nil {
-		if c.Spec.Alternator.WriteIsolation == "" {
-			c.Spec.Alternator.WriteIsolation = AlternatorWriteIsolationOnlyRMWUsesLWT
-		}
-	}
-
 	for i, repairTask := range c.Spec.Repairs {
 		if repairTask.StartDate == nil {
 			c.Spec.Repairs[i].StartDate = pointer.StringPtr("now")

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -220,7 +220,9 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 	}
 	if cluster.Spec.Alternator.Enabled() {
 		args["alternator-port"] = pointer.StringPtr(strconv.Itoa(int(cluster.Spec.Alternator.Port)))
-		args["alternator-write-isolation"] = pointer.StringPtr(cluster.Spec.Alternator.WriteIsolation)
+		if cluster.Spec.Alternator.WriteIsolation != "" {
+			args["alternator-write-isolation"] = pointer.StringPtr(cluster.Spec.Alternator.WriteIsolation)
+		}
 	}
 	// If node is being replaced
 	if addr, ok := m.ServiceLabels[naming.ReplaceLabel]; ok {


### PR DESCRIPTION
2020.1.x doesn't support this parameter, and this version couldn't start
because of the defualt value.

This change also makes operator to behave simillar to Scylla, where user
have to provide his desired write isolation.
