### PR TITLE
Fix operator upgrade bugs

### DIFF
--- a/deploy/operator/00_clusterrole_def.yaml
+++ b/deploy/operator/00_clusterrole_def.yaml
@@ -66,6 +66,7 @@ rules:
   - watch
   - create
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -77,6 +77,7 @@ rules:
   - watch
   - create
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/helm/scylla-operator/templates/clusterrole_def.yaml
+++ b/helm/scylla-operator/templates/clusterrole_def.yaml
@@ -66,6 +66,7 @@ rules:
   - watch
   - create
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/pkg/controller/helpers/apps.go
+++ b/pkg/controller/helpers/apps.go
@@ -16,11 +16,6 @@ func IsStatefulSetRolledOut(sts *appsv1.StatefulSet) (bool, error) {
 		return false, fmt.Errorf("statefulset.spec.replicas can't be nil")
 	}
 
-	if sts.Spec.UpdateStrategy.RollingUpdate == nil {
-		// This should never happen, but better safe then sorry.
-		return false, fmt.Errorf("statefulset.spec.updatestrategy.rollingupdate can't be nil")
-	}
-
 	if sts.Status.ObservedGeneration == 0 || sts.Generation > sts.Status.ObservedGeneration {
 		return false, nil
 	}
@@ -29,7 +24,7 @@ func IsStatefulSetRolledOut(sts *appsv1.StatefulSet) (bool, error) {
 		return false, nil
 	}
 
-	if sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
+	if sts.Spec.UpdateStrategy.RollingUpdate != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
 		return sts.Status.UpdatedReplicas == (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition), nil
 	} else {
 		return sts.Status.UpdateRevision == sts.Status.CurrentRevision, nil

--- a/pkg/controller/scyllacluster/resource/resource.go
+++ b/pkg/controller/scyllacluster/resource/resource.go
@@ -413,8 +413,10 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 	if existingSts != nil {
 		sts.ResourceVersion = existingSts.ResourceVersion
 		if sts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType &&
-			existingSts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType {
-			sts.Spec.UpdateStrategy.RollingUpdate.Partition = existingSts.Spec.UpdateStrategy.RollingUpdate.Partition
+			existingSts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType &&
+			existingSts.Spec.UpdateStrategy.RollingUpdate != nil &&
+			existingSts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
+			*sts.Spec.UpdateStrategy.RollingUpdate.Partition = *existingSts.Spec.UpdateStrategy.RollingUpdate.Partition
 		}
 	}
 

--- a/pkg/controller/scyllacluster/sync_agent_config.go
+++ b/pkg/controller/scyllacluster/sync_agent_config.go
@@ -65,7 +65,8 @@ func (scc *Controller) syncAgentToken(
 		return status, fmt.Errorf("can't make auth token secret: %w", err)
 	}
 
-	_, _, err = resourceapply.ApplySecret(ctx, scc.kubeClient.CoreV1(), scc.secretLister, scc.eventRecorder, secret)
+	// TODO: Remove forced ownership in v1.5 (#672)
+	_, _, err = resourceapply.ApplySecret(ctx, scc.kubeClient.CoreV1(), scc.secretLister, scc.eventRecorder, secret, true)
 	if err != nil {
 		return status, fmt.Errorf("can't apply secret %q: %w", naming.ObjRef(secret), err)
 	}

--- a/pkg/controller/scyllacluster/sync_pdb.go
+++ b/pkg/controller/scyllacluster/sync_pdb.go
@@ -48,7 +48,8 @@ func (scc *Controller) syncPodDisruptionBudgets(
 		return status, fmt.Errorf("can't delete pdb(s): %w", err)
 	}
 
-	_, _, err = resourceapply.ApplyPodDisruptionBudget(ctx, scc.kubeClient.PolicyV1beta1(), scc.pdbLister, scc.eventRecorder, requiredPDB)
+	// TODO: Remove forced ownership in v1.5 (#672)
+	_, _, err = resourceapply.ApplyPodDisruptionBudget(ctx, scc.kubeClient.PolicyV1beta1(), scc.pdbLister, scc.eventRecorder, requiredPDB, true)
 	if err != nil {
 		return status, fmt.Errorf("can't apply pdb: %w", err)
 	}

--- a/pkg/controller/scyllacluster/sync_services.go
+++ b/pkg/controller/scyllacluster/sync_services.go
@@ -125,7 +125,7 @@ func (scc *Controller) syncServices(
 
 	// We need to first propagate ReplaceAddressFirstBoot from status for the new service.
 	for _, svc := range requiredServices {
-		_, _, err = resourceapply.ApplyService(ctx, scc.kubeClient.CoreV1(), scc.serviceLister, scc.eventRecorder, svc)
+		_, _, err = resourceapply.ApplyService(ctx, scc.kubeClient.CoreV1(), scc.serviceLister, scc.eventRecorder, svc, false)
 		if err != nil {
 			return status, err
 		}

--- a/pkg/controller/scyllacluster/sync_statefulsets.go
+++ b/pkg/controller/scyllacluster/sync_statefulsets.go
@@ -353,7 +353,7 @@ func (scc *Controller) createMissingStatefulSets(
 		_, found := statefulSets[sts.Name]
 		if !found {
 			klog.V(2).InfoS("Creating missing StatefulSet", "StatefulSet", klog.KObj(sts))
-			_, changed, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, sts)
+			_, changed, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, sts, false)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("can't create missing statefulset: %w", err))
 				continue
@@ -550,7 +550,7 @@ func (scc *Controller) syncStatefulSets(
 				required.Spec.Replicas = pointer.Int32Ptr(*existing.Spec.Replicas)
 				required.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(*existing.Spec.Replicas)
 				// Use apply to also update the spec.template
-				_, _, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, required)
+				_, _, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, required, false)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("can't apply statefulset to set partition: %w", err))
 				}
@@ -708,7 +708,7 @@ func (scc *Controller) syncStatefulSets(
 			}
 		}
 
-		sts, _, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, required)
+		sts, _, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, required, false)
 		if err != nil {
 			return status, fmt.Errorf("can't apply statefulset update: %w", err)
 		}


### PR DESCRIPTION
**Description of your changes:**
Creating the ScyllaCluster with scylla-operator v1.3 and updating the scylla-operator uncovered few corner cases like objects with invalid selectors or a nil segfault.

v1.3 and previous versions didn't set selectors correctly for some cases. Given the Three laws of controllers v1.4/master (that respects them) had to release those objects. That got us to a state where we couldn't update them because we don't own them and we can't adopt them because they don't match our selector.

`forceOwnership` flag allows to migrate from such state and we'll switch it back to `false` in v1.5 (https://github.com/scylladb/scylla-operator/issues/672).