### PR TITLE
Reserve time for flake retries

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -176,12 +176,14 @@ jobs:
       run: |
         set -euExo pipefail
 
+        e2e_timeout_minutes=60
         flake_attempts=0
         if [[ -v 'FLAKE_ATTEMPTS' ]]; then
           flake_attempts="${FLAKE_ATTEMPTS}"
+          e2e_timeout_minutes="$(( ${e2e_timeout_minutes} + ${flake_attempts} * 10 ))"
         fi
 
-        timeout 60m docker run --user="$( id -u ):$( id -g )" --rm \
+        timeout "${e2e_timeout_minutes}m" docker run --user="$( id -u ):$( id -g )" --rm \
         --entrypoint=/usr/bin/scylla-operator-tests \
         -v="${ARTIFACTS_DIR}:${ARTIFACTS_DIR}:rw" \
         -v="${HOME}/.kube/config:/kubeconfig:ro" -e='KUBECONFIG=/kubeconfig' \


### PR DESCRIPTION
**Description of your changes:**
We retry flakes on promotion jobs to prevent failures that would need to be manually retriggered. But when a job flakes it's often done by waiting for an event that doesn't happen until it hits an internal timeout, which adds up. Given the global test timeout is pretty stretched this can lead to a situation when we should retry the flake but the e2e suite is terminated by the global timeout, like in https://github.com/scylladb/scylla-operator/runs/3557449206?check_suite_focus=true#step:11:776 . 

This PR adds 10 minutes per flake attempt to the overall timeout.

