### PR TITLE
Remove the PVC when the service is decommissioned

### DIFF
--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -65,6 +65,18 @@ func PVCNameForPod(podName string) string {
 	return fmt.Sprintf("%s-%s", PVCTemplateName, podName)
 }
 
+func PVCNameForService(svcName string) string {
+	return PVCNameForPod(svcName)
+}
+
+func PVCNamePrefixForScyllaCluster(scName string) string {
+	return fmt.Sprintf("%s-%s-", PVCTemplateName, scName)
+}
+
+func PVCNameForStatefulSet(stsName string, ordinal int32) string {
+	return fmt.Sprintf("%s-%s-%d", PVCTemplateName, stsName, ordinal)
+}
+
 // IndexFromName attempts to get the index from a name using the
 // naming convention <name>-<index>.
 func IndexFromName(n string) (int32, error) {


### PR DESCRIPTION
**Description of your changes:**
When a member is decommissioned we need to delete the PVC because a new scylla wouldn't bootstrap from it after the decommissioning process. Like in the case of a scaling down and up again. This is similar to what we have done in https://github.com/scylladb/scylla-operator/blob/b3413fcdd6c100dbb701d620a6428dc057faaf17/pkg/controllers/cluster/cleanup.go#L162-L165

We can't easily reconcile the PVC to match the intent in general, because PVCs are half managed by StatefulSet controller, don't have ownerRefs and user may expect those to stay around. So if you scale down the rack we will remove the PVC, but removing the whole rack won't be reconciled. And there are some race like when a StatefulSet is created before the Service and then the rack is scaled back down. Those are preexisting though.

**Which issue is resolved by this Pull Request:**
Resolves #670 #669
