### PR TITLE
Raise e2e timeout

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -211,7 +211,7 @@ jobs:
     - name: Run e2e
       run: |
         set -x
-        timeout 45m docker run --user="$( id -u ):$( id -g )" --rm --entrypoint=/usr/bin/scylla-operator-tests -v="${HOME}/.kube/config:/kubeconfig:ro" -e='KUBECONFIG=/kubeconfig' -v="${ARTIFACTS_DIR}:${ARTIFACTS_DIR}:rw" '${{ env.image_repo_ref }}:ci' run --artifacts-dir="${ARTIFACTS_DIR}"
+        timeout 60m docker run --user="$( id -u ):$( id -g )" --rm --entrypoint=/usr/bin/scylla-operator-tests -v="${HOME}/.kube/config:/kubeconfig:ro" -e='KUBECONFIG=/kubeconfig' -v="${ARTIFACTS_DIR}:${ARTIFACTS_DIR}:rw" '${{ env.image_repo_ref }}:ci' run --artifacts-dir="${ARTIFACTS_DIR}"
     - name: Dump cluster state
       if: ${{ always() }}
       working-directory: ${{ runner.temp }}


### PR DESCRIPTION
**Description of your changes:**
Last e2e run was 44m 47s, this raises the timeout from 45m to 60m. We need some room for a test failures slowdown not to fail the other test(s).

