### PR TITLE
helm: impl option to add additional rules to Scylla ClusterRole

### DIFF
--- a/helm/scylla/templates/rbac.yaml
+++ b/helm/scylla/templates/rbac.yaml
@@ -36,6 +36,9 @@ rules:
       - scyllaclusters
     verbs:
       - get
+  {{- if .Values.rbac.clusterRole.rules }}
+    {{- toYaml .Values.rbac.clusterRole.rules | nindent 2 }}
+  {{- end }}
 
 ---
 {{- if .Values.serviceAccount.create -}}

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -13,6 +13,22 @@
                 }
             }
         },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "clusterRole": {
+                    "type": "object",
+                    "properties": {
+                        "rules": {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "alternator": {
             "type": "object",
             "properties": {

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -23,6 +23,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  clusterRole:
+    # Define additional rules to add to the ClusterRole
+    rules: []
+
 alternator:
   # Allows to enable Alternator (DynamoDB compatible API) frontend
   enabled: false


### PR DESCRIPTION
**Description of your changes:**

Implements the option to add additional rules to the ClusterRole generated by the Scylla Helm Chart. 

This is a draft PR, to get a discussion going if this is something of interest to the Scylla team to support, in the meanwhile I can use this as a draft to keep moving forward until this is resolved.

**Which issue is resolved by this Pull Request:**
Resolves #440 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Image has been built (`make docker-build`) on the last commit.