### PR TITLE
Add support for discovering rack name directly from nodes

### DIFF
--- a/pkg/cmd/options/operator.go
+++ b/pkg/cmd/options/operator.go
@@ -1,7 +1,10 @@
 package options
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +17,7 @@ type OperatorOptions struct {
 	*CommonOptions
 	Image                  string
 	EnableAdmissionWebhook bool
+	RackFromNode           bool
 }
 
 func GetOperatorOptions() *OperatorOptions {
@@ -24,6 +28,7 @@ func (o *OperatorOptions) AddFlags(cmd *cobra.Command) {
 	o.CommonOptions.AddFlags(cmd)
 	cmd.Flags().StringVar(&o.Image, "image", "", "image of the operator used")
 	cmd.Flags().BoolVar(&o.EnableAdmissionWebhook, "enable-admission-webhook", true, "enable the admission webhook")
+	cmd.Flags().BoolVar(&o.RackFromNode, "rack-from-node", os.Getenv(naming.EnvVarRackFromNode) == "true", "Use node labels instead of pod labels for rack")
 }
 
 func (o *OperatorOptions) Validate() error {

--- a/pkg/cmd/options/sidecar.go
+++ b/pkg/cmd/options/sidecar.go
@@ -15,7 +15,8 @@ var sidecarOpts = &sidecarOptions{
 
 type sidecarOptions struct {
 	*CommonOptions
-	CPU string
+	CPU          string
+	RackFromNode bool
 }
 
 func GetSidecarOptions() *sidecarOptions {
@@ -25,6 +26,7 @@ func GetSidecarOptions() *sidecarOptions {
 func (o *sidecarOptions) AddFlags(cmd *cobra.Command) {
 	o.CommonOptions.AddFlags(cmd)
 	cmd.Flags().StringVar(&o.CPU, "cpu", os.Getenv(naming.EnvVarCPU), "number of cpus to use")
+	cmd.Flags().BoolVar(&o.RackFromNode, "rack-from-node", os.Getenv(naming.EnvVarRackFromNode) == "true", "Use node labels instead of pod labels for rack")
 }
 
 func (o *sidecarOptions) Validate() error {

--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -3,9 +3,11 @@ package resource
 import (
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/v1"
+	"github.com/scylladb/scylla-operator/pkg/cmd/options"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/util"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	appsv1 "k8s.io/api/apps/v1"
@@ -246,7 +248,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, sidecarI
 									},
 								},
 								{
-									Name: "CPU",
+									Name: naming.EnvVarCPU,
 									ValueFrom: &corev1.EnvVarSource{
 										ResourceFieldRef: &corev1.ResourceFieldSelector{
 											ContainerName: naming.ScyllaContainerName,
@@ -254,6 +256,10 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, sidecarI
 											Divisor:       resource.MustParse("1"),
 										},
 									},
+								},
+								{
+									Name:  naming.EnvVarRackFromNode,
+									Value: strconv.FormatBool(options.GetSidecarOptions().RackFromNode),
 								},
 							},
 							Resources: r.Resources,

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/magiconair/properties"
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-log"
-	"github.com/scylladb/scylla-operator/pkg/api/v1"
+	v1 "github.com/scylladb/scylla-operator/pkg/api/v1"
 	"github.com/scylladb/scylla-operator/pkg/cmd/options"
 	"github.com/scylladb/scylla-operator/pkg/controllers/sidecar/identity"
 	"github.com/scylladb/scylla-operator/pkg/naming"
@@ -28,8 +28,10 @@ import (
 
 const (
 	configDirScylla                     = "/etc/scylla"
+	configDirScyllaD                    = "/etc/scylla.d"
 	scyllaYAMLPath                      = configDirScylla + "/" + naming.ScyllaConfigName
 	scyllaYAMLConfigMapPath             = naming.ScyllaConfigDirName + "/" + naming.ScyllaConfigName
+	scyllaIOPropertiesPath              = configDirScyllaD + "/" + naming.ScyllaIOPropertiesName
 	scyllaRackDCPropertiesPath          = configDirScylla + "/" + naming.ScyllaRackDCPropertiesName
 	scyllaRackDCPropertiesConfigMapPath = naming.ScyllaConfigDirName + "/" + naming.ScyllaRackDCPropertiesName
 	entrypointPath                      = "/docker-entrypoint.py"
@@ -257,6 +259,12 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		} else {
 			appendScyllaArguments(ctx, s, cluster.Spec.ScyllaArgs, args)
 		}
+	}
+
+	if _, err := os.Stat(scyllaIOPropertiesPath); err == nil {
+		s.logger.Info(ctx, "Scylla IO properties are already set, skipping io tuning (feature only supported for Scylla >= 3.3)")
+		ioSetup := "0"
+		args["io-setup"] = &ioSetup
 	}
 
 	var argsList []string

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -218,6 +218,9 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		"overprovisioned":       pointer.StringPtr("0"),
 		"smp":                   pointer.StringPtr(strconv.Itoa(shards)),
 	}
+	if cluster.Spec.Network.HostNetworking {
+		args["broadcast-rpc-address"] = &m.IP
+	}
 	if cluster.Spec.Alternator.Enabled() {
 		args["alternator-port"] = pointer.StringPtr(strconv.Itoa(int(cluster.Spec.Alternator.Port)))
 		if cluster.Spec.Alternator.WriteIsolation != "" {

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -78,6 +78,7 @@ const (
 	ScyllaClientConfigFileName   = "scylla-client.yaml"
 	ScyllaConfigName             = "scylla.yaml"
 	ScyllaRackDCPropertiesName   = "cassandra-rackdc.properties"
+	ScyllaIOPropertiesName       = "io_properties.yaml"
 
 	DataDir = "/var/lib/scylla"
 

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -49,6 +49,7 @@ const (
 	EnvVarEnvVarPodName = "POD_NAME"
 	EnvVarPodNamespace  = "POD_NAMESPACE"
 	EnvVarCPU           = "CPU"
+	EnvVarRackFromNode  = "RACK_FROM_NODE"
 )
 
 // Recorder Values


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

The current system (one statefulset per rack) makes managing tens of racks impractical.
With this change it's possible to make the sidecar get the rack name directly from a label on the node.

**Which issue is resolved by this Pull Request:**
None open

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.
- [ ] Add testing 