### PR TITLE
Change cluster cpu resource to string value

### DIFF
--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -59,10 +59,10 @@ racks:
     # Scylla container resource definition
     resources:
        limits:
-         cpu: 1
+         cpu: "1"
          memory: 4Gi
        requests:
-         cpu: 1
+         cpu: "1"
          memory: 4Gi
 
 # Whether to create Prometheus ServiceMonitor


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Set resource limits in scylla cluster helm chart to string by default.
**Which issue is resolved by this Pull Request:**
Resolves #
 #505 
**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.