### PR TITLE
Fix date ranges for listing PRs in gen-release-notes

### DIFF
--- a/pkg/cmd/releasenotes/generate.go
+++ b/pkg/cmd/releasenotes/generate.go
@@ -52,5 +52,7 @@ func NewGenGitReleaseNotesCommand(ctx context.Context, streams genericclioptions
 	cmd.Flags().StringVar(&o.EndRef, "end-ref", o.EndRef, "Last commit reference, pull requests merged before (including this ref) this ref will be part of the release notes.")
 	cmd.Flags().StringVar(&o.GithubToken, "github-token", o.GithubToken, "GitHub token used to authenticate requests.")
 
+	cmdutil.InstallKlog(cmd)
+
 	return cmd
 }

--- a/pkg/cmd/releasenotes/github.go
+++ b/pkg/cmd/releasenotes/github.go
@@ -58,12 +58,14 @@ func dateToken(start, end time.Time) string {
 	// Dates before 1970 (unix epoch) are considered invalid.
 	startString, endString := "*", "*"
 	if start.Year() >= 1970 {
-		startString = start.UTC().Format(time.RFC3339)
+		// Make sure we list all the PR, GitHub ranges are exclusive.
+		startString = start.Add(-1 * time.Second).UTC().Format(time.RFC3339Nano)
 	} else {
 		klog.Warningf("Search start date is before year 1970, using 'any' filter instead")
 	}
 	if end.Year() >= 1970 {
-		endString = end.UTC().Format(time.RFC3339)
+		// Make sure we list all the PR, GitHub ranges are exclusive.
+		endString = end.Add(1 * time.Second).UTC().Format(time.RFC3339Nano)
 	} else {
 		klog.Warningf("Search end date is before year 1970, using 'any' filter instead")
 	}
@@ -86,6 +88,7 @@ func listPullRequests(ctx context.Context, ghClient *githubql.Client, owner, rep
 	}
 	var pullRequests []PullRequest
 	for {
+		klog.V(2).InfoS("Listing pull requests", "Vars", vars)
 		if err := ghClient.Query(ctx, &sq, vars); err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/releasenotes/options.go
+++ b/pkg/cmd/releasenotes/options.go
@@ -5,7 +5,6 @@ package releasenotes
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
@@ -41,31 +40,35 @@ func NewGitGenerateOptions(streams genericclioptions.IOStreams) *GenerateOptions
 
 func (o *GenerateOptions) Validate() error {
 	var errs []error
+
 	if o.ReleaseName == "" {
 		errs = append(errs, fmt.Errorf("release name can't be empty"))
 	}
+
 	if strings.HasPrefix(o.ReleaseName, "v") {
 		errs = append(errs, fmt.Errorf("release name can't has 'v' prefix"))
 	}
+
 	if o.StartRef == "" {
 		errs = append(errs, fmt.Errorf("start ref can't be empty"))
 	}
+
 	if o.EndRef == "" {
 		errs = append(errs, fmt.Errorf("end ref can't be empty"))
+	}
+
+	if len(o.GithubToken) == 0 {
+		errs = append(errs, fmt.Errorf("github-token can't be empty"))
 	}
 
 	return errors.NewAggregate(errs)
 }
 
 func (o *GenerateOptions) Complete(ctx context.Context) error {
-	var httpClient *http.Client
-	if o.GithubToken != "" {
-		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: o.GithubToken},
-		)
-		httpClient = oauth2.NewClient(ctx, ts)
-	}
-
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: o.GithubToken},
+	)
+	httpClient := oauth2.NewClient(ctx, ts)
 	o.ghClient = githubql.NewClient(httpClient)
 
 	return nil

--- a/pkg/cmd/releasenotes/options.go
+++ b/pkg/cmd/releasenotes/options.go
@@ -39,7 +39,7 @@ func NewGitGenerateOptions(streams genericclioptions.IOStreams) *GenerateOptions
 	}
 }
 
-func (o GenerateOptions) Validate() error {
+func (o *GenerateOptions) Validate() error {
 	var errs []error
 	if o.ReleaseName == "" {
 		errs = append(errs, fmt.Errorf("release name can't be empty"))

--- a/pkg/cmd/releasenotes/releasenotes.go
+++ b/pkg/cmd/releasenotes/releasenotes.go
@@ -25,7 +25,7 @@ func (o *GenerateOptions) Run(ctx context.Context) error {
 
 		n, ok := parsePullRequestNumber(c.Message)
 		if !ok {
-			klog.Infof("Can't parse pull request number from %q commit", c.Hash)
+			klog.Errorf("Can't parse pull request number from %q commit", c.Hash)
 			continue
 		}
 


### PR DESCRIPTION
**Description of your changes:**
GitHub date ranges are not inclusive and `gen-release-notes` was failing to find the first PR.
```
$ go run ./cmd/gen-release-notes --start-ref=$( git merge-base v1.3.0 v1.2.0 ) --end-ref=v1.3.0 --release-name=1.3.0 --github-token=${GITHUB_TOKEN}
Error: PR #648 not found in GitHub
```

