### PR TITLE
[1.1] helm: fix name of scylla clusters in Manager chart (#363)

### DIFF
--- a/helm/scylla-manager/templates/_helpers.tpl
+++ b/helm/scylla-manager/templates/_helpers.tpl
@@ -60,3 +60,21 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Workaround of https://github.com/helm/helm/issues/3920
+Call a template from the context of a subchart.
+
+Usage:
+  {{ include "call-nested" (list . "<subchart_name>" "<subchart_template_name>") }}
+*/}}
+{{- define "call-nested" }}
+{{- $dot := index . 0 }}
+{{- $subchart := index . 1 | splitList "." }}
+{{- $template := index . 2 }}
+{{- $values := $dot.Values }}
+{{- range $subchart }}
+{{- $values = index $values . }}
+{{- end }}
+{{- include $template (dict "Chart" (dict "Name" (last $subchart)) "Values" $values "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
+{{- end }}

--- a/helm/scylla-manager/templates/manager_config.yaml
+++ b/helm/scylla-manager/templates/manager_config.yaml
@@ -8,7 +8,7 @@ data:
       hosts:
         {{- range $rack := .Values.scylla.racks }}
         {{- range $idx, $e := until ($rack.members | int) }}
-        - {{ printf "%s-%s-%s-%d.%s.svc" $.Release.Name $.Values.scylla.datacenter $rack.name $idx $.Release.Namespace }}
+        - {{ printf "%s-%s-%s-%d.%s.svc" ( include "call-nested" (list $ "scylla" "scylla.fullname")) $.Values.scylla.datacenter $rack.name $idx $.Release.Namespace }}
         {{- end }}
         {{- end }}
 kind: ConfigMap


### PR DESCRIPTION
Wrong release name was filled by the Helm due to an open issue.

Fixes #363

