### PR TITLE
Add full support for HostNetwork pod IPs 

### DIFF
--- a/pkg/controllers/cluster/actions/upgrade_version.go
+++ b/pkg/controllers/cluster/actions/upgrade_version.go
@@ -83,9 +83,13 @@ func (a *ClusterVersionUpgrade) nonMaintenanceHosts(ctx context.Context) ([]stri
 		}
 
 		for _, s := range services {
-			a.ipMapping[s.Name] = s.Spec.ClusterIP
+			ip, err := resource.GetIpFromService(&s, a.Cluster)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get IP from member service")
+			}
+			a.ipMapping[s.Name] = ip
 			if _, ok := s.Labels[naming.NodeMaintenanceLabel]; !ok {
-				hosts = append(hosts, s.Spec.ClusterIP)
+				hosts = append(hosts, ip)
 			}
 		}
 	}

--- a/pkg/controllers/cluster/pod_event.go
+++ b/pkg/controllers/cluster/pod_event.go
@@ -1,0 +1,202 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+var _ handler.EventHandler = &EnqueueRequestForPod{}
+
+// EnqueueRequestForPod enqueues Requests for the Owners of an object.  E.g. the object that created
+// the object that was the source of the Event.
+//
+// If a ReplicaSet creates Pods, users may reconcile the ReplicaSet in response to Pod Events using:
+//
+// - a source.Kind Source with Type of Pod.
+//
+// - a handler.EnqueueRequestForPod EventHandler with an OwnerType of ReplicaSet and IsController set to true.
+type EnqueueRequestForPod struct {
+	// groupStsKind is the cached Group and Kind for sts OwnerType
+	groupStsKind schema.GroupKind
+
+	// groupClusterKind is the cached Group and Kind for ScyllaCluster OwnerType
+	groupClusterKind schema.GroupKind
+
+	// mapper maps GroupVersionKinds to Resources
+	mapper meta.RESTMapper
+
+	KubeClient kubernetes.Interface
+}
+
+// Create implements EventHandler
+func (e *EnqueueRequestForPod) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	for _, req := range e.getOwnerReconcileRequest(evt.Object.(metav1.Object)) {
+		q.Add(req)
+	}
+}
+
+// Update implements EventHandler
+func (e *EnqueueRequestForPod) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	for _, req := range e.getOwnerReconcileRequest(evt.ObjectOld.(metav1.Object)) {
+		q.Add(req)
+	}
+	for _, req := range e.getOwnerReconcileRequest(evt.ObjectNew.(metav1.Object)) {
+		q.Add(req)
+	}
+}
+
+// Delete implements EventHandler
+func (e *EnqueueRequestForPod) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	for _, req := range e.getOwnerReconcileRequest(evt.Object.(metav1.Object)) {
+		q.Add(req)
+	}
+}
+
+// Generic implements EventHandler
+func (e *EnqueueRequestForPod) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	for _, req := range e.getOwnerReconcileRequest(evt.Object.(metav1.Object)) {
+		q.Add(req)
+	}
+}
+
+// generateGroupKind generate Group and Kind and caches the result for sts and ScyllaCluster type.  Returns false
+// if sts or ScyllaCluster type could not be parsed using the scheme.
+func (e *EnqueueRequestForPod) generateGroupKind(scheme *runtime.Scheme) error {
+	// Get the kinds of the type
+	stsType := &appsv1.StatefulSet{}
+	clusterType := &scyllav1.ScyllaCluster{}
+
+	kindsSts, _, err := scheme.ObjectKinds(stsType)
+	if err != nil {
+		return err
+	}
+	kindsCluster, _, err := scheme.ObjectKinds(clusterType)
+	if err != nil {
+		return err
+	}
+	// Expect only 1 kind.  If there is more than one kind this is probably an edge case such as ListOptions.
+	if len(kindsSts) != 1 {
+		err := fmt.Errorf("Expected exactly 1 kind for OwnerType %T, but found %s kinds", stsType, kindsSts)
+		return err
+
+	}
+	// Expect only 1 kind.  If there is more than one kind this is probably an edge case such as ListOptions.
+	if len(kindsCluster) != 1 {
+		err := fmt.Errorf("Expected exactly 1 kind for OwnerType %T, but found %s kinds", clusterType, kindsCluster)
+		return err
+
+	}
+	// Cache the Group and Kind for the OwnerType
+	e.groupStsKind = schema.GroupKind{Group: kindsSts[0].Group, Kind: kindsSts[0].Kind}
+	e.groupClusterKind = schema.GroupKind{Group: kindsCluster[0].Group, Kind: kindsCluster[0].Kind}
+	return nil
+}
+
+// getOwnerReconcileRequest looks at object and returns a slice of reconcile.Request to reconcile
+// owners of object that match the ScyllaCluster type through the sts type
+func (e *EnqueueRequestForPod) getOwnerReconcileRequest(object metav1.Object) []reconcile.Request {
+	// Iterate through the OwnerReferences looking for a match on Group and Kind against what was requested
+	// by the user
+	var result []reconcile.Request
+	for _, ref := range e.getOwnersReferences(object) {
+		// Parse the Group out of the OwnerReference to compare it
+		refGV, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil {
+			return nil
+		}
+
+		// Compare the OwnerReference Group and Kind against the sts Group and Kind.
+		// If the two match, get the reconcile request from the ScyllaCluster type owner
+		if ref.Kind == e.groupStsKind.Kind && refGV.Group == e.groupStsKind.Group {
+			// Get sts and then get ScyllaCluster reference
+			sts, err := e.KubeClient.AppsV1().StatefulSets(object.GetNamespace()).Get(context.Background(), ref.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil
+			}
+			resultSts := e.getStsOwnerReconcileRequest(sts.GetObjectMeta())
+
+			result = append(result, resultSts...)
+		}
+	}
+
+	// Return the matches
+	return result
+}
+
+// getStsOwnerReconcileRequest looks at object and returns a slice of reconcile.Request to reconcile
+// owners of object that match ScyllaCluster type
+func (e *EnqueueRequestForPod) getStsOwnerReconcileRequest(object metav1.Object) []reconcile.Request {
+	// Iterate through the OwnerReferences looking for a match on Group and Kind against what was requested
+	// by the user
+	var result []reconcile.Request
+	for _, ref := range e.getOwnersReferences(object) {
+		// Parse the Group out of the OwnerReference to compare it
+		refGV, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil {
+			return nil
+		}
+
+		// Compare the OwnerReference Group and Kind against the ScyllaCluster Group and Kind.
+		// If the two match, create a Request for the objected referred to by
+		// the OwnerReference.  Use the Name from the OwnerReference and the Namespace from the
+		// object in the event.
+		if ref.Kind == e.groupClusterKind.Kind && refGV.Group == e.groupClusterKind.Group {
+			// Match found - add a Request for the object referred to in the OwnerReference
+			request := reconcile.Request{NamespacedName: types.NamespacedName{
+				Name: ref.Name,
+			}}
+
+			request.Namespace = object.GetNamespace()
+
+			result = append(result, request)
+		}
+	}
+
+	// Return the matches
+	return result
+}
+
+// getOwnersReferences returns the OwnerReferences for an object as specified by the EnqueueRequestForOwner
+// - if IsController is true: only take the Controller OwnerReference (if found)
+// - if IsController is false: take all OwnerReferences
+func (e *EnqueueRequestForPod) getOwnersReferences(object metav1.Object) []metav1.OwnerReference {
+	if object == nil {
+		return nil
+	}
+
+	// If filtered to a Controller, only take the Controller OwnerReference
+	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil {
+		return []metav1.OwnerReference{*ownerRef}
+	}
+	// No Controller OwnerReference found
+	return nil
+}
+
+var _ inject.Scheme = &EnqueueRequestForPod{}
+
+// InjectScheme is called by the Controller to provide a singleton scheme to the EnqueueRequestForOwner.
+func (e *EnqueueRequestForPod) InjectScheme(s *runtime.Scheme) error {
+	return e.generateGroupKind(s)
+}
+
+var _ inject.Mapper = &EnqueueRequestForPod{}
+
+// InjectMapper  is called by the Controller to provide the rest mapper used by the manager.
+func (e *EnqueueRequestForPod) InjectMapper(m meta.RESTMapper) error {
+	e.mapper = m
+	return nil
+}

