### PR TITLE
sidecar-injection: avoid -EBUSY on cp -a of scylla-operator

### DIFF
--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -201,7 +201,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, sidecarI
 							Command: []string{
 								"/bin/sh",
 								"-c",
-								fmt.Sprintf("cp -a /usr/bin/scylla-operator %s", naming.SharedDirName),
+								fmt.Sprintf("cp -fa /usr/bin/scylla-operator %s", naming.SharedDirName),
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{


### PR DESCRIPTION
**Description of your changes:**

sidecar attempts to copy scylla-operator binary into shared, if a process of scylla-operator is already running with that binary, this will fail with with -EBUSY. Work around by letting cp retry on failure, with unlink and retry.

```
cp: cannot create regular file '/mnt/shared/scylla-operator': Text file busy
```

**Which issue is resolved by this Pull Request:**
Resolves #N/A
