### PR TITLE
Wait for the whole cert-manager to be running

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -36,8 +36,10 @@ kubectl apply -f "${deploy_dir}"/cert-manager.yaml
 
 # Wait for cert-manager
 kubectl wait --for condition=established --timeout=60s crd/certificates.cert-manager.io crd/issuers.cert-manager.io
-wait-for-object-creation cert-manager deployment.apps/cert-manager-webhook
-kubectl -n cert-manager rollout status --timeout=5m deployment.apps/cert-manager-webhook
+for d in cert-manager{,-cainjector,-webhook}; do
+    wait-for-object-creation cert-manager deployment.apps/"${d}"
+    kubectl -n cert-manager rollout status --timeout=5m deployment.apps/"${d}"
+done
 
 kubectl apply -f "${deploy_dir}"/operator
 


### PR DESCRIPTION
**Description of your changes:**
Waits for all cert-manager deployments to be running first.

**Which issue is resolved by this Pull Request:**
Hopefully resolves or lowers the probability of 
```
Error from server (InternalError): error when creating "/home/runner/work/_temp/e2e-artifacts/deploy/operator/10_certificate.yaml": Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": x509: certificate signed by unknown authority
```
https://github.com/scylladb/scylla-operator/runs/2205859698?check_suite_focus=true#step:8:142
