### PR TITLE
Move scylla version helpers out of the api package

### DIFF
--- a/pkg/api/v1/cluster_validation.go
+++ b/pkg/api/v1/cluster_validation.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-set/strset"
+	"github.com/scylladb/scylla-operator/pkg/semver"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -41,9 +42,9 @@ func checkValues(c *ScyllaCluster) error {
 	}
 
 	if len(c.Spec.ScyllaArgs) > 0 {
-		version := NewScyllaVersion(c.Spec.Version)
-		if !version.SupportFeatureUnsafe(ScyllaVersionThatSupportsArgs) {
-			return errors.Errorf("ScyllaArgs is only supported starting from %s", ScyllaVersionThatSupportsArgs)
+		version := semver.NewScyllaVersion(c.Spec.Version)
+		if !version.SupportFeatureUnsafe(semver.ScyllaVersionThatSupportsArgs) {
+			return errors.Errorf("ScyllaArgs is only supported starting from %s", semver.ScyllaVersionThatSupportsArgs)
 		}
 	}
 

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/utils/pointer"
-
 	"github.com/ghodss/yaml"
 	"github.com/magiconair/properties"
 	"github.com/pkg/errors"
@@ -20,8 +18,10 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/cmd/scylla-operator/options"
 	"github.com/scylladb/scylla-operator/pkg/controllers/sidecar/identity"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/semver"
 	"github.com/scylladb/scylla-operator/pkg/util/cpuset"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -245,19 +245,19 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		args["cpuset"] = &cpusAllowed
 	}
 
-	version := v1.NewScyllaVersion(cluster.Spec.Version)
+	version := semver.NewScyllaVersion(cluster.Spec.Version)
 
 	s.logger.Info(ctx, "Scylla version detected", "version", version)
 
 	if len(cluster.Spec.ScyllaArgs) > 0 {
-		if !version.SupportFeatureUnsafe(v1.ScyllaVersionThatSupportsArgs) {
+		if !version.SupportFeatureUnsafe(semver.ScyllaVersionThatSupportsArgs) {
 			s.logger.Info(ctx, "This scylla version does not support ScyllaArgs. ScyllaArgs is ignored", "version", cluster.Spec.Version)
 		} else {
 			appendScyllaArguments(ctx, s, cluster.Spec.ScyllaArgs, args)
 		}
 	}
 
-	if _, err := os.Stat(scyllaIOPropertiesPath); err == nil && version.SupportFeatureSafe(v1.ScyllaVersionThatSupportsDisablingIOTuning) {
+	if _, err := os.Stat(scyllaIOPropertiesPath); err == nil && version.SupportFeatureSafe(semver.ScyllaVersionThatSupportsDisablingIOTuning) {
 		s.logger.Info(ctx, "Scylla IO properties are already set, skipping io tuning")
 		ioSetup := "0"
 		args["io-setup"] = &ioSetup

--- a/pkg/semver/version.go
+++ b/pkg/semver/version.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package semver
 
 import (
 	"github.com/blang/semver"

--- a/pkg/semver/version_test.go
+++ b/pkg/semver/version_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package semver
 
 import (
 	"testing"


### PR DESCRIPTION
Those are not API types so they don't belong there and broke deep copy
generation. Also helpers shouldn't be coupled to the API defs.