### PR TITLE
repairTask: fix intensity to be float on manager side

### DIFF
--- a/pkg/controllers/manager/types.go
+++ b/pkg/controllers/manager/types.go
@@ -3,6 +3,7 @@
 package manager
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -57,8 +58,9 @@ func (r RepairTask) ToManager() (*mermaidclient.Task, error) {
 			props["fail_fast"] = true
 		}
 	}
+
 	if r.Intensity != nil {
-		props["intensity"] = *r.Intensity
+		props["intensity"], _ = strconv.ParseFloat(*r.Intensity, 64)
 	}
 	if r.Parallel != nil {
 		props["parallel"] = *r.Parallel


### PR DESCRIPTION
**Description of your changes:**
S-o submits intensity as string to manager, while manager expects it to be float64. 

**Which issue is resolved by this Pull Request:**
Resolves #309

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.