### PR TITLE
docs: trigger build only if there are changes

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
     - master
-    tags:       
-    - '**'
-
+    paths:
+    - 'docs/**'
 jobs:
   release:
     name: Release docs


### PR DESCRIPTION
This PR will trigger the docs build only if there are changes in the docs folder. It also does not trigger builds when there are new tags, since all versions are already recreated every time the master branch receives a new commit.

There is no way to test this small change locally but other projects like sphinx-scylladb-theme and the python-driver are already using this new rule.