### PR TITLE
Fix default anti-affinity rules for scylla-operator

### DIFF
--- a/deploy/operator/50_operator.deployment.yaml
+++ b/deploy/operator/50_operator.deployment.yaml
@@ -42,7 +42,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app.kubernetes.io/instance: webhook-server
-                  app.kubernetes.io/name: webhook-server
+                  app.kubernetes.io/instance: scylla-operator
+                  app.kubernetes.io/name: scylla-operator
               topologyKey: kubernetes.io/hostname
             weight: 1

--- a/deploy/operator/50_webhookserver.deployment.yaml
+++ b/deploy/operator/50_webhookserver.deployment.yaml
@@ -66,7 +66,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app.kubernetes.io/instance: scylla-operator
-                  app.kubernetes.io/name: scylla-operator
+                  app.kubernetes.io/instance: webhook-server
+                  app.kubernetes.io/name: webhook-server
               topologyKey: kubernetes.io/hostname
             weight: 1

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -3785,8 +3785,8 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app.kubernetes.io/instance: webhook-server
-                  app.kubernetes.io/name: webhook-server
+                  app.kubernetes.io/instance: scylla-operator
+                  app.kubernetes.io/name: scylla-operator
               topologyKey: kubernetes.io/hostname
             weight: 1
 
@@ -3859,8 +3859,8 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app.kubernetes.io/instance: scylla-operator
-                  app.kubernetes.io/name: scylla-operator
+                  app.kubernetes.io/instance: webhook-server
+                  app.kubernetes.io/name: webhook-server
               topologyKey: kubernetes.io/hostname
             weight: 1
 

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -31,8 +31,8 @@ affinity:
       podAffinityTerm:
         labelSelector:
           matchLabels:
-            app.kubernetes.io/name: webhook-server
-            app.kubernetes.io/instance: webhook-server
+            app.kubernetes.io/name: scylla-operator
+            app.kubernetes.io/instance: scylla-operator
         topologyKey: kubernetes.io/hostname
 
 webhook:
@@ -72,6 +72,6 @@ webhookServerAffinity:
       podAffinityTerm:
         labelSelector:
           matchLabels:
-            app.kubernetes.io/name: scylla-operator
-            app.kubernetes.io/instance: scylla-operator
+            app.kubernetes.io/name: webhook-server
+            app.kubernetes.io/instance: webhook-server
         topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
For the moment 'scylla-operator' pods have default pod anti-affinity
rules set to be scheduled not with "webhook-server" ones.
The same vice-versa. It makes no sense because pods of the same type
may be scheduled on the same node in such a case.
It violates the HA idea.
So, fix it by switching labels between these affinity rules making
each pod of a type be scheduled on a node where there are no pods of
such a type.

**Which issue is resolved by this Pull Request:**
Resolves #
