### PR TITLE
helm: bump default scylla storage capacity to 10Gi (#501)

### DIFF
--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -55,7 +55,7 @@ racks:
     members: 3
     # Storage definition
     storage:
-      capacity: 5Gi
+      capacity: 10Gi
     # Scylla container resource definition
     resources:
        limits:


### PR DESCRIPTION
Scylla refuses to start when developerMode is disabled and disk is smaller than 10Gi.

Fixes #501
