### PR TITLE
Claim minimal Kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 ![](logo.png)
 
 ## Deploying the Operator
+The current version of scylla-operator requires Kubernetes >= 1.19.
+
 ### GitOps
 Kubernetes manifests are located in the `deploy/` folder. To deploy the operator manually using Kubernetes manifests or to integrate it into your GitOps flow please follow [these instructions](./deploy/README.md). 
 


### PR DESCRIPTION
**Description of your changes:**
Scylla-operator requires Kubernetes >= 1.19. It needs StartupProbe support and 1.19 is the last one that had StatefulSet PVC handling fixes backported. [1]

Requiring 1.19 is reasonable as that's the oldest supported release by Kubernetes project at this point. [2]
```
The Kubernetes project maintains release branches for the most recent three minor releases (1.21, 1.20, 1.19).
```

[1] - https://github.com/kubernetes/kubernetes/pull/98732#event-4566827090
[2] - https://kubernetes.io/docs/setup/release/version-skew-policy/