### PR TITLE
Pin minikube version

### DIFF
--- a/.github/actions/setup-minikube/action.yaml
+++ b/.github/actions/setup-minikube/action.yaml
@@ -8,7 +8,7 @@ runs:
     run: |
       set -x
       sudo apt-get install -y --no-install-recommends conntrack
-      sudo curl --fail -L https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 -o /usr/local/bin/minikube
+      sudo curl --fail -L https://storage.googleapis.com/minikube/releases/v1.22.0/minikube-linux-amd64 -o /usr/local/bin/minikube
       sudo chmod +x /usr/local/bin/minikube
       sudo curl --fail -L "https://dl.k8s.io/release/$( curl --fail -L https://dl.k8s.io/release/stable.txt )/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
       sudo chmod +x /usr/local/bin/kubectl


### PR DESCRIPTION
**Description of your changes:**
We should pin minikube version in the CI and bump it manually so the new version goes through CI. Currently the version is bumped through the `latest` tag at any time and if the new version doesn't work or it needs system adjustments, the CI gets borked.

**Which issue is resolved by this Pull Request:**
3 consequent nightly failures
- https://github.com/scylladb/scylla-operator/actions/runs/1199656383
- https://github.com/scylladb/scylla-operator/actions/runs/1201866410
- https://github.com/scylladb/scylla-operator/actions/runs/1204056939
