### PR TITLE
Add Verify PR jobs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,92 @@
+# Copyright (C) 2021 ScyllaDB
+
+name: Verify PR
+
+on:
+  pull_request:
+    branches:
+    - '**'
+    # GitHub doesn't allow to trigger directly when editing a milestone yet.
+    # https://github.community/t/feature-request-add-milestone-changes-as-activity-type-to-pull-request/16778/7
+    #
+    # We have to verify PR milestone in pull_request and we can't use do-not-merge/ label
+    # because it needs to react to master branch changes (when master starts being a different version).
+    # Also GH doesn't trigger on labels created with action token.
+    types:
+    - labeled
+    - unlabeled
+    - opened
+    - edited
+    - reopened
+    - synchronize
+
+jobs:
+  title:
+    name: Verify PR title
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify PR title
+      run: |
+        set -euExo pipefail
+        shopt -s inherit_errexit
+
+        pr_title=$( jq -r '.pull_request.title' "${GITHUB_EVENT_PATH}" )
+        if echo "${pr_title}" | grep -E \
+          -e '^\[WIP\]' \
+          -e '^\[DO NOT MERGE\]' \
+        ; then
+          echo "The PR title indicates it shouldn't be merged."
+          exit 1
+        fi
+
+        base_branch=$( jq -r '.pull_request.base.ref' "${GITHUB_EVENT_PATH}" )
+        pr_title_branch=$( echo "${pr_title}" | sed -E -e 's/(\[WIP\]|\[DO NOT MERGE\])?(\[([^]].*)\])?.*/\3/' )
+        if [[ "${base_branch}" == "master" ]]; then
+          if [[ "${pr_title_branch}" != "" ]]; then
+            echo "PRs to master branch are not expected to have title prefix [${pr_title_branch}]."
+            exit 1
+          fi
+        else
+          if [[ "${pr_title_branch}" != "${base_branch}" ]]; then
+            echo "PRs to ${base_branch} must have the title starting with '[${base_branch}]' prefix."
+            exit 1
+          fi
+        fi
+  labels:
+    name: Verify PR labels
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify PR labels
+      run: |
+        set -euExo pipefail
+        shopt -s inherit_errexit
+
+        labels_json=$( jq -r '[.pull_request.labels[] | .name]' "${GITHUB_EVENT_PATH}" )
+
+        kind_labels=( $( jq -r '.[] | select(startswith("kind/"))' <( echo "${labels_json}" ) ) )
+        if [[ "${#kind_labels[@]}" == "0" ]]; then
+          echo 'Missing kind/* label'
+          exit 1
+        fi
+  milestone:
+    name: Verify PR milestone
+    if: ${{ github.event.pull_request.base.ref == 'master' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Verify PR milestone
+      run: |
+        set -euExo pipefail
+        shopt -s inherit_errexit
+
+        expected_milestone=$( git describe --abbrev=0 | sed -E -e 's/(v[0-9]+\.[0-9]+)\.[0-9]+.*/\1/' )
+        [[ "${expected_milestone}" != "" ]]
+
+        current_milestone=$( jq -r '.pull_request.milestone.title // empty' "${GITHUB_EVENT_PATH}" )
+
+        if [[ "${current_milestone}" != "${expected_milestone}" ]]; then
+          echo "Expected milestone '${expected_milestone}' but PR has milestone '${current_milestone}'."
+          exit 1
+        fi


### PR DESCRIPTION
**Description of your changes:**
This sets up workflows to verify:
 - PR title
   - `[branch-name]` prefix, if not master
   - prevents merging `[WIP]` and `[DO NOT MERGE]`
 - PR has at least one `kind/*` label
 - matching milestone for the the current master

Also GitHub actions suck:
1. It can't trigger on PR milestone change :facepalm: 
2. You can catch the trigger for milestone change using `on: issues: [milestoned]` as every PR is also an issue. So I went and translated the milestone into a corresponding labels so it re-triggers the PR when change, except GitHub actions will detect that a label was changed using GitHub actions token and won't trigger the other workflow :facepalm: 
3. In all my desperation, I've tried to get a long lived token I could setup on our repo and use in that action, but I didn't find anything useful. You can't use personal access token as that's not limited to a repository and it could also be misused. GitHub Apps generate a private key for signing JWTs but with very short lifetime so it can't be set on the repo unless we'd generate the JWT inside an action using the private key and that's not really easy to do and I've already spent too much time on this.

When milestone check gets stuck, we'll just remove+add an label, edit the PR, push an update or similarly trigger the workflow.