### PR TITLE
[WIP] Remove non-OCI instructions from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # TODO: extract builder and base image into its own repo for reuse and to speed up builds
 FROM docker.io/library/ubuntu:20.04 AS builder
-SHELL ["/bin/bash", "-euEo", "pipefail", "-c"]
 ENV GOPATH=/go \
     GOROOT=/usr/local/go \
 # Enable madvdontneed=1, for golang < 1.16 https://github.com/golang/go/issues/42330
     GODEBUG=madvdontneed=1
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
-RUN apt-get update; \
+RUN set -euEo pipefail;
+    apt-get update; \
     apt-get install -y --no-install-recommends build-essential git curl gzip ca-certificates; \
     apt-get clean; \
     curl --fail -L https://storage.googleapis.com/golang/go1.16.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -


### PR DESCRIPTION
**Description of your changes:**
SHELL instruction is not in the OCI spec, some builder may ignore it:
```
WARN[0066] SHELL is not supported for OCI image format, [/bin/bash -euEo pipefail -c] will be ignored. Must use `docker` format 
```

