### PR TITLE
remove redundant build stage from dockerfile

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -19,11 +19,6 @@ dockers:
       - scylla-operator
     skip_push: false
     dockerfile: Dockerfile
-    extra_files:
-      - go.mod
-      - go.sum
-      - pkg
-      - vendor
 # Do not make github release
 release:
   disable: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,17 +11,12 @@ builds:
     goos:
       - linux
     goarch:
-        - amd64
+      - amd64
 
 dockers:
-    - image_templates:
-        - 'scylladb/scylla-operator:{{ .Tag }}'
-      binaries:
-          - scylla-operator
-      skip_push: auto
-      dockerfile: Dockerfile
-      extra_files:
-        - go.mod
-        - go.sum
-        - pkg
-        - vendor
+  - image_templates:
+      - 'scylladb/scylla-operator:{{ .Tag }}'
+    binaries:
+      - scylla-operator
+    skip_push: auto
+    dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,4 @@
-# Build the manager binary
-FROM golang:1.13 as builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy source
-COPY . .
-
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o scylla-operator github.com/scylladb/scylla-operator/pkg/cmd
-
 FROM alpine:3.12
 WORKDIR /
-COPY --from=builder /workspace/scylla-operator .
-
+COPY scylla-operator .
 ENTRYPOINT ["/scylla-operator"]


### PR DESCRIPTION
**Description of your changes:**
Currently the binary is built twice: first by the goreleaser and then in an additional build stage in Docker. This commit removes the unnecessary containerised build stage.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.