### PR TITLE
Fix service DNS names for in-cluster communication

### DIFF
--- a/deploy/operator/10_certificate.yaml
+++ b/deploy/operator/10_certificate.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   dnsNames:
   - scylla-operator-webhook.scylla-operator.svc
-  - scylla-operator-webhook.scylla-operator.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: scylla-operator-selfsigned-issuer

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -2064,7 +2064,6 @@ metadata:
 spec:
   dnsNames:
   - scylla-operator-webhook.scylla-operator.svc
-  - scylla-operator-webhook.scylla-operator.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: scylla-operator-selfsigned-issuer

--- a/helm/scylla-operator/templates/certificate.yaml
+++ b/helm/scylla-operator/templates/certificate.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   dnsNames:
   - {{ include "scylla-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
-  - {{ include "scylla-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: scylla-operator-selfsigned-issuer

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -56,7 +56,7 @@ func PodDisruptionBudgetName(c *scyllav1.ScyllaCluster) string {
 }
 
 func CrossNamespaceServiceNameForCluster(c *scyllav1.ScyllaCluster) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", HeadlessServiceNameForCluster(c), c.Namespace)
+	return fmt.Sprintf("%s.%s.svc", HeadlessServiceNameForCluster(c), c.Namespace)
 }
 
 func ManagerClusterName(c *scyllav1.ScyllaCluster) string {


### PR DESCRIPTION
**Description of your changes:**
Cluster suffix differs in each cluster. For in-cluster communication we should be using only `.svc` suffix.

**Which issue is resolved by this Pull Request:**
Resolves #575 
