### PR TITLE
helm: fix ServiceAccount Name for Scylla Chart

### DIFF
--- a/helm/scylla/templates/_helpers.tpl
+++ b/helm/scylla/templates/_helpers.tpl
@@ -54,5 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "scylla.serviceAccountName" -}}
-{{- printf "%s-%s" (include "scylla.fullname" .) "member" }}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "scylla.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**Description of your changes:**

Previously the `serviceAccount.name` wasn't used. This change aligns the
behavior with the scylla-operator and scylla-manager Helm Charts. So that the value when supplied is used to name the ServiceAccount.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.