### PR TITLE
cluster: remove unused sidecarImage field (#283)

### DIFF
--- a/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
+++ b/config/operator/crd/bases/scylla.scylladb.com_scyllaclusters.yaml
@@ -1436,19 +1436,6 @@ spec:
               type: string
             scyllaArgs:
               type: string
-            sidecarImage:
-              description: User-provided image for the sidecar that replaces default.
-              properties:
-                repository:
-                  description: Repository to pull the image from.
-                  type: string
-                version:
-                  description: Version of the image.
-                  type: string
-              required:
-              - repository
-              - version
-              type: object
             sysctls:
               description: 'Sysctl properties to be applied during initialization given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
               items:

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -1451,19 +1451,6 @@ spec:
               type: string
             scyllaArgs:
               type: string
-            sidecarImage:
-              description: User-provided image for the sidecar that replaces default.
-              properties:
-                repository:
-                  description: Repository to pull the image from.
-                  type: string
-                version:
-                  description: Version of the image.
-                  type: string
-              required:
-              - repository
-              - version
-              type: object
             sysctls:
               description: 'Sysctl properties to be applied during initialization given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
               items:

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -49,8 +49,6 @@ type ClusterSpec struct {
 	AutomaticOrphanedNodeCleanup bool `json:"automaticOrphanedNodeCleanup,omitempty"`
 	// Datacenter that will make up this cluster.
 	Datacenter DatacenterSpec `json:"datacenter"`
-	// User-provided image for the sidecar that replaces default.
-	SidecarImage *ImageSpec `json:"sidecarImage,omitempty"`
 	// Sysctl properties to be applied during initialization
 	// given as a list of key=value pairs.
 	// Example: fs.aio-max-nr=232323

--- a/pkg/api/v1alpha1/cluster_validation.go
+++ b/pkg/api/v1alpha1/cluster_validation.go
@@ -106,11 +106,6 @@ func checkTransitions(old, new *ScyllaCluster) error {
 		return errors.Errorf("repository change is currently not supported, old=%v, new=%v", *old.Spec.Repository, *new.Spec.Repository)
 	}
 
-	// Check that sidecarImage remained the same
-	if !reflect.DeepEqual(old.Spec.SidecarImage, new.Spec.SidecarImage) {
-		return errors.Errorf("change of sidecarImage is currently not supported")
-	}
-
 	// Check that the datacenter name didn't change
 	if old.Spec.Datacenter.Name != new.Spec.Datacenter.Name {
 		return errors.Errorf("change of datacenter name is currently not supported")

--- a/pkg/api/v1alpha1/cluster_validation_test.go
+++ b/pkg/api/v1alpha1/cluster_validation_test.go
@@ -91,12 +91,6 @@ func TestCheckTransitions(t *testing.T) {
 			allowed: false,
 		},
 		{
-			name:    "sidecarImage changed",
-			old:     unit.NewSingleRackCluster(3),
-			new:     sidecarImageChanged(unit.NewSingleRackCluster(3)),
-			allowed: false,
-		},
-		{
 			name:    "dcName changed",
 			old:     unit.NewSingleRackCluster(3),
 			new:     unit.NewDetailedSingleRackCluster("test-cluster", "test-ns", "repo", "2.3.1", "new-dc", "test-rack", 3),
@@ -154,14 +148,6 @@ func resourceChanged(c *v1alpha1.ScyllaCluster) *v1alpha1.ScyllaCluster {
 
 func rackDeleted(c *v1alpha1.ScyllaCluster) *v1alpha1.ScyllaCluster {
 	c.Spec.Datacenter.Racks = nil
-	return c
-}
-
-func sidecarImageChanged(c *v1alpha1.ScyllaCluster) *v1alpha1.ScyllaCluster {
-	c.Spec.SidecarImage = &v1alpha1.ImageSpec{
-		Version:    "1.0.0",
-		Repository: "my-private-repo",
-	}
 	return c
 }
 

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -131,11 +131,6 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		**out = **in
 	}
 	in.Datacenter.DeepCopyInto(&out.Datacenter)
-	if in.SidecarImage != nil {
-		in, out := &in.SidecarImage, &out.SidecarImage
-		*out = new(ImageSpec)
-		**out = **in
-	}
 	if in.Sysctls != nil {
 		in, out := &in.Sysctls, &out.Sysctls
 		*out = make([]string, len(*in))


### PR DESCRIPTION
Fixes #283

**Checklist:**
- [x] Image has been built (`make docker-build`) on the last commit.