### PR TITLE
helm: add image pull secrets on ServiceAccount for manager and scylla cluster

### DIFF
--- a/helm/scylla-manager/templates/controller_serviceaccount.yaml
+++ b/helm/scylla-manager/templates/controller_serviceaccount.yaml
@@ -10,4 +10,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -48,6 +48,8 @@ serviceAccount:
   create: true
   # Annotations to add to the service account
   annotations: {}
+  # Map of secrets used to pull images from secured docker registry
+  imagePullSecrets: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""

--- a/helm/scylla-operator/templates/deployment.yaml
+++ b/helm/scylla-operator/templates/deployment.yaml
@@ -21,10 +21,6 @@ spec:
       labels:
         {{- include "scylla-operator.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       serviceAccountName: {{ include "scylla-operator.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}

--- a/helm/scylla-operator/templates/serviceaccount.yaml
+++ b/helm/scylla-operator/templates/serviceaccount.yaml
@@ -10,4 +10,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -38,6 +38,8 @@ serviceAccount:
   create: true
   # Annotations to add to the service account
   annotations: {}
+  # Map of secrets used to pull images from secured docker registry
+  imagePullSecrets: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""

--- a/helm/scylla/templates/serviceaccount.yaml
+++ b/helm/scylla/templates/serviceaccount.yaml
@@ -10,4 +10,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -19,6 +19,8 @@ serviceAccount:
   create: true
   # Annotations to add to the service account
   annotations: {}
+  # Map of secrets used to pull images from secured docker registry
+  imagePullSecrets: {}
 
 alternator:
   # Allows to enable Alternator (DynamoDB compatible API) frontend


### PR DESCRIPTION
Needed to be able to download images from docker registry with authentication
Also update scylla-operator to use same configuration instead of specific one on sts

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Image has been built (`make docker-build`) on the last commit.