### PR TITLE
helm: use git tag as chart version 

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -151,7 +151,9 @@ jobs:
     - name: Determine promotion tag for scheduled job
       if: ${{ github.event_name == 'schedule' }}
       run: |
-        echo "IMAGE_TAG=nightly" | tee -a ${GITHUB_ENV}
+        IMAGE_TAG=nightly
+        echo "IMAGE_TAG=${IMAGE_TAG}" | tee -a ${GITHUB_ENV}
+        echo "HELM_CHART_VERSION_SUFFIX=-${IMAGE_TAG}" | tee -a ${GITHUB_ENV}
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ HELM_CHARTS ?=scylla-operator scylla-manager scylla
 HELM_CHARTS_DIR ?=helm
 HELM_LOCAL_REPO ?=$(HELM_CHARTS_DIR)/repo/$(HELM_CHANNEL)
 HELM_APP_VERSION ?=$(IMAGE_TAG)
-HELM_CHART_VERSION ?=$(GIT_TAG)-$(HELM_APP_VERSION)
+HELM_CHART_VERSION_SUFFIX ?=
+HELM_CHART_VERSION ?=$(GIT_TAG)$(HELM_CHART_VERSION_SUFFIX)
 HELM_BUCKET ?=gs://scylla-operator-charts/$(HELM_CHANNEL)
 HELM_REPOSITORY ?=https://scylla-operator-charts.storage.googleapis.com/$(HELM_CHANNEL)
 

--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,9 @@ manifests:
 	kustomize build config/manager/default > examples/common/manager.yaml
 .PHONY: manifests
 
-latest:
+image:
 	docker build . -t $(IMAGE_REF)
-.PHONY: latest
+.PHONY: image
 
 # Generate code
 generate:


### PR DESCRIPTION
Special case is when nightly job is running. Because in nighly charts we
want to use nightly Operator image, suffix differentiate it from latest
build.