### PR TITLE
Hide master from documentation version dropdown

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,6 +108,7 @@ html_theme_options = {
     ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],
+    'hide_version_dropdown': ['master'],
     'github_issues_repository': 'scylladb/scylla-operator',
     'show_sidebar_index': True,
 }


### PR DESCRIPTION
Related issues https://github.com/scylladb/sphinx-scylladb-theme/issues/157

## Context

Adds the new option hide_version_dropdown, which hides a list of tags and branch names from the multi-version dropdown.
It also fixes some broken references that prevented the docs from building locally.

## How to test this PR

1. Run ``make multiversionpreview``.

2. You should be able to preview http://0.0.0.0:5500/master/, but master should not appear as an option in the dropdown located at the right sidebar.