### PR TITLE
Prefer placing pods on different nodes for webhookserver and operator

### DIFF
--- a/deploy/operator/50_operator.deployment.yaml
+++ b/deploy/operator/50_operator.deployment.yaml
@@ -36,3 +36,13 @@ spec:
             cpu: 10m
             memory: 20Mi
       terminationGracePeriodSeconds: 10
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: webhook-server
+                  app.kubernetes.io/name: webhook-server
+              topologyKey: kubernetes.io/hostname
+            weight: 1

--- a/deploy/operator/50_webhookserver.deployment.yaml
+++ b/deploy/operator/50_webhookserver.deployment.yaml
@@ -60,3 +60,13 @@ spec:
         secret:
           defaultMode: 420
           secretName: scylla-operator-serving-cert
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: scylla-operator
+                  app.kubernetes.io/name: scylla-operator
+              topologyKey: kubernetes.io/hostname
+            weight: 1

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -3733,6 +3733,16 @@ spec:
             cpu: 10m
             memory: 20Mi
       terminationGracePeriodSeconds: 10
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: webhook-server
+                  app.kubernetes.io/name: webhook-server
+              topologyKey: kubernetes.io/hostname
+            weight: 1
 
 ---
 apiVersion: apps/v1
@@ -3797,5 +3807,15 @@ spec:
         secret:
           defaultMode: 420
           secretName: scylla-operator-serving-cert
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: scylla-operator
+                  app.kubernetes.io/name: scylla-operator
+              topologyKey: kubernetes.io/hostname
+            weight: 1
 
 ---

--- a/helm/scylla-operator/templates/_helpers.tpl
+++ b/helm/scylla-operator/templates/_helpers.tpl
@@ -34,8 +34,8 @@ Create chart name and version as used by the chart label.
 Selector labels
 */}}
 {{- define "scylla-operator.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "scylla-operator.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: scylla-operator
+app.kubernetes.io/instance: scylla-operator
 {{- end }}
 
 {{/*

--- a/helm/scylla-operator/templates/webhookserver.deployment.yaml
+++ b/helm/scylla-operator/templates/webhookserver.deployment.yaml
@@ -67,15 +67,15 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ include "scylla-operator.certificateSecretName" . }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.webhookServerNodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.webhookServerAffinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.webhookServerTolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -19,7 +19,16 @@ nodeSelector: { }
 tolerations: [ ]
 
 # Affinity for Scylla Operator pods
-affinity: { }
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 1
+      podAffinityTerm:
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: webhook-server
+            app.kubernetes.io/instance: webhook-server
+        topologyKey: kubernetes.io/hostname
 
 webhook:
   # Specifies whether a self signed certificate should be created using cert-manager
@@ -39,3 +48,21 @@ serviceAccount:
 
 ## SecurityContext holds pod-level security attributes and common container settings.
 securityContext: {}
+
+# Node selector for Webhook Server pods
+webhookServerNodeSelector: { }
+
+# Tolerations for Webhook Server pods
+webhookServerTolerations: [ ]
+
+# Affinity for Webhook Server pods
+webhookServerAffinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 1
+      podAffinityTerm:
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: scylla-operator
+            app.kubernetes.io/instance: scylla-operator
+        topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
**Description of your changes:**
- Added antiAffinities to webhook-server and operator pods so that they are preferably not scheduled on the same node.
- Added separate fields for nodeSelector, affinity and tolerations for webhook-server in values.yaml

**Which issue is resolved by this Pull Request:**
Resolves #696
