### PR TITLE
Let scylla listen on 0.0.0.0

### DIFF
--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -210,8 +210,10 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	// Listen on all interfaces so users or a service mesh can use localhost.
+	listenAddress := "0.0.0.0"
 	args := map[string]*string{
-		"listen-address":        &m.IP,
+		"listen-address":        &listenAddress,
 		"broadcast-address":     &m.StaticIP,
 		"broadcast-rpc-address": &m.StaticIP,
 		"seeds":                 pointer.StringPtr(strings.Join(seeds, ",")),


### PR DESCRIPTION
**Description of your changes:**
Scylla now listens on all interfaces except just the ClusterIP. This will allow people to connect to the localhost and allow service meshes to redirect the traffic there.

The comment for `--listen-address` saying `Never specify 0.0.0.0; it is always wrong.` is likely wrong as it predates `--broadcast-address` flag. (Pending confirmation from Scylla engineering.)

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/484
