### PR TITLE
Reduce resources for sysctl-buddy

### DIFF
--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -426,12 +426,8 @@ func sysctlInitContainer(sysctls []string) *corev1.Container {
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("200M"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("200M"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
 			},
 		},
 		Command: []string{


### PR DESCRIPTION
**Description of your changes:**
Adjusts `sysctl-buddy` resources to what it actually needs, 1 full core for calling `sysctl` in bash was way too much.

**Which issue is resolved by this Pull Request:**
Fixes https://github.com/scylladb/scylla-operator/issues/499