--- a/pkg/controllers/cluster/resource/resource.go
+++ b/pkg/controllers/cluster/resource/resource.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/util"
 	"github.com/scylladb/scylla-operator/pkg/controllers/helpers"
@@ -62,7 +64,16 @@ func MemberServiceForPod(pod *corev1.Pod, cluster *scyllav1.ScyllaCluster) *core
 	if replaceAddr, ok := cluster.Status.Racks[rackName].ReplaceAddressFirstBoot[pod.Name]; ok && replaceAddr != "" {
 		labels[naming.ReplaceLabel] = replaceAddr
 	}
-	return &corev1.Service{
+
+	// When cluster use hostNetworking we rely on pod IP
+	// The pod IP is only available when pod is running
+	if cluster.Spec.Network.HostNetworking {
+		if pod.Status.PodIP != "" {
+			labels[naming.IpLabel] = pod.Status.PodIP
+		}
+	}
+
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            pod.Name,
 			Namespace:       pod.Namespace,
@@ -76,6 +87,12 @@ func MemberServiceForPod(pod *corev1.Pod, cluster *scyllav1.ScyllaCluster) *core
 			PublishNotReadyAddresses: true,
 		},
 	}
+
+	if cluster.Spec.Network.HostNetworking {
+		service.Spec.ClusterIP = corev1.ClusterIPNone
+	}
+
+	return service
 }
 
 func memberServicePorts(cluster *scyllav1.ScyllaCluster) []corev1.ServicePort {
@@ -554,4 +571,15 @@ func stringOrDefault(str, def string) string {
 		return str
 	}
 	return def
+}
+
+func GetIpFromService(svc *corev1.Service, c *scyllav1.ScyllaCluster) (string, error) {
+	ip := svc.Spec.ClusterIP
+	if c.Spec.Network.HostNetworking {
+		var ok bool
+		if ip, ok = svc.ObjectMeta.Labels[naming.IpLabel]; !ok {
+			return "", errors.Errorf("%s label not found on member service %s", naming.IpLabel, svc.Name)
+		}
+	}
+	return ip, nil
 }

