### PR TITLE
helm: Fix ServiceAccount for Scylla Manager chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,7 @@ define generate-manager-manifests-prod
 	mv '$(3)'/scylla-manager/templates/controller_serviceaccount.yaml '$(2)'/10_controller_serviceaccount.yaml
 	mv '$(3)'/scylla-manager/templates/controller_pdb.yaml '$(2)'/10_controller_pdb.yaml
 	mv '$(3)'/scylla-manager/templates/manager_service.yaml '$(2)'/10_manager_service.yaml
+	mv '$(3)'/scylla-manager/templates/manager_serviceaccount.yaml '$(2)'/10_manager_serviceaccount.yaml
 	mv '$(3)'/scylla-manager/templates/manager_configmap.yaml '$(2)'/10_manager_configmap.yaml
 	mv '$(3)'/scylla-manager/charts/scylla/templates/serviceaccount.yaml '$(2)'/10_scyllacluster_serviceaccount.yaml
 

--- a/deploy/manager/dev/10_manager_serviceaccount.yaml
+++ b/deploy/manager/dev/10_manager_serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scylla-manager
+  namespace: scylla-manager
+  labels:
+    app.kubernetes.io/name: scylla-manager
+    app.kubernetes.io/instance: scylla-manager

--- a/deploy/manager/dev/50_manager_deployment.yaml
+++ b/deploy/manager/dev/50_manager_deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/name: scylla-manager
         app.kubernetes.io/instance: scylla-manager
     spec:
+      serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
         image: docker.io/scylladb/scylla-manager:2.2.4

--- a/deploy/manager/prod/10_manager_serviceaccount.yaml
+++ b/deploy/manager/prod/10_manager_serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scylla-manager
+  namespace: scylla-manager
+  labels:
+    app.kubernetes.io/name: scylla-manager
+    app.kubernetes.io/instance: scylla-manager

--- a/deploy/manager/prod/50_manager_deployment.yaml
+++ b/deploy/manager/prod/50_manager_deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/name: scylla-manager
         app.kubernetes.io/instance: scylla-manager
     spec:
+      serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
         image: docker.io/scylladb/scylla-manager:2.2.4

--- a/examples/common/manager.yaml
+++ b/examples/common/manager.yaml
@@ -160,6 +160,16 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: scylla-manager
+  namespace: scylla-manager
+  labels:
+    app.kubernetes.io/name: scylla-manager
+    app.kubernetes.io/instance: scylla-manager
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: scylla-manager-cluster-member
   namespace: scylla-manager
   labels:
@@ -264,6 +274,7 @@ spec:
         app.kubernetes.io/name: scylla-manager
         app.kubernetes.io/instance: scylla-manager
     spec:
+      serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
         image: docker.io/scylladb/scylla-manager:2.2.4

--- a/helm/scylla-manager/templates/manager_deployment.yaml
+++ b/helm/scylla-manager/templates/manager_deployment.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         {{- include "scylla-manager.labels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "scylla-manager.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.repository }}/scylla-manager:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/helm/scylla-manager/templates/manager_serviceaccount.yaml
+++ b/helm/scylla-manager/templates/manager_serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "scylla-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scylla-manager.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
The deploymentrelied on the "default" Service Account, but
didn't bind the right ClusterRole when another Service Account is used
as defined by the template helper `scylla-manager.serviceAccountName`.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.