### PR TITLE
Force fixed names and namespaces for system components in helm

### DIFF
--- a/helm/scylla-manager/templates/NOTES.txt
+++ b/helm/scylla-manager/templates/NOTES.txt
@@ -1,8 +1,8 @@
 
 The Scylla Manager has been installed. Check its status by running:
 
-  kubectl -n {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "scylla-manager.name" . }}"
-  kubectl -n {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "scylla-manager.name" . }}-controller"
+  kubectl -n scylla-manager get pods -l "app.kubernetes.io/name=scylla-manager"
+  kubectl -n scylla-manager get pods -l "app.kubernetes.io/name=scylla-manager-controller"
 
 Visit https://github.com/scylladb/scylla-operator for tutorials on how to
 create and configure Scylla clusters using the Scylla Operator and set up monitoring.

--- a/helm/scylla-manager/templates/controller_clusterrolebinding.yaml
+++ b/helm/scylla-manager/templates/controller_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "scylla-manager.controllerServiceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-manager

--- a/helm/scylla-manager/templates/controller_deployment.yaml
+++ b/helm/scylla-manager/templates/controller_deployment.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "scylla-manager.controllerName" . }}
-  namespace: {{ .Release.Namespace }}
+  name: scylla-manager-controller
+  namespace: scylla-manager
   labels:
     {{- include "scylla-manager.controllerLabels" . | nindent 4 }}
 spec:
@@ -22,7 +22,7 @@ spec:
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - name: {{ include "scylla-manager.controllerName" . }}
+      - name: scylla-manager-controller
         image: {{ .Values.controllerImage.repository }}/scylla-operator:{{ .Values.controllerImage.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.controllerImage.pullPolicy }}
         env:

--- a/helm/scylla-manager/templates/controller_pdb.yaml
+++ b/helm/scylla-manager/templates/controller_pdb.yaml
@@ -1,8 +1,8 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "scylla-manager.controllerName" . }}
-  namespace: {{ .Release.Namespace }}
+  name: scylla-manager-controller
+  namespace: scylla-manager
 spec:
   minAvailable: 1
   selector:

--- a/helm/scylla-manager/templates/controller_serviceaccount.yaml
+++ b/helm/scylla-manager/templates/controller_serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-manager.controllerServiceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-manager
   labels:
     {{- include "scylla-manager.controllerLabels" . | nindent 4 }}
   {{- with .Values.controllerServiceAccount.annotations }}

--- a/helm/scylla-manager/templates/manager_configmap.yaml
+++ b/helm/scylla-manager/templates/manager_configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scylla-manager-config
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-manager
 data:
   scylla-manager.yaml: |-
     http: :5080

--- a/helm/scylla-manager/templates/manager_deployment.yaml
+++ b/helm/scylla-manager/templates/manager_deployment.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "scylla-manager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: scylla-manager
+  namespace: scylla-manager
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
 spec:

