### PR TITLE
replace: eliminate conflict during cleanup of PVC finalizers (#350) 

### DIFF
--- a/pkg/controllers/cluster/util/patch.go
+++ b/pkg/controllers/cluster/util/patch.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
@@ -81,4 +82,17 @@ func PatchService(ctx context.Context, old, new *corev1.Service, kubeClient kube
 
 	_, err = kubeClient.CoreV1().Services(old.Namespace).Patch(ctx, old.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 	return err
+}
+
+// The StrategicMergePatchFunc type is an adapter to allow the use of ordinary functions as Strategic Merge Patch.
+type StrategicMergePatchFunc func(obj runtime.Object) ([]byte, error)
+
+// Type returns PatchType of Strategic Merge Patch
+func (f StrategicMergePatchFunc) Type() types.PatchType {
+	return types.StrategicMergePatchType
+}
+
+// Data returns the raw data representing the patch.
+func (f StrategicMergePatchFunc) Data(obj runtime.Object) ([]byte, error) {
+	return f(obj)
 }


### PR DESCRIPTION
Operator updated PVC which is subject for removal, so this is expected
that update may conflict.
To avoid conflicts instead updating whole resource, patch is used.

Fixes #350
