### PR TITLE
Performance improvements

### DIFF
--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -1770,6 +1770,9 @@ spec:
                 items:
                   type: string
                 type: array
+              tuneNode:
+                description: TuneNode determines if sidecar should perform node network and disk tuning for max performance. Node optimizations require running Scylla as a privileged container.
+                type: boolean
               version:
                 description: Version of Scylla to use.
                 type: string

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/bitly/go-hostpool v0.1.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8 h1:SjZ2GvvOononHOpK84APFuMvxqsk3tEIaKH/z4Rpu3g=
+github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8/go.mod h1:uEyr4WpAH4hio6LFriaPkL938XnrvLpNPmQHBdrmbIE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/api/scylla/v1/cluster_types.go
+++ b/pkg/api/scylla/v1/cluster_types.go
@@ -53,6 +53,10 @@ type ClusterSpec struct {
 	// CpuSet determines if the cluster will use cpu-pinning for max performance.
 	// +optional
 	CpuSet bool `json:"cpuset,omitempty"`
+	// TuneNode determines if sidecar should perform node network and disk tuning for max performance.
+	// Node optimizations require running Scylla as a privileged container.
+	// +optional
+	TuneNode bool `json:"tuneNode,omitempty"`
 	// AutomaticOrphanedNodeCleanup controls if automatic orphan node cleanup should be performed.
 	AutomaticOrphanedNodeCleanup bool `json:"automaticOrphanedNodeCleanup,omitempty"`
 	// GenericUpgrade allows to configure behavior of generic upgrade logic.

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -1607,6 +1607,9 @@ spec:
                 items:
                   type: string
                 type: array
+              tuneNode:
+                description: TuneNode determines if sidecar should perform node network and disk tuning for max performance. Node optimizations require running Scylla as a privileged container.
+                type: boolean
               version:
                 description: Version of Scylla to use.
                 type: string

--- a/pkg/cmd/operator/options/sidecar.go
+++ b/pkg/cmd/operator/options/sidecar.go
@@ -15,7 +15,9 @@ var sidecarOpts = &sidecarOptions{
 
 type sidecarOptions struct {
 	*CommonOptions
-	CPU string
+	CPU               string
+	RunPerftune       bool
+	DisableWriteCache bool
 }
 
 func GetSidecarOptions() *sidecarOptions {
@@ -25,6 +27,8 @@ func GetSidecarOptions() *sidecarOptions {
 func (o *sidecarOptions) AddFlags(cmd *cobra.Command) {
 	o.CommonOptions.AddFlags(cmd)
 	cmd.Flags().StringVar(&o.CPU, "cpu", os.Getenv(naming.EnvVarCPU), "number of cpus to use")
+	cmd.Flags().BoolVar(&o.RunPerftune, "run-perftune", false, "run perftune script to optimize node")
+	cmd.Flags().BoolVar(&o.DisableWriteCache, "disable-write-cache", false, "disable disk write cache")
 }
 
 func (o *sidecarOptions) Validate() error {

--- a/pkg/cmd/operator/sidecar.go
+++ b/pkg/cmd/operator/sidecar.go
@@ -6,6 +6,7 @@ import (
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/scylla-operator/pkg/cmd/operator/options"
 	"github.com/scylladb/scylla-operator/pkg/controllers/sidecar"
+	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -41,6 +42,18 @@ func NewSidecarCmd(ctx context.Context, logger log.Logger, level zap.AtomicLevel
 			})
 			if err != nil {
 				logger.Fatal(ctx, "unable to create manager", "error", err)
+			}
+
+			if opts.RunPerftune {
+				if err := runPerftune(ctx, logger); err != nil {
+					logger.Error(ctx, "unable to optimize node", "error", err)
+				}
+			}
+
+			if opts.DisableWriteCache {
+				if err := setWriteCache(ctx, logger, naming.DataDir, "write through"); err != nil {
+					logger.Error(ctx, "unable to set write cache", "error", err)
+				}
 			}
 
 			logger.Info(ctx, "Registering Components.")

--- a/pkg/cmd/operator/tune.go
+++ b/pkg/cmd/operator/tune.go
@@ -1,0 +1,165 @@
+// Copyright (C) 2021 ScyllaDB
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	linuxproc "github.com/c9s/goprocinfo/linux"
+	"github.com/scylladb/go-log"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/util/cpuset"
+)
+
+func perftuneCommand(ctx context.Context, cpuInfo *linuxproc.CPUInfo, procStatus *linuxproc.ProcessStatus) (*exec.Cmd, error) {
+	fullCpuset, err := cpuset.Parse(fmt.Sprintf("0-%d", cpuInfo.NumCPU()-1))
+	if err != nil {
+		return nil, fmt.Errorf("parse full mask")
+	}
+
+	cpusAllowedMask := cpuset.ParseMaskFormat(procStatus.CpusAllowed)
+
+	// TODO(maciej): consider banning IRQ hyperthreaded siblings in Scylla cpuset
+	// Use all CPUs *not* assigned to Scylla container for IRQs.
+	diffCpuset := fullCpuset.Difference(cpusAllowedMask)
+
+	args := []string{
+		"--tune", "net", "--irq-cpu-mask", diffCpuset.FormatMask(),
+		"--tune", "disks", "--dir", naming.DataDir,
+	}
+
+	cmd := exec.CommandContext(ctx, "/opt/scylladb/scripts/perftune.py", args...)
+	cmd.Env = append(cmd.Env, "SYSTEMD_IGNORE_CHROOT=1")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd, nil
+}
+
+func runPerftune(ctx context.Context, logger log.Logger) error {
+	cpuInfo, err := linuxproc.ReadCPUInfo("/proc/cpuinfo")
+	if err != nil {
+		return fmt.Errorf("parse cpuinfo: %w", err)
+	}
+
+	// Currently Scylla is a child process of sidecar, so look at 'self'.
+	procStatus, err := linuxproc.ReadProcessStatus("/proc/self/status")
+	if err != nil {
+		return fmt.Errorf("parse proc self status: %w", err)
+	}
+
+	cmd, err := perftuneCommand(ctx, cpuInfo, procStatus)
+	if err != nil {
+		return fmt.Errorf("prepare perftune command: %w", err)
+	}
+
+	logger.Info(ctx, "Running perftune", "args", cmd.Args)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run perftune: %w", err)
+	}
+
+	return nil
+}
+
+func setWriteCache(ctx context.Context, logger log.Logger, dir, cache string) error {
+	devPath, err := getMountDevicePath(dir)
+	if err != nil {
+		return err
+	}
+
+	physicalDevices, err := getPhysicalDevices(devPath)
+	if err != nil {
+		return err
+	}
+
+	logger.Debug(ctx, "Setting cache on physical devices", "devices", physicalDevices, "cache", cache)
+
+	for _, dev := range physicalDevices {
+		devFd, err := os.OpenFile(path.Join(dev, "queue", "write_cache"), os.O_WRONLY, 0666)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprint(devFd, cache)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getMountDevicePath(dir string) (string, error) {
+	s, err := os.Stat(dir)
+	if err != nil {
+		return "", err
+	}
+	stat := s.Sys().(*syscall.Stat_t)
+	major, minor := stat.Dev>>8&0xff, stat.Dev&0xff
+
+	blockPath := fmt.Sprintf("/sys/dev/block/%d:%d", major, minor)
+	devPath, err := resolveSymlink(blockPath)
+	if err != nil {
+		return "", err
+	}
+	return devPath, nil
+
+}
+
+func getPhysicalDevices(devPath string) ([]string, error) {
+	if !strings.Contains(devPath, "virtual") {
+		return []string{devPath}, nil
+	}
+
+	var slaves []string
+	slavesPath := path.Join(devPath, "slaves")
+	err := filepath.WalkDir(slavesPath, func(p string, d fs.DirEntry, err error) error {
+		if p == slavesPath {
+			return nil
+		}
+
+		finfo, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		if finfo.Mode()&os.ModeSymlink != 0 {
+			slaveDevPath, err := resolveSymlink(p)
+			if err != nil {
+				return err
+			}
+
+			slaves = append(slaves, slaveDevPath)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return slaves, nil
+}
+
+func resolveSymlink(linkPath string) (string, error) {
+	resolvedPath, err := os.Readlink(linkPath)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(resolvedPath) {
+		resolvedPath, err = filepath.Abs(path.Join(path.Dir(linkPath), resolvedPath))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return resolvedPath, nil
+}

--- a/pkg/cmd/operator/tune_test.go
+++ b/pkg/cmd/operator/tune_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2021 ScyllaDB
+
+package operator
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	linuxproc "github.com/c9s/goprocinfo/linux"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/util/cpuset"
+)
+
+func TestPerftuneCommand(t *testing.T) {
+	ts := []struct {
+		Name            string
+		NumCPUs         int
+		AllowedCPUs     []int
+		ExpectedIRQCPUs []int
+	}{
+		{
+			Name:            "single allowed",
+			NumCPUs:         4,
+			AllowedCPUs:     []int{0},
+			ExpectedIRQCPUs: []int{1, 2, 3},
+		},
+		{
+			Name:            "gap in the middle",
+			NumCPUs:         4,
+			AllowedCPUs:     []int{0, 1, 3},
+			ExpectedIRQCPUs: []int{2},
+		},
+		{
+			Name:            "last forbidden",
+			NumCPUs:         4,
+			AllowedCPUs:     []int{0, 1, 2},
+			ExpectedIRQCPUs: []int{3},
+		},
+		{
+			Name:            "all allowed",
+			NumCPUs:         4,
+			AllowedCPUs:     []int{0, 1, 2, 3},
+			ExpectedIRQCPUs: []int{},
+		},
+	}
+
+	for i := range ts {
+		test := ts[i]
+		cpuset.NewCPUSet(1, 2, 3)
+		t.Run(test.Name, func(t *testing.T) {
+			ctx := context.Background()
+			cpuInfo := &linuxproc.CPUInfo{
+				Processors: make([]linuxproc.Processor, test.NumCPUs),
+			}
+			procStatus := &linuxproc.ProcessStatus{
+				CpusAllowed: MustMask(test.AllowedCPUs...),
+			}
+
+			cmd, err := perftuneCommand(ctx, cpuInfo, procStatus)
+			if err != nil {
+				t.Errorf("Expected non-nil error, got %s", err)
+			}
+			expectedArgs := []string{
+				"/opt/scylladb/scripts/perftune.py",
+				"--tune", "net", "--irq-cpu-mask", cpuset.NewCPUSet(test.ExpectedIRQCPUs...).FormatMask(),
+				"--tune", "disks", "--dir", naming.DataDir,
+			}
+			if !reflect.DeepEqual(cmd.Args, expectedArgs) {
+				t.Errorf("Expected args %v, got %v", expectedArgs, cmd.Args)
+			}
+		})
+	}
+}
+
+func MustMask(cpus ...int) []uint32 {
+	cs := cpuset.NewCPUSet(cpus...)
+	mask, err := cs.Mask()
+	if err != nil {
+		panic(err)
+	}
+	return mask
+}

--- a/pkg/controllers/cluster/actions/create.go
+++ b/pkg/controllers/cluster/actions/create.go
@@ -8,6 +8,7 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/util"
+	"github.com/scylladb/scylla-operator/pkg/controllers/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,13 +24,15 @@ type RackCreate struct {
 	Rack          scyllav1.RackSpec
 	Cluster       *scyllav1.ScyllaCluster
 	OperatorImage string
+	CloudPlatform helpers.CloudPlatform
 }
 
-func NewRackCreateAction(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, image string) *RackCreate {
+func NewRackCreateAction(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, image string, platform helpers.CloudPlatform) *RackCreate {
 	return &RackCreate{
 		Rack:          r,
 		Cluster:       c,
 		OperatorImage: image,
+		CloudPlatform: platform,
 	}
 }
 
@@ -39,7 +42,7 @@ func (a *RackCreate) Name() string {
 
 func (a *RackCreate) Execute(ctx context.Context, s *State) error {
 	r, c := a.Rack, a.Cluster
-	newSts, err := resource.StatefulSetForRack(r, c, a.OperatorImage)
+	newSts, err := resource.StatefulSetForRack(r, c, a.OperatorImage, a.CloudPlatform)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/cluster/actions/rack_synchronized_test.go
+++ b/pkg/controllers/cluster/actions/rack_synchronized_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
+	"github.com/scylladb/scylla-operator/pkg/controllers/helpers"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -48,7 +49,7 @@ func TestRackSynchronizedAction_SubActionUpdatesRack(t *testing.T) {
 	})
 
 	cluster := unit.NewMultiRackCluster(1)
-	firstRack, err := resource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[0], cluster, "image")
+	firstRack, err := resource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[0], cluster, "image", helpers.UnknownPlatform)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +98,7 @@ func TestRackSynchronizedAction_RackAreUpgradedInSequence(t *testing.T) {
 	})
 
 	cluster := unit.NewMultiRackCluster(1, 1)
-	firstRack, err := resource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[0], cluster, "image")
+	firstRack, err := resource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[0], cluster, "image", helpers.UnknownPlatform)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +106,7 @@ func TestRackSynchronizedAction_RackAreUpgradedInSequence(t *testing.T) {
 	firstRackReady.Status.ObservedGeneration = firstRackReady.Generation
 	firstRackReady.Status.ReadyReplicas = cluster.Spec.Datacenter.Racks[0].Members
 
-	secondRack, err := resource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[1], cluster, "image")
+	secondRack, err := resource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[1], cluster, "image", helpers.UnknownPlatform)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controllers/cluster/actions/sidecar_upgrade_test.go
+++ b/pkg/controllers/cluster/actions/sidecar_upgrade_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
+	"github.com/scylladb/scylla-operator/pkg/controllers/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	"go.uber.org/zap"
@@ -35,7 +36,7 @@ func TestSidecarUpgradeAction(t *testing.T) {
 
 	cluster := unit.NewMultiRackCluster(1)
 	rack := cluster.Spec.Datacenter.Racks[0]
-	rackSts, err := resource.StatefulSetForRack(rack, cluster, preUpdateImage)
+	rackSts, err := resource.StatefulSetForRack(rack, cluster, preUpdateImage, helpers.UnknownPlatform)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controllers/cluster/actions/upgrade_version_test.go
+++ b/pkg/controllers/cluster/actions/upgrade_version_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/util"
+	"github.com/scylladb/scylla-operator/pkg/controllers/helpers"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +17,7 @@ func TestUpgradeStatefulSetScyllaImage(t *testing.T) {
 	ctx := context.Background()
 	cluster := unit.NewSingleRackCluster(3)
 	rack := cluster.Spec.Datacenter.Racks[0]
-	sts, err := resource.StatefulSetForRack(rack, cluster, "sidecar")
+	sts, err := resource.StatefulSetForRack(rack, cluster, "sidecar", helpers.UnknownPlatform)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -219,9 +219,9 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, sidecarI
 								fmt.Sprintf("cp -a /usr/bin/scylla-operator %s", naming.SharedDirName),
 							},
 							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("10Mi"),
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -528,9 +528,9 @@ func sysctlInitContainer(sysctls []string, image string) *corev1.Container {
 			Privileged: &opt,
 		},
 		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("10Mi"),
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
 			},
 		},
 		Command: []string{

--- a/pkg/controllers/cluster/status_test.go
+++ b/pkg/controllers/cluster/status_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
+	"github.com/scylladb/scylla-operator/pkg/controllers/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	appsv1 "k8s.io/api/apps/v1"
@@ -68,7 +69,7 @@ func TestClusterStatus_SourceOfRackStatus(t *testing.T) {
 		},
 	}
 
-	rackSts, err := resource.StatefulSetForRack(rack, cluster, "image")
+	rackSts, err := resource.StatefulSetForRack(rack, cluster, "image", helpers.UnknownPlatform)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controllers/cluster/sync.go
+++ b/pkg/controllers/cluster/sync.go
@@ -104,7 +104,7 @@ func (cc *ClusterReconciler) nextAction(ctx context.Context, cluster *scyllav1.S
 		// For each rack, check if a status entry exists
 		if _, ok := cluster.Status.Racks[rack.Name]; !ok {
 			logger.Info(ctx, "Next Action: Create rack", "name", rack.Name)
-			return actions.NewRackCreateAction(rack, cluster, cc.OperatorImage), nil
+			return actions.NewRackCreateAction(rack, cluster, cc.OperatorImage, cc.CloudPlatform), nil
 		}
 	}
 
@@ -181,7 +181,7 @@ func (cc *ClusterReconciler) nextAction(ctx context.Context, cluster *scyllav1.S
 }
 
 func (cc *ClusterReconciler) sidecarUpdateNeeded(ctx context.Context, rack scyllav1.RackSpec, cluster *scyllav1.ScyllaCluster) (bool, corev1.Container, error) {
-	desiredSts, err := resource.StatefulSetForRack(rack, cluster, cc.OperatorImage)
+	desiredSts, err := resource.StatefulSetForRack(rack, cluster, cc.OperatorImage, cc.CloudPlatform)
 	if err != nil {
 		return false, corev1.Container{}, err
 	}

--- a/pkg/controllers/cluster/sync_test.go
+++ b/pkg/controllers/cluster/sync_test.go
@@ -9,6 +9,7 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/actions"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
+	"github.com/scylladb/scylla-operator/pkg/controllers/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,7 +24,7 @@ func TestNextAction(t *testing.T) {
 
 	members := int32(3)
 	cluster := unit.NewSingleRackCluster(members)
-	rack, err := resource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[0], cluster, operatorImage)
+	rack, err := resource.StatefulSetForRack(cluster.Spec.Datacenter.Racks[0], cluster, operatorImage, helpers.UnknownPlatform)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controllers/helpers/cloud.go
+++ b/pkg/controllers/helpers/cloud.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 ScyllaDB
+
+package helpers
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type CloudPlatform string
+
+const (
+	AKSPlatform     CloudPlatform = "AKS"
+	GKEPlatform     CloudPlatform = "GKE"
+	EKSPlatform     CloudPlatform = "EKS"
+	UnknownPlatform CloudPlatform = "Unknown"
+)
+
+func GetCloudPlatform(node *corev1.Node) CloudPlatform {
+	if strings.HasSuffix(node.Status.NodeInfo.KernelVersion, "gke") {
+		return GKEPlatform
+	}
+	if strings.HasSuffix(node.Status.NodeInfo.KernelVersion, "amzn2.x86_64") {
+		return EKSPlatform
+	}
+	if strings.HasSuffix(node.Status.NodeInfo.KernelVersion, "azure") {
+		return AKSPlatform
+	}
+
+	return UnknownPlatform
+}

--- a/pkg/controllers/helpers/cloud_test.go
+++ b/pkg/controllers/helpers/cloud_test.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2021 ScyllaDB
+
+package helpers
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGetCloudPlatform(t *testing.T) {
+	ts := []struct {
+		Name     string
+		Node     *corev1.Node
+		Expected CloudPlatform
+	}{
+		{
+			Name:     "GKE",
+			Expected: GKEPlatform,
+			Node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						KernelVersion: "5.4.0-1039-gke",
+					},
+				},
+			},
+		},
+		{
+			Name:     "EKS",
+			Expected: EKSPlatform,
+			Node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						KernelVersion: "4.15.0-1018-aws",
+					},
+				},
+			},
+		},
+		{
+			Name:     "Azure",
+			Expected: AKSPlatform,
+			Node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						KernelVersion: "4.15.0-1039-azure",
+					},
+				},
+			},
+		},
+		{
+			Name:     "Unknown",
+			Expected: UnknownPlatform,
+			Node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						KernelVersion: "5.4.0-1039",
+					},
+				},
+			},
+		},
+	}
+
+	for i := range ts {
+		test := ts[i]
+		t.Run(test.Name, func(t *testing.T) {
+			platform := GetCloudPlatform(test.Node)
+			if platform != test.Expected {
+				t.Errorf("Expected %s, got %s", test.Expected, platform)
+			}
+		})
+	}
+}

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -210,6 +210,11 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	overprovisioned := "0"
+	if m.Overprovisioned {
+		overprovisioned = "1"
+	}
+
 	// Listen on all interfaces so users or a service mesh can use localhost.
 	listenAddress := "0.0.0.0"
 	args := map[string]*string{
@@ -218,7 +223,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		"broadcast-rpc-address": &m.StaticIP,
 		"seeds":                 pointer.StringPtr(strings.Join(seeds, ",")),
 		"developer-mode":        &devMode,
-		"overprovisioned":       pointer.StringPtr("0"),
+		"overprovisioned":       pointer.StringPtr(overprovisioned),
 		"smp":                   pointer.StringPtr(strconv.Itoa(shards)),
 	}
 	if cluster.Spec.Alternator.Enabled() {

--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -237,7 +237,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 	// Now we rely completely on the user to have the cpu policy correctly
 	// configured in the kubelet, otherwise scylla will crash.
 	if cluster.Spec.CpuSet {
-		cpusAllowed, err := getCPUsAllowedList("/proc/1/status")
+		cpusAllowed, err := getCPUsAllowedList("/proc/self/status")
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/pkg/controllers/sidecar/identity/member.go
+++ b/pkg/controllers/sidecar/identity/member.go
@@ -52,14 +52,14 @@ func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes
 	}
 
 	return &Member{
-		Name:          name,
-		Namespace:     namespace,
-		IP:            pod.Status.PodIP,
-		StaticIP:      memberService.Spec.ClusterIP,
-		Rack:          pod.Labels[naming.RackNameLabel],
-		Datacenter:    pod.Labels[naming.DatacenterNameLabel],
-		Cluster:       pod.Labels[naming.ClusterNameLabel],
-		ServiceLabels: memberService.Labels,
+		Name:            name,
+		Namespace:       namespace,
+		IP:              pod.Status.PodIP,
+		StaticIP:        memberService.Spec.ClusterIP,
+		Rack:            pod.Labels[naming.RackNameLabel],
+		Datacenter:      pod.Labels[naming.DatacenterNameLabel],
+		Cluster:         pod.Labels[naming.ClusterNameLabel],
+		ServiceLabels:   memberService.Labels,
 	}, nil
 }
 