--- a/helm/scylla-manager/templates/manager_service.yaml
+++ b/helm/scylla-manager/templates/manager_service.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
-  name: {{ include "scylla-manager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: scylla-manager
+  namespace: scylla-manager
 spec:
   ports:
   - name: api

--- a/helm/scylla-manager/templates/manager_serviceaccount.yaml
+++ b/helm/scylla-manager/templates/manager_serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-manager.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-manager
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/scylla-manager/templates/manager_servicemonitor.yaml
+++ b/helm/scylla-manager/templates/manager_servicemonitor.yaml
@@ -2,8 +2,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "scylla-manager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: scylla-manager
+  namespace: scylla-manager
 spec:
   jobLabel: "app"
   selector:

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -48,9 +48,6 @@
         "controllerSecurityContext": {
             "type": "object"
         },
-        "fullnameOverride": {
-            "type": "string"
-        },
         "image": {
             "type": "object",
             "properties": {
@@ -66,12 +63,6 @@
             }
         },
         "logLevel": {
-            "type": "string"
-        },
-        "nameOverride": {
-            "type": "string"
-        },
-        "namespace": {
             "type": "string"
         },
         "nodeSelector": {

--- a/helm/scylla-operator/templates/NOTES.txt
+++ b/helm/scylla-operator/templates/NOTES.txt
@@ -1,7 +1,7 @@
 
 The Scylla Operator has been installed. Check its status by running:
 
-  kubectl -n {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "scylla-operator.name" . }}"
+  kubectl -n scylla-operator get pods -l "app.kubernetes.io/name=scylla-operator"
 
 Visit https://github.com/scylladb/scylla-operator for tutorials on how to
 create and configure Scylla clusters using the Scylla Operator and set up monitoring.

--- a/helm/scylla-operator/templates/certificate.yaml
+++ b/helm/scylla-operator/templates/certificate.yaml
@@ -3,10 +3,10 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "scylla-operator.certificateName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-operator
 spec:
   dnsNames:
-  - {{ include "scylla-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "scylla-operator.webhookServiceName" . }}.scylla-operator.svc
   issuerRef:
     kind: Issuer
     name: scylla-operator-selfsigned-issuer

--- a/helm/scylla-operator/templates/clusterrolebinding.yaml
+++ b/helm/scylla-operator/templates/clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "scylla-operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-operator

--- a/helm/scylla-operator/templates/issuer.yaml
+++ b/helm/scylla-operator/templates/issuer.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: scylla-operator-selfsigned-issuer
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-operator
 spec:
   selfSigned: {}
 {{- end }}

--- a/helm/scylla-operator/templates/operator.deployment.yaml
+++ b/helm/scylla-operator/templates/operator.deployment.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "scylla-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: scylla-operator
+  namespace: scylla-operator
   labels:
     {{- include "scylla-operator.labels" . | nindent 4 }}
 spec:

--- a/helm/scylla-operator/templates/operator.serviceaccount.yaml
+++ b/helm/scylla-operator/templates/operator.serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-operator
   labels:
     {{- include "scylla-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/scylla-operator/templates/pdb.yaml
+++ b/helm/scylla-operator/templates/pdb.yaml
@@ -1,8 +1,8 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "scylla-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: scylla-operator
+  namespace: scylla-operator
 spec:
   maxUnavailable: 1
   selector:

--- a/helm/scylla-operator/templates/validatingwebhook.yaml
+++ b/helm/scylla-operator/templates/validatingwebhook.yaml
@@ -2,7 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "scylla-operator.certificateName" . }}
+    cert-manager.io/inject-ca-from: scylla-operator/{{ include "scylla-operator.certificateName" . }}
   name: scylla-operator
 webhooks:
 - name: webhook.scylla.scylladb.com
@@ -10,7 +10,7 @@ webhooks:
     caBundle: Cg==
     service:
       name: {{ include "scylla-operator.webhookServiceName" . }}
-      namespace: {{ .Release.Namespace }}
+      namespace: scylla-operator
       path: /validate
   admissionReviewVersions:
   - v1

--- a/helm/scylla-operator/templates/webhookserver.deployment.yaml
+++ b/helm/scylla-operator/templates/webhookserver.deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-operator
   name: webhook-server
   labels:
     app.kubernetes.io/name: webhook-server

--- a/helm/scylla-operator/templates/webhookserver.service.yaml
+++ b/helm/scylla-operator/templates/webhookserver.service.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
-  name: {{ include "scylla-operator.webhookServiceName" . }}
+  namespace: scylla-operator
+  name: scylla-operator-webhook
   labels:
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/instance: webhook-server

--- a/helm/scylla-operator/templates/webhookserver.serviceaccount.yaml
+++ b/helm/scylla-operator/templates/webhookserver.serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: scylla-operator
   name: webhook-server
   labels:
     app.kubernetes.io/name: webhook-server

--- a/helm/scylla-operator/values.schema.json
+++ b/helm/scylla-operator/values.schema.json
@@ -5,9 +5,6 @@
         "affinity": {
             "type": "object"
         },
-        "fullnameOverride": {
-            "type": "string"
-        },
         "image": {
             "type": "object",
             "properties": {
@@ -24,12 +21,6 @@
         },
         "logLevel": {
             "type": "integer"
-        },
-        "nameOverride": {
-            "type": "string"
-        },
-        "namespace": {
-            "type": "string"
         },
         "nodeSelector": {
             "type": "object"

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -1,8 +1,3 @@
-# Allows to override Scylla Operator name showing up in recommended k8s labels
-nameOverride: ""
-# Allows to override names used in Scylla Operator k8s objects.
-fullnameOverride: ""
-
 # Allows to customize Scylla Operator image
 image:
   repository: scylladb


### PR DESCRIPTION
**Description of your changes:**
We fully own the `scylla-operator` and `scylla-manager` system namespaces so we don't need to make the names configurable and templating those brings issues that can break the deployment. These namespaces are singletons and there will always be just one instance for each - that's why they don't match the regular helm pattern where you template the namespace name so it can deploy to multiple namespaces. We also own the whole namespace, contrary to the instance type charts that deploy into a namespace with other objects, so there can't be name collisions needing the templating.

We need fixed names so we can easily:
- talk to the deployed components, like from the manager-controller to the manager through the service DNS name
- gather artifacts when we have a "must-gather" command
- make sure the deployment always works, we only test one combination of names and namespaces in the CI like in https://github.com/scylladb/scylla-operator/issues/665
- ...

We need to mention this in the upgrade guide so people fix the names (if changed).
