### PR TITLE
Fix podman

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -144,9 +144,10 @@ jobs:
     - name: Build image
       run: |
         set -x
-        podman build --squash -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
-        podman images '${{ env.image_repo_ref }}:ci'
-        podman save '${{ env.image_repo_ref }}:ci' | lz4 - ~/operatorimage.tar.lz4
+        # Avoid podman permission error on Ubuntu 20.04 by using it as root, although it shouldn't be needed.
+        sudo podman build --squash -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
+        sudo podman images '${{ env.image_repo_ref }}:ci'
+        sudo podman save '${{ env.image_repo_ref }}:ci' | lz4 - ~/operatorimage.tar.lz4
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
**Description of your changes:**
Looks like rootless podman broke on Ubuntu 20.04. I didn't find a targeted fix but in CI we can just use the root.

**Which issue is resolved by this Pull Request:**
https://github.com/scylladb/scylla-operator/runs/2351036661?check_suite_focus=true#step:4:25
```
+ podman build --squash -f ./Dockerfile -t docker.io/scylladb/scylla-operator:ci .
STEP 1: FROM docker.io/library/ubuntu:20.04 AS builder
Getting image source signatures
Copying blob sha256:c4394a92d1f8760cf7d17fee0bcee732c94c5b858dd8d19c7ff02beecf3b4e83
Copying blob sha256:10e6159c56c084c858f5de2416454ac0a49ddda47b764e4379c5d5a147c9bf5f
Copying blob sha256:a70d879fa5984474288d52009479054b8bb2993de2a1859f43b5480600cecb24
Copying config sha256:26b77e58432b01665d7e876248c9056fa58bf4a7ab82576a024f5cf3dac146d6
Writing manifest to image destination
Storing signatures
STEP 2: FROM docker.io/library/ubuntu:20.04
Error: error creating build container: Error committing the finished image: error adding layer with blob "sha256:10e6159c56c084c858f5de2416454ac0a49ddda47b764e4379c5d5a147c9bf5f": Error processing tar file(exit status 1): operation not permitted
Error: Process completed with exit code 125.
```