### PR TITLE
Always default to cluster first DNS

### DIFF
--- a/pkg/api/scylla/v1/cluster_types.go
+++ b/pkg/api/scylla/v1/cluster_types.go
@@ -205,13 +205,11 @@ type Network struct {
 }
 
 func (s Network) GetDNSPolicy() corev1.DNSPolicy {
-	if s.DNSPolicy == "" {
-		if s.HostNetworking {
-			return corev1.DNSClusterFirstWithHostNet
-		}
-		return corev1.DNSDefault
+	if len(s.DNSPolicy) != 0 {
+		return s.DNSPolicy
 	}
-	return s.DNSPolicy
+
+	return corev1.DNSClusterFirstWithHostNet
 }
 
 // DatacenterSpec is the desired state for a Scylla Datacenter.


### PR DESCRIPTION
**Description of your changes:**
Kubernetes defaults to `ClusterFirst` DNSPolicy, yet we were defaulting to `Default` which breaks some sidecars like linkerd that use cluster DNS. Defaulting to the newer `ClusterFirstWithHostNet` as default should cover all cases.

**Which issue is resolved by this Pull Request:**
Likely https://github.com/scylladb/scylla-operator/issues/484 and https://scylladb-users.slack.com/archives/CCC9J41FW/p1616127037002500
