### PR TITLE
Fix controller leader election lock names

### DIFF
--- a/pkg/cmd/operator/manager_controller.go
+++ b/pkg/cmd/operator/manager_controller.go
@@ -142,10 +142,13 @@ func (o *ManagerControllerOptions) Run(streams genericclioptions.IOStreams, comm
 		cancel()
 	}()
 
+	// Lock names cannot be changed, because it may lead to two leaders during rolling upgrades.
+	const lockName = "scylla-manager-controller-lock"
+
 	return leaderelection.Run(
 		ctx,
 		commandName,
-		commandName+"-locks",
+		lockName,
 		o.Namespace,
 		o.kubeClient,
 		o.LeaderElectionLeaseDuration,

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -141,10 +141,13 @@ func (o *OperatorOptions) Run(streams genericclioptions.IOStreams, commandName s
 		cancel()
 	}()
 
+	// Lock names cannot be changed, because it may lead to two leaders during rolling upgrades.
+	const lockName = "scylla-operator-lock"
+
 	return leaderelection.Run(
 		ctx,
 		commandName,
-		commandName+"-locks",
+		lockName,
 		o.Namespace,
 		o.kubeClient,
 		o.LeaderElectionLeaseDuration,


### PR DESCRIPTION
1.3 controllers used different LE lock names.
During rolling upgrade to 1.4 two controllers were able to win LE and hence reconcile Scylla clusters.
Lock names are fixed to names used in 1.3.

Fixes #676
