### PR TITLE
Handle PRs with multiple "kind/" labels in release notes

### DIFF
--- a/pkg/cmd/releasenotes/releasenotes.go
+++ b/pkg/cmd/releasenotes/releasenotes.go
@@ -54,7 +54,7 @@ func (o *GenerateOptions) Run(ctx context.Context) error {
 		numberToPR[int(prs[i].Number)] = &prs[i]
 	}
 
-	var filteredPRs []PullRequest
+	var filteredPRs []*PullRequest
 	var errs []error
 	for _, prNumber := range requiredPullRequestsNumbers {
 		pr, found := numberToPR[prNumber]
@@ -63,7 +63,7 @@ func (o *GenerateOptions) Run(ctx context.Context) error {
 			continue
 		}
 
-		filteredPRs = append(filteredPRs, *pr)
+		filteredPRs = append(filteredPRs, pr)
 	}
 	if errs != nil {
 		return errors.NewAggregate(errs)

--- a/pkg/cmd/releasenotes/render_test.go
+++ b/pkg/cmd/releasenotes/render_test.go
@@ -3,7 +3,11 @@
 package releasenotes
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	githubql "github.com/shurcooL/githubv4"
 )
 
 func TestCleanupPRTitle(t *testing.T) {
@@ -41,6 +45,286 @@ func TestCleanupPRTitle(t *testing.T) {
 
 			if out != test.ExpectedTitle {
 				t.Errorf("expected title %q, got %q", test.ExpectedTitle, out)
+			}
+		})
+	}
+}
+
+func makePR(number int, labels []string) *PullRequest {
+	pr := &PullRequest{
+		Number: githubql.Int(number),
+	}
+
+	for _, label := range labels {
+		pr.Labels.Nodes = append(pr.Labels.Nodes, struct {
+			Name githubql.String
+		}{
+			Name: githubql.String(label),
+		})
+	}
+
+	return pr
+}
+
+func TestCategorizePullRequests(t *testing.T) {
+	tt := []struct {
+		name             string
+		prs              []*PullRequest
+		expectedSections []section
+	}{
+		{
+			name: "no PRs return empty sections",
+			prs:  nil,
+			expectedSections: []section{
+				{
+					Title: "API Change",
+				},
+				{
+					Title: "Feature",
+				},
+				{
+					Title: "Bug",
+				},
+				{
+					Title: "Documentation",
+				},
+				{
+					Title: "Flaky/Failing Test",
+				},
+				{
+					Title: "Other",
+				},
+				{
+					Title: "Uncategorized",
+				},
+			},
+		},
+		{
+			name: "multiple PRs with the same kind lands in the same category",
+			prs: []*PullRequest{
+				makePR(1, nil),
+				makePR(2, []string{"priority/important-soon"}),
+				makePR(3, []string{"kind/feature"}),
+				makePR(4, []string{"kind/feature"}),
+				makePR(5, []string{"kind/bug"}),
+				makePR(6, []string{"kind/bug"}),
+				makePR(7, []string{"kind/api-change"}),
+				makePR(8, []string{"kind/api-change"}),
+				makePR(9, []string{"kind/documentation"}),
+				makePR(10, []string{"kind/documentation"}),
+				makePR(11, []string{"kind/failing-test"}),
+				makePR(12, []string{"kind/flake"}),
+				makePR(13, []string{"kind/foo"}),
+				makePR(14, []string{"kind/foo"}),
+			},
+			expectedSections: []section{
+				{
+					Title: "API Change",
+					PullRequests: []*PullRequest{
+						makePR(7, []string{"kind/api-change"}),
+						makePR(8, []string{"kind/api-change"}),
+					},
+				},
+				{
+					Title: "Feature",
+					PullRequests: []*PullRequest{
+						makePR(3, []string{"kind/feature"}),
+						makePR(4, []string{"kind/feature"}),
+					},
+				},
+				{
+					Title: "Bug",
+					PullRequests: []*PullRequest{
+						makePR(5, []string{"kind/bug"}),
+						makePR(6, []string{"kind/bug"}),
+					},
+				},
+				{
+					Title: "Documentation",
+					PullRequests: []*PullRequest{
+						makePR(9, []string{"kind/documentation"}),
+						makePR(10, []string{"kind/documentation"}),
+					},
+				},
+				{
+					Title: "Flaky/Failing Test",
+					PullRequests: []*PullRequest{
+						makePR(11, []string{"kind/failing-test"}),
+						makePR(12, []string{"kind/flake"}),
+					},
+				},
+				{
+					Title: "Other",
+					PullRequests: []*PullRequest{
+						makePR(13, []string{"kind/foo"}),
+						makePR(14, []string{"kind/foo"}),
+					},
+				},
+				{
+					Title: "Uncategorized",
+					PullRequests: []*PullRequest{
+						makePR(1, nil),
+						makePR(2, []string{"priority/important-soon"}),
+					},
+				},
+			},
+		},
+		{
+			name: "precedences",
+			prs: []*PullRequest{
+				makePR(1, []string{
+					"priority/important-soon",
+					"kind/foo",
+					"kind/flake",
+					"kind/failing-test",
+					"kind/documentation",
+					"kind/bug",
+					"kind/feature",
+					"kind/api-change",
+				}),
+				makePR(2, []string{
+					"priority/important-soon",
+					"kind/foo",
+					"kind/flake",
+					"kind/failing-test",
+					"kind/documentation",
+					"kind/bug",
+					"kind/feature",
+				}),
+				makePR(3, []string{
+					"priority/important-soon",
+					"kind/foo",
+					"kind/flake",
+					"kind/failing-test",
+					"kind/documentation",
+					"kind/bug",
+				}),
+				makePR(4, []string{
+					"priority/important-soon",
+					"kind/foo",
+					"kind/flake",
+					"kind/failing-test",
+					"kind/documentation",
+				}),
+				makePR(5, []string{
+					"priority/important-soon",
+					"kind/foo",
+					"kind/flake",
+					"kind/failing-test",
+				}),
+				makePR(6, []string{
+					"priority/important-soon",
+					"kind/foo",
+					"kind/flake",
+				}),
+				makePR(7, []string{
+					"priority/important-soon",
+					"kind/foo",
+				}),
+				makePR(8, []string{
+					"priority/important-soon",
+				}),
+				makePR(9, nil),
+			},
+			expectedSections: []section{
+				{
+					Title: "API Change",
+					PullRequests: []*PullRequest{
+						makePR(1, []string{
+							"priority/important-soon",
+							"kind/foo",
+							"kind/flake",
+							"kind/failing-test",
+							"kind/documentation",
+							"kind/bug",
+							"kind/feature",
+							"kind/api-change",
+						}),
+					},
+				},
+				{
+					Title: "Feature",
+					PullRequests: []*PullRequest{
+						makePR(2, []string{
+							"priority/important-soon",
+							"kind/foo",
+							"kind/flake",
+							"kind/failing-test",
+							"kind/documentation",
+							"kind/bug",
+							"kind/feature",
+						}),
+					},
+				},
+				{
+					Title: "Bug",
+					PullRequests: []*PullRequest{
+						makePR(3, []string{
+							"priority/important-soon",
+							"kind/foo",
+							"kind/flake",
+							"kind/failing-test",
+							"kind/documentation",
+							"kind/bug",
+						}),
+					},
+				},
+				{
+					Title: "Documentation",
+					PullRequests: []*PullRequest{
+						makePR(4, []string{
+							"priority/important-soon",
+							"kind/foo",
+							"kind/flake",
+							"kind/failing-test",
+							"kind/documentation",
+						}),
+					},
+				},
+				{
+					Title: "Flaky/Failing Test",
+					PullRequests: []*PullRequest{
+						makePR(5, []string{
+							"priority/important-soon",
+							"kind/foo",
+							"kind/flake",
+							"kind/failing-test",
+						}),
+						makePR(6, []string{
+							"priority/important-soon",
+							"kind/foo",
+							"kind/flake",
+						}),
+					},
+				},
+				{
+					Title: "Other",
+					PullRequests: []*PullRequest{
+						makePR(7, []string{
+							"priority/important-soon",
+							"kind/foo",
+						}),
+					},
+				},
+				{
+					Title: "Uncategorized",
+					PullRequests: []*PullRequest{
+						makePR(8, []string{
+							"priority/important-soon",
+						}),
+						makePR(9, nil),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := categorizePullRequests(tc.prs)
+
+			if !reflect.DeepEqual(got, tc.expectedSections) {
+				t.Errorf("expected and got sections differ: %s", cmp.Diff(tc.expectedSections, got))
 			}
 		})
 	}


### PR DESCRIPTION
**Description of your changes:**
When publishing https://github.com/scylladb/scylla-operator/releases/tag/v1.4.0 the release notes wrongly assigned PR #668 as a feature and it wasn't listed under API changes. This shows that our kinds are not mutually exclusive sets and we have to prioritize it. Like in this case API changes are subset of features but we want the PR listed under API changes.

With this change, the order of sections determines the priority and the first match wins.
