### PR TITLE
Tolerate flakes on promotions

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -64,6 +64,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: make --warn-undefined-variables
+    - name: Make sure new unit tests aren't flaky
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        echo "GO_TEST_COUNT=-count=3" | tee -a ${GITHUB_ENV}
     - name: Test
       run: make test --warn-undefined-variables
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -90,6 +90,10 @@ jobs:
     - name: Install deps
       if: ${{ steps['cache-tools'].outputs['cache-hit'] != 'true' }}
       run: ./install-dependencies.sh
+    - name: Tolerate flakes on promotion jobs
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        echo "GO_TEST_EXTRA_ARGS=-ginkgo.flakeAttempts=5" | tee -a ${GITHUB_ENV}
     - name: Test integration
       run: make test-integration --warn-undefined-variables
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ GO_BUILD_BINDIR ?=
 GO_LD_EXTRA_FLAGS ?=
 GO_TEST_PACKAGES :=./pkg/... # ./cmd/...
 GO_TEST_FLAGS ?=-race
+GO_TEST_COUNT ?=
 GO_TEST_EXTRA_FLAGS ?=
 GO_TEST_ARGS ?=
 GO_TEST_EXTRA_ARGS ?=
@@ -155,11 +156,12 @@ update: update-gofmt
 .PHONY: update
 
 test-unit:
-	$(GO) test $(GO_TEST_FLAGS) $(GO_TEST_EXTRA_FLAGS) $(GO_TEST_PACKAGES) $(if $(GO_TEST_ARGS)$(GO_TEST_EXTRA_ARGS),-args $(GO_TEST_ARGS) $(GO_TEST_EXTRA_ARGS))
+	$(GO) test $(GO_TEST_COUNT) $(GO_TEST_FLAGS) $(GO_TEST_EXTRA_FLAGS) $(GO_TEST_PACKAGES) $(if $(GO_TEST_ARGS)$(GO_TEST_EXTRA_ARGS),-args $(GO_TEST_ARGS) $(GO_TEST_EXTRA_ARGS))
 .PHONY: test-unit
 
 test-integration: GO_TEST_PACKAGES :=./test/integration/...
-test-integration: GO_TEST_FLAGS += -count=1 -p=1 -timeout 30m -v
+test-integration: GO_TEST_COUNT :=-count=1
+test-integration: GO_TEST_FLAGS += -p=1 -timeout 30m -v
 test-integration: GO_TEST_ARGS += -ginkgo.progress
 test-integration: test-unit
 .PHONY: test-integration

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,12 @@ GO_BUILD_PACKAGES_EXPANDED ?=$(shell $(GO) list $(GO_BUILD_PACKAGES))
 go_build_binaries =$(notdir $(GO_BUILD_PACKAGES_EXPANDED))
 GO_BUILD_FLAGS ?=-trimpath
 GO_BUILD_BINDIR ?=
-GO_LD_EXTRAFLAGS ?=
+GO_LD_EXTRA_FLAGS ?=
 GO_TEST_PACKAGES :=./pkg/... # ./cmd/...
 GO_TEST_FLAGS ?=-race
+GO_TEST_EXTRA_FLAGS ?=
 GO_TEST_ARGS ?=
+GO_TEST_EXTRA_ARGS ?=
 
 
 define version-ldflags
@@ -153,11 +155,12 @@ update: update-gofmt
 .PHONY: update
 
 test-unit:
-	$(GO) test $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES) $(if $(GO_TEST_ARGS),-args $(GO_TEST_ARGS))
+	$(GO) test $(GO_TEST_FLAGS) $(GO_TEST_EXTRA_FLAGS) $(GO_TEST_PACKAGES) $(if $(GO_TEST_ARGS)$(GO_TEST_EXTRA_ARGS),-args $(GO_TEST_ARGS) $(GO_TEST_EXTRA_ARGS))
 .PHONY: test-unit
 
 test-integration: GO_TEST_PACKAGES :=./test/integration/...
-test-integration: GO_TEST_FLAGS += -count=1 -p=1 -timeout 30m
+test-integration: GO_TEST_FLAGS += -count=1 -p=1 -timeout 30m -v
+test-integration: GO_TEST_ARGS += -ginkgo.progress
 test-integration: test-unit
 .PHONY: test-integration
 


### PR DESCRIPTION
**Description of your changes:**
When a promotion job fails, it isn't retried and we miss e.g. updating the latest image on GH to match master. This change setup ginkgo to retry the failed jobs up to 9 times. Pull-requests don't retry flakes so we don't open ourselves to merging new flakes.
