### PR TITLE
cluster: remove PVC finalizers prior deletion (#215)

### DIFF
--- a/config/operator/rbac/role.yaml
+++ b/config/operator/rbac/role.yaml
@@ -30,6 +30,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -1704,6 +1704,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/pkg/controllers/cluster/actions/replace.go
+++ b/pkg/controllers/cluster/actions/replace.go
@@ -172,7 +172,7 @@ func (a *RackReplaceNode) replaceNode(ctx context.Context, state *State, member 
 	}
 
 	a.Logger.Info(ctx, "Deleting member PVC", "member", member.Name, "pvc", pvc.Name)
-	if err := cc.Delete(ctx, pvc); err != nil {
+	if err := cc.Delete(ctx, pvc, client.GracePeriodSeconds(0)); err != nil {
 		return errors.Wrap(err, "failed to delete pvc")
 	}
 	state.recorder.Event(c, corev1.EventTypeNormal, naming.SuccessSynced,

--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -92,7 +92,7 @@ func New(ctx context.Context, mgr ctrl.Manager, logger log.Logger) (*ClusterReco
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;delete;update
 // +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controllers/cluster/controller_integration_test.go
+++ b/pkg/controllers/cluster/controller_integration_test.go
@@ -124,6 +124,7 @@ var _ = Describe("Cluster controller", func() {
 			for _, replicas := range clusterScaleSteps(rack.Members) {
 				Expect(assertRackScaled(ctx, rack, scylla, replicas)).To(Succeed())
 				Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+				Expect(sstStub.CreatePVCs(ctx, scylla)).To(Succeed())
 			}
 		})
 

--- a/pkg/test/integration/statefulset.go
+++ b/pkg/test/integration/statefulset.go
@@ -159,12 +159,17 @@ func (s *StatefulSetOperatorStub) CreatePVCs(ctx context.Context, cluster *scyll
 		for _, pod := range pods.Items {
 			pv := &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "pv-1337",
+					GenerateName: "pv-1337",
 				},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Local: &corev1.LocalVolumeSource{
 							Path: "/random-path",
+						},
+					},
+					NodeAffinity: &corev1.VolumeNodeAffinity{
+						Required: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{{}},
 						},
 					},
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
@@ -194,7 +199,8 @@ func (s *StatefulSetOperatorStub) CreatePVCs(ctx context.Context, cluster *scyll
 					},
 				},
 			}
-			if err := s.env.Create(ctx, pvc); err != nil {
+
+			if _, err := controllerutil.CreateOrUpdate(ctx, s.env, pvc, func() error { return nil }); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Finalizers in PVC caused a race between statefulset controller
and pvc provisioner. Pod spawned on next available node was missing
PVC and manual intervention was needed.
Removing finalizers from PVC prior to PVC and Pod deletion seems to
help.

Fixes #215
