### PR TITLE
Add support for manually triggering ScyllaCluster rollout

### DIFF
--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -3066,6 +3066,10 @@ spec:
               developerMode:
                 description: developerMode determines if the cluster runs in developer-mode.
                 type: boolean
+              forceRedeploymentReason:
+                description: forceRedeploymentReason can be used to force a rolling
+                  update of all racks by providing a unique string.
+                type: string
               genericUpgrade:
                 description: genericUpgrade allows to configure behavior of generic
                   upgrade logic.

--- a/pkg/api/scylla/v1/cluster_types.go
+++ b/pkg/api/scylla/v1/cluster_types.go
@@ -86,6 +86,10 @@ type ScyllaClusterSpec struct {
 	// When Scylla Manager is not installed, these will be ignored.
 	// +optional
 	Backups []BackupTaskSpec `json:"backups,omitempty"`
+
+	// forceRedeploymentReason can be used to force a rolling update of all racks by providing a unique string.
+	// +optional
+	ForceRedeploymentReason string `json:"forceRedeploymentReason,omitempty"`
 }
 
 // GenericUpgradeFailureStrategy allows to specify how upgrade logic should handle failures.

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -2890,6 +2890,10 @@ spec:
               developerMode:
                 description: developerMode determines if the cluster runs in developer-mode.
                 type: boolean
+              forceRedeploymentReason:
+                description: forceRedeploymentReason can be used to force a rolling
+                  update of all racks by providing a unique string.
+                type: string
               genericUpgrade:
                 description: genericUpgrade allows to configure behavior of generic
                   upgrade logic.

--- a/pkg/controller/scyllacluster/resource/resource.go
+++ b/pkg/controller/scyllacluster/resource/resource.go
@@ -405,6 +405,10 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 		},
 	}
 
+	if len(c.Spec.ForceRedeploymentReason) != 0 {
+		sts.Spec.Template.Annotations[naming.ForceRedeploymentReasonAnnotation] = c.Spec.ForceRedeploymentReason
+	}
+
 	if existingSts != nil {
 		sts.ResourceVersion = existingSts.ResourceVersion
 		if sts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType &&

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -44,6 +44,8 @@ const (
 
 	PrometheusScrapeAnnotation = "prometheus.io/scrape"
 	PrometheusPortAnnotation   = "prometheus.io/port"
+
+	ForceRedeploymentReasonAnnotation = "scylla-operator.scylladb.com/force-redeployment-reason"
 )
 
 // Configuration Values


### PR DESCRIPTION
**Description of your changes:**
This PR add an API filed `ForceRedeploymentReason` that allows user to trigger a ScyllaCluster rollout manually. This maintains HA and respects the PDB, contrary to having to delete all pods manually or at once. This has been previously handled by a hack of manually forcing rollouts for all StatefulSets, but given `kubectl rollout restart` adds an annotation we'd now reconcile and remove it, which would do a second rollout. This also had to be done for each StatefulSet/Rack separately and couldn't be done for the whole cluster.

Manually triggering cluster rollout is useful e.g. for reloading scylla config.

Requires:
- [x] https://github.com/scylladb/scylla-operator/pull/668
- [x] https://github.com/scylladb/scylla-operator/pull/684