### PR TITLE
Don't fail workflow on flaky integration suite

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -305,6 +305,7 @@ jobs:
       run: make helm-publish
 
   failure-notifications:
+    name: Failure notifications
     runs-on: ubuntu-20.04
     needs:
     - success
@@ -319,7 +320,7 @@ jobs:
         set +x
         curl -X POST -H 'Content-type: application/json' --data @<( cat <<-EOF
         {
-          "text": ":warning: CI workflow \"${{ github.workflow }}\" triggered on \"${{ github.event_name }}\" event from ${{ github.ref }} (${{ github.sha }}) failed!\n:fire_extinguisher: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.:fire\ncc: <@U01L8R3RYFN> <@UN90LVATC>"
+          "text": ":warning: CI workflow \"${{ github.workflow }}\" triggered on \"${{ github.event_name }}\" event from ${{ github.ref }} (${{ github.sha }}) failed!\n:fire_extinguisher: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.:fire:\ncc: <@U01L8R3RYFN> <@UN90LVATC>"
         }
         EOF
         ) '${{ secrets.SLACK_WEBHOOK_URL }}'

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -113,7 +113,11 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         echo "GO_TEST_EXTRA_ARGS=-ginkgo.flakeAttempts=5" | tee -a ${GITHUB_ENV}
+    # Integration tests are currently too flaky so we just make sure they compile but the actual run won't fail the suite.
+    - name: Make sure integration tests compile
+      run: make test-integration GO_TEST_EXTRA_FLAGS=-c --warn-undefined-variables
     - name: Test integration
+      continue-on-error: true
       run: make test-integration --warn-undefined-variables
 
   images:


### PR DESCRIPTION
**Description of your changes:**
Don't fail the workflow on integration suite failure which isn't a required check. We should remove it when we deflake the tests and make them required or transfer them to another suite.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.