### PR TITLE
[WIP] Add deploy manifests for dev storage setup on GKE

### DIFF
--- a/deploy/storage/dev/gke/local-dirs/daemonset.yaml
+++ b/deploy/storage/dev/gke/local-dirs/daemonset.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-dirs
+  namespace: default
+  labels:
+    app: node-dirs
+spec:
+  selector:
+    matchLabels:
+      app: node-dirs
+  template:
+    metadata:
+      labels:
+        app: node-dirs
+    spec:
+      serviceAccountName: node-dirs
+      containers:
+      - image: "registry.access.redhat.com/ubi8/ubi:latest"
+        imagePullPolicy: "Always"
+        command:
+        - "/bin/bash"
+        - "-euExo"
+        - "pipefail"
+        - "-c"
+        args:
+        - |
+          while true; do
+            for d in $(seq -f "pv-%05g" 1 10); do
+              if [[ ! -d "/var/lib/k8s-local-pvs/local-dirs/${d}" ]]; then
+                mkdir "/var/lib/k8s-local-pvs/local-dirs/${d}"
+              fi
+
+              ( mount | grep " /var/lib/k8s-local-pvs/local-dirs/${d} " 2>/dev/null 1>&2 ) || \
+              mount --bind "/var/lib/k8s-local-pvs/local-dirs/${d}"{,}
+            done
+
+            sleep 30
+          done
+        name: node-dirs
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/k8s-local-pvs/local-dirs/
+          name: local-dirs
+          mountPropagation: "Bidirectional"
+      volumes:
+      - name: local-dirs
+        hostPath:
+          path: /var/lib/k8s-local-pvs/local-dirs/
+

--- a/deploy/storage/dev/gke/local-dirs/serviceaccount.yaml
+++ b/deploy/storage/dev/gke/local-dirs/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-dirs
+  namespace: default

--- a/deploy/storage/dev/gke/provisioner/clusterrolebinding.yaml
+++ b/deploy/storage/dev/gke/provisioner/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/storage/dev/gke/provisioner/configmap.yaml
+++ b/deploy/storage/dev/gke/provisioner/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config 
+  namespace: default 
+data:
+  storageClassMap: |     
+    local-dirs:
+       hostDir: /var/lib/k8s-local-pvs/local-dirs/
+       mountDir: /var/lib/k8s-local-pvs/local-dirs/
+       blockCleanerCommand:
+         - "/scripts/shred.sh"
+         - "2"
+       volumeMode: Filesystem
+       fsType: xfs
+       namePattern: "*"
+

--- a/deploy/storage/dev/gke/provisioner/daemonset.yaml
+++ b/deploy/storage/dev/gke/provisioner/daemonset.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner 
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+      - image: "k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0"
+        imagePullPolicy: "Always"
+        name: provisioner
+        securityContext:
+          privileged: true
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - mountPath: /etc/provisioner/config
+          name: provisioner-config
+          readOnly: true
+        - mountPath:  /var/lib/k8s-local-pvs
+          name: k8s-local-pvs
+          mountPropagation: "HostToContainer"
+      volumes:
+      - name: provisioner-config
+        configMap:
+          name: local-provisioner-config
+      - name: k8s-local-pvs
+        hostPath:
+          path: /var/lib/k8s-local-pvs
+

--- a/deploy/storage/dev/gke/provisioner/node.clusterrole.yaml
+++ b/deploy/storage/dev/gke/provisioner/node.clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]

--- a/deploy/storage/dev/gke/provisioner/node.clusterrolebinding.yaml
+++ b/deploy/storage/dev/gke/provisioner/node.clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/storage/dev/gke/provisioner/serviceaccount.yaml
+++ b/deploy/storage/dev/gke/provisioner/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: default

--- a/deploy/storage/dev/gke/provisioner/storageclass.yaml
+++ b/deploy/storage/dev/gke/provisioner/storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-dirs
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete


### PR DESCRIPTION
**Description of your changes:**
Just an idea for now, we may use it for running cheap GKE clusters (without dedicated SSDs) for development or CI.

As there can be only one default storage class, it needs
```
kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
```