--- a/pkg/controllers/cluster/resource/resource_test.go
+++ b/pkg/controllers/cluster/resource/resource_test.go
@@ -1,0 +1,47 @@
+package resource
+
+import (
+	"fmt"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/test/unit"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+	"testing"
+)
+
+func TestGetIpFromService(t *testing.T) {
+	cluster := unit.NewSingleRackCluster(1)
+
+	clusterIp := "10.10.10.10"
+	podIp := "20.20.20.20"
+	labels := map[string]string{
+		naming.IpLabel: podIp,
+	}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod_service",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: clusterIp,
+		},
+	}
+
+	cluster.Spec.Network.HostNetworking = false
+	ip, _ := GetIpFromService(service, cluster)
+	if ip != clusterIp {
+		t.Error("IP is not well retrieved from service ClusterIp spec")
+	}
+
+	cluster.Spec.Network.HostNetworking = true
+	_, err := GetIpFromService(service, cluster)
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("%s label not found on member service pod_service", naming.IpLabel)) {
+		t.Errorf("No Error or bad error return while %s label is missing on the service: %v", naming.IpLabel, err)
+	}
+
+	service.ObjectMeta.Labels = labels
+	ip, _ = GetIpFromService(service, cluster)
+	if ip != podIp {
+		t.Errorf("IP is not well retrieved from %s label", naming.IpLabel)
+	}
+}

--- a/pkg/controllers/cluster/status.go
+++ b/pkg/controllers/cluster/status.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
 	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/util"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	appsv1 "k8s.io/api/apps/v1"
