### PR TITLE
actions: trigger CI for every PR

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ on:
     - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
   pull_request:
     branches:
-    - '*'
+    - '**'
   schedule:
   - cron:  '0 23 * * *' # daily at 11pm
 


### PR DESCRIPTION
Single star doesn't match target branches containing '/' character.
Double star matches all branches.
