### PR TITLE
config: remove operator memory limit (#357) 

### DIFF
--- a/config/operator/operator/operator.yaml
+++ b/config/operator/operator/operator.yaml
@@ -41,9 +41,6 @@ spec:
         imagePullPolicy: IfNotPresent
         name: manager
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -1940,9 +1940,6 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
Measurements show Operator can use 50MB of RSS memory
when multpile racks are added to Scylla cluster.
Although it scales with number of objects, so no limit
is better. User may define his own limits if needed.

![Selection_225](https://user-images.githubusercontent.com/3951334/106748395-78b6c880-6625-11eb-8009-3687d08afb94.png)


Fixes #357

