### PR TITLE
Make node replacement less likely to hit StatefulSet bug

### DIFF
--- a/pkg/controller/scyllacluster/controller.go
+++ b/pkg/controller/scyllacluster/controller.go
@@ -40,7 +40,7 @@ const (
 	ControllerName = "ScyllaClusterController"
 	// maxSyncDuration enforces preemption. Do not raise the value! Controllers shouldn't actively wait,
 	// but rather use the queue.
-	maxSyncDuration = 30 * time.Second
+	maxSyncDuration = 40 * time.Second
 
 	artificialDelayForCachesToCatchUp = 10 * time.Second
 )


### PR DESCRIPTION
**Description of your changes:**
When we replace a scylla node and delete the PVC and the pod, a new PVC might not be created by Statefulset controller for the new pod. StatefulSet doesn't reconcile PVCs, it decides PVC presence only from its cache and never recreates it if it's missing, only when it creates the pod. This PR gives StatefulSet controller a higher chance to see the PVC was deleted before we deleting the pod.

**Which issue is resolved by this Pull Request:**
Resolves #687
