### PR TITLE
Get rid of busybox image

### DIFF
--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -355,7 +355,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, sidecarI
 		},
 	}
 
-	sysctlContainer := sysctlInitContainer(c.Spec.Sysctls)
+	sysctlContainer := sysctlInitContainer(c.Spec.Sysctls, sidecarImage)
 	if sysctlContainer != nil {
 		sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers, *sysctlContainer)
 	}
@@ -412,14 +412,14 @@ func containerPorts(c *scyllav1.ScyllaCluster) []corev1.ContainerPort {
 	return ports
 }
 
-func sysctlInitContainer(sysctls []string) *corev1.Container {
+func sysctlInitContainer(sysctls []string, image string) *corev1.Container {
 	if len(sysctls) == 0 {
 		return nil
 	}
 	opt := true
 	return &corev1.Container{
 		Name:            "sysctl-buddy",
-		Image:           "busybox:1.31.1",
+		Image:           image,
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &opt,

--- a/test/e2e/fixture/scyllacluster/basic.scyllacluster.yaml
+++ b/test/e2e/fixture/scyllacluster/basic.scyllacluster.yaml
@@ -9,14 +9,14 @@ spec:
   datacenter:
     name: us-east-1
     racks:
-      - name: us-east-1a
-        members: 1
-        storage:
-          capacity: 100Mi
-        resources:
-          requests:
-            cpu: 10m
-            memory: 100Mi
-          limits:
-            cpu: 1
-            memory: 1Gi
+    - name: us-east-1a
+      members: 1
+      storage:
+        capacity: 100Mi
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          cpu: 1
+          memory: 1Gi

--- a/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2021 ScyllaDB
+
+package scyllacluster
+
+import (
+	"context"
+	"fmt"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	scyllaclusterfixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scyllacluster"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/tools"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("ScyllaCluster sysctl", func() {
+	defer g.GinkgoRecover()
+
+	f := framework.NewFramework("scyllacluster")
+
+	g.It("should set container sysctl", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimout)
+		defer cancel()
+
+		sc := scyllaclusterfixture.BasicScyllaCluster.ReadOrFail()
+		fsAIOMaxNRKey := "fs.aio-max-nr"
+		fsAIOMaxNRValue := 2424242 // A unique value.
+		o.Expect(sc.Spec.Sysctls).To(o.BeEmpty())
+		sc.Spec.Sysctls = []string{fmt.Sprintf("%s=%d", fsAIOMaxNRKey, fsAIOMaxNRValue)}
+
+		framework.By("Creating a ScyllaCluster")
+		err := framework.SetupScyllaClusterSA(ctx, f.KubeClient().CoreV1(), f.KubeClient().RbacV1(), f.Namespace(), sc.Name)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaCluster to deploy")
+		waitCtx1, waitCtx1Cancel := contextForRollout(ctx, sc)
+		defer waitCtx1Cancel()
+		sc, err = waitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, scyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		framework.By("Checking the sysctl value")
+		podName := fmt.Sprintf("%s-0", naming.StatefulSetNameForRack(sc.Spec.Datacenter.Racks[0], sc))
+		stdout, stderr, err := tools.PodExec(
+			f.KubeClient().CoreV1().RESTClient(),
+			f.ClientConfig(),
+			f.Namespace(),
+			podName,
+			"scylla",
+			[]string{"/usr/sbin/sysctl", "--values", fsAIOMaxNRKey},
+			nil,
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stderr).To(o.BeEmpty())
+		o.Expect(stdout).To(o.Equal(fmt.Sprintf("%d\n", fsAIOMaxNRValue)))
+	})
+})

--- a/test/e2e/tools/exec.go
+++ b/test/e2e/tools/exec.go
@@ -1,0 +1,41 @@
+package tools
+
+import (
+	"bytes"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// PodExec runs a command inside a container and returns stdout, stderr and error.
+func PodExec(restClient restclient.Interface, config *restclient.Config, namespace, podName, containerName string, command []string, stdin io.Reader) (string, string, error) {
+	req := restClient.Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec")
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: containerName,
+		Command:   command,
+		Stdin:     stdin != nil,
+		Stdout:    true,
+		Stderr:    true,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", "", err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	return stdout.String(), stderr.String(), err
+}


### PR DESCRIPTION
**Description of your changes:**
We already have the sidecar image pulled on the machine so there is no need to pull another one, reusing is faster. It also avoid having another image that needs to be configurable.

**Which issue is resolved by this Pull Request:**
Resolves #431