@@ -121,7 +122,11 @@ func (cc *ClusterReconciler) updateStatus(ctx context.Context, cluster *scyllav1
 					return errors.New("seed node replace is not supported")
 				}
 				if replaceAddr == "" {
-					rackStatus.ReplaceAddressFirstBoot[svc.Name] = svc.Spec.ClusterIP
+					memberIp, err := resource.GetIpFromService(&svc, cluster)
+					if err != nil {
+						return err
+					}
+					rackStatus.ReplaceAddressFirstBoot[svc.Name] = memberIp
 				}
 				cc.Logger.Info(ctx, "Rack member is being replaced", "rack", rack.Name, "member", svc.Name)
 				scyllav1.SetRackCondition(&rackStatus, scyllav1.RackConditionTypeMemberReplacing)

--- a/pkg/controllers/sidecar/checks.go
+++ b/pkg/controllers/sidecar/checks.go
@@ -27,7 +27,7 @@ func (mc *MemberReconciler) setupHTTPChecks(ctx context.Context) {
 }
 
 func nodeUnderMaintenance(ctx context.Context, mc *MemberReconciler) (bool, error) {
-	member, err := identity.Retrieve(ctx, mc.member.Name, mc.member.Namespace, mc.kubeClient)
+	member, err := identity.Retrieve(ctx, mc.member.Name, mc.member.Namespace, mc.kubeClient, mc.Client)
 	if err != nil {
 		return false, errors.Wrap(err, "get member service")
 	}

--- a/pkg/controllers/sidecar/identity/member.go
+++ b/pkg/controllers/sidecar/identity/member.go
@@ -6,10 +6,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	v1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllers/cluster/resource"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Member encapsulates the identity for a single member
@@ -29,7 +32,7 @@ type Member struct {
 	ServiceLabels map[string]string
 }
 
-func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes.Interface) (*Member, error) {
+func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes.Interface, cc client.Client) (*Member, error) {
 	// Get the member's service
 	var memberService *corev1.Service
 	var err error
@@ -51,11 +54,22 @@ func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes
 		return nil, errors.Wrap(err, "failed to get pod")
 	}
 
+	cluster := &v1.ScyllaCluster{}
+	err = cc.Get(ctx, naming.NamespacedName(pod.Labels[naming.ClusterNameLabel], namespace), cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting cluster")
+	}
+
+	memberIp, err := resource.GetIpFromService(memberService, cluster)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Member{
 		Name:          name,
 		Namespace:     namespace,
 		IP:            pod.Status.PodIP,
-		StaticIP:      memberService.Spec.ClusterIP,
+		StaticIP:      memberIp,
 		Rack:          pod.Labels[naming.RackNameLabel],
 		Datacenter:    pod.Labels[naming.DatacenterNameLabel],
 		Cluster:       pod.Labels[naming.ClusterNameLabel],
@@ -63,7 +77,7 @@ func Retrieve(ctx context.Context, name, namespace string, kubeclient kubernetes
 	}, nil
 }
 
