### PR TITLE
Add optional SecurityContext to Helm Charts

### DIFF
--- a/helm/scylla-manager/templates/controller_deployment.yaml
+++ b/helm/scylla-manager/templates/controller_deployment.yaml
@@ -18,6 +18,9 @@ spec:
         {{- include "scylla-manager.controllerLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "scylla-manager.controllerServiceAccountName" . }}
+      {{- with .Values.controllerSecurityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ include "scylla-manager.controllerName" . }}
         image: {{ .Values.controllerImage.repository }}/scylla-operator:{{ .Values.controllerImage.tag | default .Chart.AppVersion }}

--- a/helm/scylla-manager/templates/manager_deployment.yaml
+++ b/helm/scylla-manager/templates/manager_deployment.yaml
@@ -22,6 +22,9 @@ spec:
         {{- include "scylla-manager.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "scylla-manager.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.repository }}/scylla-manager:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -45,6 +45,9 @@
                 }
             }
         },
+        "controllerSecurityContext": {
+            "type": "object"
+        },
         "fullnameOverride": {
             "type": "string"
         },
@@ -188,6 +191,9 @@
                     "type": "string"
                 }
             }
+        },
+        "securityContext": {
+            "type": "object"
         },
         "tolerations": {
             "type": "array"

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -37,6 +37,9 @@ tolerations: [ ]
 # Affinity for Scylla Manager pod
 affinity: { }
 
+## SecurityContext holds pod-level security attributes
+securityContext: {}
+
 # Node selector for Scylla Manager Controller pod
 controllerNodeSelector: { }
 
@@ -46,6 +49,8 @@ controllerTolerations: [ ]
 # Affinity for Scylla Manager Controller pod
 controllerAffinity: { }
 
+## ControllerSecurityContext holds pod-level security attributes
+controllerSecurityContext: {}
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/helm/scylla-operator/templates/deployment.yaml
+++ b/helm/scylla-operator/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "scylla-operator.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.repository }}/scylla-operator:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/helm/scylla-operator/values.schema.json
+++ b/helm/scylla-operator/values.schema.json
@@ -71,6 +71,9 @@
                 }
             }
         },
+        "securityContext": {
+            "type": "object"
+        },
         "tolerations": {
             "type": "array"
         },

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -41,3 +41,6 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+## SecurityContext holds pod-level security attributes and common container settings.
+securityContext: {}


### PR DESCRIPTION
This gives the option to pass an optional `securityContext` to the
operator, manager, and manager controller deployments so for example the
containers can be run using as a non-root user.

**Which issue is resolved by this Pull Request:**
Resolves #570
