### PR TITLE
[1.1] helm: Remove unused serviceAccount.name from Scylla chart

### DIFF
--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -19,9 +19,6 @@ serviceAccount:
   create: true
   # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
 
 alternator:
   # Allows to enable Alternator (DynamoDB compatible API) frontend


### PR DESCRIPTION
As referred to in
https://github.com/scylladb/scylla-operator/pull/441#issuecomment-786565522,
the Service Account name is set by the operator and isn't configurable
at the moment. Removing this value to prevent any confusion about this.
