### PR TITLE
helm: change storage class name parameter name (#485)

### DIFF
--- a/helm/scylla/templates/cluster.yaml
+++ b/helm/scylla/templates/cluster.yaml
@@ -40,7 +40,7 @@ spec:
         scyllaAgentConfig: {{ default "scylla-agent-config" .scyllaAgentConfig }}
         members: {{ .members }}
         storage:
-          storageClassName: {{ .storage.className }}
+          storageClassName: {{ .storage.storageClassName }}
           capacity: {{ .storage.capacity }}
         resources:
           {{- toYaml .resources | nindent 10 }}

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -213,6 +213,9 @@
                         "properties": {
                             "capacity": {
                                 "type": "string"
+                            },
+                            "storageClassName": {
+                                "type": "string"
                             }
                         }
                     }


### PR DESCRIPTION
change storage.className to storage.storageClassName to be consistent
with CRD.

Fixes #485
