### PR TITLE
Claim kube version >= 1.19.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ![](logo.png)
 
 ## Deploying the Operator
-The current version of scylla-operator requires Kubernetes >= 1.19.
+For version requirements see the [support matrix](./docs/source/releases.md).
 
 ### GitOps
 Kubernetes manifests are located in the `deploy/` folder. To deploy the operator manually using Kubernetes manifests or to integrate it into your GitOps flow please follow [these instructions](./deploy/README.md). 

--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -42,10 +42,10 @@ GA images aren't build from scratch but rather promoted from an existing release
 
 Support matrix table shows the version requirements for a particular **scylla-operator** version. Be sure to match these requirements, otherwise some functionality will not work.
 
-|                    | v1.4        | v1.3        | v1.2        | v1.1        | v1.0        |
-| :----------------: | :------:    | :------:    | :------:    | :------:    | :------:    |
-| Kubernetes         | `>=1.19`    | `>=1.19`    | `>=1.19`    | `>=1.11`    | `>=1.11`    |
-| Scylla OS          | `>=4.3`     | `>=4.2`     | `>=4.2`     | `>=4.0`     | `>=4.0`     |
-| Scylla Enterprise  | `>=2021.1`  | `>=2020.1`  | `>=2020.1`  | `>=2020.1`  | `>=2020.1`  |
-| Scylla Manager     | `>=2.2`     | `>=2.2`     | `>=2.2`     | `>=2.2`     | `>=2.2`     |
-| Scylla Monitoring  | `>=1.0`     | `>=1.0`     | `>=1.0`     | `>=1.0`     | `>=1.0`     |
+|                    | v1.4        | v1.3        | v1.2        | v1.1        | v1.0       |
+| :----------------: | :---------: | :---------: | :---------: | :---------: | :--------: |
+| Kubernetes         | `>=1.19.10` | `>=1.19`    | `>=1.19`    | `>=1.11`    | `>=1.11`   |
+| Scylla OS          | `>=4.3`     | `>=4.2`     | `>=4.2`     | `>=4.0`     | `>=4.0`    |
+| Scylla Enterprise  | `>=2021.1`  | `>=2020.1`  | `>=2020.1`  | `>=2020.1`  | `>=2020.1` |
+| Scylla Manager     | `>=2.2`     | `>=2.2`     | `>=2.2`     | `>=2.2`     | `>=2.2`    |
+| Scylla Monitoring  | `>=1.0`     | `>=1.0`     | `>=1.0`     | `>=1.0`     | `>=1.0`    |


### PR DESCRIPTION
**Description of your changes:**
We need [statefulset controller fix for handling PVCs](https://github.com/kubernetes/kubernetes/pull/98732), v1.19.10 is the first one to have it. It's also contained in `v1.20.0-alpha.1` and higher so we don't need to specify any particular z-stream there.

cc @vponomaryov 
