### PR TITLE
docs: added multiversion_regex_builder

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,13 +1,11 @@
 name: Release docs
 
 on:
-  workflow_dispatch:
   push:
     branches:
-      - master
-      - 'branch-**'
-    paths:
-      - 'docs/**'
+    - master
+    tags:       
+    - '**'
 
 jobs:
   release:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -45,7 +45,7 @@ singlehtml: setup
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
 .PHONY: epub
-epub: 	setup
+epub: setup
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
@@ -66,11 +66,13 @@ dummy: 	setup
 linkcheck: setup
 	$(SPHINXBUILD) -b linkcheck $(SOURCEDIR) $(BUILDDIR)/linkcheck
 
-GIT_BRANCH = $(shell git branch --show-current)
-
 .PHONY: multiversion
 multiversion: setup
 	@mkdir -p $(HOME)/.cache/pypoetry/virtualenvs
-	$(POETRY) run sphinx-multiversion -D smv_branch_whitelist=$(GIT_BRANCH) -D smv_outputdir_format=$(GIT_BRANCH:branch-%=%) $(SOURCEDIR) $(BUILDDIR)/dirhtml
+	$(POETRY) run sphinx-multiversion $(SOURCEDIR) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+.PHONY: multiversionpreview
+multiversionpreview: multiversion
+	$(POETRY) run python3 -m http.server 5500 --directory $(BUILDDIR)/dirhtml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@ from datetime import date
 from sphinx.util import logging
 import recommonmark
 from recommonmark.transform import AutoStructify
+from sphinx_scylladb_theme.utils import multiversion_regex_builder
 
 logger = logging.getLogger(__name__)
 
@@ -151,9 +152,11 @@ redirects_file = "_utils/redirections.yaml"
 
 # -- Options for multiversion extension ----------------------------------
 # Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = r'^.*$'
+TAGS = []
+smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = r"^master$"
+BRANCHES = ['master']
+smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"
 # Pattern for released versions


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/86

The new built-in function `multiversion_regex_builder(versions)` enables maintainers to define versions in an array instead of defining complex regex expressions.

## Example

**Before:** 

`smv_tag_whitelist = r'\b(3.22.0-scylla|3.21.0-scylla|3.22.3-scylla|3.24.0-scylla)\b'`

**Now:** 

`TAGS = ['3.21.0-scylla', '3.22.0-scylla', '3.22.3-scylla', '3.24.0-scylla']`

The PR  also adds a new command ``make multiversionpreview`` that launches a webserver to quickly preview the multiversion build.

## How to test this PR

1. Run ``make multiversionpreview``.
2. Open http://0.0.0.0:5500 in a new browser tab.
3. You should see folders for every version listed in ``TAGS`` (conf.py).