### PR TITLE
Implement seedless mode

### DIFF
--- a/pkg/controller/scyllacluster/resource/resource.go
+++ b/pkg/controller/scyllacluster/resource/resource.go
@@ -54,11 +54,6 @@ func MemberService(sc *scyllav1.ScyllaCluster, rackName, name string, oldService
 	labels[naming.DatacenterNameLabel] = sc.Spec.Datacenter.Name
 	labels[naming.RackNameLabel] = rackName
 
-	// If Member is seed, add the appropriate label
-	if strings.HasSuffix(name, "-0") || strings.HasSuffix(name, "-1") {
-		labels[naming.SeedLabel] = ""
-	}
-
 	// Copy the old replace label, if present.
 	var replaceAddr string
 	var hasReplaceLabel bool

--- a/pkg/controller/scyllacluster/sync_services.go
+++ b/pkg/controller/scyllacluster/sync_services.go
@@ -138,15 +138,6 @@ func (scc *Controller) syncServices(
 			continue
 		}
 
-		_, isSeed := svc.Labels[naming.SeedLabel]
-		if isSeed {
-			klog.ErrorS(nil, "Seed node replace is not supported",
-				"ScyllaCluster", klog.KObj(sc),
-				"Service", klog.KObj(svc),
-			)
-			continue
-		}
-
 		rackName, ok := svc.Labels[naming.RackNameLabel]
 		if !ok {
 			return status, fmt.Errorf("service %s/%s is missing %q label", svc.Namespace, svc.Name, naming.RackNameLabel)

--- a/pkg/sidecar/identity/member_test.go
+++ b/pkg/sidecar/identity/member_test.go
@@ -1,0 +1,133 @@
+// Copyright (C) 2021 ScyllaDB
+
+package identity
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/scylladb/scylla-operator/pkg/controller/helpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestMember_GetSeeds(t *testing.T) {
+	createPodAndSvc := func(name, ip string, creationTimestamp time.Time) (*corev1.Pod, *corev1.Service) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "namespace",
+				Labels: map[string]string{
+					naming.ClusterNameLabel: "my-cluster",
+				},
+				CreationTimestamp: metav1.NewTime(creationTimestamp),
+			},
+		}
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "namespace",
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: ip,
+			},
+		}
+		return pod, svc
+	}
+
+	now := time.Now()
+	firstPod, firstService := createPodAndSvc("pod-0", "1.1.1.1", now)
+	secondPod, secondService := createPodAndSvc("pod-1", "2.2.2.2", now.Add(time.Second))
+	thirdPod, thirdService := createPodAndSvc("pod-2", "3.3.3.3", now.Add(2*time.Second))
+
+	ts := []struct {
+		name        string
+		memberName  string
+		memberIP    string
+		objects     []runtime.Object
+		expectSeed  string
+		expectError error
+	}{
+		{
+			name:        "error when no pods are found",
+			memberName:  firstPod.Name,
+			memberIP:    firstService.Spec.ClusterIP,
+			objects:     []runtime.Object{},
+			expectError: fmt.Errorf("internal error: can't find any pod for this cluster, including itself"),
+		},
+		{
+			name:       "bootstraps with itself when cluster is empty",
+			memberName: firstPod.Name,
+			memberIP:   firstService.Spec.ClusterIP,
+			objects:    []runtime.Object{firstPod, firstService},
+			expectSeed: firstService.Spec.ClusterIP,
+		},
+		{
+			name:       "bootstrap with first created UN node",
+			memberName: firstPod.Name,
+			memberIP:   firstService.Spec.ClusterIP,
+			objects:    []runtime.Object{firstPod, firstService, markPodReady(secondPod), secondService, markPodReady(thirdPod), thirdService},
+			expectSeed: secondService.Spec.ClusterIP,
+		},
+		{
+			name:       "bootstrap only with UN node",
+			memberName: firstPod.Name,
+			memberIP:   firstService.Spec.ClusterIP,
+			objects:    []runtime.Object{firstPod, firstService, secondPod, secondService, markPodReady(thirdPod), thirdService},
+			expectSeed: thirdService.Spec.ClusterIP,
+		},
+		{
+			name:       "bootstrap with first created Pod when all are down",
+			memberName: firstPod.Name,
+			memberIP:   firstService.Spec.ClusterIP,
+			objects:    []runtime.Object{firstPod, firstService, secondPod, secondService, thirdPod, thirdService},
+			expectSeed: secondService.Spec.ClusterIP,
+		},
+	}
+
+	for i := range ts {
+		test := ts[i]
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			member := Member{
+				Cluster:   "my-cluster",
+				Namespace: "namespace",
+				Name:      test.memberName,
+				StaticIP:  test.memberIP,
+			}
+
+			fakeClient := fake.NewSimpleClientset(test.objects...)
+			seed, err := member.GetSeed(ctx, fakeClient.CoreV1())
+			if !reflect.DeepEqual(err, test.expectError) {
+				t.Errorf("expected error %v, got %v", test.expectError, err)
+			}
+			if seed != test.expectSeed {
+				t.Errorf("expected seed %v, got %v", test.expectSeed, seed)
+			}
+		})
+	}
+}
+
+func markPodReady(pod *corev1.Pod) *corev1.Pod {
+	p := pod.DeepCopy()
+	cond := helpers.GetPodCondition(p.Status.Conditions, corev1.PodReady)
+	if cond != nil {
+		cond.Status = corev1.ConditionTrue
+		return p
+	}
+
+	p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	})
+
+	return p
+}

--- a/test/e2e/set/scyllacluster/helpers.go
+++ b/test/e2e/set/scyllacluster/helpers.go
@@ -319,10 +319,6 @@ func getManagerClient(ctx context.Context, client corev1client.CoreV1Interface) 
 	return &manager, nil
 }
 
-func getFirstNonSeedNodeName(sc *scyllav1.ScyllaCluster) string {
-	return getNodeName(sc, 2)
-}
-
 func getNodeName(sc *scyllav1.ScyllaCluster, idx int) string {
 	return fmt.Sprintf(
 		"%s-%s-%s-%d",

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -22,12 +22,12 @@ var _ = g.Describe("ScyllaCluster replace", func() {
 
 	f := framework.NewFramework("scyllacluster")
 
-	g.It("should replace a non-seed node", func() {
+	g.It("should replace a node", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimout)
 		defer cancel()
 
 		sc := scyllaclusterfixture.BasicScyllaCluster.ReadOrFail()
-		sc.Spec.Datacenter.Racks[0].Members = 3
+		sc.Spec.Datacenter.Racks[0].Members = 2
 
 		framework.By("Creating a ScyllaCluster")
 		err := framework.SetupScyllaClusterSA(ctx, f.KubeClient().CoreV1(), f.KubeClient().RbacV1(), f.Namespace(), sc.Name)
@@ -44,10 +44,10 @@ var _ = g.Describe("ScyllaCluster replace", func() {
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
 
-		framework.By("Replacing a non-seed node")
+		framework.By("Replacing a node #0")
 		pod, err := f.KubeClient().CoreV1().Pods(f.Namespace()).Get(
 			ctx,
-			getFirstNonSeedNodeName(sc),
+			getNodeName(sc, 0),
 			metav1.GetOptions{},
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
From Scylla 4.3 seed concept is relaxed, and any node can be provided as
contact point during bootstrap.
From now on, sidecar will pick any UN node as a contact point if any is available,
itself when there's only single Pod, or first ever created Pod when all nodes
are down.

Fixes #292
Fixes #295
Fixes #405