### PR TITLE
[v1.3] Fix broken references in node operations documentation

### DIFF
--- a/docs/source/nodeoperations/replace_node.md
+++ b/docs/source/nodeoperations/replace_node.md
@@ -71,7 +71,7 @@ _This procedure is for replacing one dead node. To replace more than one dead no
    UN  10.43.191.172  74.77 KB   256          ?       1ffa7a82-c41c-4706-8f5f-4d45a39c7003  us-east-1a
    ```
 1. Run the repair on the cluster to make sure that the data is synced with the other nodes in the cluster. 
-   You can use [Scylla Manager](manager.md) to run the repair.
+   You can use [Scylla Manager](../manager.md) to run the repair.
 
 ### Replacing a dead seed node
 

--- a/docs/source/nodeoperations/restore.md
+++ b/docs/source/nodeoperations/restore.md
@@ -1,6 +1,6 @@
 ### Restore from backup
 
-This procedure will describe how to restore from backup taken using [Scylla Manager](manager.md) to a fresh **empty** cluster of any size.
+This procedure will describe how to restore from backup taken using [Scylla Manager](../manager.md) to a fresh **empty** cluster of any size.
 
 First identify to which snapshot you want to restore. To get list of available snapshot execute following command on Scylla Manager Pod.
 ```bash


### PR DESCRIPTION
## Context

Building multiverison locally raises a fatal exception because there are broken links in MarkDown:

```
Ha ocurrido una excepción:
  File "/home/dgarcia/.cache/pypoetry/virtualenvs/scylla-operator-docs-rSola0wq-py3.8/lib/python3.8/site-packages/sphinx/transforms/post_transforms/__init__.py", line 174, in warn_missing_reference
    logger.warning(msg % {'target': target},
ValueError: unsupported format character '(' (0x28) at index 48
```

This PR fixes the error in the versioned branch 1.3.