### PR TITLE
Revert "Hide master from documentation version dropdown"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,7 +108,6 @@ html_theme_options = {
     ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],
-    'hide_version_dropdown': ['master'],
     'github_issues_repository': 'scylladb/scylla-operator',
     'show_sidebar_index': True,
 }


### PR DESCRIPTION
Reverts scylladb/scylla-operator#655 per https://github.com/scylladb/scylla-operator/pull/655#issuecomment-897685364