### PR TITLE
Make v1.2 docs the latest version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -160,7 +160,7 @@ BRANCHES = ['master', 'v0.3', 'v1.0', 'v1.1', 'v1.2']
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.
-smv_latest_version = 'v1.1'
+smv_latest_version = 'v1.2'
 smv_rename_latest_version = 'stable'
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"


### PR DESCRIPTION
**Description of your changes:**
Marks v1.2 docs as latest. Leftover from https://github.com/scylladb/scylla-operator/pull/581