--- a/pkg/controllers/sidecar/identity/member.go
+++ b/pkg/controllers/sidecar/identity/member.go
@@ -27,6 +27,8 @@ type Member struct {
 	Datacenter    string
 	Cluster       string
 	ServiceLabels map[string]string
+
+	Overprovisioned bool
 }
 
 func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes.Interface) (*Member, error) {
@@ -60,6 +62,7 @@ func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes
 		Datacenter:      pod.Labels[naming.DatacenterNameLabel],
 		Cluster:         pod.Labels[naming.ClusterNameLabel],
 		ServiceLabels:   memberService.Labels,
+		Overprovisioned: pod.Status.QOSClass != corev1.PodQOSGuaranteed,
 	}, nil
 }
 

--- a/pkg/util/cpuset/mask.go
+++ b/pkg/util/cpuset/mask.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2021 ScyllaDB
+
+package cpuset
+
+import (
+	"fmt"
+	"math/big"
+	"math/bits"
+	"strconv"
+	"strings"
+)
+
+func ParseMaskFormat(words []uint32) CPUSet {
+	l := uint(0)
+	var set []int
+	for i := len(words) - 1; i >= 0; i-- {
+		word := words[i]
+		for b := l; word != 0; {
+			n := uint(bits.TrailingZeros32(word))
+			set = append(set, int(b+n))
+			word >>= n + 1
+			b += n + 1
+		}
+		l += 32
+	}
+
+	return NewCPUSet(set...)
+}
+
+func (cs CPUSet) FormatMask() string {
+	bitset := new(big.Int)
+	for elem := range cs.elems {
+		bitset.SetBit(bitset, elem, 1)
+	}
+
+	one := big.NewInt(1)
+	low32 := new(big.Int).Lsh(one, 32)
+	low32.Sub(low32, one)
+
+	mask := ""
+	first := true
+	zero := new(big.Int)
+	for first || bitset.Cmp(zero) != 0 {
+		word := new(big.Int).And(bitset, low32)
+		mask = fmt.Sprintf(",0x%08x%s", word, mask)
+		bitset.Rsh(bitset, 32)
+		first = false
+	}
+
+	return fmt.Sprintf("%s", mask[1:])
+}
+
+func (cs CPUSet) Mask() ([]uint32, error) {
+	f := strings.Split(cs.FormatMask(), ",")
+	mask := make([]uint32, len(f))
+	for i := range f {
+		n, err := strconv.ParseUint(strings.TrimPrefix(f[i], "0x"), 16, 32)
+		if err != nil {
+			return nil, err
+		}
+		mask[i] = uint32(n)
+	}
+
+	return mask, nil
+}

--- a/pkg/util/cpuset/mask_test.go
+++ b/pkg/util/cpuset/mask_test.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2021 ScyllaDB
+
+package cpuset
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func TestMask(t *testing.T) {
+	ts := []struct {
+		Mask     []uint32
+		Expected string
+	}{
+		{Mask: []uint32{0x00007fff}, Expected: "0-14"},
+		{Mask: []uint32{0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff}, Expected: "0-127"},
+		{Mask: []uint32{0x00000001}, Expected: "0"},
+		{Mask: []uint32{0x40000000, 0x00000000, 0x00000000}, Expected: "94"},
+		{Mask: []uint32{0x00000001, 0x00000000, 0x00000000}, Expected: "64"},
+		{Mask: []uint32{0x000000ff, 0x00000000}, Expected: "32-39"},
+		{Mask: []uint32{0x000e3862}, Expected: "1,5-6,11-13,17-19"},
+		{Mask: []uint32{0x00000001, 0x00000001, 0x00010117}, Expected: "0-2,4,8,16,32,64"},
+	}
+	for i := range ts {
+		test := ts[i]
+		t.Run(test.Expected, func(t *testing.T) {
+			mask := ParseMaskFormat(test.Mask).String()
+			if mask != test.Expected {
+				t.Errorf("Expected %v, got %v", test.Expected, mask)
+			}
+			cpuset, err := Parse(test.Expected)
+			if err != nil {
+				t.Errorf("Expected non-nil error, got %s", err)
+			}
+
+			m, err := cpuset.Mask()
+			if err != nil {
+				t.Errorf("Expected non-nil error, got %s", err)
+			}
+			if !equality.Semantic.DeepEqual(m, test.Mask) {
+				t.Errorf("Expected %v mask, got %v", test.Mask, m)
+			}
+		})
+	}
+}
+
+func integerRange(a, b int) []int {
+	r := make([]int, 0, b-a+1)
+	for i := a; i <= b; i++ {
+		r = append(r, i)
+	}
+	return r
+}
+
+func TestFormatMask(t *testing.T) {
+	ts := []struct {
+		CPUs     []int
+		Expected string
+	}{
+		{CPUs: integerRange(0, 14), Expected: "0x00007fff"},
+		{CPUs: integerRange(0, 127), Expected: "0xffffffff,0xffffffff,0xffffffff,0xffffffff"},
+		{CPUs: integerRange(0, 0), Expected: "0x00000001"},
+		{CPUs: integerRange(94, 94), Expected: "0x40000000,0x00000000,0x00000000"},
+		{CPUs: integerRange(64, 64), Expected: "0x00000001,0x00000000,0x00000000"},
+		{CPUs: integerRange(32, 39), Expected: "0x000000ff,0x00000000"},
+		{CPUs: []int{1, 5, 6, 11, 12, 13, 17, 18, 19}, Expected: "0x000e3862"},
+		{CPUs: []int{0, 1, 2, 4, 8, 16, 32, 64}, Expected: "0x00000001,0x00000001,0x00010117"},
+	}
+	for i := range ts {
+		test := ts[i]
+		t.Run(test.Expected, func(t *testing.T) {
+			cpuset := NewCPUSet(test.CPUs...)
+			mask := cpuset.FormatMask()
+			if mask != test.Expected {
+				t.Errorf("Expected %v, got %v", test.Expected, mask)
+			}
+		})
+	}
+
+}

