### PR TITLE
Convert ginkgo based unit test to golang test framework

### DIFF
--- a/pkg/controllers/cluster/cluster_controller_test.go
+++ b/pkg/controllers/cluster/cluster_controller_test.go
@@ -4,55 +4,91 @@ package cluster
 
 import (
 	"context"
+	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
-	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-operator/pkg/cmd/options"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
-var _ = Describe("Cluster controller", func() {
-
-	DescribeTable("Operator image", func(containerImages []string, expectedImage string) {
-		const (
-			namespace = "ns"
-			name      = "name"
-		)
-		opts := &options.OperatorOptions{
-			CommonOptions: &options.CommonOptions{
-				Name:      name,
-				Namespace: namespace,
+func TestGetOperatorImage(t *testing.T) {
+	tt := []struct {
+		name            string
+		containerImages []string
+		expectedImage   string
+		expectedError   error
+	}{
+		{
+			name: "single correct",
+			containerImages: []string{
+				"scylladb/scylla-operator:0.3.0",
 			},
-		}
-
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      name,
+			expectedImage: "scylladb/scylla-operator:0.3.0",
+			expectedError: nil,
+		},
+		{
+			name: "operator with sidecar",
+			containerImages: []string{
+				"scylladb/scylla-operator:0.3.0",
+				"random/sidecar:latest",
 			},
-		}
-		for _, ci := range containerImages {
-			pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
-				Image: ci,
-			})
-		}
+			expectedImage: "scylladb/scylla-operator:0.3.0",
+			expectedError: nil,
+		},
+		{
+			name: "custom operator",
+			containerImages: []string{
+				"random/my-scylla-operator:0.3.0",
+			},
+			expectedImage: "random/my-scylla-operator:0.3.0",
+			expectedError: nil,
+		},
+		{
+			name: "incorrect operator",
+			containerImages: []string{
+				"random/my-operator:0.3.0",
+			},
+			expectedImage: "",
+			expectedError: errors.New("cannot find scylla operator container in pod spec"),
+		},
+	}
 
-		kubeClientFake := kubefake.NewSimpleClientset(pod)
-		image, err := getOperatorImage(context.Background(), kubeClientFake, opts)
-		if expectedImage == "" {
-			Expect(err).To(HaveOccurred())
-		} else {
-			Expect(err).ToNot(HaveOccurred())
-			Expect(image).To(Equal(expectedImage))
-		}
-	},
-		Entry("single correct", []string{"scylladb/scylla-operator:0.3.0"}, "scylladb/scylla-operator:0.3.0"),
-		Entry("operator with sidecar", []string{"scylladb/scylla-operator:0.3.0", "random/sidecar:latest"}, "scylladb/scylla-operator:0.3.0"),
-		Entry("custom operator", []string{"random/my-scylla-operator:0.3.0"}, "random/my-scylla-operator:0.3.0"),
-		Entry("incorrect operator", []string{"random/my-operator:0.3.0"}, ""),
-	)
+	for _, tc := range tt {
+		t.Run(t.Name(), func(t *testing.T) {
+			const (
+				namespace = "ns"
+				name      = "name"
+			)
+			opts := &options.OperatorOptions{
+				CommonOptions: &options.CommonOptions{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+			}
+			for _, ci := range tc.containerImages {
+				pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+					Image: ci,
+				})
+			}
 
-})
+			kubeClientFake := kubefake.NewSimpleClientset(pod)
+			image, err := getOperatorImage(context.Background(), kubeClientFake, opts)
+			// Can't use DeepEqual because of different stacks in pkg/error
+			if (err == nil && tc.expectedError != nil) || (err != nil && tc.expectedError == nil) || (err != tc.expectedError && err.Error() != tc.expectedError.Error()) {
+				t.Errorf("expected error %#v, got %#v", tc.expectedError, err)
+			}
+
+			if image != tc.expectedImage {
+				t.Errorf("expected image %q, got %q", tc.expectedImage, image)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description of your changes:**
Ginkgo tests aren't run in the regular unit tests yet this unit is registering using ginkgo framework so it won't be run. Converting it to standard golang table based tests makes sure it runs and we don't mix frameworks.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.