### PR TITLE
Add coredns rollout status checking to github actions

### DIFF
--- a/.github/actions/setup-minikube/action.yaml
+++ b/.github/actions/setup-minikube/action.yaml
@@ -52,3 +52,6 @@ runs:
         echo 'Waiting for apiserver to come up.'
         sleep 1
       done
+
+      kubectl -n kube-system rollout status --timeout=5m deployment.apps/coredns
+


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
- Add coredns rollout status checking to github actions. It allows for discovering a failing component at an earlier stage compared to failing at e2e tests stage and having to backtrack the cause of the failure. 

**Which issue is resolved by this Pull Request:**
Resolves #716 