-func (m *Member) GetSeeds(ctx context.Context, kubeClient kubernetes.Interface) ([]string, error) {
+func (m *Member) GetSeeds(ctx context.Context, kubeClient kubernetes.Interface, cluster *v1.ScyllaCluster) ([]string, error) {
 	var services *corev1.ServiceList
 	var err error
 
@@ -83,7 +97,11 @@ func (m *Member) GetSeeds(ctx context.Context, kubeClient kubernetes.Interface) 
 
 	seeds := []string{}
 	for _, svc := range services.Items {
-		seeds = append(seeds, svc.Spec.ClusterIP)
+		seedIp, err := resource.GetIpFromService(&svc, cluster)
+		if err != nil {
+			return nil, err
+		}
+		seeds = append(seeds, seedIp)
 	}
 	return seeds, nil
 }

--- a/pkg/controllers/sidecar/sidecar_controller.go
+++ b/pkg/controllers/sidecar/sidecar_controller.go
@@ -88,20 +88,20 @@ func (mc *MemberReconciler) Reconcile(ctx context.Context, request reconcile.Req
 
 // newReconciler returns a new reconcile.Reconciler
 func New(ctx context.Context, mgr manager.Manager, logger log.Logger) (*MemberReconciler, error) {
-	opts := options.GetSidecarOptions()
-	kubeClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
-	member, err := identity.Retrieve(ctx, opts.Name, opts.Namespace, kubeClient)
-	if err != nil {
-		return nil, errors.Wrap(err, "get member")
-	}
-	logger.Info(ctx, "Member loaded", "member", member)
-
 	c, err := client.New(mgr.GetConfig(), client.Options{
 		Scheme: mgr.GetScheme(),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "get dynamic client")
 	}
+
+	opts := options.GetSidecarOptions()
+	kubeClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
+	member, err := identity.Retrieve(ctx, opts.Name, opts.Namespace, kubeClient, c)
+	if err != nil {
+		return nil, errors.Wrap(err, "get member")
+	}
+	logger.Info(ctx, "Member loaded", "member", member)
 
 	host, err := network.FindFirstNonLocalIP()
 	if err != nil {

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -12,6 +12,10 @@ const (
 	// SeedLabel determines if a member is a seed or not.
 	SeedLabel = "scylla/seed"
 
+	// IpLabel determines ip of pod when using hostNetwork
+	// Used for pod replacement, seed ip and listen/broadcast ip
+	IpLabel = "scylla/ip"
+
 	// DecommissionLabel expresses the intent to decommission
 	// the specific member. The presence of the label expresses
 	// the intent to decommission. If the value is true, it means

--- a/test/integration/upgrade_version_test.go
+++ b/test/integration/upgrade_version_test.go
@@ -58,9 +58,9 @@ var _ = Describe("Cluster controller", func() {
 		// Cluster should be scaled sequentially up to member count
 		for _, rack := range scylla.Spec.Datacenter.Racks {
 			for _, replicas := range testEnv.ClusterScaleSteps(rack.Members) {
-				Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+				Expect(sstStub.CreatePods(ctx, scylla, false)).To(Succeed())
 				Expect(testEnv.AssertRackScaled(ctx, rack, scylla, replicas)).To(Succeed())
-				Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+				Expect(sstStub.CreatePods(ctx, scylla, false)).To(Succeed())
 			}
 		}
 
@@ -129,7 +129,7 @@ var _ = Describe("Cluster controller", func() {
 			rack := scylla.Spec.Datacenter.Racks[0]
 			for _, replicas := range testEnv.ClusterScaleSteps(rack.Members) {
 				Expect(testEnv.AssertRackScaled(ctx, rack, scylla, replicas)).To(Succeed())
-				Expect(sstStub.CreatePods(ctx, scylla)).To(Succeed())
+				Expect(sstStub.CreatePods(ctx, scylla, false)).To(Succeed())
 			}
 
 			originalActionsScyllaClientForClusterFunc = actions.ScyllaClientForClusterFunc
@@ -260,7 +260,7 @@ var _ = Describe("Cluster controller", func() {
 				}, shortWait).Should(Equal(int(rack.Members - 1)))
 
 				By("When: node pod comes up")
-				Expect(sstStub.CreatePodsPartition(ctx, scylla, nodeUnderUpgradeIdx)).To(Succeed())
+				Expect(sstStub.CreatePodsPartition(ctx, scylla, nodeUnderUpgradeIdx, false)).To(Succeed())
 
 				podList := &corev1.PodList{}
 				Expect(testEnv.List(ctx, podList, &client.ListOptions{LabelSelector: naming.RackSelector(rack, scylla)})).To(Succeed())


### PR DESCRIPTION

**Description of your changes:**

This PR add full support for HostNetworking on scylla clusters.

The reason why HostNetworking is needed is when the clients are not inside the same Kubernetes clusters and that internal IPs are not routable outside of the cluster.

The previously proposed solution was to only override the rpc_address so that clients can connect with another address than the peer address. https://github.com/scylladb/scylla-operator/commit/a457bd5df65bbbc51368115a3ac2da934cb36ff8
However this doesn't work when joining an external cluster as nodes are using the peer address.

The main difficulty was to keep all the operations (notably replace) working. The way it was solve was to add a label on the member service with the real IP of the pod.
Since the IP is assigned only after the pod is scheduled, we need to listen for changes on scylla managed pods. 

**Which issue is resolved by this Pull Request:**
Resolves #
