### PR TITLE
Make a replace race with StatefulSet controller less likely

### DIFF
--- a/pkg/controllers/cluster/actions/replace.go
+++ b/pkg/controllers/cluster/actions/replace.go
@@ -213,6 +213,9 @@ func (a *RackReplaceNode) replaceNode(ctx context.Context, state *State, member 
 		fmt.Sprintf("Rack %q removed %q Service", r.Name, member.Name),
 	)
 
+	// Give StatefulSet controller a chance to see the PVC was deleted before deleting the pod.
+	time.Sleep(10 * time.Second)
+
 	a.Logger.Info(ctx, "Deleting member Pod", "member", member.Name)
 	if err := cc.Delete(ctx, pod, client.GracePeriodSeconds(0)); err != nil {
 		return errors.Wrap(err, "delete pod")


### PR DESCRIPTION
**Description of your changes:**
Give StatefulSet controller caches a chance to see the PVC is gone.

The actual bug is being fix in https://github.com/kubernetes/kubernetes/pull/93457 but this fixes the workaround.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/524
