### PR TITLE
Add cluster delete instructions and reference to generic in gke docs

### DIFF
--- a/docs/source/eks.md
+++ b/docs/source/eks.md
@@ -37,9 +37,9 @@ EKS_ZONES=us-east-1a,us-east-1b,us-east-1c
 CLUSTER_NAME=scylla-demo
 ```
 
-#### Creating a EKS cluster
+#### Creating an EKS cluster
 
-For this guide, we'll create a EKS cluster with the following:
+For this guide, we'll create an EKS cluster with the following:
 
 * A NodeGroup of 3 `i3-2xlarge` Nodes, where the Scylla Pods will be deployed. These nodes will only accept pods having `scylla-clusters` toleration.
 
@@ -110,10 +110,14 @@ kubectl apply -f node-setup-daemonset.yaml
 
 Now you can follow the [generic guide](generic.md) to launch your Scylla cluster in a highly performant environment.
 
-#### Deleting a EKS cluster
+#### Accessing the database
 
-Once you are done with your experiments delete your cluster using following command:
+Instructions on how to access the database can also be found in the [generic guide](generic.md).
+
+### Deleting an EKS cluster
+
+Once you are done with your experiments delete your cluster using the following command:
 
 ```
-eksctl delete cluster <cluster_name>
+eksctl delete cluster "${CLUSTER_NAME}"
 ```

--- a/docs/source/gke.md
+++ b/docs/source/gke.md
@@ -153,4 +153,18 @@ sed -i "s/<gcp_region>/${GCP_REGION}/g;s/<gcp_zone>/${GCP_ZONE}/g" examples/gke/
 
 This will inject your region and zone into the cluster definition so that it matches the kubernetes cluster you just created.
 
+### Installing the Scylla Operator and Scylla
+
 Now you can follow the [generic guide](generic.md) to install the operator and launch your Scylla cluster in a highly performant environment.
+
+#### Accessing the database
+
+Instructions on how to access the database can also be found in the [generic guide](generic.md).
+
+### Deleting a GKE cluster
+
+Once you are done with your experiments delete your cluster using the following command:
+
+```
+gcloud container --project "${GCP_PROJECT}" clusters delete --zone "${GCP_ZONE}" "${CLUSTER_NAME}"
+```


### PR DESCRIPTION
**Description of your changes:**
- Add instructions on how to delete a GKE cluster in GKE docs.
- Add references to generic instructions on how to access the database in EWS and GKE docs.

**Which issue is resolved by this Pull Request:**
Resolves #637
