### PR TITLE
dockerfile: fix binary path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ FROM docker.io/library/ubuntu:20.04
 SHELL ["/bin/bash", "-euEo", "pipefail", "-c"]
 # sidecar-injection container and existing installations use binary from root,
 # we have to keep it there until we figure out how to properly upgrade them.
-COPY --from=builder /go/src/github.com/scylladb/scylla-operator/scylla-operator /
-RUN ln -s /scylla-operator /usr/bin/scylla-operator
+COPY --from=builder /go/src/github.com/scylladb/scylla-operator/scylla-operator /usr/bin/
+RUN ln -s /usr/bin/scylla-operator /scylla-operator
 ENTRYPOINT ["/usr/bin/scylla-operator"]


### PR DESCRIPTION
Sidecar copied symbolic link into Scylla image which
pointed to not existing binary in root dir.
