### PR TITLE
[v1.3] Explicitly set Scylla's metrics listen IP

### DIFF
--- a/pkg/controllers/sidecar/config/config.go
+++ b/pkg/controllers/sidecar/config/config.go
@@ -212,6 +212,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 
 	// Listen on all interfaces so users or a service mesh can use localhost.
 	listenAddress := "0.0.0.0"
+	prometheusAddress := "0.0.0.0"
 	args := map[string]*string{
 		"listen-address":        &listenAddress,
 		"broadcast-address":     &m.StaticIP,
@@ -220,6 +221,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		"developer-mode":        &devMode,
 		"overprovisioned":       pointer.StringPtr("0"),
 		"smp":                   pointer.StringPtr(strconv.Itoa(shards)),
+		"prometheus-address":    &prometheusAddress,
 	}
 	if cluster.Spec.Alternator.Enabled() {
 		args["alternator-port"] = pointer.StringPtr(strconv.Itoa(int(cluster.Spec.Alternator.Port)))


### PR DESCRIPTION
backport of #741 
