### PR TITLE
Fix scylla manager DNS name in the URL

### DIFF
--- a/pkg/cmd/operator/manager_controller.go
+++ b/pkg/cmd/operator/manager_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
 	"github.com/scylladb/scylla-operator/pkg/leaderelection"
 	"github.com/scylladb/scylla-operator/pkg/mermaidclient"
+	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
@@ -121,7 +122,8 @@ func (o *ManagerControllerOptions) Complete() error {
 	}
 
 	// TODO: Use https and wire certs.
-	managerClient, err := mermaidclient.NewClient("http://scylla-manager.scylla-manager.svc/api/v1", &http.Transport{})
+	url := fmt.Sprintf("http://%s/api/v1", naming.ScyllaManagerServiceName)
+	managerClient, err := mermaidclient.NewClient(url, &http.Transport{})
 	if err != nil {
 		return fmt.Errorf("can't build manager client: %w", err)
 	}

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -75,3 +75,8 @@ const (
 
 	OperatorEnvVarPrefix = "SCYLLA_OPERATOR_"
 )
+
+const (
+	ScyllaManagerNamespace   = "scylla-manager"
+	ScyllaManagerServiceName = "scylla-manager"
+)

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -17,6 +17,4 @@ const (
 
 	baseManagerSyncTimeout = 30 * time.Second
 	managerTaskSyncTimeout = 2 * time.Second
-
-	managerNamespace = "scylla-manager"
 )

--- a/test/e2e/set/scyllacluster/helpers.go
+++ b/test/e2e/set/scyllacluster/helpers.go
@@ -323,8 +323,9 @@ func getScyllaClient(ctx context.Context, client corev1client.CoreV1Interface, s
 	return scyllaClient, hosts, nil
 }
 
+// getManagerClient gets managerClient using IP address. E2E tests shouldn't rely on InCluster DNS.
 func getManagerClient(ctx context.Context, client corev1client.CoreV1Interface) (*mermaidclient.Client, error) {
-	managerService, err := client.Services(managerNamespace).Get(ctx, "scylla-manager", metav1.GetOptions{})
+	managerService, err := client.Services(naming.ScyllaManagerNamespace).Get(ctx, naming.ScyllaManagerServiceName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description of your changes:**
We claim global namespace `scylla-manager` but unfortunately as the helm charts allow it to be configurable, some still have the old namespace name `scylla-manager-system`. This PR makes sure the manager URL works in both environments and referencing the same namespace is more flexible and correct.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/665