--- a/vendor/github.com/c9s/goprocinfo/LICENSE
+++ b/vendor/github.com/c9s/goprocinfo/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-2014 Yo-An Lin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/c9s/goprocinfo/linux/cpuinfo.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/cpuinfo.go
@@ -1,0 +1,133 @@
+package linux
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type CPUInfo struct {
+	Processors []Processor `json:"processors"`
+}
+
+func (self *CPUInfo) NumCPU() int {
+	return len(self.Processors)
+}
+
+func (self *CPUInfo) NumCore() int {
+	core := make(map[string]bool)
+
+	for _, p := range self.Processors {
+		pid := p.PhysicalId
+		cid := p.CoreId
+
+		if pid == -1 {
+			return self.NumCPU()
+		} else {
+			// to avoid fmt import
+			key := strconv.FormatInt(int64(pid), 10) + ":" + strconv.FormatInt(int64(cid), 10)
+			core[key] = true
+		}
+	}
+
+	return len(core)
+}
+
+func (self *CPUInfo) NumPhysicalCPU() int {
+	pcpu := make(map[string]bool)
+
+	for _, p := range self.Processors {
+		pid := p.PhysicalId
+
+		if pid == -1 {
+			return self.NumCPU()
+		} else {
+			// to avoid fmt import
+			key := strconv.FormatInt(int64(pid), 10)
+			pcpu[key] = true
+		}
+	}
+
+	return len(pcpu)
+}
+
+type Processor struct {
+	Id         int64    `json:"id"`
+	VendorId   string   `json:"vendor_id"`
+	Model      int64    `json:"model"`
+	ModelName  string   `json:"model_name"`
+	Flags      []string `json:"flags"`
+	Cores      int64    `json:"cores"`
+	MHz        float64  `json:"mhz"`
+	CacheSize  int64    `json:"cache_size"` // KB
+	PhysicalId int64    `json:"physical_id"`
+	CoreId     int64    `json:"core_id"`
+}
+
+var cpuinfoRegExp = regexp.MustCompile("([^:]*?)\\s*:\\s*(.*)$")
+
+func ReadCPUInfo(path string) (*CPUInfo, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	content := string(b)
+	lines := strings.Split(content, "\n")
+
+	var cpuinfo = CPUInfo{}
+	var processor = &Processor{CoreId: -1, PhysicalId: -1}
+
+	for i, line := range lines {
+		var key string
+		var value string
+
+		if len(line) == 0 && i != len(lines)-1 {
+			// end of processor
+			cpuinfo.Processors = append(cpuinfo.Processors, *processor)
+			processor = &Processor{}
+			continue
+		} else if i == len(lines)-1 {
+			continue
+		}
+
+		submatches := cpuinfoRegExp.FindStringSubmatch(line)
+		key = submatches[1]
+		value = submatches[2]
+
+		switch key {
+		case "processor":
+			processor.Id, _ = strconv.ParseInt(value, 10, 64)
+		case "vendor_id":
+			processor.VendorId = value
+		case "model":
+			processor.Model, _ = strconv.ParseInt(value, 10, 64)
+		case "model name":
+			processor.ModelName = value
+		case "flags":
+			processor.Flags = strings.Fields(value)
+		case "cpu cores":
+			processor.Cores, _ = strconv.ParseInt(value, 10, 64)
+		case "cpu MHz":
+			processor.MHz, _ = strconv.ParseFloat(value, 64)
+		case "cache size":
+			processor.CacheSize, _ = strconv.ParseInt(value[:strings.IndexAny(value, " \t\n")], 10, 64)
+			if strings.HasSuffix(line, "MB") {
+				processor.CacheSize *= 1024
+			}
+		case "physical id":
+			processor.PhysicalId, _ = strconv.ParseInt(value, 10, 64)
+		case "core id":
+			processor.CoreId, _ = strconv.ParseInt(value, 10, 64)
+		}
+		/*
+			processor	: 0
+			vendor_id	: GenuineIntel
+			cpu family	: 6
+			model		: 26
+			model name	: Intel(R) Xeon(R) CPU           L5520  @ 2.27GHz
+		*/
+	}
+	return &cpuinfo, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/disk.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/disk.go
@@ -1,0 +1,26 @@
+package linux
+
+import (
+	"syscall"
+)
+
+type Disk struct {
+	All        uint64 `json:"all"`
+	Used       uint64 `json:"used"`
+	Free       uint64 `json:"free"`
+	FreeInodes uint64 `json:"freeInodes"`
+}
+
+func ReadDisk(path string) (*Disk, error) {
+	fs := syscall.Statfs_t{}
+	err := syscall.Statfs(path, &fs)
+	if err != nil {
+		return nil, err
+	}
+	disk := Disk{}
+	disk.All = fs.Blocks * uint64(fs.Bsize)
+	disk.Free = fs.Bfree * uint64(fs.Bsize)
+	disk.Used = disk.All - disk.Free
+	disk.FreeInodes = fs.Ffree
+	return &disk, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/diskstat.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/diskstat.go
@@ -1,0 +1,100 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DiskStat is disk statistics to help measure disk activity.
+//
+// Note:
+// * On a very busy or long-lived system values may wrap.
+// * No kernel locks are held while modifying these counters. This implies that
+//   minor inaccuracies may occur.
+//
+// More more info see:
+// https://www.kernel.org/doc/Documentation/iostats.txt and
+// https://www.kernel.org/doc/Documentation/block/stat.txt
+type DiskStat struct {
+	Major        int    `json:"major"`         // major device number
+	Minor        int    `json:"minor"`         // minor device number
+	Name         string `json:"name"`          // device name
+	ReadIOs      uint64 `json:"read_ios"`      // number of read I/Os processed
+	ReadMerges   uint64 `json:"read_merges"`   // number of read I/Os merged with in-queue I/O
+	ReadSectors  uint64 `json:"read_sectors"`  // number of 512 byte sectors read
+	ReadTicks    uint64 `json:"read_ticks"`    // total wait time for read requests in milliseconds
+	WriteIOs     uint64 `json:"write_ios"`     // number of write I/Os processed
+	WriteMerges  uint64 `json:"write_merges"`  // number of write I/Os merged with in-queue I/O
+	WriteSectors uint64 `json:"write_sectors"` // number of 512 byte sectors written
+	WriteTicks   uint64 `json:"write_ticks"`   // total wait time for write requests in milliseconds
+	InFlight     uint64 `json:"in_flight"`     // number of I/Os currently in flight
+	IOTicks      uint64 `json:"io_ticks"`      // total time this block device has been active in milliseconds
+	TimeInQueue  uint64 `json:"time_in_queue"` // total wait time for all requests in milliseconds
+}
+
+// ReadDiskStats reads and parses the file.
+//
+// Note:
+// * Assumes a well formed file and will panic if it isn't.
+func ReadDiskStats(path string) ([]DiskStat, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	devices := strings.Split(string(data), "\n")
+	results := make([]DiskStat, len(devices)-1)
+
+	for i := range results {
+		fields := strings.Fields(devices[i])
+		Major, _ := strconv.ParseInt(fields[0], 10, strconv.IntSize)
+		results[i].Major = int(Major)
+		Minor, _ := strconv.ParseInt(fields[1], 10, strconv.IntSize)
+		results[i].Minor = int(Minor)
+		results[i].Name = fields[2]
+		results[i].ReadIOs, _ = strconv.ParseUint(fields[3], 10, 64)
+		results[i].ReadMerges, _ = strconv.ParseUint(fields[4], 10, 64)
+		results[i].ReadSectors, _ = strconv.ParseUint(fields[5], 10, 64)
+		results[i].ReadTicks, _ = strconv.ParseUint(fields[6], 10, 64)
+		results[i].WriteIOs, _ = strconv.ParseUint(fields[7], 10, 64)
+		results[i].WriteMerges, _ = strconv.ParseUint(fields[8], 10, 64)
+		results[i].WriteSectors, _ = strconv.ParseUint(fields[9], 10, 64)
+		results[i].WriteTicks, _ = strconv.ParseUint(fields[10], 10, 64)
+		results[i].InFlight, _ = strconv.ParseUint(fields[11], 10, 64)
+		results[i].IOTicks, _ = strconv.ParseUint(fields[12], 10, 64)
+		results[i].TimeInQueue, _ = strconv.ParseUint(fields[13], 10, 64)
+	}
+
+	return results, nil
+}
+
+// GetReadBytes returns the number of bytes read.
+func (ds *DiskStat) GetReadBytes() int64 {
+	return int64(ds.ReadSectors) * 512
+}
+
+// GetReadTicks returns the duration waited for read requests.
+func (ds *DiskStat) GetReadTicks() time.Duration {
+	return time.Duration(ds.ReadTicks) * time.Millisecond
+}
+
+// GetWriteBytes returns the number of bytes written.
+func (ds *DiskStat) GetWriteBytes() int64 {
+	return int64(ds.WriteSectors) * 512
+}
+
+// GetWriteTicks returns the duration waited for write requests.
+func (ds *DiskStat) GetWriteTicks() time.Duration {
+	return time.Duration(ds.WriteTicks) * time.Millisecond
+}
+
+// GetIOTicks returns the duration the disk has been active.
+func (ds *DiskStat) GetIOTicks() time.Duration {
+	return time.Duration(ds.IOTicks) * time.Millisecond
+}
+
+// GetTimeInQueue returns the duration waited for all requests.
+func (ds *DiskStat) GetTimeInQueue() time.Duration {
+	return time.Duration(ds.TimeInQueue) * time.Millisecond
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/interrupts.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/interrupts.go
@@ -1,0 +1,56 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+type Interrupt struct {
+	Name        string
+	Counts      []uint64
+	Description string
+}
+
+type Interrupts struct {
+	Interrupts []Interrupt
+}
+
+func ReadInterrupts(path string) (*Interrupts, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	content := string(b)
+	lines := strings.Split(content, "\n")
+	cpus := lines[0]
+	lines = append(lines[:0], lines[1:]...)
+	numCpus := len(strings.Fields(cpus))
+	interrupts := make([]Interrupt, 0)
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		counts := make([]uint64, 0)
+		i := 0
+		for ; i < numCpus; i++ {
+			if len(fields) <= i+1 {
+				break
+			}
+			count, err := strconv.ParseInt(fields[i+1], 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			counts = append(counts, uint64(count))
+		}
+		name := strings.TrimSuffix(fields[0], ":")
+		description := strings.Join(fields[i+1:], " ")
+		interrupts = append(interrupts, Interrupt{
+			Name:        name,
+			Counts:      counts,
+			Description: description,
+		})
+	}
+	return &Interrupts{Interrupts: interrupts}, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/loadavg.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/loadavg.go
@@ -1,0 +1,67 @@
+package linux
+
+import (
+	"errors"
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+type LoadAvg struct {
+	Last1Min       float64 `json:"last1min"`
+	Last5Min       float64 `json:"last5min"`
+	Last15Min      float64 `json:"last15min"`
+	ProcessRunning uint64  `json:"process_running"`
+	ProcessTotal   uint64  `json:"process_total"`
+	LastPID        uint64  `json:"last_pid"`
+}
+
+func ReadLoadAvg(path string) (*LoadAvg, error) {
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	content := strings.TrimSpace(string(b))
+	fields := strings.Fields(content)
+
+	if len(fields) < 5 {
+		return nil, errors.New("Cannot parse loadavg: " + content)
+	}
+
+	process := strings.Split(fields[3], "/")
+
+	if len(process) != 2 {
+		return nil, errors.New("Cannot parse loadavg: " + content)
+	}
+
+	loadavg := LoadAvg{}
+
+	if loadavg.Last1Min, err = strconv.ParseFloat(fields[0], 64); err != nil {
+		return nil, err
+	}
+
+	if loadavg.Last5Min, err = strconv.ParseFloat(fields[1], 64); err != nil {
+		return nil, err
+	}
+
+	if loadavg.Last15Min, err = strconv.ParseFloat(fields[2], 64); err != nil {
+		return nil, err
+	}
+
+	if loadavg.ProcessRunning, err = strconv.ParseUint(process[0], 10, 64); err != nil {
+		return nil, err
+	}
+
+	if loadavg.ProcessTotal, err = strconv.ParseUint(process[1], 10, 64); err != nil {
+		return nil, err
+	}
+
+	if loadavg.LastPID, err = strconv.ParseUint(fields[4], 10, 64); err != nil {
+		return nil, err
+	}
+
+	return &loadavg, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/meminfo.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/meminfo.go
@@ -1,0 +1,97 @@
+package linux
+
+import (
+	"io/ioutil"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type MemInfo struct {
+	MemTotal          uint64 `json:"mem_total"`
+	MemFree           uint64 `json:"mem_free"`
+	MemAvailable      uint64 `json:"mem_available"`
+	Buffers           uint64 `json:"buffers"`
+	Cached            uint64 `json:"cached"`
+	SwapCached        uint64 `json:"swap_cached"`
+	Active            uint64 `json:"active"`
+	Inactive          uint64 `json:"inactive"`
+	ActiveAnon        uint64 `json:"active_anon" field:"Active(anon)"`
+	InactiveAnon      uint64 `json:"inactive_anon" field:"Inactive(anon)"`
+	ActiveFile        uint64 `json:"active_file" field:"Active(file)"`
+	InactiveFile      uint64 `json:"inactive_file" field:"Inactive(file)"`
+	Unevictable       uint64 `json:"unevictable"`
+	Mlocked           uint64 `json:"mlocked"`
+	SwapTotal         uint64 `json:"swap_total"`
+	SwapFree          uint64 `json:"swap_free"`
+	Dirty             uint64 `json:"dirty"`
+	Writeback         uint64 `json:"write_back"`
+	AnonPages         uint64 `json:"anon_pages"`
+	Mapped            uint64 `json:"mapped"`
+	Shmem             uint64 `json:"shmem"`
+	Slab              uint64 `json:"slab"`
+	SReclaimable      uint64 `json:"s_reclaimable"`
+	SUnreclaim        uint64 `json:"s_unclaim"`
+	KernelStack       uint64 `json:"kernel_stack"`
+	PageTables        uint64 `json:"page_tables"`
+	NFS_Unstable      uint64 `json:"nfs_unstable"`
+	Bounce            uint64 `json:"bounce"`
+	WritebackTmp      uint64 `json:"writeback_tmp"`
+	CommitLimit       uint64 `json:"commit_limit"`
+	Committed_AS      uint64 `json:"committed_as"`
+	VmallocTotal      uint64 `json:"vmalloc_total"`
+	VmallocUsed       uint64 `json:"vmalloc_used"`
+	VmallocChunk      uint64 `json:"vmalloc_chunk"`
+	HardwareCorrupted uint64 `json:"hardware_corrupted"`
+	AnonHugePages     uint64 `json:"anon_huge_pages"`
+	HugePages_Total   uint64 `json:"huge_pages_total"`
+	HugePages_Free    uint64 `json:"huge_pages_free"`
+	HugePages_Rsvd    uint64 `json:"huge_pages_rsvd"`
+	HugePages_Surp    uint64 `json:"huge_pages_surp"`
+	Hugepagesize      uint64 `json:"hugepagesize"`
+	DirectMap4k       uint64 `json:"direct_map_4k"`
+	DirectMap2M       uint64 `json:"direct_map_2M"`
+	DirectMap1G       uint64 `json:"direct_map_1G"`
+}
+
+func ReadMemInfo(path string) (*MemInfo, error) {
+	data, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+
+	// Maps a meminfo metric to its value (i.e. MemTotal --> 100000)
+	statMap := make(map[string]uint64)
+
+	var info = MemInfo{}
+
+	for _, line := range lines {
+		fields := strings.SplitN(line, ":", 2)
+		if len(fields) < 2 {
+			continue
+		}
+		valFields := strings.Fields(fields[1])
+		val, _ := strconv.ParseUint(valFields[0], 10, 64)
+		statMap[fields[0]] = val
+	}
+
+	elem := reflect.ValueOf(&info).Elem()
+	typeOfElem := elem.Type()
+
+	for i := 0; i < elem.NumField(); i++ {
+		val, ok := statMap[typeOfElem.Field(i).Name]
+		if ok {
+			elem.Field(i).SetUint(val)
+			continue
+		}
+		val, ok = statMap[typeOfElem.Field(i).Tag.Get("field")]
+		if ok {
+			elem.Field(i).SetUint(val)
+		}
+	}
+
+	return &info, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/mounts.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/mounts.go
@@ -1,0 +1,49 @@
+package linux
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+type Mounts struct {
+	Mounts []Mount `json:"mounts"`
+}
+
+type Mount struct {
+	Device     string `json:"device"`
+	MountPoint string `json:"mountpoint"`
+	FSType     string `json:"fstype"`
+	Options    string `json:"options"`
+}
+
+const (
+	DefaultBufferSize = 1024
+)
+
+func ReadMounts(path string) (*Mounts, error) {
+	fin, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fin.Close()
+
+	var mounts = Mounts{}
+
+	scanner := bufio.NewScanner(fin)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		var mount = &Mount{
+			fields[0],
+			fields[1],
+			fields[2],
+			fields[3],
+		}
+		mounts.Mounts = append(mounts.Mounts, *mount)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return &mounts, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/net_ip.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/net_ip.go
@@ -1,0 +1,173 @@
+package linux
+
+import (
+	"errors"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	ipv4RegExp = regexp.MustCompile("^[0-9a-fA-F]{8}:[0-9a-fA-F]{4}$")  // Regex for NetIPv4Decoder
+	ipv6RegExp = regexp.MustCompile("^[0-9a-fA-F]{32}:[0-9a-fA-F]{4}$") // Regex for NetIPv6Decoder
+)
+
+type NetIPDecoder func(string) (string, error) // Either NetIPv4Decoder or NetIPv6Decoder
+
+type NetSocket struct {
+	LocalAddress         string `json:"local_address"`
+	RemoteAddress        string `json:"remote_address"`
+	Status               uint8  `json:"st"`
+	TxQueue              uint64 `json:"tx_queue"`
+	RxQueue              uint64 `json:"rx_queue"`
+	Uid                  uint32 `json:"uid"`
+	Inode                uint64 `json:"inode"`
+	SocketReferenceCount uint64 `json:"ref"`
+}
+
+func parseNetSocket(f []string, ip NetIPDecoder) (*NetSocket, error) {
+
+	if len(f) < 11 {
+		return nil, errors.New("Cannot parse net socket line: " + strings.Join(f, " "))
+	}
+
+	if strings.Index(f[4], ":") == -1 {
+		return nil, errors.New("Cannot parse tx/rx queues: " + f[4])
+	}
+
+	q := strings.Split(f[4], ":")
+
+	socket := &NetSocket{}
+
+	var s uint64  // socket.Status
+	var u uint64  // socket.Uid
+	var err error // parse error
+
+	if socket.LocalAddress, err = ip(f[1]); err != nil {
+		return nil, err
+	}
+
+	if socket.RemoteAddress, err = ip(f[2]); err != nil {
+		return nil, err
+	}
+
+	if s, err = strconv.ParseUint(f[3], 16, 8); err != nil {
+		return nil, err
+	}
+
+	if socket.TxQueue, err = strconv.ParseUint(q[0], 16, 64); err != nil {
+		return nil, err
+	}
+
+	if socket.RxQueue, err = strconv.ParseUint(q[1], 16, 64); err != nil {
+		return nil, err
+	}
+
+	if u, err = strconv.ParseUint(f[7], 10, 32); err != nil {
+		return nil, err
+	}
+
+	if socket.Inode, err = strconv.ParseUint(f[9], 10, 64); err != nil {
+		return nil, err
+	}
+
+	if socket.SocketReferenceCount, err = strconv.ParseUint(f[10], 10, 64); err != nil {
+		return nil, err
+	}
+
+	socket.Status = uint8(s)
+	socket.Uid = uint32(u)
+
+	return socket, nil
+}
+
+// NetIPv4Decoder decodes an IPv4 address with port from a given hex string
+// NOTE: This function match NetIPDecoder type
+func NetIPv4Decoder(s string) (string, error) {
+
+	if !ipv4RegExp.MatchString(s) {
+		return "", errors.New("Cannot decode ipv4 address: " + s)
+	}
+
+	i := strings.Split(s, ":")
+
+	b := make([]byte, 4)
+
+	for j := 0; j < 4; j++ {
+
+		x := j * 2
+		y := x + 2
+		z := 3 - j
+
+		// Extract 2 characters from hex string, 4 times.
+		//
+		// s: "0100007F" -> [
+		//     h: "01", h: "00", h: "00", h: "7F",
+		// ]
+		h := i[0][x:y]
+
+		// Reverse byte order
+		n, _ := strconv.ParseUint(h, 16, 8)
+		b[z] = byte(n)
+
+	}
+
+	h := net.IP(b).String()
+	n, _ := strconv.ParseUint(i[1], 16, 64)
+	p := strconv.FormatUint(n, 10)
+
+	// ipv4:port
+	v := h + ":" + p
+
+	return v, nil
+}
+
+// NetIPv6Decoder decodes an IPv6 address with port from a given hex string
+// NOTE: This function match NetIPDecoder type
+func NetIPv6Decoder(s string) (string, error) {
+
+	if !ipv6RegExp.MatchString(s) {
+		return "", errors.New("Cannot decode ipv6 address: " + s)
+	}
+
+	i := strings.Split(s, ":")
+
+	b := make([]byte, 16)
+
+	for j := 0; j < 4; j++ {
+
+		x := j * 8
+		y := x + 8
+
+		// Extract 8 characters from hex string, 4 times.
+		//
+		// s: "350E012A900F122E85EDEAADA64DAAD1" -> [
+		//     h: "350E012A", h: "900F122E",
+		//     h: "85EDEAAD", h: "A64DAAD1",
+		// ]
+		h := i[0][x:y]
+
+		for k := 0; k < 4; k++ {
+
+			// Reverse byte order
+			// "350E012A" -> [ 0x2A, 0x01, 0x0E, 0x35 ]
+			z := (j * 4) + k
+			g := 8 - (k * 2)
+			f := g - 2
+
+			n, _ := strconv.ParseUint(h[f:g], 16, 8)
+			b[z] = byte(n)
+
+		}
+	}
+
+	h := net.IP(b).String()
+	n, _ := strconv.ParseUint(i[1], 16, 64)
+	p := strconv.FormatUint(n, 10)
+
+	// ipv6:port
+	v := h + ":" + p
+
+	return v, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/net_tcp.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/net_tcp.go
@@ -1,0 +1,82 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+type NetTCPSockets struct {
+	Sockets []NetTCPSocket `json:"sockets"`
+}
+
+type NetTCPSocket struct {
+	NetSocket
+	RetransmitTimeout       uint64 `json:"retransmit_timeout"`
+	PredictedTick           uint64 `json:"predicted_tick"`
+	AckQuick                uint8  `json:"ack_quick"`
+	AckPingpong             bool   `json:"ack_pingpong"`
+	SendingCongestionWindow uint64 `json:"sending_congestion_window"`
+	SlowStartSizeThreshold  int64  `json:"slow_start_size_threshold"`
+}
+
+func ReadNetTCPSockets(path string, ip NetIPDecoder) (*NetTCPSockets, error) {
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(strings.TrimRight(string(b), "\n "), "\n")
+
+	tcp := &NetTCPSockets{}
+
+	for i := 1; i < len(lines); i++ {
+
+		line := lines[i]
+
+		f := strings.Fields(line)
+
+		s, err := parseNetSocket(f, ip)
+
+		if err != nil {
+			return nil, err
+		}
+
+		var n int64
+		e := &NetTCPSocket{
+			NetSocket: *s,
+		}
+
+		// Depending on socket state, the number of fields presented is either
+		// 12 or 17.
+		if len(f) >= 17 {
+			if e.RetransmitTimeout, err = strconv.ParseUint(f[12], 10, 64); err != nil {
+				return nil, err
+			}
+
+			if e.PredictedTick, err = strconv.ParseUint(f[13], 10, 64); err != nil {
+				return nil, err
+			}
+
+			if n, err = strconv.ParseInt(f[14], 10, 8); err != nil {
+				return nil, err
+			}
+			e.AckQuick = uint8(n >> 1)
+			e.AckPingpong = ((n & 1) == 1)
+
+			if e.SendingCongestionWindow, err = strconv.ParseUint(f[15], 10, 64); err != nil {
+				return nil, err
+			}
+
+			if e.SlowStartSizeThreshold, err = strconv.ParseInt(f[16], 10, 32); err != nil {
+				return nil, err
+			}
+		}
+
+		tcp.Sockets = append(tcp.Sockets, *e)
+	}
+
+	return tcp, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/net_udp.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/net_udp.go
@@ -1,0 +1,59 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+type NetUDPSockets struct {
+	Sockets []NetUDPSocket `json:"sockets"`
+}
+
+type NetUDPSocket struct {
+	NetSocket
+	Drops uint64 `json:"drops"`
+}
+
+func ReadNetUDPSockets(path string, ip NetIPDecoder) (*NetUDPSockets, error) {
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(b), "\n")
+
+	udp := &NetUDPSockets{}
+
+	for i := 1; i < len(lines); i++ {
+
+		line := lines[i]
+
+		f := strings.Fields(line)
+
+		if len(f) < 13 {
+			continue
+		}
+
+		s, err := parseNetSocket(f, ip)
+
+		if err != nil {
+			return nil, err
+		}
+
+		e := &NetUDPSocket{
+			NetSocket: *s,
+			Drops:     0,
+		}
+
+		if e.Drops, err = strconv.ParseUint(f[12], 10, 64); err != nil {
+			return nil, err
+		}
+
+		udp.Sockets = append(udp.Sockets, *e)
+	}
+
+	return udp, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/net_unix.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/net_unix.go
@@ -1,0 +1,72 @@
+package linux
+
+import (
+	"errors"
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+type NetUnixDomainSockets struct {
+	Sockets []NetUnixDomainSocket `json:"sockets"`
+}
+
+type NetUnixDomainSocket struct {
+	Protocol uint64 `json:"protocol"`
+	RefCount uint64 `json:"ref_count"`
+	Flags    uint64 `json:"flags"`
+	Type     uint64 `json:"type"`
+	State    uint64 `json:"state"`
+	Inode    uint64 `json:"inode"`
+	Path     string `json:"path"`
+}
+
+// ReadNetUnixDomainSockets parser to /proc/net/unix
+func ReadNetUnixDomainSockets(fpath string) (*NetUnixDomainSockets, error) {
+	b, err := ioutil.ReadFile(fpath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(b), "\n")
+	unixDomainSockets := &NetUnixDomainSockets{}
+
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
+		f := strings.Fields(line)
+
+		if len(f) < 8 {
+			continue
+		}
+
+		socket := NetUnixDomainSocket{}
+		if socket.RefCount, err = strconv.ParseUint(f[1], 16, 64); err != nil {
+			return nil, errors.New("Cannot parse unix domain socket [invalid RefCount]: " + f[1])
+		}
+
+		if socket.Protocol, err = strconv.ParseUint(f[2], 10, 64); err != nil {
+			return nil, errors.New("Cannot parse unix domain socket [invalid Protocol]: " + f[2])
+		}
+
+		if socket.Flags, err = strconv.ParseUint(f[3], 10, 64); err != nil {
+			return nil, errors.New("Cannot parse unix domain socket [invalid Flags]: " + f[3])
+		}
+
+		if socket.Type, err = strconv.ParseUint(f[4], 10, 64); err != nil {
+			return nil, errors.New("Cannot parse unix domain socket [invalid Type]: " + f[4])
+		}
+
+		if socket.State, err = strconv.ParseUint(f[5], 10, 64); err != nil {
+			return nil, errors.New("Cannot parse unix domain socket [invalid State]: " + f[5])
+		}
+
+		if socket.Inode, err = strconv.ParseUint(f[6], 10, 64); err != nil {
+			return nil, errors.New("Cannot parse unix domain socket [invalid Inode]: " + f[6])
+		}
+
+		socket.Path = f[7]
+		unixDomainSockets.Sockets = append(unixDomainSockets.Sockets, socket)
+	}
+	return unixDomainSockets, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/netstat.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/netstat.go
@@ -1,0 +1,174 @@
+package linux
+
+import (
+	"io/ioutil"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type NetStat struct {
+	// TcpExt
+	SyncookiesSent            uint64 `json:"syncookie_sent"`
+	SyncookiesRecv            uint64 `json:"syncookies_recv"`
+	SyncookiesFailed          uint64 `json:"syncookies_failed"`
+	EmbryonicRsts             uint64 `json:"embryonic_rsts"`
+	PruneCalled               uint64 `json:"prune_called"`
+	RcvPruned                 uint64 `json:"rcv_pruned"`
+	OfoPruned                 uint64 `json:"ofo_pruned"`
+	OutOfWindowIcmps          uint64 `json:"out_of_window_icmps"`
+	LockDroppedIcmps          uint64 `json:"lock_dropped_icmps"`
+	ArpFilter                 uint64 `json:"arp_filter"`
+	TW                        uint64 `json:"tw"`
+	TWRecycled                uint64 `json:"tw_recycled"`
+	TWKilled                  uint64 `json:"tw_killed"`
+	PAWSPassive               uint64 `json:"paws_passive"`
+	PAWSActive                uint64 `json:"paws_active"`
+	PAWSEstab                 uint64 `json:"paws_estab"`
+	DelayedACKs               uint64 `json:"delayed_acks"`
+	DelayedACKLocked          uint64 `json:"delayed_ack_locked"`
+	DelayedACKLost            uint64 `json:"delayed_ack_lost"`
+	ListenOverflows           uint64 `json:"listen_overflows"`
+	ListenDrops               uint64 `json:"listen_drops"`
+	TCPPrequeued              uint64 `json:"tcp_prequeued"`
+	TCPDirectCopyFromBacklog  uint64 `json:"tcp_direct_copy_from_backlog"`
+	TCPDirectCopyFromPrequeue uint64 `json:"tcp_direct_copy_from_prequeue"`
+	TCPPrequeueDropped        uint64 `json:"tcp_prequeue_dropped"`
+	TCPHPHits                 uint64 `json:"tcp_hp_hits"`
+	TCPHPHitsToUser           uint64 `json:"tcp_hp_hits_to_user"`
+	TCPPureAcks               uint64 `json:"tcp_pure_acks"`
+	TCPHPAcks                 uint64 `json:"tcp_hp_acks"`
+	TCPRenoRecovery           uint64 `json:"tcp_reno_recovery"`
+	TCPSackRecovery           uint64 `json:"tcp_sack_recovery"`
+	TCPSACKReneging           uint64 `json:"tcp_sack_reneging"`
+	TCPFACKReorder            uint64 `json:"tcp_fack_reorder"`
+	TCPSACKReorder            uint64 `json:"tcp_sack_reorder"`
+	TCPRenoReorder            uint64 `json:"tcp_reno_reorder"`
+	TCPTSReorder              uint64 `json:"tcp_ts_reorder"`
+	TCPFullUndo               uint64 `json:"tcp_full_undo"`
+	TCPPartialUndo            uint64 `json:"tcp_partial_undo"`
+	TCPDSACKUndo              uint64 `json:"tcp_dsack_undo"`
+	TCPLossUndo               uint64 `json:"tcp_loss_undo"`
+	TCPLoss                   uint64 `json:"tcp_loss"`
+	TCPLostRetransmit         uint64 `json:"tcp_lost_retransmit"`
+	TCPRenoFailures           uint64 `json:"tcp_reno_failures"`
+	TCPSackFailures           uint64 `json:"tcp_sack_failures"`
+	TCPLossFailures           uint64 `json:"tcp_loss_failures"`
+	TCPFastRetrans            uint64 `json:"tcp_fast_retrans"`
+	TCPForwardRetrans         uint64 `json:"tcp_forward_retrans"`
+	TCPSlowStartRetrans       uint64 `json:"tcp_slow_start_retrans"`
+	TCPTimeouts               uint64 `json:"tcp_timeouts"`
+	TCPLossProbes             uint64 `json:"tcp_loss_probes"`
+	TCPLossProbeRecovery      uint64 `json:"tcp_loss_probe_recovery"`
+	TCPRenoRecoveryFail       uint64 `json:"tcp_reno_recovery_fail"`
+	TCPSackRecoveryFail       uint64 `json:"tcp_sack_recovery_fail"`
+	TCPSchedulerFailed        uint64 `json:"tcp_scheduler_failed"`
+	TCPRcvCollapsed           uint64 `json:"tcp_rcv_collapsed"`
+	TCPDSACKOldSent           uint64 `json:"tcp_dsack_old_sent"`
+	TCPDSACKOfoSent           uint64 `json:"tcp_dsack_ofo_sent"`
+	TCPDSACKRecv              uint64 `json:"tcp_dsack_recv"`
+	TCPDSACKOfoRecv           uint64 `json:"tcp_dsack_ofo_recv"`
+	TCPAbortOnSyn             uint64 `json:"tcp_abort_on_syn"`
+	TCPAbortOnData            uint64 `json:"tcp_abort_on_data"`
+	TCPAbortOnClose           uint64 `json:"tcp_abort_on_close"`
+	TCPAbortOnMemory          uint64 `json:"tcp_abort_on_memory"`
+	TCPAbortOnTimeout         uint64 `json:"tcp_abort_on_timeout"`
+	TCPAbortOnLinger          uint64 `json:"tcp_abort_on_linger"`
+	TCPAbortFailed            uint64 `json:"tcp_abort_failed"`
+	TCPMemoryPressures        uint64 `json:"tcp_memory_pressures"`
+	TCPSACKDiscard            uint64 `json:"tcp_sack_discard"`
+	TCPDSACKIgnoredOld        uint64 `json:"tcp_dsack_ignored_old"`
+	TCPDSACKIgnoredNoUndo     uint64 `json:"tcp_dsack_ignored_no_undo"`
+	TCPSpuriousRTOs           uint64 `json:"tcp_spurious_rtos"`
+	TCPMD5NotFound            uint64 `json:"tcp_md5_not_found"`
+	TCPMD5Unexpected          uint64 `json:"tcp_md5_unexpected"`
+	TCPSackShifted            uint64 `json:"tcp_sack_shifted"`
+	TCPSackMerged             uint64 `json:"tcp_sack_merged"`
+	TCPSackShiftFallback      uint64 `json:"tcp_sack_shift_fallback"`
+	TCPBacklogDrop            uint64 `json:"tcp_backlog_drop"`
+	TCPMinTTLDrop             uint64 `json:"tcp_min_ttl_drop"`
+	TCPDeferAcceptDrop        uint64 `json:"tcp_defer_accept_drop"`
+	IPReversePathFilter       uint64 `json:"ip_reverse_path_filter"`
+	TCPTimeWaitOverflow       uint64 `json:"tcp_time_wait_overflow"`
+	TCPReqQFullDoCookies      uint64 `json:"tcp_req_q_full_do_cookies"`
+	TCPReqQFullDrop           uint64 `json:"tcp_req_q_full_drop"`
+	TCPRetransFail            uint64 `json:"tcp_retrans_fail"`
+	TCPRcvCoalesce            uint64 `json:"tcp_rcv_coalesce"`
+	TCPOFOQueue               uint64 `json:"tcp_ofo_queue"`
+	TCPOFODrop                uint64 `json:"tcp_ofo_drop"`
+	TCPOFOMerge               uint64 `json:"tcp_ofo_merge"`
+	TCPChallengeACK           uint64 `json:"tcp_challenge_ack"`
+	TCPSYNChallenge           uint64 `json:"tcp_syn_challenge"`
+	TCPFastOpenActive         uint64 `json:"tcp_fast_open_active"`
+	TCPFastOpenActiveFail     uint64 `json:"tcp_fast_open_active_fail"`
+	TCPFastOpenPassive        uint64 `json:"tcp_fast_open_passive"`
+	TCPFastOpenPassiveFail    uint64 `json:"tcp_fast_open_passive_fail"`
+	TCPFastOpenListenOverflow uint64 `json:"tcp_fast_open_listen_overflow"`
+	TCPFastOpenCookieReqd     uint64 `json:"tcp_fast_open_cookie_reqd"`
+	TCPSpuriousRtxHostQueues  uint64 `json:"tcp_spurious_rtx_host_queues"`
+	BusyPollRxPackets         uint64 `json:"busy_poll_rx_packets"`
+	TCPAutoCorking            uint64 `json:"tcp_auto_corking"`
+	TCPFromZeroWindowAdv      uint64 `json:"tcp_from_zero_window_adv"`
+	TCPToZeroWindowAdv        uint64 `json:"tcp_to_zero_window_adv"`
+	TCPWantZeroWindowAdv      uint64 `json:"tcp_want_zero_window_adv"`
+	TCPSynRetrans             uint64 `json:"tcp_syn_retrans"`
+	TCPOrigDataSent           uint64 `json:"tcp_orig_data_sent"`
+	// IpExt
+	InNoRoutes      uint64 `json:"in_no_routes"`
+	InTruncatedPkts uint64 `json:"in_truncated_pkts"`
+	InMcastPkts     uint64 `json:"in_mcast_pkts"`
+	OutMcastPkts    uint64 `json:"out_mcast_pkts"`
+	InBcastPkts     uint64 `json:"in_bcast_pkts"`
+	OutBcastPkts    uint64 `json:"out_bcast_pkts"`
+	InOctets        uint64 `json:"in_octets"`
+	OutOctets       uint64 `json:"out_octets"`
+	InMcastOctets   uint64 `json:"in_mcast_octets"`
+	OutMcastOctets  uint64 `json:"out_mcast_octets"`
+	InBcastOctets   uint64 `json:"in_bcast_octets"`
+	OutBcastOctets  uint64 `json:"out_bcast_octets"`
+	InCsumErrors    uint64 `json:"in_csum_errors"`
+	InNoECTPkts     uint64 `json:"in_no_ect_pkts"`
+	InECT1Pkts      uint64 `json:"in_ect1_pkts"`
+	InECT0Pkts      uint64 `json:"in_ect0_pkts"`
+	InCEPkts        uint64 `json:"in_ce_pkts"`
+}
+
+func ReadNetStat(path string) (*NetStat, error) {
+	data, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+
+	// Maps a netstat metric to its value (i.e. SyncookiesSent --> 0)
+	statMap := make(map[string]string)
+
+	// patterns
+	// TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed... <-- header
+	// TcpExt: 0 0 1764... <-- values
+
+	for i := 1; i < len(lines); i = i + 2 {
+		headers := strings.Fields(lines[i-1][strings.Index(lines[i-1], ":")+1:])
+		values := strings.Fields(lines[i][strings.Index(lines[i], ":")+1:])
+
+		for j, header := range headers {
+			statMap[header] = values[j]
+		}
+	}
+
+	var netstat NetStat = NetStat{}
+
+	elem := reflect.ValueOf(&netstat).Elem()
+	typeOfElem := elem.Type()
+
+	for i := 0; i < elem.NumField(); i++ {
+		if val, ok := statMap[typeOfElem.Field(i).Name]; ok {
+			parsedVal, _ := strconv.ParseUint(val, 10, 64)
+			elem.Field(i).SetUint(parsedVal)
+		}
+	}
+
+	return &netstat, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/network_stat.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/network_stat.go
@@ -1,0 +1,73 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+type NetworkStat struct {
+	Iface        string `json:"iface"`
+	RxBytes      uint64 `json:"rxbytes"`
+	RxPackets    uint64 `json:"rxpackets"`
+	RxErrs       uint64 `json:"rxerrs"`
+	RxDrop       uint64 `json:"rxdrop"`
+	RxFifo       uint64 `json:"rxfifo"`
+	RxFrame      uint64 `json:"rxframe"`
+	RxCompressed uint64 `json:"rxcompressed"`
+	RxMulticast  uint64 `json:"rxmulticast"`
+	TxBytes      uint64 `json:"txbytes"`
+	TxPackets    uint64 `json:"txpackets"`
+	TxErrs       uint64 `json:"txerrs"`
+	TxDrop       uint64 `json:"txdrop"`
+	TxFifo       uint64 `json:"txfifo"`
+	TxColls      uint64 `json:"txcolls"`
+	TxCarrier    uint64 `json:"txcarrier"`
+	TxCompressed uint64 `json:"txcompressed"`
+}
+
+func ReadNetworkStat(path string) ([]NetworkStat, error) {
+	data, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+
+	// lines[2:] remove /proc/net/dev header
+	results := make([]NetworkStat, len(lines[2:])-1)
+
+	for i, line := range lines[2:] {
+		// patterns
+		// <iface>: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+		// or
+		// <iface>:0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 (without space after colon)
+		colon := strings.Index(line, ":")
+
+		if colon > 0 {
+			metrics := line[colon+1:]
+			fields := strings.Fields(metrics)
+
+			results[i].Iface = strings.Replace(line[0:colon], " ", "", -1)
+			results[i].RxBytes, _ = strconv.ParseUint(fields[0], 10, 64)
+			results[i].RxPackets, _ = strconv.ParseUint(fields[1], 10, 64)
+			results[i].RxErrs, _ = strconv.ParseUint(fields[2], 10, 64)
+			results[i].RxDrop, _ = strconv.ParseUint(fields[3], 10, 64)
+			results[i].RxFifo, _ = strconv.ParseUint(fields[4], 10, 64)
+			results[i].RxFrame, _ = strconv.ParseUint(fields[5], 10, 64)
+			results[i].RxCompressed, _ = strconv.ParseUint(fields[6], 10, 64)
+			results[i].RxMulticast, _ = strconv.ParseUint(fields[7], 10, 64)
+			results[i].TxBytes, _ = strconv.ParseUint(fields[8], 10, 64)
+			results[i].TxPackets, _ = strconv.ParseUint(fields[9], 10, 64)
+			results[i].TxErrs, _ = strconv.ParseUint(fields[10], 10, 64)
+			results[i].TxDrop, _ = strconv.ParseUint(fields[11], 10, 64)
+			results[i].TxFifo, _ = strconv.ParseUint(fields[12], 10, 64)
+			results[i].TxColls, _ = strconv.ParseUint(fields[13], 10, 64)
+			results[i].TxCarrier, _ = strconv.ParseUint(fields[14], 10, 64)
+			results[i].TxCompressed, _ = strconv.ParseUint(fields[15], 10, 64)
+		}
+	}
+
+	return results, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/process.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/process.go
@@ -1,0 +1,62 @@
+package linux
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+type Process struct {
+	Status  ProcessStatus `json:"status"`
+	Statm   ProcessStatm  `json:"statm"`
+	Stat    ProcessStat   `json:"stat"`
+	IO      ProcessIO     `json:"io"`
+	Cmdline string        `json:"cmdline"`
+}
+
+func ReadProcess(pid uint64, path string) (*Process, error) {
+
+	var err error
+
+	p := filepath.Join(path, strconv.FormatUint(pid, 10))
+
+	if _, err = os.Stat(p); err != nil {
+		return nil, err
+	}
+
+	process := Process{}
+
+	var io *ProcessIO
+	var stat *ProcessStat
+	var statm *ProcessStatm
+	var status *ProcessStatus
+	var cmdline string
+
+	if io, err = ReadProcessIO(filepath.Join(p, "io")); err != nil {
+		return nil, err
+	}
+
+	if stat, err = ReadProcessStat(filepath.Join(p, "stat")); err != nil {
+		return nil, err
+	}
+
+	if statm, err = ReadProcessStatm(filepath.Join(p, "statm")); err != nil {
+		return nil, err
+	}
+
+	if status, err = ReadProcessStatus(filepath.Join(p, "status")); err != nil {
+		return nil, err
+	}
+
+	if cmdline, err = ReadProcessCmdline(filepath.Join(p, "cmdline")); err != nil {
+		return nil, err
+	}
+
+	process.IO = *io
+	process.Stat = *stat
+	process.Statm = *statm
+	process.Status = *status
+	process.Cmdline = cmdline
+
+	return &process, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/process_cmdline.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/process_cmdline.go
@@ -1,0 +1,39 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func ReadProcessCmdline(path string) (string, error) {
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return "", err
+	}
+
+	l := len(b) - 1 // Define limit before last byte ('\0')
+	z := byte(0)    // '\0' or null byte
+	s := byte(0x20) // space byte
+	c := 0          // cursor of useful bytes
+
+	for i := 0; i < l; i++ {
+
+		// Check if next byte is not a '\0' byte.
+		if b[i+1] != z {
+
+			// Offset must match a '\0' byte.
+			c = i + 2
+
+			// If current byte is '\0', replace it with a space byte.
+			if b[i] == z {
+				b[i] = s
+			}
+		}
+	}
+
+	x := strings.TrimSpace(string(b[0:c]))
+
+	return x, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/process_io.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/process_io.go
@@ -1,0 +1,71 @@
+package linux
+
+import (
+	"io/ioutil"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// I/O statistics for the process.
+type ProcessIO struct {
+	RChar               uint64 `json:"rchar" field:"rchar"`                                 // chars read
+	WChar               uint64 `json:"wchar" field:"wchar"`                                 // chars written
+	Syscr               uint64 `json:"syscr" field:"syscr"`                                 // read syscalls
+	Syscw               uint64 `json:"syscw" field:"syscw"`                                 // write syscalls
+	ReadBytes           uint64 `json:"read_bytes" field:"read_bytes"`                       // bytes read
+	WriteBytes          uint64 `json:"write_bytes" field:"write_bytes"`                     // bytes written
+	CancelledWriteBytes uint64 `json:"cancelled_write_bytes" field:"cancelled_write_bytes"` // bytes truncated
+}
+
+func ReadProcessIO(path string) (*ProcessIO, error) {
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Maps a io metric to its value (i.e. rchar --> 100000)
+	m := map[string]uint64{}
+
+	io := ProcessIO{}
+
+	lines := strings.Split(string(b), "\n")
+
+	for _, line := range lines {
+
+		if strings.Index(line, ": ") == -1 {
+			continue
+		}
+
+		l := strings.Split(line, ": ")
+
+		k := l[0]
+		v, err := strconv.ParseUint(l[1], 10, 64)
+
+		if err != nil {
+			return nil, err
+		}
+
+		m[k] = v
+
+	}
+
+	e := reflect.ValueOf(&io).Elem()
+	t := e.Type()
+
+	for i := 0; i < e.NumField(); i++ {
+
+		k := t.Field(i).Tag.Get("field")
+
+		v, ok := m[k]
+
+		if ok {
+			e.Field(i).SetUint(v)
+		}
+
+	}
+
+	return &io, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/process_pid.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/process_pid.go
@@ -1,0 +1,54 @@
+package linux
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func ReadMaxPID(path string) (uint64, error) {
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return 0, err
+	}
+
+	s := strings.TrimSpace(string(b))
+
+	i, err := strconv.ParseUint(s, 10, 64)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return i, nil
+
+}
+
+func ListPID(path string, max uint64) ([]uint64, error) {
+
+	l := make([]uint64, 0, 5)
+
+	for i := uint64(1); i <= max; i++ {
+
+		p := filepath.Join(path, strconv.FormatUint(i, 10))
+
+		s, err := os.Stat(p)
+
+		if err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+
+		if err != nil || !s.IsDir() {
+			continue
+		}
+
+		l = append(l, i)
+
+	}
+
+	return l, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/process_sched_stat.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/process_sched_stat.go
@@ -1,0 +1,46 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+// https://www.kernel.org/doc/Documentation/scheduler/sched-stats.txt
+type ProcessSchedStat struct {
+	RunTime      uint64 `json:"run_time"`      // time spent on the cpu
+	RunqueueTime uint64 `json:"runqueue_time"` // time spent waiting on a runqueue
+	RunPeriods   uint64 `json:"run_periods"`   // # of timeslices run on this cpu
+}
+
+func ReadProcessSchedStat(path string) (*ProcessSchedStat, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	s := string(b)
+	f := strings.Fields(s)
+
+	schedStat := ProcessSchedStat{}
+
+	var n uint64
+
+	for i := 0; i < len(f); i++ {
+
+		if n, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+			return nil, err
+		}
+
+		switch i {
+		case 0:
+			schedStat.RunTime = n
+		case 1:
+			schedStat.RunqueueTime = n
+		case 2:
+			schedStat.RunPeriods = n
+		}
+
+	}
+	return &schedStat, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/process_stat.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/process_stat.go
@@ -1,0 +1,303 @@
+package linux
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Status information about the process.
+type ProcessStat struct {
+	Pid                 uint64 `json:"pid"`
+	Comm                string `json:"comm"`
+	State               string `json:"state"`
+	Ppid                int64  `json:"ppid"`
+	Pgrp                int64  `json:"pgrp"`
+	Session             int64  `json:"session"`
+	TtyNr               int64  `json:"tty_nr"`
+	Tpgid               int64  `json:"tpgid"`
+	Flags               uint64 `json:"flags"`
+	Minflt              uint64 `json:"minflt"`
+	Cminflt             uint64 `json:"cminflt"`
+	Majflt              uint64 `json:"majflt"`
+	Cmajflt             uint64 `json:"cmajflt"`
+	Utime               uint64 `json:"utime"`
+	Stime               uint64 `json:"stime"`
+	Cutime              int64  `json:"cutime"`
+	Cstime              int64  `json:"cstime"`
+	Priority            int64  `json:"priority"`
+	Nice                int64  `json:"nice"`
+	NumThreads          int64  `json:"num_threads"`
+	Itrealvalue         int64  `json:"itrealvalue"`
+	Starttime           uint64 `json:"starttime"`
+	Vsize               uint64 `json:"vsize"`
+	Rss                 int64  `json:"rss"`
+	Rsslim              uint64 `json:"rsslim"`
+	Startcode           uint64 `json:"startcode"`
+	Endcode             uint64 `json:"endcode"`
+	Startstack          uint64 `json:"startstack"`
+	Kstkesp             uint64 `json:"kstkesp"`
+	Kstkeip             uint64 `json:"kstkeip"`
+	Signal              uint64 `json:"signal"`
+	Blocked             uint64 `json:"blocked"`
+	Sigignore           uint64 `json:"sigignore"`
+	Sigcatch            uint64 `json:"sigcatch"`
+	Wchan               uint64 `json:"wchan"`
+	Nswap               uint64 `json:"nswap"`
+	Cnswap              uint64 `json:"cnswap"`
+	ExitSignal          int64  `json:"exit_signal"`
+	Processor           int64  `json:"processor"`
+	RtPriority          uint64 `json:"rt_priority"`
+	Policy              uint64 `json:"policy"`
+	DelayacctBlkioTicks uint64 `json:"delayacct_blkio_ticks"`
+	GuestTime           uint64 `json:"guest_time"`
+	CguestTime          int64  `json:"cguest_time"`
+	StartData           uint64 `json:"start_data"`
+	EndData             uint64 `json:"end_data"`
+	StartBrk            uint64 `json:"start_brk"`
+	ArgStart            uint64 `json:"arg_start"`
+	ArgEnd              uint64 `json:"arg_end"`
+	EnvStart            uint64 `json:"env_start"`
+	EnvEnd              uint64 `json:"env_end"`
+	ExitCode            int64  `json:"exit_code"`
+}
+
+var processStatRegExp = regexp.MustCompile("^(\\d+)( \\(.*?\\) )(.*)$")
+
+func ReadProcessStat(path string) (*ProcessStat, error) {
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	s := string(b)
+
+	f := make([]string, 0, 32)
+
+	e := processStatRegExp.FindStringSubmatch(strings.TrimSpace(s))
+
+	// Inject process Pid
+	f = append(f, e[1])
+
+	// Inject process Comm
+	f = append(f, strings.TrimSpace(e[2]))
+
+	// Inject all remaining process info
+	f = append(f, (strings.Fields(e[3]))...)
+
+	stat := ProcessStat{}
+
+	for i := 0; i < len(f); i++ {
+		switch i {
+		case 0:
+			if stat.Pid, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 1:
+			stat.Comm = f[i]
+		case 2:
+			stat.State = f[i]
+		case 3:
+			if stat.Ppid, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 4:
+			if stat.Pgrp, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 5:
+			if stat.Session, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 6:
+			if stat.TtyNr, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 7:
+			if stat.Tpgid, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 8:
+			if stat.Flags, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 9:
+			if stat.Minflt, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 10:
+			if stat.Cminflt, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 11:
+			if stat.Majflt, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 12:
+			if stat.Cmajflt, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 13:
+			if stat.Utime, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 14:
+			if stat.Stime, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 15:
+			if stat.Cutime, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 16:
+			if stat.Cstime, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 17:
+			if stat.Priority, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 18:
+			if stat.Nice, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 19:
+			if stat.NumThreads, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 20:
+			if stat.Itrealvalue, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 21:
+			if stat.Starttime, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 22:
+			if stat.Vsize, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 23:
+			if stat.Rss, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 24:
+			if stat.Rsslim, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 25:
+			if stat.Startcode, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 26:
+			if stat.Endcode, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 27:
+			if stat.Startstack, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 28:
+			if stat.Kstkesp, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 29:
+			if stat.Kstkeip, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 30:
+			if stat.Signal, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 31:
+			if stat.Blocked, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 32:
+			if stat.Sigignore, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 33:
+			if stat.Sigcatch, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 34:
+			if stat.Wchan, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 35:
+			if stat.Nswap, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 36:
+			if stat.Cnswap, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 37:
+			if stat.ExitSignal, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 38:
+			if stat.Processor, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 39:
+			if stat.RtPriority, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 40:
+			if stat.Policy, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 41:
+			if stat.DelayacctBlkioTicks, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 42:
+			if stat.GuestTime, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 43:
+			if stat.CguestTime, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 44:
+			if stat.StartData, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 45:
+			if stat.EndData, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 46:
+			if stat.StartBrk, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 47:
+			if stat.ArgStart, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 48:
+			if stat.ArgEnd, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 49:
+			if stat.EnvStart, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 50:
+			if stat.EnvEnd, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		case 51:
+			if stat.ExitCode, err = strconv.ParseInt(f[i], 10, 64); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &stat, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/process_statm.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/process_statm.go
@@ -1,0 +1,61 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+// Provides information about memory usage, measured in pages.
+type ProcessStatm struct {
+	Size     uint64 `json:"size"`     // total program size
+	Resident uint64 `json:"resident"` // resident set size
+	Share    uint64 `json:"share"`    // shared pages
+	Text     uint64 `json:"text"`     // text (code)
+	Lib      uint64 `json:"lib"`      // library (unused in Linux 2.6)
+	Data     uint64 `json:"data"`     // data + stack
+	Dirty    uint64 `json:"dirty"`    // dirty pages (unused in Linux 2.6)
+}
+
+func ReadProcessStatm(path string) (*ProcessStatm, error) {
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	s := string(b)
+	f := strings.Fields(s)
+
+	statm := ProcessStatm{}
+
+	var n uint64
+
+	for i := 0; i < len(f); i++ {
+
+		if n, err = strconv.ParseUint(f[i], 10, 64); err != nil {
+			return nil, err
+		}
+
+		switch i {
+		case 0:
+			statm.Size = n
+		case 1:
+			statm.Resident = n
+		case 2:
+			statm.Share = n
+		case 3:
+			statm.Text = n
+		case 4:
+			statm.Lib = n
+		case 5:
+			statm.Data = n
+		case 6:
+			statm.Dirty = n
+		}
+
+	}
+
+	return &statm, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/process_status.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/process_status.go
@@ -1,0 +1,331 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+// Provides much of the information from ProcessStatm and ProcessStat
+type ProcessStatus struct {
+	Name                     string
+	State                    string
+	Tgid                     uint64
+	Pid                      uint64
+	PPid                     int64
+	TracerPid                uint64
+	RealUid                  uint64
+	EffectiveUid             uint64
+	SavedSetUid              uint64
+	FilesystemUid            uint64
+	RealGid                  uint64
+	EffectiveGid             uint64
+	SavedSetGid              uint64
+	FilesystemGid            uint64
+	FDSize                   uint64
+	Groups                   []int64
+	VmPeak                   uint64
+	VmSize                   uint64
+	VmLck                    uint64
+	VmHWM                    uint64
+	VmRSS                    uint64
+	VmData                   uint64
+	VmStk                    uint64
+	VmExe                    uint64
+	VmLib                    uint64
+	VmPTE                    uint64
+	VmSwap                   uint64
+	Threads                  uint64
+	SigQLength               uint64
+	SigQLimit                uint64
+	SigPnd                   uint64
+	ShdPnd                   uint64
+	SigBlk                   uint64
+	SigIgn                   uint64
+	SigCgt                   uint64
+	CapInh                   uint64
+	CapPrm                   uint64
+	CapEff                   uint64
+	CapBnd                   uint64
+	Seccomp                  uint8
+	CpusAllowed              []uint32
+	MemsAllowed              []uint32
+	VoluntaryCtxtSwitches    uint64
+	NonvoluntaryCtxtSwitches uint64
+}
+
+func ReadProcessStatus(path string) (*ProcessStatus, error) {
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	status := ProcessStatus{}
+
+	lines := strings.Split(string(b), "\n")
+
+	for _, line := range lines {
+
+		if strings.Index(line, ":") == -1 {
+			continue
+		}
+
+		l := strings.Split(line, ":")
+
+		k := strings.TrimSpace(l[0])
+		v := strings.TrimSpace(l[1])
+
+		switch k {
+		case "Name":
+			status.Name = v
+		case "State":
+			status.State = v
+		case "Tgid":
+			if status.Tgid, err = strconv.ParseUint(v, 10, 64); err != nil {
+				return nil, err
+			}
+		case "Pid":
+			if status.Pid, err = strconv.ParseUint(v, 10, 64); err != nil {
+				return nil, err
+			}
+		case "PPid":
+			if status.PPid, err = strconv.ParseInt(v, 10, 64); err != nil {
+				return nil, err
+			}
+		case "TracerPid":
+			if status.TracerPid, err = strconv.ParseUint(v, 10, 64); err != nil {
+				return nil, err
+			}
+		case "Uid":
+			if f := strings.Fields(v); len(f) == 4 {
+				if status.RealUid, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+				if status.EffectiveUid, err = strconv.ParseUint(f[1], 10, 64); err != nil {
+					return nil, err
+				}
+				if status.SavedSetUid, err = strconv.ParseUint(f[2], 10, 64); err != nil {
+					return nil, err
+				}
+				if status.FilesystemUid, err = strconv.ParseUint(f[3], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "Gid":
+			if f := strings.Fields(v); len(f) == 4 {
+				if status.RealGid, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+				if status.EffectiveGid, err = strconv.ParseUint(f[1], 10, 64); err != nil {
+					return nil, err
+				}
+				if status.SavedSetGid, err = strconv.ParseUint(f[2], 10, 64); err != nil {
+					return nil, err
+				}
+				if status.FilesystemGid, err = strconv.ParseUint(f[3], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "FDSize":
+			if status.FDSize, err = strconv.ParseUint(v, 10, 64); err != nil {
+				return nil, err
+			}
+		case "Groups":
+			{
+
+				f := strings.Fields(v)
+				status.Groups = make([]int64, len(f))
+
+				for i := range status.Groups {
+					if status.Groups[i], err = strconv.ParseInt(f[i], 10, 64); err != nil {
+						return nil, err
+					}
+				}
+
+			}
+		case "VmPeak":
+			{
+				f := strings.Fields(v)
+				if status.VmPeak, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmSize":
+			{
+				f := strings.Fields(v)
+				if status.VmSize, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmLck":
+			{
+				f := strings.Fields(v)
+				if status.VmLck, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmHWM":
+			{
+				f := strings.Fields(v)
+				if status.VmHWM, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmRSS":
+			{
+				f := strings.Fields(v)
+				if status.VmRSS, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmData":
+			{
+				f := strings.Fields(v)
+				if status.VmData, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmStk":
+			{
+				f := strings.Fields(v)
+				if status.VmStk, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmExe":
+			{
+				f := strings.Fields(v)
+				if status.VmExe, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmLib":
+			{
+				f := strings.Fields(v)
+				if status.VmLib, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmPTE":
+			{
+				f := strings.Fields(v)
+				if status.VmPTE, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "VmSwap":
+			{
+				f := strings.Fields(v)
+				if status.VmSwap, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+					return nil, err
+				}
+			}
+		case "Threads":
+			if status.Threads, err = strconv.ParseUint(v, 10, 64); err != nil {
+				return nil, err
+			}
+		case "SigQ":
+			{
+				if f := strings.Split(v, "/"); len(f) == 2 {
+					if status.SigQLength, err = strconv.ParseUint(f[0], 10, 64); err != nil {
+						return nil, err
+					}
+					if status.SigQLimit, err = strconv.ParseUint(f[1], 10, 64); err != nil {
+						return nil, err
+					}
+				}
+			}
+		case "SigPnd":
+			if status.SigPnd, err = strconv.ParseUint(v, 16, 64); err != nil {
+				return nil, err
+			}
+		case "ShdPnd":
+			if status.ShdPnd, err = strconv.ParseUint(v, 16, 64); err != nil {
+				return nil, err
+			}
+		case "SigBlk":
+			if status.SigBlk, err = strconv.ParseUint(v, 16, 64); err != nil {
+				return nil, err
+			}
+		case "SigIgn":
+			if status.SigIgn, err = strconv.ParseUint(v, 16, 64); err != nil {
+				return nil, err
+			}
+		case "SigCgt":
+			if status.SigCgt, err = strconv.ParseUint(v, 16, 64); err != nil {
+				return nil, err
+			}
+		case "CapInh":
+			if status.CapInh, err = strconv.ParseUint(v, 16, 64); err != nil {
+				return nil, err
+			}
+		case "CapPrm":
+			if status.CapPrm, err = strconv.ParseUint(v, 16, 64); err != nil {
+				return nil, err
+			}
+		case "CapEff":
+			if status.CapEff, err = strconv.ParseUint(v, 16, 64); err != nil {
+				return nil, err
+			}
+		case "CapBnd":
+			if status.CapBnd, err = strconv.ParseUint(v, 16, 64); err != nil {
+				return nil, err
+			}
+		case "Seccomp":
+			{
+
+				var n uint64
+
+				if n, err = strconv.ParseUint(v, 10, 8); err != nil {
+					return nil, err
+				}
+
+				status.Seccomp = uint8(n)
+			}
+		case "Cpus_allowed":
+			{
+
+				var n uint64
+
+				f := strings.Split(v, ",")
+				status.CpusAllowed = make([]uint32, len(f))
+
+				for i := range status.CpusAllowed {
+					if n, err = strconv.ParseUint(f[i], 16, 32); err != nil {
+						return nil, err
+					}
+					status.CpusAllowed[i] = uint32(n)
+				}
+
+			}
+		case "Mems_allowed":
+			{
+
+				var n uint64
+
+				f := strings.Split(v, ",")
+				status.MemsAllowed = make([]uint32, len(f))
+
+				for i := range status.MemsAllowed {
+					if n, err = strconv.ParseUint(f[i], 16, 32); err != nil {
+						return nil, err
+					}
+					status.MemsAllowed[i] = uint32(n)
+				}
+
+			}
+		case "voluntary_ctxt_switches":
+			if status.VoluntaryCtxtSwitches, err = strconv.ParseUint(v, 10, 64); err != nil {
+				return nil, err
+			}
+		case "nonvoluntary_ctxt_switches":
+			if status.NonvoluntaryCtxtSwitches, err = strconv.ParseUint(v, 10, 64); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &status, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/snmp.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/snmp.go
@@ -1,0 +1,151 @@
+package linux
+
+import (
+	"io/ioutil"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type Snmp struct {
+	// Ip
+	IpForwarding      uint64 `json:"ip_forwarding"`
+	IpDefaultTTL      uint64 `json:"ip_default_ttl"`
+	IpInReceives      uint64 `json:"ip_in_receives"`
+	IpInHdrErrors     uint64 `json:"ip_in_hdr_errors"`
+	IpInAddrErrors    uint64 `json:"ip_in_addr_errors"`
+	IpForwDatagrams   uint64 `json:"ip_forw_datagrams"`
+	IpInUnknownProtos uint64 `json:"ip_in_unknown_protos"`
+	IpInDiscards      uint64 `json:"ip_in_discards"`
+	IpInDelivers      uint64 `json:"ip_in_delivers"`
+	IpOutRequests     uint64 `json:"ip_out_requests"`
+	IpOutDiscards     uint64 `json:"ip_out_discards"`
+	IpOutNoRoutes     uint64 `json:"ip_out_no_routes"`
+	IpReasmTimeout    uint64 `json:"ip_reasm_timeout"`
+	IpReasmReqds      uint64 `json:"ip_reasm_reqds"`
+	IpReasmOKs        uint64 `json:"ip_reasm_oks"`
+	IpReasmFails      uint64 `json:"ip_reasm_fails"`
+	IpFragOKs         uint64 `json:"ip_frag_oks"`
+	IpFragFails       uint64 `json:"ip_frag_fails"`
+	IpFragCreates     uint64 `json:"ip_frag_creates"`
+	// Icmp
+	IcmpInMsgs           uint64 `json:"icmp_in_msgs"`
+	IcmpInErrors         uint64 `json:"icmp_in_errors"`
+	IcmpInCsumErrors     uint64 `json:"icmp_in_csum_errors"`
+	IcmpInDestUnreachs   uint64 `json:"icmp_in_dest_unreachs"`
+	IcmpInTimeExcds      uint64 `json:"icmp_in_time_excds"`
+	IcmpInParmProbs      uint64 `json:"icmp_in_parm_probs"`
+	IcmpInSrcQuenchs     uint64 `json:"icmp_in_src_quenchs"`
+	IcmpInRedirects      uint64 `json:"icmp_in_redirects"`
+	IcmpInEchos          uint64 `json:"icmp_in_echos"`
+	IcmpInEchoReps       uint64 `json:"icmp_in_echo_reps"`
+	IcmpInTimestamps     uint64 `json:"icmp_in_timestamps"`
+	IcmpInTimestampReps  uint64 `json:"icmp_in_timestamp_reps"`
+	IcmpInAddrMasks      uint64 `json:"icmp_in_addr_masks"`
+	IcmpInAddrMaskReps   uint64 `json:"icmp_in_addr_mask_reps"`
+	IcmpOutMsgs          uint64 `json:"icmp_out_msgs"`
+	IcmpOutErrors        uint64 `json:"icmp_out_errors"`
+	IcmpOutDestUnreachs  uint64 `json:"icmp_out_dest_unreachs"`
+	IcmpOutTimeExcds     uint64 `json:"icmp_out_time_excds"`
+	IcmpOutParmProbs     uint64 `json:"icmp_out_parm_probs"`
+	IcmpOutSrcQuenchs    uint64 `json:"icmp_out_src_quenchs"`
+	IcmpOutRedirects     uint64 `json:"icmp_out_redirects"`
+	IcmpOutEchos         uint64 `json:"icmp_out_echos"`
+	IcmpOutEchoReps      uint64 `json:"icmp_out_echo_reps"`
+	IcmpOutTimestamps    uint64 `json:"icmp_out_timestamps"`
+	IcmpOutTimestampReps uint64 `json:"icmp_out_timestamp_reps"`
+	IcmpOutAddrMasks     uint64 `json:"icmp_out_addr_masks"`
+	IcmpOutAddrMaskReps  uint64 `json:"icmp_out_addr_mask_reps"`
+	// IcmpMsg
+	IcmpMsgInType0   uint64 `json:"icmpmsg_in_type0"`
+	IcmpMsgInType3   uint64 `json:"icmpmsg_in_type3"`
+	IcmpMsgInType5   uint64 `json:"icmpmsg_in_type5"`
+	IcmpMsgInType8   uint64 `json:"icmpmsg_in_type8"`
+	IcmpMsgInType11  uint64 `json:"icmpmsg_in_type11"`
+	IcmpMsgInType13  uint64 `json:"icmpmsg_in_type13"`
+	IcmpMsgOutType0  uint64 `json:"icmpmsg_out_type0"`
+	IcmpMsgOutType3  uint64 `json:"icmpmsg_out_type3"`
+	IcmpMsgOutType8  uint64 `json:"icmpmsg_out_type8"`
+	IcmpMsgOutType14 uint64 `json:"icmpmsg_out_type14"`
+	IcmpMsgOutType69 uint64 `json:"icmpmsg_out_type69"`
+	// TCP
+	TcpRtoAlgorithm uint64 `json:"tcp_rto_algorithm"`
+	TcpRtoMin       uint64 `json:"tcp_rto_min"`
+	TcpRtoMax       uint64 `json:"tcp_rto_max"`
+	TcpMaxConn      uint64 `json:"tcp_max_conn"`
+	TcpActiveOpens  uint64 `json:"tcp_active_opens"`
+	TcpPassiveOpens uint64 `json:"tcp_passive_opens"`
+	TcpAttemptFails uint64 `json:"tcp_attempt_fails"`
+	TcpEstabResets  uint64 `json:"tcp_estab_resets"`
+	TcpCurrEstab    uint64 `json:"tcp_curr_estab"`
+	TcpInSegs       uint64 `json:"tcp_in_segs"`
+	TcpOutSegs      uint64 `json:"tcp_out_segs"`
+	TcpRetransSegs  uint64 `json:"tcp_retrans_segs"`
+	TcpInErrs       uint64 `json:"tcp_in_errs"`
+	TcpOutRsts      uint64 `json:"tcp_out_rsts"`
+	TcpInCsumErrors uint64 `json:"tcp_in_csum_errors"`
+	// UDP
+	UdpInDatagrams  uint64 `json:"udp_in_datagrams"`
+	UdpNoPorts      uint64 `json:"udp_no_ports"`
+	UdpInErrors     uint64 `json:"udp_in_errors"`
+	UdpOutDatagrams uint64 `json:"udp_out_datagrams"`
+	UdpRcvbufErrors uint64 `json:"udp_rcvbuf_errors"`
+	UdpSndbufErrors uint64 `json:"udp_sndbuf_errors"`
+	UdpInCsumErrors uint64 `json:"udp_in_csum_errors"`
+	// UDPLite
+	UdpLiteInDatagrams  uint64 `json:"udp_lite_in_datagrams"`
+	UdpLiteNoPorts      uint64 `json:"udp_lite_no_ports"`
+	UdpLiteInErrors     uint64 `json:"udp_lite_in_errors"`
+	UdpLiteOutDatagrams uint64 `json:"udp_lite_out_datagrams"`
+	UdpLiteRcvbufErrors uint64 `json:"udp_lite_rcvbuf_errors"`
+	UdpLiteSndbufErrors uint64 `json:"udp_lite_sndbuf_errors"`
+	UdpLiteInCsumErrors uint64 `json:"udp_lite_in_csum_errors"`
+}
+
+func ReadSnmp(path string) (*Snmp, error) {
+	data, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+
+	// Maps an SNMP metric to its value (i.e. SyncookiesSent --> 0)
+	statMap := make(map[string]string)
+
+	// patterns
+	// Ip: Forwarding DefaultTTL InReceives InHdrErrors... <-- header
+	// Ip: 2 64 9305753793 0 0 0 0 0... <-- values
+
+	for i := 1; i < len(lines); i = i + 2 {
+		headers := strings.Fields(lines[i-1][strings.Index(lines[i-1], ":")+1:])
+		values := strings.Fields(lines[i][strings.Index(lines[i], ":")+1:])
+		protocol := strings.Replace(strings.Fields(lines[i-1])[0], ":", "", -1)
+
+		for j, header := range headers {
+			var val string
+			if len(values) > j {
+				val = values[j]
+			} else {
+				val = "UNKNOWN"
+			}
+
+			statMap[protocol+header] = val
+		}
+	}
+
+	var snmp Snmp = Snmp{}
+
+	elem := reflect.ValueOf(&snmp).Elem()
+	typeOfElem := elem.Type()
+
+	for i := 0; i < elem.NumField(); i++ {
+		if val, ok := statMap[typeOfElem.Field(i).Name]; ok {
+			parsedVal, _ := strconv.ParseUint(val, 10, 64)
+			elem.Field(i).SetUint(parsedVal)
+		}
+	}
+
+	return &snmp, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/sockstat.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/sockstat.go
@@ -1,0 +1,98 @@
+package linux
+
+import (
+	"io/ioutil"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type SockStat struct {
+	// sockets:
+	SocketsUsed uint64 `json:"sockets_used" field:"sockets.used"`
+
+	// TCP:
+	TCPInUse     uint64 `json:"tcp_in_use" field:"TCP.inuse"`
+	TCPOrphan    uint64 `json:"tcp_orphan" field:"TCP.orphan"`
+	TCPTimeWait  uint64 `json:"tcp_time_wait" field:"TCP.tw"`
+	TCPAllocated uint64 `json:"tcp_allocated" field:"TCP.alloc"`
+	TCPMemory    uint64 `json:"tcp_memory" field:"TCP.mem"`
+
+	//TCP6:
+	TCP6InUse    uint64 `json:"tcp6_in_use" field:"TCP6.inuse"`
+
+	// UDP:
+	UDPInUse  uint64 `json:"udp_in_use" field:"UDP.inuse"`
+	UDPMemory uint64 `json:"udp_memory" field:"UDP.mem"`
+
+	// UDP6:
+	UDP6InUse uint64 `json:"udp6_in_use" field:"UDP6.inuse"`
+
+	// UDPLITE:
+	UDPLITEInUse uint64 `json:"udplite_in_use" field:"UDPLITE.inuse"`
+
+	// UDPLITE6:
+	UDPLITE6InUse uint64 `json:"udplite6_in_use" field:"UDPLITE6.inuse"`
+
+	// RAW:
+	RAWInUse uint64 `json:"raw_in_use" field:"RAW.inuse"`
+
+	// RAW6:
+	RAW6InUse uint64 `json:"raw6_in_use" field:"RAW6.inuse"`
+
+	// FRAG:
+	FRAGInUse  uint64 `json:"frag_in_use" field:"FRAG.inuse"`
+	FRAGMemory uint64 `json:"frag_memory" field:"FRAG.memory"`
+
+	// FRAG6:
+	FRAG6InUse  uint64 `json:"frag6_in_use" field:"FRAG6.inuse"`
+	FRAG6Memory uint64 `json:"frag6_memory" field:"FRAG6.memory"`
+}
+
+func ReadSockStat(path string) (*SockStat, error) {
+	data, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+
+	// Maps a meminfo metric to its value (i.e. MemTotal --> 100000)
+	statMap := map[string]uint64{}
+
+	var sockStat SockStat = SockStat{}
+
+	for _, line := range lines {
+		if strings.Index(line, ":") == -1 {
+			continue
+		}
+
+		statType := line[0:strings.Index(line, ":")] + "."
+
+		// The fields have this pattern: inuse 27 orphan 1 tw 23 alloc 31 mem 3
+		// The stats are grouped into pairs and need to be parsed and placed into the stat map.
+		key := ""
+		for k, v := range strings.Fields(line[strings.Index(line, ":")+1:]) {
+			// Every second field is a value.
+			if (k+1)%2 != 0 {
+				key = v
+				continue
+			}
+			val, _ := strconv.ParseUint(v, 10, 64)
+			statMap[statType+key] = val
+		}
+	}
+
+	elem := reflect.ValueOf(&sockStat).Elem()
+	typeOfElem := elem.Type()
+
+	for i := 0; i < elem.NumField(); i++ {
+		val, ok := statMap[typeOfElem.Field(i).Tag.Get("field")]
+		if ok {
+			elem.Field(i).SetUint(val)
+		}
+	}
+
+	return &sockStat, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/stat.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/stat.go
@@ -1,0 +1,106 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Stat struct {
+	CPUStatAll      CPUStat   `json:"cpu_all"`
+	CPUStats        []CPUStat `json:"cpus"`
+	Interrupts      uint64    `json:"intr"`
+	ContextSwitches uint64    `json:"ctxt"`
+	BootTime        time.Time `json:"btime"`
+	Processes       uint64    `json:"processes"`
+	ProcsRunning    uint64    `json:"procs_running"`
+	ProcsBlocked    uint64    `json:"procs_blocked"`
+}
+
+type CPUStat struct {
+	Id        string `json:"id"`
+	User      uint64 `json:"user"`
+	Nice      uint64 `json:"nice"`
+	System    uint64 `json:"system"`
+	Idle      uint64 `json:"idle"`
+	IOWait    uint64 `json:"iowait"`
+	IRQ       uint64 `json:"irq"`
+	SoftIRQ   uint64 `json:"softirq"`
+	Steal     uint64 `json:"steal"`
+	Guest     uint64 `json:"guest"`
+	GuestNice uint64 `json:"guest_nice"`
+}
+
+func createCPUStat(fields []string) *CPUStat {
+	s := CPUStat{}
+	s.Id = fields[0]
+
+	for i := 1; i < len(fields); i++ {
+		v, _ := strconv.ParseUint(fields[i], 10, 64)
+		switch i {
+		case 1:
+			s.User = v
+		case 2:
+			s.Nice = v
+		case 3:
+			s.System = v
+		case 4:
+			s.Idle = v
+		case 5:
+			s.IOWait = v
+		case 6:
+			s.IRQ = v
+		case 7:
+			s.SoftIRQ = v
+		case 8:
+			s.Steal = v
+		case 9:
+			s.Guest = v
+		case 10:
+			s.GuestNice = v
+		}
+	}
+	return &s
+}
+
+func ReadStat(path string) (*Stat, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	content := string(b)
+	lines := strings.Split(content, "\n")
+
+	var stat Stat = Stat{}
+
+	for i, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if fields[0][:3] == "cpu" {
+			if cpuStat := createCPUStat(fields); cpuStat != nil {
+				if i == 0 {
+					stat.CPUStatAll = *cpuStat
+				} else {
+					stat.CPUStats = append(stat.CPUStats, *cpuStat)
+				}
+			}
+		} else if fields[0] == "intr" {
+			stat.Interrupts, _ = strconv.ParseUint(fields[1], 10, 64)
+		} else if fields[0] == "ctxt" {
+			stat.ContextSwitches, _ = strconv.ParseUint(fields[1], 10, 64)
+		} else if fields[0] == "btime" {
+			seconds, _ := strconv.ParseInt(fields[1], 10, 64)
+			stat.BootTime = time.Unix(seconds, 0)
+		} else if fields[0] == "processes" {
+			stat.Processes, _ = strconv.ParseUint(fields[1], 10, 64)
+		} else if fields[0] == "procs_running" {
+			stat.ProcsRunning, _ = strconv.ParseUint(fields[1], 10, 64)
+		} else if fields[0] == "procs_blocked" {
+			stat.ProcsBlocked, _ = strconv.ParseUint(fields[1], 10, 64)
+		}
+	}
+	return &stat, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/uptime.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/uptime.go
@@ -1,0 +1,43 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Uptime struct {
+	Total float64 `json:"total"`
+	Idle  float64 `json:"idle"`
+}
+
+func (self *Uptime) GetTotalDuration() time.Duration {
+	return time.Duration(self.Total) * time.Second
+}
+
+func (self *Uptime) GetIdleDuration() time.Duration {
+	return time.Duration(self.Idle) * time.Second
+}
+
+func (self *Uptime) CalculateIdle() float64 {
+	// XXX
+	// num2/(num1*N)     # N = SMP CPU numbers
+	return 0
+}
+
+func ReadUptime(path string) (*Uptime, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	fields := strings.Fields(string(b))
+	uptime := Uptime{}
+	if uptime.Total, err = strconv.ParseFloat(fields[0], 64); err != nil {
+		return nil, err
+	}
+	if uptime.Idle, err = strconv.ParseFloat(fields[1], 64); err != nil {
+		return nil, err
+	}
+	return &uptime, nil
+}

--- a/vendor/github.com/c9s/goprocinfo/linux/vmstat.go
+++ b/vendor/github.com/c9s/goprocinfo/linux/vmstat.go
@@ -1,0 +1,373 @@
+package linux
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+type VMStat struct {
+	NrFreePages                   uint64 `json:"nr_free_pages"`
+	NrAllocBatch                  uint64 `json:"nr_alloc_batch"`
+	NrInactiveAnon                uint64 `json:"nr_inactive_anon"`
+	NrActiveAnon                  uint64 `json:"nr_active_anon"`
+	NrInactiveFile                uint64 `json:"nr_inactive_file"`
+	NrActiveFile                  uint64 `json:"nr_active_file"`
+	NrUnevictable                 uint64 `json:"nr_unevictable"`
+	NrMlock                       uint64 `json:"nr_mlock"`
+	NrAnonPages                   uint64 `json:"nr_anon_pages"`
+	NrMapped                      uint64 `json:"nr_mapped"`
+	NrFilePages                   uint64 `json:"nr_file_pages"`
+	NrDirty                       uint64 `json:"nr_dirty"`
+	NrWriteback                   uint64 `json:"nr_writeback"`
+	NrSlabReclaimable             uint64 `json:"nr_slab_reclaimable"`
+	NrSlabUnreclaimable           uint64 `json:"nr_slab_unreclaimable"`
+	NrPageTablePages              uint64 `json:"nr_page_table_pages"`
+	NrKernelStack                 uint64 `json:"nr_kernel_stack"`
+	NrUnstable                    uint64 `json:"nr_unstable"`
+	NrBounce                      uint64 `json:"nr_bounce"`
+	NrVmscanWrite                 uint64 `json:"nr_vmscan_write"`
+	NrVmscanImmediateReclaim      uint64 `json:"nr_vmscan_immediate_reclaim"`
+	NrWritebackTemp               uint64 `json:"nr_writeback_temp"`
+	NrIsolatedAnon                uint64 `json:"nr_isolated_anon"`
+	NrIsolatedFile                uint64 `json:"nr_isolated_file"`
+	NrShmem                       uint64 `json:"nr_shmem"`
+	NrDirtied                     uint64 `json:"nr_dirtied"`
+	NrWritten                     uint64 `json:"nr_written"`
+	NumaHit                       uint64 `json:"numa_hit"`
+	NumaMiss                      uint64 `json:"numa_miss"`
+	NumaForeign                   uint64 `json:"numa_foreign"`
+	NumaInterleave                uint64 `json:"numa_interleave"`
+	NumaLocal                     uint64 `json:"numa_local"`
+	NumaOther                     uint64 `json:"numa_other"`
+	WorkingsetRefault             uint64 `json:"workingset_refault"`
+	WorkingsetActivate            uint64 `json:"workingset_activate"`
+	WorkingsetNodereclaim         uint64 `json:"workingset_nodereclaim"`
+	NrAnonTransparentHugepages    uint64 `json:"nr_anon_transparent_hugepages"`
+	NrFreeCma                     uint64 `json:"nr_free_cma"`
+	NrDirtyThreshold              uint64 `json:"nr_dirty_threshold"`
+	NrDirtyBackgroundThreshold    uint64 `json:"nr_dirty_background_threshold"`
+	PagePagein                    uint64 `json:"pgpgin"`
+	PagePageout                   uint64 `json:"pgpgout"`
+	PageSwapin                    uint64 `json:"pswpin"`
+	PageSwapout                   uint64 `json:"pswpout"`
+	PageAllocDMA                  uint64 `json:"pgalloc_dma"`
+	PageAllocDMA32                uint64 `json:"pgalloc_dma32"`
+	PageAllocNormal               uint64 `json:"pgalloc_normal"`
+	PageAllocMovable              uint64 `json:"pgalloc_movable"`
+	PageFree                      uint64 `json:"pgfree"`
+	PageActivate                  uint64 `json:"pgactivate"`
+	PageDeactivate                uint64 `json:"pgdeactivate"`
+	PageFault                     uint64 `json:"pgfault"`
+	PageMajorFault                uint64 `json:"pgmajfault"`
+	PageRefillDMA                 uint64 `json:"pgrefill_dma"`
+	PageRefillDMA32               uint64 `json:"pgrefill_dma32"`
+	PageRefillMormal              uint64 `json:"pgrefill_normal"`
+	PageRefillMovable             uint64 `json:"pgrefill_movable"`
+	PageStealKswapdDMA            uint64 `json:"pgsteal_kswapd_dma"`
+	PageStealKswapdDMA32          uint64 `json:"pgsteal_kswapd_dma32"`
+	PageStealKswapdNormal         uint64 `json:"pgsteal_kswapd_normal"`
+	PageStealKswapdMovable        uint64 `json:"pgsteal_kswapd_movable"`
+	PageStealDirectDMA            uint64 `json:"pgsteal_direct_dma"`
+	PageStealDirectDMA32          uint64 `json:"pgsteal_direct_dma32"`
+	PageStealDirectNormal         uint64 `json:"pgsteal_direct_normal"`
+	PageStealDirectMovable        uint64 `json:"pgsteal_direct_movable"`
+	PageScanKswapdDMA             uint64 `json:"pgscan_kswapd_dma"`
+	PageScanKswapdDMA32           uint64 `json:"pgscan_kswapd_dma32"`
+	PageScanKswapdNormal          uint64 `json:"pgscan_kswapd_normal"`
+	PageScanKswapdMovable         uint64 `json:"pgscan_kswapd_movable"`
+	PageScanDirectDMA             uint64 `json:"pgscan_direct_dma"`
+	PageScanDirectDMA32           uint64 `json:"pgscan_direct_dma32"`
+	PageScanDirectNormal          uint64 `json:"pgscan_direct_normal"`
+	PageScanDirectMovable         uint64 `json:"pgscan_direct_movable"`
+	PageScanDirectThrottle        uint64 `json:"pgscan_direct_throttle"`
+	ZoneReclaimFailed             uint64 `json:"zone_reclaim_failed"`
+	PageInodeSteal                uint64 `json:"pginodesteal"`
+	SlabsScanned                  uint64 `json:"slabs_scanned"`
+	KswapdInodesteal              uint64 `json:"kswapd_inodesteal"`
+	KswapdLowWatermarkHitQuickly  uint64 `json:"kswapd_low_wmark_hit_quickly"`
+	KswapdHighWatermarkHitQuickly uint64 `json:"kswapd_high_wmark_hit_quickly"`
+	PageoutRun                    uint64 `json:"pageoutrun"`
+	AllocStall                    uint64 `json:"allocstall"`
+	PageRotated                   uint64 `json:"pgrotated"`
+	DropPagecache                 uint64 `json:"drop_pagecache"`
+	DropSlab                      uint64 `json:"drop_slab"`
+	NumaPteUpdates                uint64 `json:"numa_pte_updates"`
+	NumaHugePteUpdates            uint64 `json:"numa_huge_pte_updates"`
+	NumaHintFaults                uint64 `json:"numa_hint_faults"`
+	NumaHintFaults_local          uint64 `json:"numa_hint_faults_local"`
+	NumaPagesMigrated             uint64 `json:"numa_pages_migrated"`
+	PageMigrateSuccess            uint64 `json:"pgmigrate_success"`
+	PageMigrateFail               uint64 `json:"pgmigrate_fail"`
+	CompactMigrateScanned         uint64 `json:"compact_migrate_scanned"`
+	CompactFreeScanned            uint64 `json:"compact_free_scanned"`
+	CompactIsolated               uint64 `json:"compact_isolated"`
+	CompactStall                  uint64 `json:"compact_stall"`
+	CompactFail                   uint64 `json:"compact_fail"`
+	CompactSuccess                uint64 `json:"compact_success"`
+	HtlbBuddyAllocSuccess         uint64 `json:"htlb_buddy_alloc_success"`
+	HtlbBuddyAllocFail            uint64 `json:"htlb_buddy_alloc_fail"`
+	UnevictablePagesCulled        uint64 `json:"unevictable_pgs_culled"`
+	UnevictablePagesScanned       uint64 `json:"unevictable_pgs_scanned"`
+	UnevictablePagesRescued       uint64 `json:"unevictable_pgs_rescued"`
+	UnevictablePagesMlocked       uint64 `json:"unevictable_pgs_mlocked"`
+	UnevictablePagesMunlocked     uint64 `json:"unevictable_pgs_munlocked"`
+	UnevictablePagesCleared       uint64 `json:"unevictable_pgs_cleared"`
+	UnevictablePagesStranded      uint64 `json:"unevictable_pgs_stranded"`
+	THPFaultAlloc                 uint64 `json:"thp_fault_alloc"`
+	THPFaultFallback              uint64 `json:"thp_fault_fallback"`
+	THPCollapseAlloc              uint64 `json:"thp_collapse_alloc"`
+	THPCollapseAllocFailed        uint64 `json:"thp_collapse_alloc_failed"`
+	THPSplit                      uint64 `json:"thp_split"`
+	THPZeroPageAlloc              uint64 `json:"thp_zero_page_alloc"`
+	THPZeroPageAllocFailed        uint64 `json:"thp_zero_page_alloc_failed"`
+}
+
+func ReadVMStat(path string) (*VMStat, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	content := string(b)
+	lines := strings.Split(content, "\n")
+	vmstat := VMStat{}
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		name := fields[0]
+		value, _ := strconv.ParseUint(fields[1], 10, 64)
+		switch name {
+		case "nr_free_pages":
+			vmstat.NrFreePages = value
+		case "nr_alloc_batch":
+			vmstat.NrAllocBatch = value
+		case "nr_inactive_anon":
+			vmstat.NrInactiveAnon = value
+		case "nr_active_anon":
+			vmstat.NrActiveAnon = value
+		case "nr_inactive_file":
+			vmstat.NrInactiveFile = value
+		case "nr_active_file":
+			vmstat.NrActiveFile = value
+		case "nr_unevictable":
+			vmstat.NrUnevictable = value
+		case "nr_mlock":
+			vmstat.NrMlock = value
+		case "nr_anon_pages":
+			vmstat.NrAnonPages = value
+		case "nr_mapped":
+			vmstat.NrMapped = value
+		case "nr_file_pages":
+			vmstat.NrFilePages = value
+		case "nr_dirty":
+			vmstat.NrDirty = value
+		case "nr_writeback":
+			vmstat.NrWriteback = value
+		case "nr_slab_reclaimable":
+			vmstat.NrSlabReclaimable = value
+		case "nr_slab_unreclaimable":
+			vmstat.NrSlabUnreclaimable = value
+		case "nr_page_table_pages":
+			vmstat.NrPageTablePages = value
+		case "nr_kernel_stack":
+			vmstat.NrKernelStack = value
+		case "nr_unstable":
+			vmstat.NrUnstable = value
+		case "nr_bounce":
+			vmstat.NrBounce = value
+		case "nr_vmscan_write":
+			vmstat.NrVmscanWrite = value
+		case "nr_vmscan_immediate_reclaim":
+			vmstat.NrVmscanImmediateReclaim = value
+		case "nr_writeback_temp":
+			vmstat.NrWritebackTemp = value
+		case "nr_isolated_anon":
+			vmstat.NrIsolatedAnon = value
+		case "nr_isolated_file":
+			vmstat.NrIsolatedFile = value
+		case "nr_shmem":
+			vmstat.NrShmem = value
+		case "nr_dirtied":
+			vmstat.NrDirtied = value
+		case "nr_written":
+			vmstat.NrWritten = value
+		case "numa_hit":
+			vmstat.NumaHit = value
+		case "numa_miss":
+			vmstat.NumaMiss = value
+		case "numa_foreign":
+			vmstat.NumaForeign = value
+		case "numa_interleave":
+			vmstat.NumaInterleave = value
+		case "numa_local":
+			vmstat.NumaLocal = value
+		case "numa_other":
+			vmstat.NumaOther = value
+		case "workingset_refault":
+			vmstat.WorkingsetRefault = value
+		case "workingset_activate":
+			vmstat.WorkingsetActivate = value
+		case "workingset_nodereclaim":
+			vmstat.WorkingsetNodereclaim = value
+		case "nr_anon_transparent_hugepages":
+			vmstat.NrAnonTransparentHugepages = value
+		case "nr_free_cma":
+			vmstat.NrFreeCma = value
+		case "nr_dirty_threshold":
+			vmstat.NrDirtyThreshold = value
+		case "nr_dirty_background_threshold":
+			vmstat.NrDirtyBackgroundThreshold = value
+		case "pgpgin":
+			vmstat.PagePagein = value
+		case "pgpgout":
+			vmstat.PagePageout = value
+		case "pswpin":
+			vmstat.PageSwapin = value
+		case "pswpout":
+			vmstat.PageSwapout = value
+		case "pgalloc_dma":
+			vmstat.PageAllocDMA = value
+		case "pgalloc_dma32":
+			vmstat.PageAllocDMA32 = value
+		case "pgalloc_normal":
+			vmstat.PageAllocNormal = value
+		case "pgalloc_movable":
+			vmstat.PageAllocMovable = value
+		case "pgfree":
+			vmstat.PageFree = value
+		case "pgactivate":
+			vmstat.PageActivate = value
+		case "pgdeactivate":
+			vmstat.PageDeactivate = value
+		case "pgfault":
+			vmstat.PageFault = value
+		case "pgmajfault":
+			vmstat.PageMajorFault = value
+		case "pgrefill_dma":
+			vmstat.PageRefillDMA = value
+		case "pgrefill_dma32":
+			vmstat.PageRefillDMA32 = value
+		case "pgrefill_normal":
+			vmstat.PageRefillMormal = value
+		case "pgrefill_movable":
+			vmstat.PageRefillMovable = value
+		case "pgsteal_kswapd_dma":
+			vmstat.PageStealKswapdDMA = value
+		case "pgsteal_kswapd_dma32":
+			vmstat.PageStealKswapdDMA32 = value
+		case "pgsteal_kswapd_normal":
+			vmstat.PageStealKswapdNormal = value
+		case "pgsteal_kswapd_movable":
+			vmstat.PageStealKswapdMovable = value
+		case "pgsteal_direct_dma":
+			vmstat.PageStealDirectDMA = value
+		case "pgsteal_direct_dma32":
+			vmstat.PageStealDirectDMA32 = value
+		case "pgsteal_direct_normal":
+			vmstat.PageStealDirectNormal = value
+		case "pgsteal_direct_movable":
+			vmstat.PageStealDirectMovable = value
+		case "pgscan_kswapd_dma":
+			vmstat.PageScanKswapdDMA = value
+		case "pgscan_kswapd_dma32":
+			vmstat.PageScanKswapdDMA32 = value
+		case "pgscan_kswapd_normal":
+			vmstat.PageScanKswapdNormal = value
+		case "pgscan_kswapd_movable":
+			vmstat.PageScanKswapdMovable = value
+		case "pgscan_direct_dma":
+			vmstat.PageScanDirectDMA = value
+		case "pgscan_direct_dma32":
+			vmstat.PageScanDirectDMA32 = value
+		case "pgscan_direct_normal":
+			vmstat.PageScanDirectNormal = value
+		case "pgscan_direct_movable":
+			vmstat.PageScanDirectMovable = value
+		case "pgscan_direct_throttle":
+			vmstat.PageScanDirectThrottle = value
+		case "zone_reclaim_failed":
+			vmstat.ZoneReclaimFailed = value
+		case "pginodesteal":
+			vmstat.PageInodeSteal = value
+		case "slabs_scanned":
+			vmstat.SlabsScanned = value
+		case "kswapd_inodesteal":
+			vmstat.KswapdInodesteal = value
+		case "kswapd_low_wmark_hit_quickly":
+			vmstat.KswapdLowWatermarkHitQuickly = value
+		case "kswapd_high_wmark_hit_quickly":
+			vmstat.KswapdHighWatermarkHitQuickly = value
+		case "pageoutrun":
+			vmstat.PageoutRun = value
+		case "allocstall":
+			vmstat.AllocStall = value
+		case "pgrotated":
+			vmstat.PageRotated = value
+		case "drop_pagecache":
+			vmstat.DropPagecache = value
+		case "drop_slab":
+			vmstat.DropSlab = value
+		case "numa_pte_updates":
+			vmstat.NumaPteUpdates = value
+		case "numa_huge_pte_updates":
+			vmstat.NumaHugePteUpdates = value
+		case "numa_hint_faults":
+			vmstat.NumaHintFaults = value
+		case "numa_hint_faults_local":
+			vmstat.NumaHintFaults_local = value
+		case "numa_pages_migrated":
+			vmstat.NumaPagesMigrated = value
+		case "pgmigrate_success":
+			vmstat.PageMigrateSuccess = value
+		case "pgmigrate_fail":
+			vmstat.PageMigrateFail = value
+		case "compact_migrate_scanned":
+			vmstat.CompactMigrateScanned = value
+		case "compact_free_scanned":
+			vmstat.CompactFreeScanned = value
+		case "compact_isolated":
+			vmstat.CompactIsolated = value
+		case "compact_stall":
+			vmstat.CompactStall = value
+		case "compact_fail":
+			vmstat.CompactFail = value
+		case "compact_success":
+			vmstat.CompactSuccess = value
+		case "htlb_buddy_alloc_success":
+			vmstat.HtlbBuddyAllocSuccess = value
+		case "htlb_buddy_alloc_fail":
+			vmstat.HtlbBuddyAllocFail = value
+		case "unevictable_pgs_culled":
+			vmstat.UnevictablePagesCulled = value
+		case "unevictable_pgs_scanned":
+			vmstat.UnevictablePagesScanned = value
+		case "unevictable_pgs_rescued":
+			vmstat.UnevictablePagesRescued = value
+		case "unevictable_pgs_mlocked":
+			vmstat.UnevictablePagesMlocked = value
+		case "unevictable_pgs_munlocked":
+			vmstat.UnevictablePagesMunlocked = value
+		case "unevictable_pgs_cleared":
+			vmstat.UnevictablePagesCleared = value
+		case "unevictable_pgs_stranded":
+			vmstat.UnevictablePagesStranded = value
+		case "thp_fault_alloc":
+			vmstat.THPFaultAlloc = value
+		case "thp_fault_fallback":
+			vmstat.THPFaultFallback = value
+		case "thp_collapse_alloc":
+			vmstat.THPCollapseAlloc = value
+		case "thp_collapse_alloc_failed":
+			vmstat.THPCollapseAllocFailed = value
+		case "thp_split":
+			vmstat.THPSplit = value
+		case "thp_zero_page_alloc":
+			vmstat.THPZeroPageAlloc = value
+		case "thp_zero_page_alloc_failed":
+			vmstat.THPZeroPageAllocFailed = value
+		}
+	}
+	return &vmstat, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,6 +21,9 @@ github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
 ## explicit
 github.com/blang/semver
+# github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8
+## explicit
+github.com/c9s/goprocinfo/linux
 # github.com/cenkalti/backoff v2.2.1+incompatible
 ## explicit
 github.com/cenkalti/backoff


### PR DESCRIPTION
We have to calculate CPU mask for CPUs handling IRQs and those dedicated for Scylla. Because CPU allocation is known only after Scylla container is created, the perftune is being run during sidecar startup.
New CRD field controls if script should be run. It is not always executed because it requires root priviledges and host PID namespace, and it may not work on dev environments. 

GKE the disk write cache is disabled which greatly improves overall performance.

In addition helper containers have their resource limits set - without them Scylla pod cannot get Guaranteed QoS class required for exclusive CPU allocation.

