### PR TITLE
Fix GH action to work with new minikube 1.22.0

### DIFF
--- a/.github/actions/setup-minikube/action.yaml
+++ b/.github/actions/setup-minikube/action.yaml
@@ -17,7 +17,7 @@ runs:
     run: |
       set -x
       sudo minikube config set driver none
-      sudo minikube config set embed-certs true
+      sudo minikube config set EmbedCerts true
       sudo ip link set docker0 promisc on
   - name: Start minikube
     shell: bash


### PR DESCRIPTION
**Description of your changes:**
Minikube https://github.com/kubernetes/minikube/pull/11576 broke our install script, this PR reacts to the change and renames the config value.

This is currently blocking all CI.
```
# minikube config set embed-certs true

❌  Exiting due to MK_CONFIG_SET: find settings for "embed-certs" value of "true": property name "embed-certs" not found
```