### PR TITLE
cluster: Register HTTP live/readyness probes (#308)

### DIFF
--- a/config/operator/default/kustomization.yaml
+++ b/config/operator/default/kustomization.yaml
@@ -22,6 +22,7 @@ bases:
 patchesStrategicMerge:
 - manager_webhook_patch.yaml
 - webhookcainjection_patch.yaml
+- probes_patch.yaml
 
 vars:
 - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR

--- a/config/operator/default/manager_webhook_patch.yaml
+++ b/config/operator/default/manager_webhook_patch.yaml
@@ -12,11 +12,6 @@ spec:
         - containerPort: 443
           name: webhook-server
           protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 443
-          initialDelaySeconds: 5
-          periodSeconds: 10
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/config/operator/default/probes_patch.yaml
+++ b/config/operator/default/probes_patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -1922,16 +1922,23 @@ spec:
               fieldPath: metadata.namespace
         image: scylladb/scylla-operator:nightly
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
         name: manager
         ports:
         - containerPort: 443
           name: webhook-server
           protocol: TCP
         readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+            scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
-          tcpSocket:
-            port: 443
         resources:
           limits:
             cpu: 100m

--- a/pkg/cmd/operator.go
+++ b/pkg/cmd/operator.go
@@ -36,7 +36,8 @@ func newOperatorCmd(ctx context.Context, logger log.Logger, level zap.AtomicLeve
 			cfg := ctrl.GetConfigOrDie()
 			// Create a new Cmd to provide shared dependencies and start components
 			mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-				Scheme: scheme,
+				Scheme:             scheme,
+				MetricsBindAddress: fmt.Sprintf(":%d", naming.MetricsPort),
 			})
 			if err != nil {
 				logger.Fatal(ctx, "unable to create manager", "error", err)

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -83,4 +83,5 @@ const (
 	ReadinessProbePath = "/readyz"
 	LivenessProbePath  = "/healthz"
 	ProbePort          = 8080
+	MetricsPort        = 8081
 )


### PR DESCRIPTION
Previous probe was querying webhook server trying to establish TCP session
but webhook service expect TLS traffic.
This lack of TLS handshake generated EOF message every 10s.

Fixes #308
