### PR TITLE
Raise manager e2e timeout

### DIFF
--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -15,6 +15,6 @@ const (
 	memberRolloutTimeout = 3 * time.Minute
 	baseRolloutTimout    = 30 * time.Second
 
-	baseManagerSyncTimeout = 30 * time.Second
-	managerTaskSyncTimeout = 2 * time.Second
+	baseManagerSyncTimeout = 3 * time.Minute
+	managerTaskSyncTimeout = 30 * time.Second
 )


### PR DESCRIPTION
**Description of your changes:**
This has failed 5 times in a row in one job https://github.com/scylladb/scylla-operator/runs/3090472337?check_suite_focus=true#step:11:1093

I've went through the audit logs from https://github.com/scylladb/scylla-operator/runs/3090472337?check_suite_focus=true#step:11:186 (https://github.com/scylladb/scylla-operator/suites/3260919811/artifacts/75884718) and none of the manager status fields were ever written to (so it wasn't accidentally overwritten / cleared). When I managed to get it failed locally and rechecked manually, the fields were there. The timeout seems to be pretty low for an external component. We should raise it to a limit that makes it clear if the component didn't sync at all and account for update conflicts, not performance benchmark the sync time.

**Which issue is resolved by this Pull Request:**
Resolves #660
