### PR TITLE
Fix zone/region mapping in gke example cluster

### DIFF
--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -47,9 +47,9 @@ spec:
   network:
     hostNetworking: true
   datacenter:
-    name: <gcp_zone>
+    name: <gcp_region>
     racks:
-      - name: <gcp_region>
+      - name: <gcp_zone>
         scyllaConfig: "scylla-config"
         scyllaAgentConfig: "scylla-agent-config"
         members: 2


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
- Swap zone/region mapping in GKE example cluster so that GCP_REGION corresponds to Datacenter and GCP_ZONE to Rack

**Which issue is resolved by this Pull Request:**
Resolves #719 
