### PR TITLE
Use RHEL UBI images

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -115,7 +115,7 @@ jobs:
         set -x
         # Avoid podman permission error on Ubuntu 20.04 by using it as root, although it shouldn't be needed.
         # Use --format=docker to support SHELL instruction in the Dockerfile. (SHELL didn't make it to OCI spec.)
-        sudo podman build --format=docker --squash -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
+        sudo podman build --squash -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
         sudo podman images '${{ env.image_repo_ref }}:ci'
         sudo podman save '${{ env.image_repo_ref }}:ci' | lz4 - ~/operatorimage.tar.lz4
     - name: Upload artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,22 @@
 # TODO: extract builder and base image into its own repo for reuse and to speed up builds
-FROM docker.io/library/ubuntu:20.04 AS builder
-SHELL ["/bin/bash", "-euEo", "pipefail", "-c"]
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
 ENV GOPATH=/go \
     GOROOT=/usr/local/go \
 # Enable madvdontneed=1, for golang < 1.16 https://github.com/golang/go/issues/42330
     GODEBUG=madvdontneed=1
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
-RUN apt-get update; \
-    apt-get install -y --no-install-recommends build-essential git curl gzip ca-certificates; \
-    apt-get clean; \
+RUN set -euExo pipefail && \
+    microdnf install -y make git curl tar && \
+    microdnf clean all && \
     curl --fail -L https://storage.googleapis.com/golang/go1.16.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 WORKDIR /go/src/github.com/scylladb/scylla-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM docker.io/library/ubuntu:20.04
-SHELL ["/bin/bash", "-euEo", "pipefail", "-c"]
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+RUN set -euExo pipefail && \
+    microdnf install -y procps-ng && \
+    microdnf clean all
 # sidecar-injection container and existing installations use binary from root,
 # we have to keep it there until we figure out how to properly upgrade them.
 COPY --from=builder /go/src/github.com/scylladb/scylla-operator/scylla-operator /usr/bin/


### PR DESCRIPTION
**Description of your changes:**
Changes our base image to `registry.access.redhat.com/ubi8/ubi-minimal`. We also get rid of Dash workarounds and go back to OCI compatible builds.
