### PR TITLE
Use --format=docker to support SHELL instruction in the Dockerfile

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -150,7 +150,8 @@ jobs:
       run: |
         set -x
         # Avoid podman permission error on Ubuntu 20.04 by using it as root, although it shouldn't be needed.
-        sudo podman build --squash -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
+        # Use --format=docker to support SHELL instruction in the Dockerfile. (SHELL didn't make it to OCI spec.)
+        sudo podman build --format=docker --squash -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
         sudo podman images '${{ env.image_repo_ref }}:ci'
         sudo podman save '${{ env.image_repo_ref }}:ci' | lz4 - ~/operatorimage.tar.lz4
     - name: Upload artifact


### PR DESCRIPTION
**Description of your changes:**
SHELL instruction is not in the OCI spec, and podman would ignore it so we use `--format=docker`.
```
WARN[0066] SHELL is not supported for OCI image format, [/bin/bash -euEo pipefail -c] will be ignored. Must use `docker` format 
```
We can't use the default because Ubuntu has `dash` that doesn't support `-o pipefail`.

