### PR TITLE
Allow code generation for multiple API versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GOPATH=/go \
     GODEBUG=madvdontneed=1
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 RUN apt-get update; \
-    apt-get install -y --no-install-recommends build-essential git curl gzip ca-certificates; \
+    apt-get install -y --no-install-recommends build-essential git curl gzip ca-certificates jq; \
     apt-get clean; \
     curl --fail -L https://storage.googleapis.com/golang/go1.16.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 WORKDIR /go/src/github.com/scylladb/scylla-operator

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -174,8 +174,6 @@ metadata:
   name: scylla-operator
 
 ---
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -192,3317 +190,1938 @@ spec:
     singular: scyllacluster
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ScyllaCluster defines a Scylla cluster.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec defines the desired state of this scylla cluster.
-            properties:
-              agentRepository:
-                default: docker.io/scylladb/scylla-manager-agent
-                description: agentRepository is the repository to pull the agent image
-                  from.
-                type: string
-              agentVersion:
-                default: latest
-                description: agentVersion indicates the version of Scylla Manager
-                  Agent to use.
-                type: string
-              alternator:
-                description: alternator designates this cluster an Alternator cluster.
-                properties:
-                  port:
-                    description: port is the port number used to bind the Alternator
-                      API.
-                    format: int32
-                    type: integer
-                  writeIsolation:
-                    description: writeIsolation indicates the isolation level.
-                    type: string
-                type: object
-              automaticOrphanedNodeCleanup:
-                description: automaticOrphanedNodeCleanup controls if automatic orphan
-                  node cleanup should be performed.
-                type: boolean
-              backups:
-                description: backups specifies backup tasks in Scylla Manager. When
-                  Scylla Manager is not installed, these will be ignored.
-                items:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ScyllaCluster defines a Scylla cluster.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec defines the desired state of this scylla cluster.
+              properties:
+                agentRepository:
+                  default: docker.io/scylladb/scylla-manager-agent
+                  description: agentRepository is the repository to pull the agent image from.
+                  type: string
+                agentVersion:
+                  default: latest
+                  description: agentVersion indicates the version of Scylla Manager Agent to use.
+                  type: string
+                alternator:
+                  description: alternator designates this cluster an Alternator cluster.
                   properties:
-                    dc:
-                      description: dc is a list of datacenter glob patterns, e.g.
-                        'dc1,!otherdc*' used to specify the DCs to include or exclude
-                        from backup.
-                      items:
-                        type: string
-                      type: array
-                    interval:
-                      default: "0"
-                      description: interval represents a task schedule interval e.g.
-                        3d2h10m, valid units are d, h, m, s.
-                      type: string
-                    keyspace:
-                      description: keyspace is a list of keyspace/tables glob patterns,
-                        e.g. 'keyspace,!keyspace.table_prefix_*' used to include or
-                        exclude keyspaces from repair.
-                      items:
-                        type: string
-                      type: array
-                    location:
-                      description: 'location is a list of backup locations in the
-                        format [<dc>:]<provider>:<name> ex. s3:my-bucket. The <dc>:
-                        part is optional and is only needed when different datacenters
-                        are being used to upload data to different locations. <name>
-                        must be an alphanumeric string and may contain a dash and
-                        or a dot, but other characters are forbidden. The only supported
-                        storage <provider> at the moment are s3 and gcs.'
-                      items:
-                        type: string
-                      type: array
-                    name:
-                      description: name is a unique name of a task.
-                      type: string
-                    numRetries:
-                      default: 3
-                      description: numRetries indicates how many times a scheduled
-                        task will be retried before failing.
-                      format: int64
+                    port:
+                      description: port is the port number used to bind the Alternator API.
+                      format: int32
                       type: integer
-                    rateLimit:
-                      description: 'rateLimit is a list of megabytes (MiB) per second
-                        rate limits expressed in the format [<dc>:]<limit>. The <dc>:
-                        part is optional and only needed when different datacenters
-                        need different upload limits. Set to 0 for no limit (default
-                        100).'
-                      items:
-                        type: string
-                      type: array
-                    retention:
-                      default: 3
-                      description: retention is the number of backups which are to
-                        be stored.
-                      format: int64
-                      type: integer
-                    snapshotParallel:
-                      description: 'snapshotParallel is a list of snapshot parallelism
-                        limits in the format [<dc>:]<limit>. The <dc>: part is optional
-                        and allows for specifying different limits in selected datacenters.
-                        If The <dc>: part is not set, the limit is global (e.g. ''dc1:2,5'')
-                        the runs are parallel in n nodes (2 in dc1) and n nodes in
-                        all the other datacenters.'
-                      items:
-                        type: string
-                      type: array
-                    startDate:
-                      default: now
-                      description: startDate specifies the task start date expressed
-                        in the RFC3339 format or now[+duration], e.g. now+3d2h10m,
-                        valid units are d, h, m, s.
+                    writeIsolation:
+                      description: writeIsolation indicates the isolation level.
                       type: string
-                    uploadParallel:
-                      description: 'uploadParallel is a list of upload parallelism
-                        limits in the format [<dc>:]<limit>. The <dc>: part is optional
-                        and allows for specifying different limits in selected datacenters.
-                        If The <dc>: part is not set the limit is global (e.g. ''dc1:2,5'')
-                        the runs are parallel in n nodes (2 in dc1) and n nodes in
-                        all the other datacenters.'
-                      items:
-                        type: string
-                      type: array
                   type: object
-                type: array
-              cpuset:
-                description: cpuset determines if the cluster will use cpu-pinning
-                  for max performance.
-                type: boolean
-              datacenter:
-                description: datacenter holds a specification of a datacenter.
-                properties:
-                  name:
-                    description: name is the name of the scylla datacenter. Used in
-                      the cassandra-rackdc.properties file.
-                    type: string
-                  racks:
-                    description: racks specify the racks in the datacenter.
-                    items:
-                      description: RackSpec is the desired state for a Scylla Rack.
-                      properties:
-                        agentResources:
-                          default:
-                            requests:
-                              cpu: 50m
-                              memory: 10M
-                          description: agentResources specify the resources for the
-                            Agent container.
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                          type: object
-                        agentVolumeMounts:
-                          description: AgentVolumeMounts to be added to Agent container.
-                          items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
-                            properties:
-                              mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
-                                type: string
-                              mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
-                                type: string
-                              name:
-                                description: This must match the Name of a Volume.
-                                type: string
-                              readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
-                                type: boolean
-                              subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
-                                type: string
-                              subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
-                                type: string
-                            required:
-                            - mountPath
-                            - name
-                            type: object
-                          type: array
-                        members:
-                          description: members is the number of Scylla instances in
-                            this rack.
-                          format: int32
-                          type: integer
-                        name:
-                          description: name is the name of the Scylla Rack. Used in
-                            the cassandra-rackdc.properties file.
+                automaticOrphanedNodeCleanup:
+                  description: automaticOrphanedNodeCleanup controls if automatic orphan node cleanup should be performed.
+                  type: boolean
+                backups:
+                  description: backups specifies backup tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
+                  items:
+                    properties:
+                      dc:
+                        description: dc is a list of datacenter glob patterns, e.g. 'dc1,!otherdc*' used to specify the DCs to include or exclude from backup.
+                        items:
                           type: string
-                        placement:
-                          description: placement describes restrictions for the nodes
-                            Scylla is scheduled on.
-                          properties:
-                            nodeAffinity:
-                              description: nodeAffinity describes node affinity scheduling
-                                rules for the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule
-                                    pods to nodes that satisfy the affinity expressions
-                                    specified by this field, but it may choose a node
-                                    that violates one or more of the expressions.
-                                    The node that is most preferred is the one with
-                                    the greatest sum of weights, i.e. for each node
-                                    that meets all of the scheduling requirements
-                                    (resource request, requiredDuringScheduling affinity
-                                    expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding
-                                    "weight" to the sum if the node matches the corresponding
-                                    matchExpressions; the node(s) with the highest
-                                    sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term
-                                      matches all objects with implicit weight 0 (i.e.
-                                      it's a no-op). A null preferred scheduling term
-                                      matches no objects (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's
-                                                    relationship to a set of values.
-                                                    Valid operators are In, NotIn,
-                                                    Exists, DoesNotExist. Gt, and
-                                                    Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string
-                                                    values. If the operator is In
-                                                    or NotIn, the values array must
-                                                    be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. If
-                                                    the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's
-                                                    relationship to a set of values.
-                                                    Valid operators are In, NotIn,
-                                                    Exists, DoesNotExist. Gt, and
-                                                    Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string
-                                                    values. If the operator is In
-                                                    or NotIn, the values array must
-                                                    be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. If
-                                                    the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching
-                                          the corresponding nodeSelectorTerm, in the
-                                          range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - preference
-                                    - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified
-                                    by this field are not met at scheduling time,
-                                    the pod will not be scheduled onto the node. If
-                                    the affinity requirements specified by this field
-                                    cease to be met at some point during pod execution
-                                    (e.g. due to an update), the system may or may
-                                    not try to eventually evict the pod from its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector
-                                        terms. The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector
-                                          term matches no objects. The requirements
-                                          of them are ANDed. The TopologySelectorTerm
-                                          type implements a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's
-                                                    relationship to a set of values.
-                                                    Valid operators are In, NotIn,
-                                                    Exists, DoesNotExist. Gt, and
-                                                    Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string
-                                                    values. If the operator is In
-                                                    or NotIn, the values array must
-                                                    be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. If
-                                                    the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's
-                                                    relationship to a set of values.
-                                                    Valid operators are In, NotIn,
-                                                    Exists, DoesNotExist. Gt, and
-                                                    Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string
-                                                    values. If the operator is In
-                                                    or NotIn, the values array must
-                                                    be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. If
-                                                    the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                  - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: podAffinity describes pod affinity scheduling
-                                rules.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule
-                                    pods to nodes that satisfy the affinity expressions
-                                    specified by this field, but it may choose a node
-                                    that violates one or more of the expressions.
-                                    The node that is most preferred is the one with
-                                    the greatest sum of weights, i.e. for each node
-                                    that meets all of the scheduling requirements
-                                    (resource request, requiredDuringScheduling affinity
-                                    expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding
-                                    "weight" to the sum if the node has pods which
-                                    matches the corresponding podAffinityTerm; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: The weights of all of the matched
-                                      WeightedPodAffinityTerm fields are added per-node
-                                      to find the most preferred node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set
-                                              of resources, in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
-                                                type: object
-                                            type: object
-                                          namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
-                                              This field is alpha-level and is only
-                                              honored when PodAffinityNamespaceSelector
-                                              feature is enabled.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                        - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching
-                                          the corresponding podAffinityTerm, in the
-                                          range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - podAffinityTerm
-                                    - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified
-                                    by this field are not met at scheduling time,
-                                    the pod will not be scheduled onto the node. If
-                                    the affinity requirements specified by this field
-                                    cease to be met at some point during pod execution
-                                    (e.g. due to a pod label update), the system may
-                                    or may not try to eventually evict the pod from
-                                    its node. When there are multiple elements, the
-                                    lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those
-                                      matching the labelSelector relative to the given
-                                      namespace(s)) that this pod should be co-located
-                                      (affinity) or not co-located (anti-affinity)
-                                      with, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      <topologyKey> matches that of any node on which
-                                      a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of
-                                          namespaces that the term applies to. The
-                                          term is applied to the union of the namespaces
-                                          selected by this field and the ones listed
-                                          in the namespaces field. null selector and
-                                          null or empty namespaces list means "this
-                                          pod's namespace". An empty selector ({})
-                                          matches all namespaces. This field is alpha-level
-                                          and is only honored when PodAffinityNamespaceSelector
-                                          feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static
-                                          list of namespace names that the term applies
-                                          to. The term is applied to the union of
-                                          the namespaces listed in this field and
-                                          the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector
-                                          means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: podAntiAffinity describes pod anti-affinity
-                                scheduling rules.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule
-                                    pods to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node
-                                    that violates one or more of the expressions.
-                                    The node that is most preferred is the one with
-                                    the greatest sum of weights, i.e. for each node
-                                    that meets all of the scheduling requirements
-                                    (resource request, requiredDuringScheduling anti-affinity
-                                    expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding
-                                    "weight" to the sum if the node has pods which
-                                    matches the corresponding podAffinityTerm; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: The weights of all of the matched
-                                      WeightedPodAffinityTerm fields are added per-node
-                                      to find the most preferred node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set
-                                              of resources, in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
-                                                type: object
-                                            type: object
-                                          namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
-                                              This field is alpha-level and is only
-                                              honored when PodAffinityNamespaceSelector
-                                              feature is enabled.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                        - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching
-                                          the corresponding podAffinityTerm, in the
-                                          range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - podAffinityTerm
-                                    - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time,
-                                    the pod will not be scheduled onto the node. If
-                                    the anti-affinity requirements specified by this
-                                    field cease to be met at some point during pod
-                                    execution (e.g. due to a pod label update), the
-                                    system may or may not try to eventually evict
-                                    the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to
-                                    each podAffinityTerm are intersected, i.e. all
-                                    terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those
-                                      matching the labelSelector relative to the given
-                                      namespace(s)) that this pod should be co-located
-                                      (affinity) or not co-located (anti-affinity)
-                                      with, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      <topologyKey> matches that of any node on which
-                                      a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of
-                                          namespaces that the term applies to. The
-                                          term is applied to the union of the namespaces
-                                          selected by this field and the ones listed
-                                          in the namespaces field. null selector and
-                                          null or empty namespaces list means "this
-                                          pod's namespace". An empty selector ({})
-                                          matches all namespaces. This field is alpha-level
-                                          and is only honored when PodAffinityNamespaceSelector
-                                          feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static
-                                          list of namespace names that the term applies
-                                          to. The term is applied to the union of
-                                          the namespaces listed in this field and
-                                          the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector
-                                          means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            tolerations:
-                              description: tolerations allow the pod to tolerate any
-                                taint that matches the triple <key,value,effect> using
-                                the matching operator.
-                              items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
-                                properties:
-                                  effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
-                                    type: string
-                                  key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
-                                    type: string
-                                  operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
-                                    type: string
-                                  tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        resources:
-                          description: resources the Scylla container will use.
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                          type: object
-                        scyllaAgentConfig:
-                          description: Scylla config map name to customize scylla
-                            manager agent
+                        type: array
+                      interval:
+                        default: "0"
+                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      keyspace:
+                        description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+                        items:
                           type: string
-                        scyllaConfig:
-                          description: Scylla config map name to customize scylla.yaml
+                        type: array
+                      location:
+                        description: 'location is a list of backup locations in the format [<dc>:]<provider>:<name> ex. s3:my-bucket. The <dc>: part is optional and is only needed when different datacenters are being used to upload data to different locations. <name> must be an alphanumeric string and may contain a dash and or a dot, but other characters are forbidden. The only supported storage <provider> at the moment are s3 and gcs.'
+                        items:
                           type: string
-                        storage:
-                          description: storage describes the underlying storage that
-                            Scylla will consume.
-                          properties:
-                            capacity:
-                              description: capacity describes the requested size of
-                                each persistent volume.
-                              type: string
-                            storageClassName:
-                              description: storageClassName is the name of a storageClass
-                                to request.
-                              type: string
-                          type: object
-                        volumeMounts:
-                          description: VolumeMounts to be added to Scylla container.
-                          items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
+                        type: array
+                      name:
+                        description: name is a unique name of a task.
+                        type: string
+                      numRetries:
+                        default: 3
+                        description: numRetries indicates how many times a scheduled task will be retried before failing.
+                        format: int64
+                        type: integer
+                      rateLimit:
+                        description: 'rateLimit is a list of megabytes (MiB) per second rate limits expressed in the format [<dc>:]<limit>. The <dc>: part is optional and only needed when different datacenters need different upload limits. Set to 0 for no limit (default 100).'
+                        items:
+                          type: string
+                        type: array
+                      retention:
+                        default: 3
+                        description: retention is the number of backups which are to be stored.
+                        format: int64
+                        type: integer
+                      snapshotParallel:
+                        description: 'snapshotParallel is a list of snapshot parallelism limits in the format [<dc>:]<limit>. The <dc>: part is optional and allows for specifying different limits in selected datacenters. If The <dc>: part is not set, the limit is global (e.g. ''dc1:2,5'') the runs are parallel in n nodes (2 in dc1) and n nodes in all the other datacenters.'
+                        items:
+                          type: string
+                        type: array
+                      startDate:
+                        default: now
+                        description: startDate specifies the task start date expressed in the RFC3339 format or now[+duration], e.g. now+3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      uploadParallel:
+                        description: 'uploadParallel is a list of upload parallelism limits in the format [<dc>:]<limit>. The <dc>: part is optional and allows for specifying different limits in selected datacenters. If The <dc>: part is not set the limit is global (e.g. ''dc1:2,5'') the runs are parallel in n nodes (2 in dc1) and n nodes in all the other datacenters.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                cpuset:
+                  description: cpuset determines if the cluster will use cpu-pinning for max performance.
+                  type: boolean
+                datacenter:
+                  description: datacenter holds a specification of a datacenter.
+                  properties:
+                    name:
+                      description: name is the name of the scylla datacenter. Used in the cassandra-rackdc.properties file.
+                      type: string
+                    racks:
+                      description: racks specify the racks in the datacenter.
+                      items:
+                        description: RackSpec is the desired state for a Scylla Rack.
+                        properties:
+                          agentResources:
+                            default:
+                              requests:
+                                cpu: 50m
+                                memory: 10M
+                            description: agentResources specify the resources for the Agent container.
                             properties:
-                              mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
-                                type: string
-                              mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
-                                type: string
-                              name:
-                                description: This must match the Name of a Volume.
-                                type: string
-                              readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
-                                type: boolean
-                              subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
-                                type: string
-                              subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
-                                type: string
-                            required:
-                            - mountPath
-                            - name
-                            type: object
-                          type: array
-                        volumes:
-                          description: Volumes added to Scylla Pod.
-                          items:
-                            description: Volume represents a named volume in a pod
-                              that may be accessed by any container in the pod.
-                            properties:
-                              awsElasticBlockStore:
-                                description: 'AWSElasticBlockStore represents an AWS
-                                  Disk resource that is attached to a kubelet''s host
-                                  machine and then exposed to the pod. More info:
-                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type of the volume that
-                                      you want to mount. Tip: Ensure that the filesystem
-                                      type is supported by the host operating system.
-                                      Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
-                                    type: string
-                                  partition:
-                                    description: 'The partition in the volume that
-                                      you want to mount. If omitted, the default is
-                                      to mount by volume name. Examples: For volume
-                                      /dev/sda1, you specify the partition as "1".
-                                      Similarly, the volume partition for /dev/sda
-                                      is "0" (or you can leave the property empty).'
-                                    format: int32
-                                    type: integer
-                                  readOnly:
-                                    description: 'Specify "true" to force and set
-                                      the ReadOnly property in VolumeMounts to "true".
-                                      If omitted, the default is "false". More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                                    type: boolean
-                                  volumeID:
-                                    description: 'Unique ID of the persistent disk
-                                      resource in AWS (Amazon EBS volume). More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                                    type: string
-                                required:
-                                - volumeID
-                                type: object
-                              azureDisk:
-                                description: AzureDisk represents an Azure Data Disk
-                                  mount on the host and bind mount to the pod.
-                                properties:
-                                  cachingMode:
-                                    description: 'Host Caching mode: None, Read Only,
-                                      Read Write.'
-                                    type: string
-                                  diskName:
-                                    description: The Name of the data disk in the
-                                      blob storage
-                                    type: string
-                                  diskURI:
-                                    description: The URI the data disk in the blob
-                                      storage
-                                    type: string
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified.
-                                    type: string
-                                  kind:
-                                    description: 'Expected values Shared: multiple
-                                      blob disks per storage account  Dedicated: single
-                                      blob disk per storage account  Managed: azure
-                                      managed data disk (only in managed availability
-                                      set). defaults to shared'
-                                    type: string
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                required:
-                                - diskName
-                                - diskURI
-                                type: object
-                              azureFile:
-                                description: AzureFile represents an Azure File Service
-                                  mount on the host and bind mount to the pod.
-                                properties:
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                  secretName:
-                                    description: the name of secret that contains
-                                      Azure Storage Account Name and Key
-                                    type: string
-                                  shareName:
-                                    description: Share Name
-                                    type: string
-                                required:
-                                - secretName
-                                - shareName
-                                type: object
-                              cephfs:
-                                description: CephFS represents a Ceph FS mount on
-                                  the host that shares a pod's lifetime
-                                properties:
-                                  monitors:
-                                    description: 'Required: Monitors is a collection
-                                      of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    items:
-                                      type: string
-                                    type: array
-                                  path:
-                                    description: 'Optional: Used as the mounted root,
-                                      rather than the full Ceph tree, default is /'
-                                    type: string
-                                  readOnly:
-                                    description: 'Optional: Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    type: boolean
-                                  secretFile:
-                                    description: 'Optional: SecretFile is the path
-                                      to key ring for User, default is /etc/ceph/user.secret
-                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    type: string
-                                  secretRef:
-                                    description: 'Optional: SecretRef is reference
-                                      to the authentication secret for User, default
-                                      is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  user:
-                                    description: 'Optional: User is the rados user
-                                      name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    type: string
-                                required:
-                                - monitors
-                                type: object
-                              cinder:
-                                description: 'Cinder represents a cinder volume attached
-                                  and mounted on kubelets host machine. More info:
-                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                    type: string
-                                  readOnly:
-                                    description: 'Optional: Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                    type: boolean
-                                  secretRef:
-                                    description: 'Optional: points to a secret object
-                                      containing parameters used to connect to OpenStack.'
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  volumeID:
-                                    description: 'volume id used to identify the volume
-                                      in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                    type: string
-                                required:
-                                - volumeID
-                                type: object
-                              configMap:
-                                description: ConfigMap represents a configMap that
-                                  should populate this volume
-                                properties:
-                                  defaultMode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on created files by default. Must
-                                      be an octal value between 0000 and 0777 or a
-                                      decimal value between 0 and 511. YAML accepts
-                                      both octal and decimal values, JSON requires
-                                      decimal values for mode bits. Defaults to 0644.
-                                      Directories within the path are not affected
-                                      by this setting. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
-                                    format: int32
-                                    type: integer
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file. Must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or
-                                      its keys must be defined
-                                    type: boolean
-                                type: object
-                              csi:
-                                description: CSI (Container Storage Interface) represents
-                                  ephemeral storage that is handled by certain external
-                                  CSI drivers (Beta feature).
-                                properties:
-                                  driver:
-                                    description: Driver is the name of the CSI driver
-                                      that handles this volume. Consult with your
-                                      admin for the correct name as registered in
-                                      the cluster.
-                                    type: string
-                                  fsType:
-                                    description: Filesystem type to mount. Ex. "ext4",
-                                      "xfs", "ntfs". If not provided, the empty value
-                                      is passed to the associated CSI driver which
-                                      will determine the default filesystem to apply.
-                                    type: string
-                                  nodePublishSecretRef:
-                                    description: NodePublishSecretRef is a reference
-                                      to the secret object containing sensitive information
-                                      to pass to the CSI driver to complete the CSI
-                                      NodePublishVolume and NodeUnpublishVolume calls.
-                                      This field is optional, and  may be empty if
-                                      no secret is required. If the secret object
-                                      contains more than one secret, all secret references
-                                      are passed.
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  readOnly:
-                                    description: Specifies a read-only configuration
-                                      for the volume. Defaults to false (read/write).
-                                    type: boolean
-                                  volumeAttributes:
-                                    additionalProperties:
-                                      type: string
-                                    description: VolumeAttributes stores driver-specific
-                                      properties that are passed to the CSI driver.
-                                      Consult your driver's documentation for supported
-                                      values.
-                                    type: object
-                                required:
-                                - driver
-                                type: object
-                              downwardAPI:
-                                description: DownwardAPI represents downward API about
-                                  the pod that should populate this volume
-                                properties:
-                                  defaultMode:
-                                    description: 'Optional: mode bits to use on created
-                                      files by default. Must be a Optional: mode bits
-                                      used to set permissions on created files by
-                                      default. Must be an octal value between 0000
-                                      and 0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal values,
-                                      JSON requires decimal values for mode bits.
-                                      Defaults to 0644. Directories within the path
-                                      are not affected by this setting. This might
-                                      be in conflict with other options that affect
-                                      the file mode, like fsGroup, and the result
-                                      can be other mode bits set.'
-                                    format: int32
-                                    type: integer
-                                  items:
-                                    description: Items is a list of downward API volume
-                                      file
-                                    items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
-                                      properties:
-                                        fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
-                                          properties:
-                                            apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
-                                              type: string
-                                            fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file, must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
-                                          type: string
-                                        resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
-                                          properties:
-                                            containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              description: 'Required: resource to
-                                                select'
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              emptyDir:
-                                description: 'EmptyDir represents a temporary directory
-                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                properties:
-                                  medium:
-                                    description: 'What type of storage medium should
-                                      back this directory. The default is "" which
-                                      means to use the node''s default medium. Must
-                                      be an empty string (default) or Memory. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                    type: string
-                                  sizeLimit:
-                                    anyOf:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
                                     - type: integer
                                     - type: string
-                                    description: 'Total amount of local storage required
-                                      for this EmptyDir volume. The size limit is
-                                      also applicable for memory medium. The maximum
-                                      usage on memory medium EmptyDir would be the
-                                      minimum value between the SizeLimit specified
-                                      here and the sum of memory limits of all containers
-                                      in a pod. The default is nil which means that
-                                      the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
-                              ephemeral:
-                                description: "Ephemeral represents a volume that is
-                                  handled by a cluster storage driver. The volume's
-                                  lifecycle is tied to the pod that defines it - it
-                                  will be created before the pod starts, and deleted
-                                  when the pod is removed. \n Use this if: a) the
-                                  volume is only needed while the pod runs, b) features
-                                  of normal volumes like restoring from snapshot or
-                                  capacity    tracking are needed, c) the storage
-                                  driver is specified through a storage class, and
-                                  d) the storage driver supports dynamic volume provisioning
-                                  through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                                  for more    information on the connection between
-                                  this volume type    and PersistentVolumeClaim).
-                                  \n Use PersistentVolumeClaim or one of the vendor-specific
-                                  APIs for volumes that persist for longer than the
-                                  lifecycle of an individual pod. \n Use CSI for light-weight
-                                  local ephemeral volumes if the CSI driver is meant
-                                  to be used that way - see the documentation of the
-                                  driver for more information. \n A pod can use both
-                                  types of ephemeral volumes and persistent volumes
-                                  at the same time. \n This is a beta feature and
-                                  only available when the GenericEphemeralVolume feature
-                                  gate is enabled."
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          agentVolumeMounts:
+                            description: AgentVolumeMounts to be added to Agent container.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                          members:
+                            description: members is the number of Scylla instances in this rack.
+                            format: int32
+                            type: integer
+                          name:
+                            description: name is the name of the Scylla Rack. Used in the cassandra-rackdc.properties file.
+                            type: string
+                          placement:
+                            description: placement describes restrictions for the nodes Scylla is scheduled on.
+                            properties:
+                              nodeAffinity:
+                                description: nodeAffinity describes node affinity scheduling rules for the pod.
                                 properties:
-                                  volumeClaimTemplate:
-                                    description: "Will be used to create a stand-alone
-                                      PVC to provision the volume. The pod in which
-                                      this EphemeralVolumeSource is embedded will
-                                      be the owner of the PVC, i.e. the PVC will be
-                                      deleted together with the pod.  The name of
-                                      the PVC will be `<pod name>-<volume name>` where
-                                      `<volume name>` is the name from the `PodSpec.Volumes`
-                                      array entry. Pod validation will reject the
-                                      pod if the concatenated name is not valid for
-                                      a PVC (for example, too long). \n An existing
-                                      PVC with that name that is not owned by the
-                                      pod will *not* be used for the pod to avoid
-                                      using an unrelated volume by mistake. Starting
-                                      the pod is then blocked until the unrelated
-                                      PVC is removed. If such a pre-created PVC is
-                                      meant to be used by the pod, the PVC has to
-                                      updated with an owner reference to the pod once
-                                      the pod exists. Normally this should not be
-                                      necessary, but it may be useful when manually
-                                      reconstructing a broken cluster. \n This field
-                                      is read-only and no changes will be made by
-                                      Kubernetes to the PVC after it has been created.
-                                      \n Required, must not be nil."
-                                    properties:
-                                      metadata:
-                                        description: May contain labels and annotations
-                                          that will be copied into the PVC when creating
-                                          it. No other fields are allowed and will
-                                          be rejected during validation.
-                                        type: object
-                                      spec:
-                                        description: The specification for the PersistentVolumeClaim.
-                                          The entire content is copied unchanged into
-                                          the PVC that gets created from this template.
-                                          The same fields as in a PersistentVolumeClaim
-                                          are also valid here.
-                                        properties:
-                                          accessModes:
-                                            description: 'AccessModes contains the
-                                              desired access modes the volume should
-                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                            items:
-                                              type: string
-                                            type: array
-                                          dataSource:
-                                            description: 'This field can be used to
-                                              specify either: * An existing VolumeSnapshot
-                                              object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                              * An existing PVC (PersistentVolumeClaim)
-                                              * An existing custom resource that implements
-                                              data population (Alpha) In order to
-                                              use custom resource types that implement
-                                              data population, the AnyVolumeDataSource
-                                              feature gate must be enabled. If the
-                                              provisioner or an external controller
-                                              can support the specified data source,
-                                              it will create a new volume based on
-                                              the contents of the specified data source.'
-                                            properties:
-                                              apiGroup:
-                                                description: APIGroup is the group
-                                                  for the resource being referenced.
-                                                  If APIGroup is not specified, the
-                                                  specified Kind must be in the core
-                                                  API group. For any other third-party
-                                                  types, APIGroup is required.
-                                                type: string
-                                              kind:
-                                                description: Kind is the type of resource
-                                                  being referenced
-                                                type: string
-                                              name:
-                                                description: Name is the name of resource
-                                                  being referenced
-                                                type: string
-                                            required:
-                                            - kind
-                                            - name
-                                            type: object
-                                          resources:
-                                            description: 'Resources represents the
-                                              minimum resources the volume should
-                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                            properties:
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                description: 'Limits describes the
-                                                  maximum amount of compute resources
-                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                description: 'Requests describes the
-                                                  minimum amount of compute resources
-                                                  required. If Requests is omitted
-                                                  for a container, it defaults to
-                                                  Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined
-                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                                type: object
-                                            type: object
-                                          selector:
-                                            description: A label query over volumes
-                                              to consider for binding.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                      properties:
+                                        preference:
+                                          description: A node selector term, associated with the corresponding weight.
+                                          properties:
+                                            matchExpressions:
+                                              description: A list of node selector requirements by node's labels.
+                                              items:
+                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    items:
                                                       type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
+                                                    type: array
+                                                required:
                                                   - key
                                                   - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
                                                 type: object
-                                            type: object
-                                          storageClassName:
-                                            description: 'Name of the StorageClass
-                                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                            type: string
-                                          volumeMode:
-                                            description: volumeMode defines what type
-                                              of volume is required by the claim.
-                                              Value of Filesystem is implied when
-                                              not included in claim spec.
-                                            type: string
-                                          volumeName:
-                                            description: VolumeName is the binding
-                                              reference to the PersistentVolume backing
-                                              this claim.
-                                            type: string
-                                        type: object
-                                    required:
-                                    - spec
-                                    type: object
-                                type: object
-                              fc:
-                                description: FC represents a Fibre Channel resource
-                                  that is attached to a kubelet's host machine and
-                                  then exposed to the pod.
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. TODO:
-                                      how do we prevent errors in the filesystem from
-                                      compromising the machine'
-                                    type: string
-                                  lun:
-                                    description: 'Optional: FC target lun number'
-                                    format: int32
-                                    type: integer
-                                  readOnly:
-                                    description: 'Optional: Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.'
-                                    type: boolean
-                                  targetWWNs:
-                                    description: 'Optional: FC target worldwide names
-                                      (WWNs)'
-                                    items:
-                                      type: string
-                                    type: array
-                                  wwids:
-                                    description: 'Optional: FC volume world wide identifiers
-                                      (wwids) Either wwids or combination of targetWWNs
-                                      and lun must be set, but not both simultaneously.'
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              flexVolume:
-                                description: FlexVolume represents a generic volume
-                                  resource that is provisioned/attached using an exec
-                                  based plugin.
-                                properties:
-                                  driver:
-                                    description: Driver is the name of the driver
-                                      to use for this volume.
-                                    type: string
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". The default
-                                      filesystem depends on FlexVolume script.
-                                    type: string
-                                  options:
-                                    additionalProperties:
-                                      type: string
-                                    description: 'Optional: Extra command options
-                                      if any.'
-                                    type: object
-                                  readOnly:
-                                    description: 'Optional: Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.'
-                                    type: boolean
-                                  secretRef:
-                                    description: 'Optional: SecretRef is reference
-                                      to the secret object containing sensitive information
-                                      to pass to the plugin scripts. This may be empty
-                                      if no secret object is specified. If the secret
-                                      object contains more than one secret, all secrets
-                                      are passed to the plugin scripts.'
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                required:
-                                - driver
-                                type: object
-                              flocker:
-                                description: Flocker represents a Flocker volume attached
-                                  to a kubelet's host machine. This depends on the
-                                  Flocker control service being running
-                                properties:
-                                  datasetName:
-                                    description: Name of the dataset stored as metadata
-                                      -> name on the dataset for Flocker should be
-                                      considered as deprecated
-                                    type: string
-                                  datasetUUID:
-                                    description: UUID of the dataset. This is unique
-                                      identifier of a Flocker dataset
-                                    type: string
-                                type: object
-                              gcePersistentDisk:
-                                description: 'GCEPersistentDisk represents a GCE Disk
-                                  resource that is attached to a kubelet''s host machine
-                                  and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type of the volume that
-                                      you want to mount. Tip: Ensure that the filesystem
-                                      type is supported by the host operating system.
-                                      Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
-                                    type: string
-                                  partition:
-                                    description: 'The partition in the volume that
-                                      you want to mount. If omitted, the default is
-                                      to mount by volume name. Examples: For volume
-                                      /dev/sda1, you specify the partition as "1".
-                                      Similarly, the volume partition for /dev/sda
-                                      is "0" (or you can leave the property empty).
-                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                    format: int32
-                                    type: integer
-                                  pdName:
-                                    description: 'Unique name of the PD resource in
-                                      GCE. Used to identify the disk in GCE. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                    type: string
-                                  readOnly:
-                                    description: 'ReadOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                    type: boolean
-                                required:
-                                - pdName
-                                type: object
-                              gitRepo:
-                                description: 'GitRepo represents a git repository
-                                  at a particular revision. DEPRECATED: GitRepo is
-                                  deprecated. To provision a container with a git
-                                  repo, mount an EmptyDir into an InitContainer that
-                                  clones the repo using git, then mount the EmptyDir
-                                  into the Pod''s container.'
-                                properties:
-                                  directory:
-                                    description: Target directory name. Must not contain
-                                      or start with '..'.  If '.' is supplied, the
-                                      volume directory will be the git repository.  Otherwise,
-                                      if specified, the volume will contain the git
-                                      repository in the subdirectory with the given
-                                      name.
-                                    type: string
-                                  repository:
-                                    description: Repository URL
-                                    type: string
-                                  revision:
-                                    description: Commit hash for the specified revision.
-                                    type: string
-                                required:
-                                - repository
-                                type: object
-                              glusterfs:
-                                description: 'Glusterfs represents a Glusterfs mount
-                                  on the host that shares a pod''s lifetime. More
-                                  info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                                properties:
-                                  endpoints:
-                                    description: 'EndpointsName is the endpoint name
-                                      that details Glusterfs topology. More info:
-                                      https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                                    type: string
-                                  path:
-                                    description: 'Path is the Glusterfs volume path.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                                    type: string
-                                  readOnly:
-                                    description: 'ReadOnly here will force the Glusterfs
-                                      volume to be mounted with read-only permissions.
-                                      Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                                    type: boolean
-                                required:
-                                - endpoints
-                                - path
-                                type: object
-                              hostPath:
-                                description: 'HostPath represents a pre-existing file
-                                  or directory on the host machine that is directly
-                                  exposed to the container. This is generally used
-                                  for system agents or other privileged things that
-                                  are allowed to see the host machine. Most containers
-                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                  --- TODO(jonesdl) We need to restrict who can use
-                                  host directory mounts and who can/can not mount
-                                  host directories as read/write.'
-                                properties:
-                                  path:
-                                    description: 'Path of the directory on the host.
-                                      If the path is a symlink, it will follow the
-                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                                    type: string
-                                  type:
-                                    description: 'Type for HostPath Volume Defaults
-                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                              iscsi:
-                                description: 'ISCSI represents an ISCSI Disk resource
-                                  that is attached to a kubelet''s host machine and
-                                  then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                                properties:
-                                  chapAuthDiscovery:
-                                    description: whether support iSCSI Discovery CHAP
-                                      authentication
-                                    type: boolean
-                                  chapAuthSession:
-                                    description: whether support iSCSI Session CHAP
-                                      authentication
-                                    type: boolean
-                                  fsType:
-                                    description: 'Filesystem type of the volume that
-                                      you want to mount. Tip: Ensure that the filesystem
-                                      type is supported by the host operating system.
-                                      Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
-                                    type: string
-                                  initiatorName:
-                                    description: Custom iSCSI Initiator Name. If initiatorName
-                                      is specified with iscsiInterface simultaneously,
-                                      new iSCSI interface <target portal>:<volume
-                                      name> will be created for the connection.
-                                    type: string
-                                  iqn:
-                                    description: Target iSCSI Qualified Name.
-                                    type: string
-                                  iscsiInterface:
-                                    description: iSCSI Interface Name that uses an
-                                      iSCSI transport. Defaults to 'default' (tcp).
-                                    type: string
-                                  lun:
-                                    description: iSCSI Target Lun number.
-                                    format: int32
-                                    type: integer
-                                  portals:
-                                    description: iSCSI Target Portal List. The portal
-                                      is either an IP or ip_addr:port if the port
-                                      is other than default (typically TCP ports 860
-                                      and 3260).
-                                    items:
-                                      type: string
-                                    type: array
-                                  readOnly:
-                                    description: ReadOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                    type: boolean
-                                  secretRef:
-                                    description: CHAP Secret for iSCSI target and
-                                      initiator authentication
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  targetPortal:
-                                    description: iSCSI Target Portal. The Portal is
-                                      either an IP or ip_addr:port if the port is
-                                      other than default (typically TCP ports 860
-                                      and 3260).
-                                    type: string
-                                required:
-                                - iqn
-                                - lun
-                                - targetPortal
-                                type: object
-                              name:
-                                description: 'Volume''s name. Must be a DNS_LABEL
-                                  and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                              nfs:
-                                description: 'NFS represents an NFS mount on the host
-                                  that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                properties:
-                                  path:
-                                    description: 'Path that is exported by the NFS
-                                      server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                    type: string
-                                  readOnly:
-                                    description: 'ReadOnly here will force the NFS
-                                      export to be mounted with read-only permissions.
-                                      Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                    type: boolean
-                                  server:
-                                    description: 'Server is the hostname or IP address
-                                      of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                    type: string
-                                required:
-                                - path
-                                - server
-                                type: object
-                              persistentVolumeClaim:
-                                description: 'PersistentVolumeClaimVolumeSource represents
-                                  a reference to a PersistentVolumeClaim in the same
-                                  namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                properties:
-                                  claimName:
-                                    description: 'ClaimName is the name of a PersistentVolumeClaim
-                                      in the same namespace as the pod using this
-                                      volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                    type: string
-                                  readOnly:
-                                    description: Will force the ReadOnly setting in
-                                      VolumeMounts. Default false.
-                                    type: boolean
-                                required:
-                                - claimName
-                                type: object
-                              photonPersistentDisk:
-                                description: PhotonPersistentDisk represents a PhotonController
-                                  persistent disk attached and mounted on kubelets
-                                  host machine
-                                properties:
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified.
-                                    type: string
-                                  pdID:
-                                    description: ID that identifies Photon Controller
-                                      persistent disk
-                                    type: string
-                                required:
-                                - pdID
-                                type: object
-                              portworxVolume:
-                                description: PortworxVolume represents a portworx
-                                  volume attached and mounted on kubelets host machine
-                                properties:
-                                  fsType:
-                                    description: FSType represents the filesystem
-                                      type to mount Must be a filesystem type supported
-                                      by the host operating system. Ex. "ext4", "xfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
-                                    type: string
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                  volumeID:
-                                    description: VolumeID uniquely identifies a Portworx
-                                      volume
-                                    type: string
-                                required:
-                                - volumeID
-                                type: object
-                              projected:
-                                description: Items for all in one resources secrets,
-                                  configmaps, and downward API
-                                properties:
-                                  defaultMode:
-                                    description: Mode bits used to set permissions
-                                      on created files by default. Must be an octal
-                                      value between 0000 and 0777 or a decimal value
-                                      between 0 and 511. YAML accepts both octal and
-                                      decimal values, JSON requires decimal values
-                                      for mode bits. Directories within the path are
-                                      not affected by this setting. This might be
-                                      in conflict with other options that affect the
-                                      file mode, like fsGroup, and the result can
-                                      be other mode bits set.
-                                    format: int32
-                                    type: integer
-                                  sources:
-                                    description: list of volume projections
-                                    items:
-                                      description: Projection that may be projected
-                                        along with other supported volume types
-                                      properties:
-                                        configMap:
-                                          description: information about the configMap
-                                            data to project
-                                          properties:
-                                            items:
-                                              description: If unspecified, each key-value
-                                                pair in the Data field of the referenced
-                                                ConfigMap will be projected into the
-                                                volume as a file whose name is the
-                                                key and content is the value. If specified,
-                                                the listed keys will be projected
-                                                into the specified paths, and unlisted
-                                                keys will not be present. If a key
-                                                is specified which is not present
-                                                in the ConfigMap, the volume setup
-                                                will error unless it is marked optional.
-                                                Paths must be relative and may not
-                                                contain the '..' path or start with
-                                                '..'.
+                                              type: array
+                                            matchFields:
+                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: Maps a string key to
-                                                  a path within a volume.
+                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: The label key that the selector applies to.
                                                     type: string
-                                                  mode:
-                                                    description: 'Optional: mode bits
-                                                      used to set permissions on this
-                                                      file. Must be an octal value
-                                                      between 0000 and 0777 or a decimal
-                                                      value between 0 and 511. YAML
-                                                      accepts both octal and decimal
-                                                      values, JSON requires decimal
-                                                      values for mode bits. If not
-                                                      specified, the volume defaultMode
-                                                      will be used. This might be
-                                                      in conflict with other options
-                                                      that affect the file mode, like
-                                                      fsGroup, and the result can
-                                                      be other mode bits set.'
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    description: The relative path
-                                                      of the file to map the key to.
-                                                      May not be an absolute path.
-                                                      May not contain the path element
-                                                      '..'. May not start with the
-                                                      string '..'.
+                                                  operator:
+                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
+                                                  values:
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
                                                 required:
-                                                - key
-                                                - path
-                                                type: object
-                                              type: array
-                                            name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
-                                              type: string
-                                            optional:
-                                              description: Specify whether the ConfigMap
-                                                or its keys must be defined
-                                              type: boolean
-                                          type: object
-                                        downwardAPI:
-                                          description: information about the downwardAPI
-                                            data to project
-                                          properties:
-                                            items:
-                                              description: Items is a list of DownwardAPIVolume
-                                                file
-                                              items:
-                                                description: DownwardAPIVolumeFile
-                                                  represents information to create
-                                                  the file containing the pod field
-                                                properties:
-                                                  fieldRef:
-                                                    description: 'Required: Selects
-                                                      a field of the pod: only annotations,
-                                                      labels, name and namespace are
-                                                      supported.'
-                                                    properties:
-                                                      apiVersion:
-                                                        description: Version of the
-                                                          schema the FieldPath is
-                                                          written in terms of, defaults
-                                                          to "v1".
-                                                        type: string
-                                                      fieldPath:
-                                                        description: Path of the field
-                                                          to select in the specified
-                                                          API version.
-                                                        type: string
-                                                    required:
-                                                    - fieldPath
-                                                    type: object
-                                                  mode:
-                                                    description: 'Optional: mode bits
-                                                      used to set permissions on this
-                                                      file, must be an octal value
-                                                      between 0000 and 0777 or a decimal
-                                                      value between 0 and 511. YAML
-                                                      accepts both octal and decimal
-                                                      values, JSON requires decimal
-                                                      values for mode bits. If not
-                                                      specified, the volume defaultMode
-                                                      will be used. This might be
-                                                      in conflict with other options
-                                                      that affect the file mode, like
-                                                      fsGroup, and the result can
-                                                      be other mode bits set.'
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    description: 'Required: Path is  the
-                                                      relative path name of the file
-                                                      to be created. Must not be absolute
-                                                      or contain the ''..'' path.
-                                                      Must be utf-8 encoded. The first
-                                                      item of the relative path must
-                                                      not start with ''..'''
-                                                    type: string
-                                                  resourceFieldRef:
-                                                    description: 'Selects a resource
-                                                      of the container: only resources
-                                                      limits and requests (limits.cpu,
-                                                      limits.memory, requests.cpu
-                                                      and requests.memory) are currently
-                                                      supported.'
-                                                    properties:
-                                                      containerName:
-                                                        description: 'Container name:
-                                                          required for volumes, optional
-                                                          for env vars'
-                                                        type: string
-                                                      divisor:
-                                                        anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                        description: Specifies the
-                                                          output format of the exposed
-                                                          resources, defaults to "1"
-                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                        x-kubernetes-int-or-string: true
-                                                      resource:
-                                                        description: 'Required: resource
-                                                          to select'
-                                                        type: string
-                                                    required:
-                                                    - resource
-                                                    type: object
-                                                required:
-                                                - path
+                                                  - key
+                                                  - operator
                                                 type: object
                                               type: array
                                           type: object
-                                        secret:
-                                          description: information about the secret
-                                            data to project
-                                          properties:
-                                            items:
-                                              description: If unspecified, each key-value
-                                                pair in the Data field of the referenced
-                                                Secret will be projected into the
-                                                volume as a file whose name is the
-                                                key and content is the value. If specified,
-                                                the listed keys will be projected
-                                                into the specified paths, and unlisted
-                                                keys will not be present. If a key
-                                                is specified which is not present
-                                                in the Secret, the volume setup will
-                                                error unless it is marked optional.
-                                                Paths must be relative and may not
-                                                contain the '..' path or start with
-                                                '..'.
-                                              items:
-                                                description: Maps a string key to
-                                                  a path within a volume.
-                                                properties:
-                                                  key:
-                                                    description: The key to project.
-                                                    type: string
-                                                  mode:
-                                                    description: 'Optional: mode bits
-                                                      used to set permissions on this
-                                                      file. Must be an octal value
-                                                      between 0000 and 0777 or a decimal
-                                                      value between 0 and 511. YAML
-                                                      accepts both octal and decimal
-                                                      values, JSON requires decimal
-                                                      values for mode bits. If not
-                                                      specified, the volume defaultMode
-                                                      will be used. This might be
-                                                      in conflict with other options
-                                                      that affect the file mode, like
-                                                      fsGroup, and the result can
-                                                      be other mode bits set.'
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    description: The relative path
-                                                      of the file to map the key to.
-                                                      May not be an absolute path.
-                                                      May not contain the path element
-                                                      '..'. May not start with the
-                                                      string '..'.
-                                                    type: string
-                                                required:
-                                                - key
-                                                - path
-                                                type: object
-                                              type: array
-                                            name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
-                                              type: string
-                                            optional:
-                                              description: Specify whether the Secret
-                                                or its key must be defined
-                                              type: boolean
-                                          type: object
-                                        serviceAccountToken:
-                                          description: information about the serviceAccountToken
-                                            data to project
-                                          properties:
-                                            audience:
-                                              description: Audience is the intended
-                                                audience of the token. A recipient
-                                                of a token must identify itself with
-                                                an identifier specified in the audience
-                                                of the token, and otherwise should
-                                                reject the token. The audience defaults
-                                                to the identifier of the apiserver.
-                                              type: string
-                                            expirationSeconds:
-                                              description: ExpirationSeconds is the
-                                                requested duration of validity of
-                                                the service account token. As the
-                                                token approaches expiration, the kubelet
-                                                volume plugin will proactively rotate
-                                                the service account token. The kubelet
-                                                will start trying to rotate the token
-                                                if the token is older than 80 percent
-                                                of its time to live or if the token
-                                                is older than 24 hours.Defaults to
-                                                1 hour and must be at least 10 minutes.
-                                              format: int64
-                                              type: integer
-                                            path:
-                                              description: Path is the path relative
-                                                to the mount point of the file to
-                                                project the token into.
-                                              type: string
-                                          required:
-                                          - path
-                                          type: object
-                                      type: object
-                                    type: array
-                                type: object
-                              quobyte:
-                                description: Quobyte represents a Quobyte mount on
-                                  the host that shares a pod's lifetime
-                                properties:
-                                  group:
-                                    description: Group to map volume access to Default
-                                      is no group
-                                    type: string
-                                  readOnly:
-                                    description: ReadOnly here will force the Quobyte
-                                      volume to be mounted with read-only permissions.
-                                      Defaults to false.
-                                    type: boolean
-                                  registry:
-                                    description: Registry represents a single or multiple
-                                      Quobyte Registry services specified as a string
-                                      as host:port pair (multiple entries are separated
-                                      with commas) which acts as the central registry
-                                      for volumes
-                                    type: string
-                                  tenant:
-                                    description: Tenant owning the given Quobyte volume
-                                      in the Backend Used with dynamically provisioned
-                                      Quobyte volumes, value is set by the plugin
-                                    type: string
-                                  user:
-                                    description: User to map volume access to Defaults
-                                      to serivceaccount user
-                                    type: string
-                                  volume:
-                                    description: Volume is a string that references
-                                      an already created Quobyte volume by name.
-                                    type: string
-                                required:
-                                - registry
-                                - volume
-                                type: object
-                              rbd:
-                                description: 'RBD represents a Rados Block Device
-                                  mount on the host that shares a pod''s lifetime.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md'
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type of the volume that
-                                      you want to mount. Tip: Ensure that the filesystem
-                                      type is supported by the host operating system.
-                                      Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
-                                    type: string
-                                  image:
-                                    description: 'The rados image name. More info:
-                                      https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: string
-                                  keyring:
-                                    description: 'Keyring is the path to key ring
-                                      for RBDUser. Default is /etc/ceph/keyring. More
-                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: string
-                                  monitors:
-                                    description: 'A collection of Ceph monitors. More
-                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    items:
-                                      type: string
-                                    type: array
-                                  pool:
-                                    description: 'The rados pool name. Default is
-                                      rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: string
-                                  readOnly:
-                                    description: 'ReadOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: boolean
-                                  secretRef:
-                                    description: 'SecretRef is name of the authentication
-                                      secret for RBDUser. If provided overrides keyring.
-                                      Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  user:
-                                    description: 'The rados user name. Default is
-                                      admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: string
-                                required:
-                                - image
-                                - monitors
-                                type: object
-                              scaleIO:
-                                description: ScaleIO represents a ScaleIO persistent
-                                  volume attached and mounted on Kubernetes nodes.
-                                properties:
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Default is
-                                      "xfs".
-                                    type: string
-                                  gateway:
-                                    description: The host address of the ScaleIO API
-                                      Gateway.
-                                    type: string
-                                  protectionDomain:
-                                    description: The name of the ScaleIO Protection
-                                      Domain for the configured storage.
-                                    type: string
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                  secretRef:
-                                    description: SecretRef references to the secret
-                                      for ScaleIO user and other sensitive information.
-                                      If this is not provided, Login operation will
-                                      fail.
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  sslEnabled:
-                                    description: Flag to enable/disable SSL communication
-                                      with Gateway, default false
-                                    type: boolean
-                                  storageMode:
-                                    description: Indicates whether the storage for
-                                      a volume should be ThickProvisioned or ThinProvisioned.
-                                      Default is ThinProvisioned.
-                                    type: string
-                                  storagePool:
-                                    description: The ScaleIO Storage Pool associated
-                                      with the protection domain.
-                                    type: string
-                                  system:
-                                    description: The name of the storage system as
-                                      configured in ScaleIO.
-                                    type: string
-                                  volumeName:
-                                    description: The name of a volume already created
-                                      in the ScaleIO system that is associated with
-                                      this volume source.
-                                    type: string
-                                required:
-                                - gateway
-                                - secretRef
-                                - system
-                                type: object
-                              secret:
-                                description: 'Secret represents a secret that should
-                                  populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                properties:
-                                  defaultMode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on created files by default. Must
-                                      be an octal value between 0000 and 0777 or a
-                                      decimal value between 0 and 511. YAML accepts
-                                      both octal and decimal values, JSON requires
-                                      decimal values for mode bits. Defaults to 0644.
-                                      Directories within the path are not affected
-                                      by this setting. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
-                                    format: int32
-                                    type: integer
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose
-                                      name is the key and content is the value. If
-                                      specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file. Must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                        weight:
+                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                           format: int32
                                           type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
                                       required:
-                                      - key
-                                      - path
+                                        - preference
+                                        - weight
                                       type: object
                                     type: array
-                                  optional:
-                                    description: Specify whether the Secret or its
-                                      keys must be defined
-                                    type: boolean
-                                  secretName:
-                                    description: 'Name of the secret in the pod''s
-                                      namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                    type: string
-                                type: object
-                              storageos:
-                                description: StorageOS represents a StorageOS volume
-                                  attached and mounted on Kubernetes nodes.
-                                properties:
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified.
-                                    type: string
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                  secretRef:
-                                    description: SecretRef specifies the secret to
-                                      use for obtaining the StorageOS API credentials.  If
-                                      not specified, default values will be attempted.
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                     properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
+                                      nodeSelectorTerms:
+                                        description: Required. A list of node selector terms. The terms are ORed.
+                                        items:
+                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                          properties:
+                                            matchExpressions:
+                                              description: A list of node selector requirements by node's labels.
+                                              items:
+                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchFields:
+                                              description: A list of node selector requirements by node's fields.
+                                              items:
+                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                          type: object
+                                        type: array
+                                    required:
+                                      - nodeSelectorTerms
                                     type: object
-                                  volumeName:
-                                    description: VolumeName is the human-readable
-                                      name of the StorageOS volume.  Volume names
-                                      are only unique within a namespace.
-                                    type: string
-                                  volumeNamespace:
-                                    description: VolumeNamespace specifies the scope
-                                      of the volume within StorageOS.  If no namespace
-                                      is specified then the Pod's namespace will be
-                                      used.  This allows the Kubernetes name scoping
-                                      to be mirrored within StorageOS for tighter
-                                      integration. Set VolumeName to any name to override
-                                      the default behaviour. Set to "default" if you
-                                      are not using namespaces within StorageOS. Namespaces
-                                      that do not pre-exist within StorageOS will
-                                      be created.
-                                    type: string
                                 type: object
-                              vsphereVolume:
-                                description: VsphereVolume represents a vSphere volume
-                                  attached and mounted on kubelets host machine
+                              podAffinity:
+                                description: podAffinity describes pod affinity scheduling rules.
                                 properties:
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified.
-                                    type: string
-                                  storagePolicyID:
-                                    description: Storage Policy Based Management (SPBM)
-                                      profile ID associated with the StoragePolicyName.
-                                    type: string
-                                  storagePolicyName:
-                                    description: Storage Policy Based Management (SPBM)
-                                      profile name.
-                                    type: string
-                                  volumePath:
-                                    description: Path that identifies vSphere volume
-                                      vmdk
-                                    type: string
-                                required:
-                                - volumePath
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      properties:
+                                        podAffinityTerm:
+                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                            - topologyKey
+                                          type: object
+                                        weight:
+                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                        - podAffinityTerm
+                                        - weight
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    items:
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    type: array
                                 type: object
-                            required:
-                            - name
+                              podAntiAffinity:
+                                description: podAntiAffinity describes pod anti-affinity scheduling rules.
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      properties:
+                                        podAffinityTerm:
+                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                            - topologyKey
+                                          type: object
+                                        weight:
+                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                        - podAffinityTerm
+                                        - weight
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    items:
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    type: array
+                                type: object
+                              tolerations:
+                                description: tolerations allow the pod to tolerate any taint that matches the triple <key,value,effect> using the matching operator.
+                                items:
+                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      type: string
+                                  type: object
+                                type: array
                             type: object
-                          type: array
-                      type: object
-                    type: array
-                type: object
-              developerMode:
-                description: developerMode determines if the cluster runs in developer-mode.
-                type: boolean
-              forceRedeploymentReason:
-                description: forceRedeploymentReason can be used to force a rolling
-                  update of all racks by providing a unique string.
-                type: string
-              genericUpgrade:
-                description: genericUpgrade allows to configure behavior of generic
-                  upgrade logic.
-                properties:
-                  failureStrategy:
-                    default: Retry
-                    description: failureStrategy specifies which logic is executed
-                      when upgrade failure happens. Currently only Retry is supported.
-                    type: string
-                  pollInterval:
-                    default: 1s
-                    description: pollInterval specifies how often upgrade logic polls
-                      on state updates. Increasing this value should lower number
-                      of requests sent to apiserver, but it may affect overall time
-                      spent during upgrade. DEPRECATED.
-                    type: string
-                type: object
-              imagePullSecrets:
-                description: imagePullSecrets is an optional list of references to
-                  secrets in the same namespace used for pulling Scylla and Agent
-                  images.
-                items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                type: array
-              network:
-                description: network holds the networking config.
-                properties:
-                  dnsPolicy:
-                    description: dnsPolicy defines how a pod's DNS will be configured.
-                    type: string
-                  hostNetworking:
-                    description: hostNetworking determines if scylla uses the host's
-                      network namespace. Setting this option avoids going through
-                      Kubernetes SDN and exposes scylla on node's IP.
-                    type: boolean
-                type: object
-              repairs:
-                description: repairs specify repair tasks in Scylla Manager. When
-                  Scylla Manager is not installed, these will be ignored.
-                items:
-                  properties:
-                    dc:
-                      description: dc is a list of datacenter glob patterns, e.g.
-                        'dc1', '!otherdc*' used to specify the DCs to include or exclude
-                        from backup.
-                      items:
-                        type: string
-                      type: array
-                    failFast:
-                      description: failFast indicates if a repair should be stopped
-                        on first error.
-                      type: boolean
-                    host:
-                      description: host specifies a host to repair. If empty, all
-                        hosts are repaired.
-                      type: string
-                    intensity:
-                      default: "1"
-                      description: intensity indicates how many token ranges (per
-                        shard) to repair in a single Scylla repair job. By default
-                        this is 1. If you set it to 0 the number of token ranges is
-                        adjusted to the maximum supported by node (see max_repair_ranges_in_parallel
-                        in Scylla logs). Valid values are 0 and integers >= 1. Higher
-                        values will result in increased cluster load and slightly
-                        faster repairs. Changing the intensity impacts repair granularity
-                        if you need to resume it, the higher the value the more work
-                        on resume. For Scylla clusters that *do not support row-level
-                        repair*, intensity can be a decimal between (0,1). In that
-                        case it specifies percent of shards that can be repaired in
-                        parallel on a repair master node. For Scylla clusters that
-                        are row-level repair enabled, setting intensity below 1 has
-                        the same effect as setting intensity 1.
-                      type: string
-                    interval:
-                      default: "0"
-                      description: interval represents a task schedule interval e.g.
-                        3d2h10m, valid units are d, h, m, s.
-                      type: string
-                    keyspace:
-                      description: keyspace is a list of keyspace/tables glob patterns,
-                        e.g. 'keyspace,!keyspace.table_prefix_*' used to include or
-                        exclude keyspaces from repair.
-                      items:
-                        type: string
-                      type: array
-                    name:
-                      description: name is a unique name of a task.
-                      type: string
-                    numRetries:
-                      default: 3
-                      description: numRetries indicates how many times a scheduled
-                        task will be retried before failing.
-                      format: int64
-                      type: integer
-                    parallel:
-                      default: 0
-                      description: 'parallel is the maximum number of Scylla repair
-                        jobs that can run at the same time (on different token ranges
-                        and replicas). Each node can take part in at most one repair
-                        at any given moment. By default the maximum possible parallelism
-                        is used. The effective parallelism depends on a keyspace replication
-                        factor (RF) and the number of nodes. The formula to calculate
-                        it is as follows: number of nodes / RF, ex. for 6 node cluster
-                        with RF=3 the maximum parallelism is 2.'
-                      format: int64
-                      type: integer
-                    smallTableThreshold:
-                      default: 1GiB
-                      description: smallTableThreshold enable small table optimization
-                        for tables of size lower than given threshold. Supported units
-                        [B, MiB, GiB, TiB].
-                      type: string
-                    startDate:
-                      default: now
-                      description: startDate specifies the task start date expressed
-                        in the RFC3339 format or now[+duration], e.g. now+3d2h10m,
-                        valid units are d, h, m, s.
-                      type: string
-                  type: object
-                type: array
-              repository:
-                default: docker.io/scylladb/scylla
-                description: repository is the image repository to pull the Scylla
-                  image from.
-                type: string
-              scyllaArgs:
-                description: scyllaArgs will be appended to Scylla binary during startup.
-                  This is supported from 4.2.0 Scylla version.
-                type: string
-              sysctls:
-                description: 'sysctls holds the sysctl properties to be applied during
-                  initialization given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
-                items:
-                  type: string
-                type: array
-              version:
-                description: version is a version tag of Scylla to use.
-                type: string
-            type: object
-          status:
-            description: status is the current status of this scylla cluster.
-            properties:
-              backups:
-                description: backups reflects status of backup tasks.
-                items:
-                  properties:
-                    dc:
-                      description: dc is a list of datacenter glob patterns, e.g.
-                        'dc1,!otherdc*' used to specify the DCs to include or exclude
-                        from backup.
-                      items:
-                        type: string
-                      type: array
-                    error:
-                      description: error holds the backup task error, if any.
-                      type: string
-                    id:
-                      description: id is the identification number of the backup task.
-                      type: string
-                    interval:
-                      default: "0"
-                      description: interval represents a task schedule interval e.g.
-                        3d2h10m, valid units are d, h, m, s.
-                      type: string
-                    keyspace:
-                      description: keyspace is a list of keyspace/tables glob patterns,
-                        e.g. 'keyspace,!keyspace.table_prefix_*' used to include or
-                        exclude keyspaces from repair.
-                      items:
-                        type: string
-                      type: array
-                    location:
-                      description: 'location is a list of backup locations in the
-                        format [<dc>:]<provider>:<name> ex. s3:my-bucket. The <dc>:
-                        part is optional and is only needed when different datacenters
-                        are being used to upload data to different locations. <name>
-                        must be an alphanumeric string and may contain a dash and
-                        or a dot, but other characters are forbidden. The only supported
-                        storage <provider> at the moment are s3 and gcs.'
-                      items:
-                        type: string
-                      type: array
-                    name:
-                      description: name is a unique name of a task.
-                      type: string
-                    numRetries:
-                      default: 3
-                      description: numRetries indicates how many times a scheduled
-                        task will be retried before failing.
-                      format: int64
-                      type: integer
-                    rateLimit:
-                      description: 'rateLimit is a list of megabytes (MiB) per second
-                        rate limits expressed in the format [<dc>:]<limit>. The <dc>:
-                        part is optional and only needed when different datacenters
-                        need different upload limits. Set to 0 for no limit (default
-                        100).'
-                      items:
-                        type: string
-                      type: array
-                    retention:
-                      default: 3
-                      description: retention is the number of backups which are to
-                        be stored.
-                      format: int64
-                      type: integer
-                    snapshotParallel:
-                      description: 'snapshotParallel is a list of snapshot parallelism
-                        limits in the format [<dc>:]<limit>. The <dc>: part is optional
-                        and allows for specifying different limits in selected datacenters.
-                        If The <dc>: part is not set, the limit is global (e.g. ''dc1:2,5'')
-                        the runs are parallel in n nodes (2 in dc1) and n nodes in
-                        all the other datacenters.'
-                      items:
-                        type: string
-                      type: array
-                    startDate:
-                      default: now
-                      description: startDate specifies the task start date expressed
-                        in the RFC3339 format or now[+duration], e.g. now+3d2h10m,
-                        valid units are d, h, m, s.
-                      type: string
-                    uploadParallel:
-                      description: 'uploadParallel is a list of upload parallelism
-                        limits in the format [<dc>:]<limit>. The <dc>: part is optional
-                        and allows for specifying different limits in selected datacenters.
-                        If The <dc>: part is not set the limit is global (e.g. ''dc1:2,5'')
-                        the runs are parallel in n nodes (2 in dc1) and n nodes in
-                        all the other datacenters.'
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                type: array
-              managerId:
-                description: managerId contains ID under which cluster was registered
-                  in Scylla Manager.
-                type: string
-              observedGeneration:
-                description: observedGeneration is the most recent generation observed
-                  for this ScyllaCluster. It corresponds to the ScyllaCluster's generation,
-                  which is updated on mutation by the API Server.
-                format: int64
-                type: integer
-              racks:
-                additionalProperties:
-                  description: RackStatus is the status of a Scylla Rack
-                  properties:
-                    conditions:
-                      description: conditions are the latest available observations
-                        of a rack's state.
-                      items:
-                        description: RackCondition is an observation about the state
-                          of a rack.
-                        properties:
-                          status:
-                            description: status represent condition status.
+                          resources:
+                            description: resources the Scylla container will use.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          scyllaAgentConfig:
+                            description: Scylla config map name to customize scylla manager agent
                             type: string
-                          type:
-                            description: type holds the condition type.
+                          scyllaConfig:
+                            description: Scylla config map name to customize scylla.yaml
                             type: string
+                          storage:
+                            description: storage describes the underlying storage that Scylla will consume.
+                            properties:
+                              capacity:
+                                description: capacity describes the requested size of each persistent volume.
+                                type: string
+                              storageClassName:
+                                description: storageClassName is the name of a storageClass to request.
+                                type: string
+                            type: object
+                          volumeMounts:
+                            description: VolumeMounts to be added to Scylla container.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                          volumes:
+                            description: Volumes added to Scylla Pod.
+                            items:
+                              description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                              properties:
+                                awsElasticBlockStore:
+                                  description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    partition:
+                                      description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      type: boolean
+                                    volumeID:
+                                      description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      type: string
+                                  required:
+                                    - volumeID
+                                  type: object
+                                azureDisk:
+                                  description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                  properties:
+                                    cachingMode:
+                                      description: 'Host Caching mode: None, Read Only, Read Write.'
+                                      type: string
+                                    diskName:
+                                      description: The Name of the data disk in the blob storage
+                                      type: string
+                                    diskURI:
+                                      description: The URI the data disk in the blob storage
+                                      type: string
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    kind:
+                                      description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                      type: string
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                  required:
+                                    - diskName
+                                    - diskURI
+                                  type: object
+                                azureFile:
+                                  description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                  properties:
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretName:
+                                      description: the name of secret that contains Azure Storage Account Name and Key
+                                      type: string
+                                    shareName:
+                                      description: Share Name
+                                      type: string
+                                  required:
+                                    - secretName
+                                    - shareName
+                                  type: object
+                                cephfs:
+                                  description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                  properties:
+                                    monitors:
+                                      description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      items:
+                                        type: string
+                                      type: array
+                                    path:
+                                      description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                      type: string
+                                    readOnly:
+                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      type: boolean
+                                    secretFile:
+                                      description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      type: string
+                                    secretRef:
+                                      description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    user:
+                                      description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      type: string
+                                  required:
+                                    - monitors
+                                  type: object
+                                cinder:
+                                  description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      type: string
+                                    readOnly:
+                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      type: boolean
+                                    secretRef:
+                                      description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    volumeID:
+                                      description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      type: string
+                                  required:
+                                    - volumeID
+                                  type: object
+                                configMap:
+                                  description: ConfigMap represents a configMap that should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its keys must be defined
+                                      type: boolean
+                                  type: object
+                                csi:
+                                  description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                                  properties:
+                                    driver:
+                                      description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                      type: string
+                                    fsType:
+                                      description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                      type: string
+                                    nodePublishSecretRef:
+                                      description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    readOnly:
+                                      description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                      type: object
+                                  required:
+                                    - driver
+                                  type: object
+                                downwardAPI:
+                                  description: DownwardAPI represents downward API about the pod that should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: Items is a list of downward API volume file
+                                      items:
+                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select in the specified API version.
+                                                type: string
+                                            required:
+                                              - fieldPath
+                                            type: object
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to select'
+                                                type: string
+                                            required:
+                                              - resource
+                                            type: object
+                                        required:
+                                          - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                emptyDir:
+                                  description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  properties:
+                                    medium:
+                                      description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      type: string
+                                    sizeLimit:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                ephemeral:
+                                  description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time. \n This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled."
+                                  properties:
+                                    volumeClaimTemplate:
+                                      description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
+                                      properties:
+                                        metadata:
+                                          description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                          type: object
+                                        spec:
+                                          description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                          properties:
+                                            accessModes:
+                                              description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                              items:
+                                                type: string
+                                              type: array
+                                            dataSource:
+                                              description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) * An existing custom resource that implements data population (Alpha) In order to use custom resource types that implement data population, the AnyVolumeDataSource feature gate must be enabled. If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source.'
+                                              properties:
+                                                apiGroup:
+                                                  description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                  type: string
+                                                kind:
+                                                  description: Kind is the type of resource being referenced
+                                                  type: string
+                                                name:
+                                                  description: Name is the name of resource being referenced
+                                                  type: string
+                                              required:
+                                                - kind
+                                                - name
+                                              type: object
+                                            resources:
+                                              description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  type: object
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              description: A label query over volumes to consider for binding.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            storageClassName:
+                                              description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                              type: string
+                                            volumeMode:
+                                              description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                              type: string
+                                            volumeName:
+                                              description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                              type: string
+                                          type: object
+                                      required:
+                                        - spec
+                                      type: object
+                                  type: object
+                                fc:
+                                  description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    lun:
+                                      description: 'Optional: FC target lun number'
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                      type: boolean
+                                    targetWWNs:
+                                      description: 'Optional: FC target worldwide names (WWNs)'
+                                      items:
+                                        type: string
+                                      type: array
+                                    wwids:
+                                      description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                flexVolume:
+                                  description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                                  properties:
+                                    driver:
+                                      description: Driver is the name of the driver to use for this volume.
+                                      type: string
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                      type: string
+                                    options:
+                                      additionalProperties:
+                                        type: string
+                                      description: 'Optional: Extra command options if any.'
+                                      type: object
+                                    readOnly:
+                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                      type: boolean
+                                    secretRef:
+                                      description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                  required:
+                                    - driver
+                                  type: object
+                                flocker:
+                                  description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                                  properties:
+                                    datasetName:
+                                      description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                      type: string
+                                    datasetUUID:
+                                      description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                      type: string
+                                  type: object
+                                gcePersistentDisk:
+                                  description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    partition:
+                                      description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      format: int32
+                                      type: integer
+                                    pdName:
+                                      description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      type: string
+                                    readOnly:
+                                      description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      type: boolean
+                                  required:
+                                    - pdName
+                                  type: object
+                                gitRepo:
+                                  description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                                  properties:
+                                    directory:
+                                      description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                      type: string
+                                    repository:
+                                      description: Repository URL
+                                      type: string
+                                    revision:
+                                      description: Commit hash for the specified revision.
+                                      type: string
+                                  required:
+                                    - repository
+                                  type: object
+                                glusterfs:
+                                  description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                  properties:
+                                    endpoints:
+                                      description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                      type: string
+                                    path:
+                                      description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                      type: string
+                                    readOnly:
+                                      description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                      type: boolean
+                                  required:
+                                    - endpoints
+                                    - path
+                                  type: object
+                                hostPath:
+                                  description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                                  properties:
+                                    path:
+                                      description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      type: string
+                                    type:
+                                      description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      type: string
+                                  required:
+                                    - path
+                                  type: object
+                                iscsi:
+                                  description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                  properties:
+                                    chapAuthDiscovery:
+                                      description: whether support iSCSI Discovery CHAP authentication
+                                      type: boolean
+                                    chapAuthSession:
+                                      description: whether support iSCSI Session CHAP authentication
+                                      type: boolean
+                                    fsType:
+                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    initiatorName:
+                                      description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                      type: string
+                                    iqn:
+                                      description: Target iSCSI Qualified Name.
+                                      type: string
+                                    iscsiInterface:
+                                      description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                      type: string
+                                    lun:
+                                      description: iSCSI Target Lun number.
+                                      format: int32
+                                      type: integer
+                                    portals:
+                                      description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                      items:
+                                        type: string
+                                      type: array
+                                    readOnly:
+                                      description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                      type: boolean
+                                    secretRef:
+                                      description: CHAP Secret for iSCSI target and initiator authentication
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    targetPortal:
+                                      description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                      type: string
+                                  required:
+                                    - iqn
+                                    - lun
+                                    - targetPortal
+                                  type: object
+                                name:
+                                  description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                nfs:
+                                  description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  properties:
+                                    path:
+                                      description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      type: string
+                                    readOnly:
+                                      description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      type: boolean
+                                    server:
+                                      description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      type: string
+                                  required:
+                                    - path
+                                    - server
+                                  type: object
+                                persistentVolumeClaim:
+                                  description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  properties:
+                                    claimName:
+                                      description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      type: string
+                                    readOnly:
+                                      description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                      type: boolean
+                                  required:
+                                    - claimName
+                                  type: object
+                                photonPersistentDisk:
+                                  description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                                  properties:
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    pdID:
+                                      description: ID that identifies Photon Controller persistent disk
+                                      type: string
+                                  required:
+                                    - pdID
+                                  type: object
+                                portworxVolume:
+                                  description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                  properties:
+                                    fsType:
+                                      description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    volumeID:
+                                      description: VolumeID uniquely identifies a Portworx volume
+                                      type: string
+                                  required:
+                                    - volumeID
+                                  type: object
+                                projected:
+                                  description: Items for all in one resources secrets, configmaps, and downward API
+                                  properties:
+                                    defaultMode:
+                                      description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    sources:
+                                      description: list of volume projections
+                                      items:
+                                        description: Projection that may be projected along with other supported volume types
+                                        properties:
+                                          configMap:
+                                            description: information about the configMap data to project
+                                            properties:
+                                              items:
+                                                description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: The key to project.
+                                                      type: string
+                                                    mode:
+                                                      description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                  type: object
+                                                type: array
+                                              name:
+                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap or its keys must be defined
+                                                type: boolean
+                                            type: object
+                                          downwardAPI:
+                                            description: information about the downwardAPI data to project
+                                            properties:
+                                              items:
+                                                description: Items is a list of DownwardAPIVolume file
+                                                items:
+                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                  properties:
+                                                    fieldRef:
+                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                      properties:
+                                                        apiVersion:
+                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                          type: string
+                                                        fieldPath:
+                                                          description: Path of the field to select in the specified API version.
+                                                          type: string
+                                                      required:
+                                                        - fieldPath
+                                                      type: object
+                                                    mode:
+                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                      properties:
+                                                        containerName:
+                                                          description: 'Container name: required for volumes, optional for env vars'
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          description: 'Required: resource to select'
+                                                          type: string
+                                                      required:
+                                                        - resource
+                                                      type: object
+                                                  required:
+                                                    - path
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          secret:
+                                            description: information about the secret data to project
+                                            properties:
+                                              items:
+                                                description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: The key to project.
+                                                      type: string
+                                                    mode:
+                                                      description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                  type: object
+                                                type: array
+                                              name:
+                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret or its key must be defined
+                                                type: boolean
+                                            type: object
+                                          serviceAccountToken:
+                                            description: information about the serviceAccountToken data to project
+                                            properties:
+                                              audience:
+                                                description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                type: string
+                                              expirationSeconds:
+                                                description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                format: int64
+                                                type: integer
+                                              path:
+                                                description: Path is the path relative to the mount point of the file to project the token into.
+                                                type: string
+                                            required:
+                                              - path
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                quobyte:
+                                  description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                  properties:
+                                    group:
+                                      description: Group to map volume access to Default is no group
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                      type: boolean
+                                    registry:
+                                      description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                      type: string
+                                    tenant:
+                                      description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                      type: string
+                                    user:
+                                      description: User to map volume access to Defaults to serivceaccount user
+                                      type: string
+                                    volume:
+                                      description: Volume is a string that references an already created Quobyte volume by name.
+                                      type: string
+                                  required:
+                                    - registry
+                                    - volume
+                                  type: object
+                                rbd:
+                                  description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    image:
+                                      description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: string
+                                    keyring:
+                                      description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: string
+                                    monitors:
+                                      description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      items:
+                                        type: string
+                                      type: array
+                                    pool:
+                                      description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: string
+                                    readOnly:
+                                      description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: boolean
+                                    secretRef:
+                                      description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    user:
+                                      description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: string
+                                  required:
+                                    - image
+                                    - monitors
+                                  type: object
+                                scaleIO:
+                                  description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                  properties:
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                      type: string
+                                    gateway:
+                                      description: The host address of the ScaleIO API Gateway.
+                                      type: string
+                                    protectionDomain:
+                                      description: The name of the ScaleIO Protection Domain for the configured storage.
+                                      type: string
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    sslEnabled:
+                                      description: Flag to enable/disable SSL communication with Gateway, default false
+                                      type: boolean
+                                    storageMode:
+                                      description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                      type: string
+                                    storagePool:
+                                      description: The ScaleIO Storage Pool associated with the protection domain.
+                                      type: string
+                                    system:
+                                      description: The name of the storage system as configured in ScaleIO.
+                                      type: string
+                                    volumeName:
+                                      description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                      type: string
+                                  required:
+                                    - gateway
+                                    - secretRef
+                                    - system
+                                  type: object
+                                secret:
+                                  description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                    optional:
+                                      description: Specify whether the Secret or its keys must be defined
+                                      type: boolean
+                                    secretName:
+                                      description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      type: string
+                                  type: object
+                                storageos:
+                                  description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                  properties:
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    volumeName:
+                                      description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                      type: string
+                                    volumeNamespace:
+                                      description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                      type: string
+                                  type: object
+                                vsphereVolume:
+                                  description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                  properties:
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    storagePolicyID:
+                                      description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                      type: string
+                                    storagePolicyName:
+                                      description: Storage Policy Based Management (SPBM) profile name.
+                                      type: string
+                                    volumePath:
+                                      description: Path that identifies vSphere volume vmdk
+                                      type: string
+                                  required:
+                                    - volumePath
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
                         type: object
                       type: array
-                    members:
-                      description: members is the current number of members requested
-                        in the specific Rack
-                      format: int32
-                      type: integer
-                    readyMembers:
-                      description: readyMembers is the number of ready members in
-                        the specific Rack
-                      format: int32
-                      type: integer
-                    replace_address_first_boot:
-                      additionalProperties:
-                        type: string
-                      description: 'FIXME: The json value should have been a camelCase
-                        string.        We need to deprecate this value and introduce
-                        a new one. replace_address_first_boot holds addresses which
-                        should be replaced by new nodes.'
-                      type: object
-                    stale:
-                      description: stale indicates if the current rack status is collected
-                        for a previous generation. stale should eventually become
-                        false when the appropriate controller writes a fresh status.
-                      type: boolean
-                    updatedMembers:
-                      description: updatedMembers is the number of members matching
-                        the current spec.
-                      format: int32
-                      type: integer
-                    version:
-                      description: version is the current version of Scylla in use.
-                      type: string
                   type: object
-                description: racks reflect status of cluster racks.
-                type: object
-              repairs:
-                description: repairs reflects status of repair tasks.
-                items:
+                developerMode:
+                  description: developerMode determines if the cluster runs in developer-mode.
+                  type: boolean
+                forceRedeploymentReason:
+                  description: forceRedeploymentReason can be used to force a rolling update of all racks by providing a unique string.
+                  type: string
+                genericUpgrade:
+                  description: genericUpgrade allows to configure behavior of generic upgrade logic.
                   properties:
-                    dc:
-                      description: dc is a list of datacenter glob patterns, e.g.
-                        'dc1', '!otherdc*' used to specify the DCs to include or exclude
-                        from backup.
-                      items:
-                        type: string
-                      type: array
-                    error:
-                      description: error holds the repair task error, if any.
+                    failureStrategy:
+                      default: Retry
+                      description: failureStrategy specifies which logic is executed when upgrade failure happens. Currently only Retry is supported.
                       type: string
-                    failFast:
-                      description: failFast indicates if a repair should be stopped
-                        on first error.
-                      type: boolean
-                    host:
-                      description: host specifies a host to repair. If empty, all
-                        hosts are repaired.
-                      type: string
-                    id:
-                      description: id is the identification number of the repair task.
-                      type: string
-                    intensity:
-                      default: "1"
-                      description: intensity indicates how many token ranges (per
-                        shard) to repair in a single Scylla repair job. By default
-                        this is 1. If you set it to 0 the number of token ranges is
-                        adjusted to the maximum supported by node (see max_repair_ranges_in_parallel
-                        in Scylla logs). Valid values are 0 and integers >= 1. Higher
-                        values will result in increased cluster load and slightly
-                        faster repairs. Changing the intensity impacts repair granularity
-                        if you need to resume it, the higher the value the more work
-                        on resume. For Scylla clusters that *do not support row-level
-                        repair*, intensity can be a decimal between (0,1). In that
-                        case it specifies percent of shards that can be repaired in
-                        parallel on a repair master node. For Scylla clusters that
-                        are row-level repair enabled, setting intensity below 1 has
-                        the same effect as setting intensity 1.
-                      type: string
-                    interval:
-                      default: "0"
-                      description: interval represents a task schedule interval e.g.
-                        3d2h10m, valid units are d, h, m, s.
-                      type: string
-                    keyspace:
-                      description: keyspace is a list of keyspace/tables glob patterns,
-                        e.g. 'keyspace,!keyspace.table_prefix_*' used to include or
-                        exclude keyspaces from repair.
-                      items:
-                        type: string
-                      type: array
-                    name:
-                      description: name is a unique name of a task.
-                      type: string
-                    numRetries:
-                      default: 3
-                      description: numRetries indicates how many times a scheduled
-                        task will be retried before failing.
-                      format: int64
-                      type: integer
-                    parallel:
-                      default: 0
-                      description: 'parallel is the maximum number of Scylla repair
-                        jobs that can run at the same time (on different token ranges
-                        and replicas). Each node can take part in at most one repair
-                        at any given moment. By default the maximum possible parallelism
-                        is used. The effective parallelism depends on a keyspace replication
-                        factor (RF) and the number of nodes. The formula to calculate
-                        it is as follows: number of nodes / RF, ex. for 6 node cluster
-                        with RF=3 the maximum parallelism is 2.'
-                      format: int64
-                      type: integer
-                    smallTableThreshold:
-                      default: 1GiB
-                      description: smallTableThreshold enable small table optimization
-                        for tables of size lower than given threshold. Supported units
-                        [B, MiB, GiB, TiB].
-                      type: string
-                    startDate:
-                      default: now
-                      description: startDate specifies the task start date expressed
-                        in the RFC3339 format or now[+duration], e.g. now+3d2h10m,
-                        valid units are d, h, m, s.
+                    pollInterval:
+                      default: 1s
+                      description: pollInterval specifies how often upgrade logic polls on state updates. Increasing this value should lower number of requests sent to apiserver, but it may affect overall time spent during upgrade. DEPRECATED.
                       type: string
                   type: object
-                type: array
-              upgrade:
-                description: upgrade reflects state of ongoing upgrade procedure.
-                properties:
-                  currentNode:
-                    description: currentNode node under upgrade. DEPRECATED.
+                imagePullSecrets:
+                  description: imagePullSecrets is an optional list of references to secrets in the same namespace used for pulling Scylla and Agent images.
+                  items:
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  type: array
+                network:
+                  description: network holds the networking config.
+                  properties:
+                    dnsPolicy:
+                      description: dnsPolicy defines how a pod's DNS will be configured.
+                      type: string
+                    hostNetworking:
+                      description: hostNetworking determines if scylla uses the host's network namespace. Setting this option avoids going through Kubernetes SDN and exposes scylla on node's IP.
+                      type: boolean
+                  type: object
+                repairs:
+                  description: repairs specify repair tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
+                  items:
+                    properties:
+                      dc:
+                        description: dc is a list of datacenter glob patterns, e.g. 'dc1', '!otherdc*' used to specify the DCs to include or exclude from backup.
+                        items:
+                          type: string
+                        type: array
+                      failFast:
+                        description: failFast indicates if a repair should be stopped on first error.
+                        type: boolean
+                      host:
+                        description: host specifies a host to repair. If empty, all hosts are repaired.
+                        type: string
+                      intensity:
+                        default: "1"
+                        description: intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
+                        type: string
+                      interval:
+                        default: "0"
+                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      keyspace:
+                        description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: name is a unique name of a task.
+                        type: string
+                      numRetries:
+                        default: 3
+                        description: numRetries indicates how many times a scheduled task will be retried before failing.
+                        format: int64
+                        type: integer
+                      parallel:
+                        default: 0
+                        description: 'parallel is the maximum number of Scylla repair jobs that can run at the same time (on different token ranges and replicas). Each node can take part in at most one repair at any given moment. By default the maximum possible parallelism is used. The effective parallelism depends on a keyspace replication factor (RF) and the number of nodes. The formula to calculate it is as follows: number of nodes / RF, ex. for 6 node cluster with RF=3 the maximum parallelism is 2.'
+                        format: int64
+                        type: integer
+                      smallTableThreshold:
+                        default: 1GiB
+                        description: smallTableThreshold enable small table optimization for tables of size lower than given threshold. Supported units [B, MiB, GiB, TiB].
+                        type: string
+                      startDate:
+                        default: now
+                        description: startDate specifies the task start date expressed in the RFC3339 format or now[+duration], e.g. now+3d2h10m, valid units are d, h, m, s.
+                        type: string
+                    type: object
+                  type: array
+                repository:
+                  default: docker.io/scylladb/scylla
+                  description: repository is the image repository to pull the Scylla image from.
+                  type: string
+                scyllaArgs:
+                  description: scyllaArgs will be appended to Scylla binary during startup. This is supported from 4.2.0 Scylla version.
+                  type: string
+                sysctls:
+                  description: 'sysctls holds the sysctl properties to be applied during initialization given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
+                  items:
                     type: string
-                  currentRack:
-                    description: currentRack rack under upgrade. DEPRECATED.
-                    type: string
-                  dataSnapshotTag:
-                    description: dataSnapshotTag is the snapshot tag of data keyspaces.
-                    type: string
-                  fromVersion:
-                    description: fromVersion reflects from which version ScyllaCluster
-                      is being upgraded.
-                    type: string
-                  state:
-                    description: state reflects current upgrade state.
-                    type: string
-                  systemSnapshotTag:
-                    description: systemSnapshotTag is the snapshot tag of system keyspaces.
-                    type: string
-                  toVersion:
-                    description: toVersion reflects to which version ScyllaCluster
-                      is being upgraded.
-                    type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                version:
+                  description: version is a version tag of Scylla to use.
+                  type: string
+              type: object
+            status:
+              description: status is the current status of this scylla cluster.
+              properties:
+                backups:
+                  description: backups reflects status of backup tasks.
+                  items:
+                    properties:
+                      dc:
+                        description: dc is a list of datacenter glob patterns, e.g. 'dc1,!otherdc*' used to specify the DCs to include or exclude from backup.
+                        items:
+                          type: string
+                        type: array
+                      error:
+                        description: error holds the backup task error, if any.
+                        type: string
+                      id:
+                        description: id is the identification number of the backup task.
+                        type: string
+                      interval:
+                        default: "0"
+                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      keyspace:
+                        description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+                        items:
+                          type: string
+                        type: array
+                      location:
+                        description: 'location is a list of backup locations in the format [<dc>:]<provider>:<name> ex. s3:my-bucket. The <dc>: part is optional and is only needed when different datacenters are being used to upload data to different locations. <name> must be an alphanumeric string and may contain a dash and or a dot, but other characters are forbidden. The only supported storage <provider> at the moment are s3 and gcs.'
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: name is a unique name of a task.
+                        type: string
+                      numRetries:
+                        default: 3
+                        description: numRetries indicates how many times a scheduled task will be retried before failing.
+                        format: int64
+                        type: integer
+                      rateLimit:
+                        description: 'rateLimit is a list of megabytes (MiB) per second rate limits expressed in the format [<dc>:]<limit>. The <dc>: part is optional and only needed when different datacenters need different upload limits. Set to 0 for no limit (default 100).'
+                        items:
+                          type: string
+                        type: array
+                      retention:
+                        default: 3
+                        description: retention is the number of backups which are to be stored.
+                        format: int64
+                        type: integer
+                      snapshotParallel:
+                        description: 'snapshotParallel is a list of snapshot parallelism limits in the format [<dc>:]<limit>. The <dc>: part is optional and allows for specifying different limits in selected datacenters. If The <dc>: part is not set, the limit is global (e.g. ''dc1:2,5'') the runs are parallel in n nodes (2 in dc1) and n nodes in all the other datacenters.'
+                        items:
+                          type: string
+                        type: array
+                      startDate:
+                        default: now
+                        description: startDate specifies the task start date expressed in the RFC3339 format or now[+duration], e.g. now+3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      uploadParallel:
+                        description: 'uploadParallel is a list of upload parallelism limits in the format [<dc>:]<limit>. The <dc>: part is optional and allows for specifying different limits in selected datacenters. If The <dc>: part is not set the limit is global (e.g. ''dc1:2,5'') the runs are parallel in n nodes (2 in dc1) and n nodes in all the other datacenters.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                managerId:
+                  description: managerId contains ID under which cluster was registered in Scylla Manager.
+                  type: string
+                observedGeneration:
+                  description: observedGeneration is the most recent generation observed for this ScyllaCluster. It corresponds to the ScyllaCluster's generation, which is updated on mutation by the API Server.
+                  format: int64
+                  type: integer
+                racks:
+                  additionalProperties:
+                    description: RackStatus is the status of a Scylla Rack
+                    properties:
+                      conditions:
+                        description: conditions are the latest available observations of a rack's state.
+                        items:
+                          description: RackCondition is an observation about the state of a rack.
+                          properties:
+                            status:
+                              description: status represent condition status.
+                              type: string
+                            type:
+                              description: type holds the condition type.
+                              type: string
+                          type: object
+                        type: array
+                      members:
+                        description: members is the current number of members requested in the specific Rack
+                        format: int32
+                        type: integer
+                      readyMembers:
+                        description: readyMembers is the number of ready members in the specific Rack
+                        format: int32
+                        type: integer
+                      replace_address_first_boot:
+                        additionalProperties:
+                          type: string
+                        description: 'FIXME: The json value should have been a camelCase string.        We need to deprecate this value and introduce a new one. replace_address_first_boot holds addresses which should be replaced by new nodes.'
+                        type: object
+                      stale:
+                        description: stale indicates if the current rack status is collected for a previous generation. stale should eventually become false when the appropriate controller writes a fresh status.
+                        type: boolean
+                      updatedMembers:
+                        description: updatedMembers is the number of members matching the current spec.
+                        format: int32
+                        type: integer
+                      version:
+                        description: version is the current version of Scylla in use.
+                        type: string
+                    type: object
+                  description: racks reflect status of cluster racks.
+                  type: object
+                repairs:
+                  description: repairs reflects status of repair tasks.
+                  items:
+                    properties:
+                      dc:
+                        description: dc is a list of datacenter glob patterns, e.g. 'dc1', '!otherdc*' used to specify the DCs to include or exclude from backup.
+                        items:
+                          type: string
+                        type: array
+                      error:
+                        description: error holds the repair task error, if any.
+                        type: string
+                      failFast:
+                        description: failFast indicates if a repair should be stopped on first error.
+                        type: boolean
+                      host:
+                        description: host specifies a host to repair. If empty, all hosts are repaired.
+                        type: string
+                      id:
+                        description: id is the identification number of the repair task.
+                        type: string
+                      intensity:
+                        default: "1"
+                        description: intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
+                        type: string
+                      interval:
+                        default: "0"
+                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      keyspace:
+                        description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: name is a unique name of a task.
+                        type: string
+                      numRetries:
+                        default: 3
+                        description: numRetries indicates how many times a scheduled task will be retried before failing.
+                        format: int64
+                        type: integer
+                      parallel:
+                        default: 0
+                        description: 'parallel is the maximum number of Scylla repair jobs that can run at the same time (on different token ranges and replicas). Each node can take part in at most one repair at any given moment. By default the maximum possible parallelism is used. The effective parallelism depends on a keyspace replication factor (RF) and the number of nodes. The formula to calculate it is as follows: number of nodes / RF, ex. for 6 node cluster with RF=3 the maximum parallelism is 2.'
+                        format: int64
+                        type: integer
+                      smallTableThreshold:
+                        default: 1GiB
+                        description: smallTableThreshold enable small table optimization for tables of size lower than given threshold. Supported units [B, MiB, GiB, TiB].
+                        type: string
+                      startDate:
+                        default: now
+                        description: startDate specifies the task start date expressed in the RFC3339 format or now[+duration], e.g. now+3d2h10m, valid units are d, h, m, s.
+                        type: string
+                    type: object
+                  type: array
+                upgrade:
+                  description: upgrade reflects state of ongoing upgrade procedure.
+                  properties:
+                    currentNode:
+                      description: currentNode node under upgrade. DEPRECATED.
+                      type: string
+                    currentRack:
+                      description: currentRack rack under upgrade. DEPRECATED.
+                      type: string
+                    dataSnapshotTag:
+                      description: dataSnapshotTag is the snapshot tag of data keyspaces.
+                      type: string
+                    fromVersion:
+                      description: fromVersion reflects from which version ScyllaCluster is being upgraded.
+                      type: string
+                    state:
+                      description: state reflects current upgrade state.
+                      type: string
+                    systemSnapshotTag:
+                      description: systemSnapshotTag is the snapshot tag of system keyspaces.
+                      type: string
+                    toVersion:
+                      description: toVersion reflects to which version ScyllaCluster is being upgraded.
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -16,3317 +14,1938 @@ spec:
     singular: scyllacluster
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ScyllaCluster defines a Scylla cluster.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec defines the desired state of this scylla cluster.
-            properties:
-              agentRepository:
-                default: docker.io/scylladb/scylla-manager-agent
-                description: agentRepository is the repository to pull the agent image
-                  from.
-                type: string
-              agentVersion:
-                default: latest
-                description: agentVersion indicates the version of Scylla Manager
-                  Agent to use.
-                type: string
-              alternator:
-                description: alternator designates this cluster an Alternator cluster.
-                properties:
-                  port:
-                    description: port is the port number used to bind the Alternator
-                      API.
-                    format: int32
-                    type: integer
-                  writeIsolation:
-                    description: writeIsolation indicates the isolation level.
-                    type: string
-                type: object
-              automaticOrphanedNodeCleanup:
-                description: automaticOrphanedNodeCleanup controls if automatic orphan
-                  node cleanup should be performed.
-                type: boolean
-              backups:
-                description: backups specifies backup tasks in Scylla Manager. When
-                  Scylla Manager is not installed, these will be ignored.
-                items:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ScyllaCluster defines a Scylla cluster.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec defines the desired state of this scylla cluster.
+              properties:
+                agentRepository:
+                  default: docker.io/scylladb/scylla-manager-agent
+                  description: agentRepository is the repository to pull the agent image from.
+                  type: string
+                agentVersion:
+                  default: latest
+                  description: agentVersion indicates the version of Scylla Manager Agent to use.
+                  type: string
+                alternator:
+                  description: alternator designates this cluster an Alternator cluster.
                   properties:
-                    dc:
-                      description: dc is a list of datacenter glob patterns, e.g.
-                        'dc1,!otherdc*' used to specify the DCs to include or exclude
-                        from backup.
-                      items:
-                        type: string
-                      type: array
-                    interval:
-                      default: "0"
-                      description: interval represents a task schedule interval e.g.
-                        3d2h10m, valid units are d, h, m, s.
-                      type: string
-                    keyspace:
-                      description: keyspace is a list of keyspace/tables glob patterns,
-                        e.g. 'keyspace,!keyspace.table_prefix_*' used to include or
-                        exclude keyspaces from repair.
-                      items:
-                        type: string
-                      type: array
-                    location:
-                      description: 'location is a list of backup locations in the
-                        format [<dc>:]<provider>:<name> ex. s3:my-bucket. The <dc>:
-                        part is optional and is only needed when different datacenters
-                        are being used to upload data to different locations. <name>
-                        must be an alphanumeric string and may contain a dash and
-                        or a dot, but other characters are forbidden. The only supported
-                        storage <provider> at the moment are s3 and gcs.'
-                      items:
-                        type: string
-                      type: array
-                    name:
-                      description: name is a unique name of a task.
-                      type: string
-                    numRetries:
-                      default: 3
-                      description: numRetries indicates how many times a scheduled
-                        task will be retried before failing.
-                      format: int64
+                    port:
+                      description: port is the port number used to bind the Alternator API.
+                      format: int32
                       type: integer
-                    rateLimit:
-                      description: 'rateLimit is a list of megabytes (MiB) per second
-                        rate limits expressed in the format [<dc>:]<limit>. The <dc>:
-                        part is optional and only needed when different datacenters
-                        need different upload limits. Set to 0 for no limit (default
-                        100).'
-                      items:
-                        type: string
-                      type: array
-                    retention:
-                      default: 3
-                      description: retention is the number of backups which are to
-                        be stored.
-                      format: int64
-                      type: integer
-                    snapshotParallel:
-                      description: 'snapshotParallel is a list of snapshot parallelism
-                        limits in the format [<dc>:]<limit>. The <dc>: part is optional
-                        and allows for specifying different limits in selected datacenters.
-                        If The <dc>: part is not set, the limit is global (e.g. ''dc1:2,5'')
-                        the runs are parallel in n nodes (2 in dc1) and n nodes in
-                        all the other datacenters.'
-                      items:
-                        type: string
-                      type: array
-                    startDate:
-                      default: now
-                      description: startDate specifies the task start date expressed
-                        in the RFC3339 format or now[+duration], e.g. now+3d2h10m,
-                        valid units are d, h, m, s.
+                    writeIsolation:
+                      description: writeIsolation indicates the isolation level.
                       type: string
-                    uploadParallel:
-                      description: 'uploadParallel is a list of upload parallelism
-                        limits in the format [<dc>:]<limit>. The <dc>: part is optional
-                        and allows for specifying different limits in selected datacenters.
-                        If The <dc>: part is not set the limit is global (e.g. ''dc1:2,5'')
-                        the runs are parallel in n nodes (2 in dc1) and n nodes in
-                        all the other datacenters.'
-                      items:
-                        type: string
-                      type: array
                   type: object
-                type: array
-              cpuset:
-                description: cpuset determines if the cluster will use cpu-pinning
-                  for max performance.
-                type: boolean
-              datacenter:
-                description: datacenter holds a specification of a datacenter.
-                properties:
-                  name:
-                    description: name is the name of the scylla datacenter. Used in
-                      the cassandra-rackdc.properties file.
-                    type: string
-                  racks:
-                    description: racks specify the racks in the datacenter.
-                    items:
-                      description: RackSpec is the desired state for a Scylla Rack.
-                      properties:
-                        agentResources:
-                          default:
-                            requests:
-                              cpu: 50m
-                              memory: 10M
-                          description: agentResources specify the resources for the
-                            Agent container.
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                          type: object
-                        agentVolumeMounts:
-                          description: AgentVolumeMounts to be added to Agent container.
-                          items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
-                            properties:
-                              mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
-                                type: string
-                              mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
-                                type: string
-                              name:
-                                description: This must match the Name of a Volume.
-                                type: string
-                              readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
-                                type: boolean
-                              subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
-                                type: string
-                              subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
-                                type: string
-                            required:
-                            - mountPath
-                            - name
-                            type: object
-                          type: array
-                        members:
-                          description: members is the number of Scylla instances in
-                            this rack.
-                          format: int32
-                          type: integer
-                        name:
-                          description: name is the name of the Scylla Rack. Used in
-                            the cassandra-rackdc.properties file.
+                automaticOrphanedNodeCleanup:
+                  description: automaticOrphanedNodeCleanup controls if automatic orphan node cleanup should be performed.
+                  type: boolean
+                backups:
+                  description: backups specifies backup tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
+                  items:
+                    properties:
+                      dc:
+                        description: dc is a list of datacenter glob patterns, e.g. 'dc1,!otherdc*' used to specify the DCs to include or exclude from backup.
+                        items:
                           type: string
-                        placement:
-                          description: placement describes restrictions for the nodes
-                            Scylla is scheduled on.
-                          properties:
-                            nodeAffinity:
-                              description: nodeAffinity describes node affinity scheduling
-                                rules for the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule
-                                    pods to nodes that satisfy the affinity expressions
-                                    specified by this field, but it may choose a node
-                                    that violates one or more of the expressions.
-                                    The node that is most preferred is the one with
-                                    the greatest sum of weights, i.e. for each node
-                                    that meets all of the scheduling requirements
-                                    (resource request, requiredDuringScheduling affinity
-                                    expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding
-                                    "weight" to the sum if the node matches the corresponding
-                                    matchExpressions; the node(s) with the highest
-                                    sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term
-                                      matches all objects with implicit weight 0 (i.e.
-                                      it's a no-op). A null preferred scheduling term
-                                      matches no objects (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's
-                                                    relationship to a set of values.
-                                                    Valid operators are In, NotIn,
-                                                    Exists, DoesNotExist. Gt, and
-                                                    Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string
-                                                    values. If the operator is In
-                                                    or NotIn, the values array must
-                                                    be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. If
-                                                    the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's
-                                                    relationship to a set of values.
-                                                    Valid operators are In, NotIn,
-                                                    Exists, DoesNotExist. Gt, and
-                                                    Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string
-                                                    values. If the operator is In
-                                                    or NotIn, the values array must
-                                                    be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. If
-                                                    the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching
-                                          the corresponding nodeSelectorTerm, in the
-                                          range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - preference
-                                    - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified
-                                    by this field are not met at scheduling time,
-                                    the pod will not be scheduled onto the node. If
-                                    the affinity requirements specified by this field
-                                    cease to be met at some point during pod execution
-                                    (e.g. due to an update), the system may or may
-                                    not try to eventually evict the pod from its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector
-                                        terms. The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector
-                                          term matches no objects. The requirements
-                                          of them are ANDed. The TopologySelectorTerm
-                                          type implements a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's
-                                                    relationship to a set of values.
-                                                    Valid operators are In, NotIn,
-                                                    Exists, DoesNotExist. Gt, and
-                                                    Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string
-                                                    values. If the operator is In
-                                                    or NotIn, the values array must
-                                                    be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. If
-                                                    the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's
-                                                    relationship to a set of values.
-                                                    Valid operators are In, NotIn,
-                                                    Exists, DoesNotExist. Gt, and
-                                                    Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string
-                                                    values. If the operator is In
-                                                    or NotIn, the values array must
-                                                    be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. If
-                                                    the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                  - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: podAffinity describes pod affinity scheduling
-                                rules.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule
-                                    pods to nodes that satisfy the affinity expressions
-                                    specified by this field, but it may choose a node
-                                    that violates one or more of the expressions.
-                                    The node that is most preferred is the one with
-                                    the greatest sum of weights, i.e. for each node
-                                    that meets all of the scheduling requirements
-                                    (resource request, requiredDuringScheduling affinity
-                                    expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding
-                                    "weight" to the sum if the node has pods which
-                                    matches the corresponding podAffinityTerm; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: The weights of all of the matched
-                                      WeightedPodAffinityTerm fields are added per-node
-                                      to find the most preferred node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set
-                                              of resources, in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
-                                                type: object
-                                            type: object
-                                          namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
-                                              This field is alpha-level and is only
-                                              honored when PodAffinityNamespaceSelector
-                                              feature is enabled.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                        - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching
-                                          the corresponding podAffinityTerm, in the
-                                          range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - podAffinityTerm
-                                    - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified
-                                    by this field are not met at scheduling time,
-                                    the pod will not be scheduled onto the node. If
-                                    the affinity requirements specified by this field
-                                    cease to be met at some point during pod execution
-                                    (e.g. due to a pod label update), the system may
-                                    or may not try to eventually evict the pod from
-                                    its node. When there are multiple elements, the
-                                    lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those
-                                      matching the labelSelector relative to the given
-                                      namespace(s)) that this pod should be co-located
-                                      (affinity) or not co-located (anti-affinity)
-                                      with, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      <topologyKey> matches that of any node on which
-                                      a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of
-                                          namespaces that the term applies to. The
-                                          term is applied to the union of the namespaces
-                                          selected by this field and the ones listed
-                                          in the namespaces field. null selector and
-                                          null or empty namespaces list means "this
-                                          pod's namespace". An empty selector ({})
-                                          matches all namespaces. This field is alpha-level
-                                          and is only honored when PodAffinityNamespaceSelector
-                                          feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static
-                                          list of namespace names that the term applies
-                                          to. The term is applied to the union of
-                                          the namespaces listed in this field and
-                                          the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector
-                                          means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: podAntiAffinity describes pod anti-affinity
-                                scheduling rules.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule
-                                    pods to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node
-                                    that violates one or more of the expressions.
-                                    The node that is most preferred is the one with
-                                    the greatest sum of weights, i.e. for each node
-                                    that meets all of the scheduling requirements
-                                    (resource request, requiredDuringScheduling anti-affinity
-                                    expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding
-                                    "weight" to the sum if the node has pods which
-                                    matches the corresponding podAffinityTerm; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: The weights of all of the matched
-                                      WeightedPodAffinityTerm fields are added per-node
-                                      to find the most preferred node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set
-                                              of resources, in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
-                                                type: object
-                                            type: object
-                                          namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
-                                              This field is alpha-level and is only
-                                              honored when PodAffinityNamespaceSelector
-                                              feature is enabled.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                        - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching
-                                          the corresponding podAffinityTerm, in the
-                                          range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - podAffinityTerm
-                                    - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time,
-                                    the pod will not be scheduled onto the node. If
-                                    the anti-affinity requirements specified by this
-                                    field cease to be met at some point during pod
-                                    execution (e.g. due to a pod label update), the
-                                    system may or may not try to eventually evict
-                                    the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to
-                                    each podAffinityTerm are intersected, i.e. all
-                                    terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those
-                                      matching the labelSelector relative to the given
-                                      namespace(s)) that this pod should be co-located
-                                      (affinity) or not co-located (anti-affinity)
-                                      with, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      <topologyKey> matches that of any node on which
-                                      a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of
-                                          namespaces that the term applies to. The
-                                          term is applied to the union of the namespaces
-                                          selected by this field and the ones listed
-                                          in the namespaces field. null selector and
-                                          null or empty namespaces list means "this
-                                          pod's namespace". An empty selector ({})
-                                          matches all namespaces. This field is alpha-level
-                                          and is only honored when PodAffinityNamespaceSelector
-                                          feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static
-                                          list of namespace names that the term applies
-                                          to. The term is applied to the union of
-                                          the namespaces listed in this field and
-                                          the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector
-                                          means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            tolerations:
-                              description: tolerations allow the pod to tolerate any
-                                taint that matches the triple <key,value,effect> using
-                                the matching operator.
-                              items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
-                                properties:
-                                  effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
-                                    type: string
-                                  key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
-                                    type: string
-                                  operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
-                                    type: string
-                                  tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        resources:
-                          description: resources the Scylla container will use.
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                          type: object
-                        scyllaAgentConfig:
-                          description: Scylla config map name to customize scylla
-                            manager agent
+                        type: array
+                      interval:
+                        default: "0"
+                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      keyspace:
+                        description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+                        items:
                           type: string
-                        scyllaConfig:
-                          description: Scylla config map name to customize scylla.yaml
+                        type: array
+                      location:
+                        description: 'location is a list of backup locations in the format [<dc>:]<provider>:<name> ex. s3:my-bucket. The <dc>: part is optional and is only needed when different datacenters are being used to upload data to different locations. <name> must be an alphanumeric string and may contain a dash and or a dot, but other characters are forbidden. The only supported storage <provider> at the moment are s3 and gcs.'
+                        items:
                           type: string
-                        storage:
-                          description: storage describes the underlying storage that
-                            Scylla will consume.
-                          properties:
-                            capacity:
-                              description: capacity describes the requested size of
-                                each persistent volume.
-                              type: string
-                            storageClassName:
-                              description: storageClassName is the name of a storageClass
-                                to request.
-                              type: string
-                          type: object
-                        volumeMounts:
-                          description: VolumeMounts to be added to Scylla container.
-                          items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
+                        type: array
+                      name:
+                        description: name is a unique name of a task.
+                        type: string
+                      numRetries:
+                        default: 3
+                        description: numRetries indicates how many times a scheduled task will be retried before failing.
+                        format: int64
+                        type: integer
+                      rateLimit:
+                        description: 'rateLimit is a list of megabytes (MiB) per second rate limits expressed in the format [<dc>:]<limit>. The <dc>: part is optional and only needed when different datacenters need different upload limits. Set to 0 for no limit (default 100).'
+                        items:
+                          type: string
+                        type: array
+                      retention:
+                        default: 3
+                        description: retention is the number of backups which are to be stored.
+                        format: int64
+                        type: integer
+                      snapshotParallel:
+                        description: 'snapshotParallel is a list of snapshot parallelism limits in the format [<dc>:]<limit>. The <dc>: part is optional and allows for specifying different limits in selected datacenters. If The <dc>: part is not set, the limit is global (e.g. ''dc1:2,5'') the runs are parallel in n nodes (2 in dc1) and n nodes in all the other datacenters.'
+                        items:
+                          type: string
+                        type: array
+                      startDate:
+                        default: now
+                        description: startDate specifies the task start date expressed in the RFC3339 format or now[+duration], e.g. now+3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      uploadParallel:
+                        description: 'uploadParallel is a list of upload parallelism limits in the format [<dc>:]<limit>. The <dc>: part is optional and allows for specifying different limits in selected datacenters. If The <dc>: part is not set the limit is global (e.g. ''dc1:2,5'') the runs are parallel in n nodes (2 in dc1) and n nodes in all the other datacenters.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                cpuset:
+                  description: cpuset determines if the cluster will use cpu-pinning for max performance.
+                  type: boolean
+                datacenter:
+                  description: datacenter holds a specification of a datacenter.
+                  properties:
+                    name:
+                      description: name is the name of the scylla datacenter. Used in the cassandra-rackdc.properties file.
+                      type: string
+                    racks:
+                      description: racks specify the racks in the datacenter.
+                      items:
+                        description: RackSpec is the desired state for a Scylla Rack.
+                        properties:
+                          agentResources:
+                            default:
+                              requests:
+                                cpu: 50m
+                                memory: 10M
+                            description: agentResources specify the resources for the Agent container.
                             properties:
-                              mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
-                                type: string
-                              mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
-                                type: string
-                              name:
-                                description: This must match the Name of a Volume.
-                                type: string
-                              readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
-                                type: boolean
-                              subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
-                                type: string
-                              subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
-                                type: string
-                            required:
-                            - mountPath
-                            - name
-                            type: object
-                          type: array
-                        volumes:
-                          description: Volumes added to Scylla Pod.
-                          items:
-                            description: Volume represents a named volume in a pod
-                              that may be accessed by any container in the pod.
-                            properties:
-                              awsElasticBlockStore:
-                                description: 'AWSElasticBlockStore represents an AWS
-                                  Disk resource that is attached to a kubelet''s host
-                                  machine and then exposed to the pod. More info:
-                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type of the volume that
-                                      you want to mount. Tip: Ensure that the filesystem
-                                      type is supported by the host operating system.
-                                      Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
-                                    type: string
-                                  partition:
-                                    description: 'The partition in the volume that
-                                      you want to mount. If omitted, the default is
-                                      to mount by volume name. Examples: For volume
-                                      /dev/sda1, you specify the partition as "1".
-                                      Similarly, the volume partition for /dev/sda
-                                      is "0" (or you can leave the property empty).'
-                                    format: int32
-                                    type: integer
-                                  readOnly:
-                                    description: 'Specify "true" to force and set
-                                      the ReadOnly property in VolumeMounts to "true".
-                                      If omitted, the default is "false". More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                                    type: boolean
-                                  volumeID:
-                                    description: 'Unique ID of the persistent disk
-                                      resource in AWS (Amazon EBS volume). More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                                    type: string
-                                required:
-                                - volumeID
-                                type: object
-                              azureDisk:
-                                description: AzureDisk represents an Azure Data Disk
-                                  mount on the host and bind mount to the pod.
-                                properties:
-                                  cachingMode:
-                                    description: 'Host Caching mode: None, Read Only,
-                                      Read Write.'
-                                    type: string
-                                  diskName:
-                                    description: The Name of the data disk in the
-                                      blob storage
-                                    type: string
-                                  diskURI:
-                                    description: The URI the data disk in the blob
-                                      storage
-                                    type: string
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified.
-                                    type: string
-                                  kind:
-                                    description: 'Expected values Shared: multiple
-                                      blob disks per storage account  Dedicated: single
-                                      blob disk per storage account  Managed: azure
-                                      managed data disk (only in managed availability
-                                      set). defaults to shared'
-                                    type: string
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                required:
-                                - diskName
-                                - diskURI
-                                type: object
-                              azureFile:
-                                description: AzureFile represents an Azure File Service
-                                  mount on the host and bind mount to the pod.
-                                properties:
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                  secretName:
-                                    description: the name of secret that contains
-                                      Azure Storage Account Name and Key
-                                    type: string
-                                  shareName:
-                                    description: Share Name
-                                    type: string
-                                required:
-                                - secretName
-                                - shareName
-                                type: object
-                              cephfs:
-                                description: CephFS represents a Ceph FS mount on
-                                  the host that shares a pod's lifetime
-                                properties:
-                                  monitors:
-                                    description: 'Required: Monitors is a collection
-                                      of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    items:
-                                      type: string
-                                    type: array
-                                  path:
-                                    description: 'Optional: Used as the mounted root,
-                                      rather than the full Ceph tree, default is /'
-                                    type: string
-                                  readOnly:
-                                    description: 'Optional: Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    type: boolean
-                                  secretFile:
-                                    description: 'Optional: SecretFile is the path
-                                      to key ring for User, default is /etc/ceph/user.secret
-                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    type: string
-                                  secretRef:
-                                    description: 'Optional: SecretRef is reference
-                                      to the authentication secret for User, default
-                                      is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  user:
-                                    description: 'Optional: User is the rados user
-                                      name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                    type: string
-                                required:
-                                - monitors
-                                type: object
-                              cinder:
-                                description: 'Cinder represents a cinder volume attached
-                                  and mounted on kubelets host machine. More info:
-                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                    type: string
-                                  readOnly:
-                                    description: 'Optional: Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                    type: boolean
-                                  secretRef:
-                                    description: 'Optional: points to a secret object
-                                      containing parameters used to connect to OpenStack.'
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  volumeID:
-                                    description: 'volume id used to identify the volume
-                                      in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                    type: string
-                                required:
-                                - volumeID
-                                type: object
-                              configMap:
-                                description: ConfigMap represents a configMap that
-                                  should populate this volume
-                                properties:
-                                  defaultMode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on created files by default. Must
-                                      be an octal value between 0000 and 0777 or a
-                                      decimal value between 0 and 511. YAML accepts
-                                      both octal and decimal values, JSON requires
-                                      decimal values for mode bits. Defaults to 0644.
-                                      Directories within the path are not affected
-                                      by this setting. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
-                                    format: int32
-                                    type: integer
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file. Must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or
-                                      its keys must be defined
-                                    type: boolean
-                                type: object
-                              csi:
-                                description: CSI (Container Storage Interface) represents
-                                  ephemeral storage that is handled by certain external
-                                  CSI drivers (Beta feature).
-                                properties:
-                                  driver:
-                                    description: Driver is the name of the CSI driver
-                                      that handles this volume. Consult with your
-                                      admin for the correct name as registered in
-                                      the cluster.
-                                    type: string
-                                  fsType:
-                                    description: Filesystem type to mount. Ex. "ext4",
-                                      "xfs", "ntfs". If not provided, the empty value
-                                      is passed to the associated CSI driver which
-                                      will determine the default filesystem to apply.
-                                    type: string
-                                  nodePublishSecretRef:
-                                    description: NodePublishSecretRef is a reference
-                                      to the secret object containing sensitive information
-                                      to pass to the CSI driver to complete the CSI
-                                      NodePublishVolume and NodeUnpublishVolume calls.
-                                      This field is optional, and  may be empty if
-                                      no secret is required. If the secret object
-                                      contains more than one secret, all secret references
-                                      are passed.
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  readOnly:
-                                    description: Specifies a read-only configuration
-                                      for the volume. Defaults to false (read/write).
-                                    type: boolean
-                                  volumeAttributes:
-                                    additionalProperties:
-                                      type: string
-                                    description: VolumeAttributes stores driver-specific
-                                      properties that are passed to the CSI driver.
-                                      Consult your driver's documentation for supported
-                                      values.
-                                    type: object
-                                required:
-                                - driver
-                                type: object
-                              downwardAPI:
-                                description: DownwardAPI represents downward API about
-                                  the pod that should populate this volume
-                                properties:
-                                  defaultMode:
-                                    description: 'Optional: mode bits to use on created
-                                      files by default. Must be a Optional: mode bits
-                                      used to set permissions on created files by
-                                      default. Must be an octal value between 0000
-                                      and 0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal values,
-                                      JSON requires decimal values for mode bits.
-                                      Defaults to 0644. Directories within the path
-                                      are not affected by this setting. This might
-                                      be in conflict with other options that affect
-                                      the file mode, like fsGroup, and the result
-                                      can be other mode bits set.'
-                                    format: int32
-                                    type: integer
-                                  items:
-                                    description: Items is a list of downward API volume
-                                      file
-                                    items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
-                                      properties:
-                                        fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
-                                          properties:
-                                            apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
-                                              type: string
-                                            fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file, must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
-                                          type: string
-                                        resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
-                                          properties:
-                                            containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              description: 'Required: resource to
-                                                select'
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              emptyDir:
-                                description: 'EmptyDir represents a temporary directory
-                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                properties:
-                                  medium:
-                                    description: 'What type of storage medium should
-                                      back this directory. The default is "" which
-                                      means to use the node''s default medium. Must
-                                      be an empty string (default) or Memory. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                    type: string
-                                  sizeLimit:
-                                    anyOf:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
                                     - type: integer
                                     - type: string
-                                    description: 'Total amount of local storage required
-                                      for this EmptyDir volume. The size limit is
-                                      also applicable for memory medium. The maximum
-                                      usage on memory medium EmptyDir would be the
-                                      minimum value between the SizeLimit specified
-                                      here and the sum of memory limits of all containers
-                                      in a pod. The default is nil which means that
-                                      the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
-                              ephemeral:
-                                description: "Ephemeral represents a volume that is
-                                  handled by a cluster storage driver. The volume's
-                                  lifecycle is tied to the pod that defines it - it
-                                  will be created before the pod starts, and deleted
-                                  when the pod is removed. \n Use this if: a) the
-                                  volume is only needed while the pod runs, b) features
-                                  of normal volumes like restoring from snapshot or
-                                  capacity    tracking are needed, c) the storage
-                                  driver is specified through a storage class, and
-                                  d) the storage driver supports dynamic volume provisioning
-                                  through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                                  for more    information on the connection between
-                                  this volume type    and PersistentVolumeClaim).
-                                  \n Use PersistentVolumeClaim or one of the vendor-specific
-                                  APIs for volumes that persist for longer than the
-                                  lifecycle of an individual pod. \n Use CSI for light-weight
-                                  local ephemeral volumes if the CSI driver is meant
-                                  to be used that way - see the documentation of the
-                                  driver for more information. \n A pod can use both
-                                  types of ephemeral volumes and persistent volumes
-                                  at the same time. \n This is a beta feature and
-                                  only available when the GenericEphemeralVolume feature
-                                  gate is enabled."
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          agentVolumeMounts:
+                            description: AgentVolumeMounts to be added to Agent container.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                          members:
+                            description: members is the number of Scylla instances in this rack.
+                            format: int32
+                            type: integer
+                          name:
+                            description: name is the name of the Scylla Rack. Used in the cassandra-rackdc.properties file.
+                            type: string
+                          placement:
+                            description: placement describes restrictions for the nodes Scylla is scheduled on.
+                            properties:
+                              nodeAffinity:
+                                description: nodeAffinity describes node affinity scheduling rules for the pod.
                                 properties:
-                                  volumeClaimTemplate:
-                                    description: "Will be used to create a stand-alone
-                                      PVC to provision the volume. The pod in which
-                                      this EphemeralVolumeSource is embedded will
-                                      be the owner of the PVC, i.e. the PVC will be
-                                      deleted together with the pod.  The name of
-                                      the PVC will be `<pod name>-<volume name>` where
-                                      `<volume name>` is the name from the `PodSpec.Volumes`
-                                      array entry. Pod validation will reject the
-                                      pod if the concatenated name is not valid for
-                                      a PVC (for example, too long). \n An existing
-                                      PVC with that name that is not owned by the
-                                      pod will *not* be used for the pod to avoid
-                                      using an unrelated volume by mistake. Starting
-                                      the pod is then blocked until the unrelated
-                                      PVC is removed. If such a pre-created PVC is
-                                      meant to be used by the pod, the PVC has to
-                                      updated with an owner reference to the pod once
-                                      the pod exists. Normally this should not be
-                                      necessary, but it may be useful when manually
-                                      reconstructing a broken cluster. \n This field
-                                      is read-only and no changes will be made by
-                                      Kubernetes to the PVC after it has been created.
-                                      \n Required, must not be nil."
-                                    properties:
-                                      metadata:
-                                        description: May contain labels and annotations
-                                          that will be copied into the PVC when creating
-                                          it. No other fields are allowed and will
-                                          be rejected during validation.
-                                        type: object
-                                      spec:
-                                        description: The specification for the PersistentVolumeClaim.
-                                          The entire content is copied unchanged into
-                                          the PVC that gets created from this template.
-                                          The same fields as in a PersistentVolumeClaim
-                                          are also valid here.
-                                        properties:
-                                          accessModes:
-                                            description: 'AccessModes contains the
-                                              desired access modes the volume should
-                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                            items:
-                                              type: string
-                                            type: array
-                                          dataSource:
-                                            description: 'This field can be used to
-                                              specify either: * An existing VolumeSnapshot
-                                              object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                              * An existing PVC (PersistentVolumeClaim)
-                                              * An existing custom resource that implements
-                                              data population (Alpha) In order to
-                                              use custom resource types that implement
-                                              data population, the AnyVolumeDataSource
-                                              feature gate must be enabled. If the
-                                              provisioner or an external controller
-                                              can support the specified data source,
-                                              it will create a new volume based on
-                                              the contents of the specified data source.'
-                                            properties:
-                                              apiGroup:
-                                                description: APIGroup is the group
-                                                  for the resource being referenced.
-                                                  If APIGroup is not specified, the
-                                                  specified Kind must be in the core
-                                                  API group. For any other third-party
-                                                  types, APIGroup is required.
-                                                type: string
-                                              kind:
-                                                description: Kind is the type of resource
-                                                  being referenced
-                                                type: string
-                                              name:
-                                                description: Name is the name of resource
-                                                  being referenced
-                                                type: string
-                                            required:
-                                            - kind
-                                            - name
-                                            type: object
-                                          resources:
-                                            description: 'Resources represents the
-                                              minimum resources the volume should
-                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                            properties:
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                description: 'Limits describes the
-                                                  maximum amount of compute resources
-                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                description: 'Requests describes the
-                                                  minimum amount of compute resources
-                                                  required. If Requests is omitted
-                                                  for a container, it defaults to
-                                                  Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined
-                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                                type: object
-                                            type: object
-                                          selector:
-                                            description: A label query over volumes
-                                              to consider for binding.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                      properties:
+                                        preference:
+                                          description: A node selector term, associated with the corresponding weight.
+                                          properties:
+                                            matchExpressions:
+                                              description: A list of node selector requirements by node's labels.
+                                              items:
+                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    items:
                                                       type: string
-                                                    operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
+                                                    type: array
+                                                required:
                                                   - key
                                                   - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
                                                 type: object
-                                            type: object
-                                          storageClassName:
-                                            description: 'Name of the StorageClass
-                                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                            type: string
-                                          volumeMode:
-                                            description: volumeMode defines what type
-                                              of volume is required by the claim.
-                                              Value of Filesystem is implied when
-                                              not included in claim spec.
-                                            type: string
-                                          volumeName:
-                                            description: VolumeName is the binding
-                                              reference to the PersistentVolume backing
-                                              this claim.
-                                            type: string
-                                        type: object
-                                    required:
-                                    - spec
-                                    type: object
-                                type: object
-                              fc:
-                                description: FC represents a Fibre Channel resource
-                                  that is attached to a kubelet's host machine and
-                                  then exposed to the pod.
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. TODO:
-                                      how do we prevent errors in the filesystem from
-                                      compromising the machine'
-                                    type: string
-                                  lun:
-                                    description: 'Optional: FC target lun number'
-                                    format: int32
-                                    type: integer
-                                  readOnly:
-                                    description: 'Optional: Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.'
-                                    type: boolean
-                                  targetWWNs:
-                                    description: 'Optional: FC target worldwide names
-                                      (WWNs)'
-                                    items:
-                                      type: string
-                                    type: array
-                                  wwids:
-                                    description: 'Optional: FC volume world wide identifiers
-                                      (wwids) Either wwids or combination of targetWWNs
-                                      and lun must be set, but not both simultaneously.'
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              flexVolume:
-                                description: FlexVolume represents a generic volume
-                                  resource that is provisioned/attached using an exec
-                                  based plugin.
-                                properties:
-                                  driver:
-                                    description: Driver is the name of the driver
-                                      to use for this volume.
-                                    type: string
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". The default
-                                      filesystem depends on FlexVolume script.
-                                    type: string
-                                  options:
-                                    additionalProperties:
-                                      type: string
-                                    description: 'Optional: Extra command options
-                                      if any.'
-                                    type: object
-                                  readOnly:
-                                    description: 'Optional: Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.'
-                                    type: boolean
-                                  secretRef:
-                                    description: 'Optional: SecretRef is reference
-                                      to the secret object containing sensitive information
-                                      to pass to the plugin scripts. This may be empty
-                                      if no secret object is specified. If the secret
-                                      object contains more than one secret, all secrets
-                                      are passed to the plugin scripts.'
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                required:
-                                - driver
-                                type: object
-                              flocker:
-                                description: Flocker represents a Flocker volume attached
-                                  to a kubelet's host machine. This depends on the
-                                  Flocker control service being running
-                                properties:
-                                  datasetName:
-                                    description: Name of the dataset stored as metadata
-                                      -> name on the dataset for Flocker should be
-                                      considered as deprecated
-                                    type: string
-                                  datasetUUID:
-                                    description: UUID of the dataset. This is unique
-                                      identifier of a Flocker dataset
-                                    type: string
-                                type: object
-                              gcePersistentDisk:
-                                description: 'GCEPersistentDisk represents a GCE Disk
-                                  resource that is attached to a kubelet''s host machine
-                                  and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type of the volume that
-                                      you want to mount. Tip: Ensure that the filesystem
-                                      type is supported by the host operating system.
-                                      Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
-                                    type: string
-                                  partition:
-                                    description: 'The partition in the volume that
-                                      you want to mount. If omitted, the default is
-                                      to mount by volume name. Examples: For volume
-                                      /dev/sda1, you specify the partition as "1".
-                                      Similarly, the volume partition for /dev/sda
-                                      is "0" (or you can leave the property empty).
-                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                    format: int32
-                                    type: integer
-                                  pdName:
-                                    description: 'Unique name of the PD resource in
-                                      GCE. Used to identify the disk in GCE. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                    type: string
-                                  readOnly:
-                                    description: 'ReadOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                    type: boolean
-                                required:
-                                - pdName
-                                type: object
-                              gitRepo:
-                                description: 'GitRepo represents a git repository
-                                  at a particular revision. DEPRECATED: GitRepo is
-                                  deprecated. To provision a container with a git
-                                  repo, mount an EmptyDir into an InitContainer that
-                                  clones the repo using git, then mount the EmptyDir
-                                  into the Pod''s container.'
-                                properties:
-                                  directory:
-                                    description: Target directory name. Must not contain
-                                      or start with '..'.  If '.' is supplied, the
-                                      volume directory will be the git repository.  Otherwise,
-                                      if specified, the volume will contain the git
-                                      repository in the subdirectory with the given
-                                      name.
-                                    type: string
-                                  repository:
-                                    description: Repository URL
-                                    type: string
-                                  revision:
-                                    description: Commit hash for the specified revision.
-                                    type: string
-                                required:
-                                - repository
-                                type: object
-                              glusterfs:
-                                description: 'Glusterfs represents a Glusterfs mount
-                                  on the host that shares a pod''s lifetime. More
-                                  info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                                properties:
-                                  endpoints:
-                                    description: 'EndpointsName is the endpoint name
-                                      that details Glusterfs topology. More info:
-                                      https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                                    type: string
-                                  path:
-                                    description: 'Path is the Glusterfs volume path.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                                    type: string
-                                  readOnly:
-                                    description: 'ReadOnly here will force the Glusterfs
-                                      volume to be mounted with read-only permissions.
-                                      Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                                    type: boolean
-                                required:
-                                - endpoints
-                                - path
-                                type: object
-                              hostPath:
-                                description: 'HostPath represents a pre-existing file
-                                  or directory on the host machine that is directly
-                                  exposed to the container. This is generally used
-                                  for system agents or other privileged things that
-                                  are allowed to see the host machine. Most containers
-                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                  --- TODO(jonesdl) We need to restrict who can use
-                                  host directory mounts and who can/can not mount
-                                  host directories as read/write.'
-                                properties:
-                                  path:
-                                    description: 'Path of the directory on the host.
-                                      If the path is a symlink, it will follow the
-                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                                    type: string
-                                  type:
-                                    description: 'Type for HostPath Volume Defaults
-                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                              iscsi:
-                                description: 'ISCSI represents an ISCSI Disk resource
-                                  that is attached to a kubelet''s host machine and
-                                  then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                                properties:
-                                  chapAuthDiscovery:
-                                    description: whether support iSCSI Discovery CHAP
-                                      authentication
-                                    type: boolean
-                                  chapAuthSession:
-                                    description: whether support iSCSI Session CHAP
-                                      authentication
-                                    type: boolean
-                                  fsType:
-                                    description: 'Filesystem type of the volume that
-                                      you want to mount. Tip: Ensure that the filesystem
-                                      type is supported by the host operating system.
-                                      Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
-                                    type: string
-                                  initiatorName:
-                                    description: Custom iSCSI Initiator Name. If initiatorName
-                                      is specified with iscsiInterface simultaneously,
-                                      new iSCSI interface <target portal>:<volume
-                                      name> will be created for the connection.
-                                    type: string
-                                  iqn:
-                                    description: Target iSCSI Qualified Name.
-                                    type: string
-                                  iscsiInterface:
-                                    description: iSCSI Interface Name that uses an
-                                      iSCSI transport. Defaults to 'default' (tcp).
-                                    type: string
-                                  lun:
-                                    description: iSCSI Target Lun number.
-                                    format: int32
-                                    type: integer
-                                  portals:
-                                    description: iSCSI Target Portal List. The portal
-                                      is either an IP or ip_addr:port if the port
-                                      is other than default (typically TCP ports 860
-                                      and 3260).
-                                    items:
-                                      type: string
-                                    type: array
-                                  readOnly:
-                                    description: ReadOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                    type: boolean
-                                  secretRef:
-                                    description: CHAP Secret for iSCSI target and
-                                      initiator authentication
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  targetPortal:
-                                    description: iSCSI Target Portal. The Portal is
-                                      either an IP or ip_addr:port if the port is
-                                      other than default (typically TCP ports 860
-                                      and 3260).
-                                    type: string
-                                required:
-                                - iqn
-                                - lun
-                                - targetPortal
-                                type: object
-                              name:
-                                description: 'Volume''s name. Must be a DNS_LABEL
-                                  and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                              nfs:
-                                description: 'NFS represents an NFS mount on the host
-                                  that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                properties:
-                                  path:
-                                    description: 'Path that is exported by the NFS
-                                      server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                    type: string
-                                  readOnly:
-                                    description: 'ReadOnly here will force the NFS
-                                      export to be mounted with read-only permissions.
-                                      Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                    type: boolean
-                                  server:
-                                    description: 'Server is the hostname or IP address
-                                      of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                    type: string
-                                required:
-                                - path
-                                - server
-                                type: object
-                              persistentVolumeClaim:
-                                description: 'PersistentVolumeClaimVolumeSource represents
-                                  a reference to a PersistentVolumeClaim in the same
-                                  namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                properties:
-                                  claimName:
-                                    description: 'ClaimName is the name of a PersistentVolumeClaim
-                                      in the same namespace as the pod using this
-                                      volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                    type: string
-                                  readOnly:
-                                    description: Will force the ReadOnly setting in
-                                      VolumeMounts. Default false.
-                                    type: boolean
-                                required:
-                                - claimName
-                                type: object
-                              photonPersistentDisk:
-                                description: PhotonPersistentDisk represents a PhotonController
-                                  persistent disk attached and mounted on kubelets
-                                  host machine
-                                properties:
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified.
-                                    type: string
-                                  pdID:
-                                    description: ID that identifies Photon Controller
-                                      persistent disk
-                                    type: string
-                                required:
-                                - pdID
-                                type: object
-                              portworxVolume:
-                                description: PortworxVolume represents a portworx
-                                  volume attached and mounted on kubelets host machine
-                                properties:
-                                  fsType:
-                                    description: FSType represents the filesystem
-                                      type to mount Must be a filesystem type supported
-                                      by the host operating system. Ex. "ext4", "xfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
-                                    type: string
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                  volumeID:
-                                    description: VolumeID uniquely identifies a Portworx
-                                      volume
-                                    type: string
-                                required:
-                                - volumeID
-                                type: object
-                              projected:
-                                description: Items for all in one resources secrets,
-                                  configmaps, and downward API
-                                properties:
-                                  defaultMode:
-                                    description: Mode bits used to set permissions
-                                      on created files by default. Must be an octal
-                                      value between 0000 and 0777 or a decimal value
-                                      between 0 and 511. YAML accepts both octal and
-                                      decimal values, JSON requires decimal values
-                                      for mode bits. Directories within the path are
-                                      not affected by this setting. This might be
-                                      in conflict with other options that affect the
-                                      file mode, like fsGroup, and the result can
-                                      be other mode bits set.
-                                    format: int32
-                                    type: integer
-                                  sources:
-                                    description: list of volume projections
-                                    items:
-                                      description: Projection that may be projected
-                                        along with other supported volume types
-                                      properties:
-                                        configMap:
-                                          description: information about the configMap
-                                            data to project
-                                          properties:
-                                            items:
-                                              description: If unspecified, each key-value
-                                                pair in the Data field of the referenced
-                                                ConfigMap will be projected into the
-                                                volume as a file whose name is the
-                                                key and content is the value. If specified,
-                                                the listed keys will be projected
-                                                into the specified paths, and unlisted
-                                                keys will not be present. If a key
-                                                is specified which is not present
-                                                in the ConfigMap, the volume setup
-                                                will error unless it is marked optional.
-                                                Paths must be relative and may not
-                                                contain the '..' path or start with
-                                                '..'.
+                                              type: array
+                                            matchFields:
+                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: Maps a string key to
-                                                  a path within a volume.
+                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: The label key that the selector applies to.
                                                     type: string
-                                                  mode:
-                                                    description: 'Optional: mode bits
-                                                      used to set permissions on this
-                                                      file. Must be an octal value
-                                                      between 0000 and 0777 or a decimal
-                                                      value between 0 and 511. YAML
-                                                      accepts both octal and decimal
-                                                      values, JSON requires decimal
-                                                      values for mode bits. If not
-                                                      specified, the volume defaultMode
-                                                      will be used. This might be
-                                                      in conflict with other options
-                                                      that affect the file mode, like
-                                                      fsGroup, and the result can
-                                                      be other mode bits set.'
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    description: The relative path
-                                                      of the file to map the key to.
-                                                      May not be an absolute path.
-                                                      May not contain the path element
-                                                      '..'. May not start with the
-                                                      string '..'.
+                                                  operator:
+                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
+                                                  values:
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
                                                 required:
-                                                - key
-                                                - path
-                                                type: object
-                                              type: array
-                                            name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
-                                              type: string
-                                            optional:
-                                              description: Specify whether the ConfigMap
-                                                or its keys must be defined
-                                              type: boolean
-                                          type: object
-                                        downwardAPI:
-                                          description: information about the downwardAPI
-                                            data to project
-                                          properties:
-                                            items:
-                                              description: Items is a list of DownwardAPIVolume
-                                                file
-                                              items:
-                                                description: DownwardAPIVolumeFile
-                                                  represents information to create
-                                                  the file containing the pod field
-                                                properties:
-                                                  fieldRef:
-                                                    description: 'Required: Selects
-                                                      a field of the pod: only annotations,
-                                                      labels, name and namespace are
-                                                      supported.'
-                                                    properties:
-                                                      apiVersion:
-                                                        description: Version of the
-                                                          schema the FieldPath is
-                                                          written in terms of, defaults
-                                                          to "v1".
-                                                        type: string
-                                                      fieldPath:
-                                                        description: Path of the field
-                                                          to select in the specified
-                                                          API version.
-                                                        type: string
-                                                    required:
-                                                    - fieldPath
-                                                    type: object
-                                                  mode:
-                                                    description: 'Optional: mode bits
-                                                      used to set permissions on this
-                                                      file, must be an octal value
-                                                      between 0000 and 0777 or a decimal
-                                                      value between 0 and 511. YAML
-                                                      accepts both octal and decimal
-                                                      values, JSON requires decimal
-                                                      values for mode bits. If not
-                                                      specified, the volume defaultMode
-                                                      will be used. This might be
-                                                      in conflict with other options
-                                                      that affect the file mode, like
-                                                      fsGroup, and the result can
-                                                      be other mode bits set.'
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    description: 'Required: Path is  the
-                                                      relative path name of the file
-                                                      to be created. Must not be absolute
-                                                      or contain the ''..'' path.
-                                                      Must be utf-8 encoded. The first
-                                                      item of the relative path must
-                                                      not start with ''..'''
-                                                    type: string
-                                                  resourceFieldRef:
-                                                    description: 'Selects a resource
-                                                      of the container: only resources
-                                                      limits and requests (limits.cpu,
-                                                      limits.memory, requests.cpu
-                                                      and requests.memory) are currently
-                                                      supported.'
-                                                    properties:
-                                                      containerName:
-                                                        description: 'Container name:
-                                                          required for volumes, optional
-                                                          for env vars'
-                                                        type: string
-                                                      divisor:
-                                                        anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                        description: Specifies the
-                                                          output format of the exposed
-                                                          resources, defaults to "1"
-                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                        x-kubernetes-int-or-string: true
-                                                      resource:
-                                                        description: 'Required: resource
-                                                          to select'
-                                                        type: string
-                                                    required:
-                                                    - resource
-                                                    type: object
-                                                required:
-                                                - path
+                                                  - key
+                                                  - operator
                                                 type: object
                                               type: array
                                           type: object
-                                        secret:
-                                          description: information about the secret
-                                            data to project
-                                          properties:
-                                            items:
-                                              description: If unspecified, each key-value
-                                                pair in the Data field of the referenced
-                                                Secret will be projected into the
-                                                volume as a file whose name is the
-                                                key and content is the value. If specified,
-                                                the listed keys will be projected
-                                                into the specified paths, and unlisted
-                                                keys will not be present. If a key
-                                                is specified which is not present
-                                                in the Secret, the volume setup will
-                                                error unless it is marked optional.
-                                                Paths must be relative and may not
-                                                contain the '..' path or start with
-                                                '..'.
-                                              items:
-                                                description: Maps a string key to
-                                                  a path within a volume.
-                                                properties:
-                                                  key:
-                                                    description: The key to project.
-                                                    type: string
-                                                  mode:
-                                                    description: 'Optional: mode bits
-                                                      used to set permissions on this
-                                                      file. Must be an octal value
-                                                      between 0000 and 0777 or a decimal
-                                                      value between 0 and 511. YAML
-                                                      accepts both octal and decimal
-                                                      values, JSON requires decimal
-                                                      values for mode bits. If not
-                                                      specified, the volume defaultMode
-                                                      will be used. This might be
-                                                      in conflict with other options
-                                                      that affect the file mode, like
-                                                      fsGroup, and the result can
-                                                      be other mode bits set.'
-                                                    format: int32
-                                                    type: integer
-                                                  path:
-                                                    description: The relative path
-                                                      of the file to map the key to.
-                                                      May not be an absolute path.
-                                                      May not contain the path element
-                                                      '..'. May not start with the
-                                                      string '..'.
-                                                    type: string
-                                                required:
-                                                - key
-                                                - path
-                                                type: object
-                                              type: array
-                                            name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
-                                              type: string
-                                            optional:
-                                              description: Specify whether the Secret
-                                                or its key must be defined
-                                              type: boolean
-                                          type: object
-                                        serviceAccountToken:
-                                          description: information about the serviceAccountToken
-                                            data to project
-                                          properties:
-                                            audience:
-                                              description: Audience is the intended
-                                                audience of the token. A recipient
-                                                of a token must identify itself with
-                                                an identifier specified in the audience
-                                                of the token, and otherwise should
-                                                reject the token. The audience defaults
-                                                to the identifier of the apiserver.
-                                              type: string
-                                            expirationSeconds:
-                                              description: ExpirationSeconds is the
-                                                requested duration of validity of
-                                                the service account token. As the
-                                                token approaches expiration, the kubelet
-                                                volume plugin will proactively rotate
-                                                the service account token. The kubelet
-                                                will start trying to rotate the token
-                                                if the token is older than 80 percent
-                                                of its time to live or if the token
-                                                is older than 24 hours.Defaults to
-                                                1 hour and must be at least 10 minutes.
-                                              format: int64
-                                              type: integer
-                                            path:
-                                              description: Path is the path relative
-                                                to the mount point of the file to
-                                                project the token into.
-                                              type: string
-                                          required:
-                                          - path
-                                          type: object
-                                      type: object
-                                    type: array
-                                type: object
-                              quobyte:
-                                description: Quobyte represents a Quobyte mount on
-                                  the host that shares a pod's lifetime
-                                properties:
-                                  group:
-                                    description: Group to map volume access to Default
-                                      is no group
-                                    type: string
-                                  readOnly:
-                                    description: ReadOnly here will force the Quobyte
-                                      volume to be mounted with read-only permissions.
-                                      Defaults to false.
-                                    type: boolean
-                                  registry:
-                                    description: Registry represents a single or multiple
-                                      Quobyte Registry services specified as a string
-                                      as host:port pair (multiple entries are separated
-                                      with commas) which acts as the central registry
-                                      for volumes
-                                    type: string
-                                  tenant:
-                                    description: Tenant owning the given Quobyte volume
-                                      in the Backend Used with dynamically provisioned
-                                      Quobyte volumes, value is set by the plugin
-                                    type: string
-                                  user:
-                                    description: User to map volume access to Defaults
-                                      to serivceaccount user
-                                    type: string
-                                  volume:
-                                    description: Volume is a string that references
-                                      an already created Quobyte volume by name.
-                                    type: string
-                                required:
-                                - registry
-                                - volume
-                                type: object
-                              rbd:
-                                description: 'RBD represents a Rados Block Device
-                                  mount on the host that shares a pod''s lifetime.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md'
-                                properties:
-                                  fsType:
-                                    description: 'Filesystem type of the volume that
-                                      you want to mount. Tip: Ensure that the filesystem
-                                      type is supported by the host operating system.
-                                      Examples: "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
-                                    type: string
-                                  image:
-                                    description: 'The rados image name. More info:
-                                      https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: string
-                                  keyring:
-                                    description: 'Keyring is the path to key ring
-                                      for RBDUser. Default is /etc/ceph/keyring. More
-                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: string
-                                  monitors:
-                                    description: 'A collection of Ceph monitors. More
-                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    items:
-                                      type: string
-                                    type: array
-                                  pool:
-                                    description: 'The rados pool name. Default is
-                                      rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: string
-                                  readOnly:
-                                    description: 'ReadOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: boolean
-                                  secretRef:
-                                    description: 'SecretRef is name of the authentication
-                                      secret for RBDUser. If provided overrides keyring.
-                                      Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  user:
-                                    description: 'The rados user name. Default is
-                                      admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                    type: string
-                                required:
-                                - image
-                                - monitors
-                                type: object
-                              scaleIO:
-                                description: ScaleIO represents a ScaleIO persistent
-                                  volume attached and mounted on Kubernetes nodes.
-                                properties:
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Default is
-                                      "xfs".
-                                    type: string
-                                  gateway:
-                                    description: The host address of the ScaleIO API
-                                      Gateway.
-                                    type: string
-                                  protectionDomain:
-                                    description: The name of the ScaleIO Protection
-                                      Domain for the configured storage.
-                                    type: string
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                  secretRef:
-                                    description: SecretRef references to the secret
-                                      for ScaleIO user and other sensitive information.
-                                      If this is not provided, Login operation will
-                                      fail.
-                                    properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                    type: object
-                                  sslEnabled:
-                                    description: Flag to enable/disable SSL communication
-                                      with Gateway, default false
-                                    type: boolean
-                                  storageMode:
-                                    description: Indicates whether the storage for
-                                      a volume should be ThickProvisioned or ThinProvisioned.
-                                      Default is ThinProvisioned.
-                                    type: string
-                                  storagePool:
-                                    description: The ScaleIO Storage Pool associated
-                                      with the protection domain.
-                                    type: string
-                                  system:
-                                    description: The name of the storage system as
-                                      configured in ScaleIO.
-                                    type: string
-                                  volumeName:
-                                    description: The name of a volume already created
-                                      in the ScaleIO system that is associated with
-                                      this volume source.
-                                    type: string
-                                required:
-                                - gateway
-                                - secretRef
-                                - system
-                                type: object
-                              secret:
-                                description: 'Secret represents a secret that should
-                                  populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                properties:
-                                  defaultMode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on created files by default. Must
-                                      be an octal value between 0000 and 0777 or a
-                                      decimal value between 0 and 511. YAML accepts
-                                      both octal and decimal values, JSON requires
-                                      decimal values for mode bits. Defaults to 0644.
-                                      Directories within the path are not affected
-                                      by this setting. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
-                                    format: int32
-                                    type: integer
-                                  items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose
-                                      name is the key and content is the value. If
-                                      specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: The key to project.
-                                          type: string
-                                        mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file. Must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                        weight:
+                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                           format: int32
                                           type: integer
-                                        path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element
-                                            '..'. May not start with the string '..'.
-                                          type: string
                                       required:
-                                      - key
-                                      - path
+                                        - preference
+                                        - weight
                                       type: object
                                     type: array
-                                  optional:
-                                    description: Specify whether the Secret or its
-                                      keys must be defined
-                                    type: boolean
-                                  secretName:
-                                    description: 'Name of the secret in the pod''s
-                                      namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                    type: string
-                                type: object
-                              storageos:
-                                description: StorageOS represents a StorageOS volume
-                                  attached and mounted on Kubernetes nodes.
-                                properties:
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified.
-                                    type: string
-                                  readOnly:
-                                    description: Defaults to false (read/write). ReadOnly
-                                      here will force the ReadOnly setting in VolumeMounts.
-                                    type: boolean
-                                  secretRef:
-                                    description: SecretRef specifies the secret to
-                                      use for obtaining the StorageOS API credentials.  If
-                                      not specified, default values will be attempted.
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                     properties:
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
+                                      nodeSelectorTerms:
+                                        description: Required. A list of node selector terms. The terms are ORed.
+                                        items:
+                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                          properties:
+                                            matchExpressions:
+                                              description: A list of node selector requirements by node's labels.
+                                              items:
+                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchFields:
+                                              description: A list of node selector requirements by node's fields.
+                                              items:
+                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                          type: object
+                                        type: array
+                                    required:
+                                      - nodeSelectorTerms
                                     type: object
-                                  volumeName:
-                                    description: VolumeName is the human-readable
-                                      name of the StorageOS volume.  Volume names
-                                      are only unique within a namespace.
-                                    type: string
-                                  volumeNamespace:
-                                    description: VolumeNamespace specifies the scope
-                                      of the volume within StorageOS.  If no namespace
-                                      is specified then the Pod's namespace will be
-                                      used.  This allows the Kubernetes name scoping
-                                      to be mirrored within StorageOS for tighter
-                                      integration. Set VolumeName to any name to override
-                                      the default behaviour. Set to "default" if you
-                                      are not using namespaces within StorageOS. Namespaces
-                                      that do not pre-exist within StorageOS will
-                                      be created.
-                                    type: string
                                 type: object
-                              vsphereVolume:
-                                description: VsphereVolume represents a vSphere volume
-                                  attached and mounted on kubelets host machine
+                              podAffinity:
+                                description: podAffinity describes pod affinity scheduling rules.
                                 properties:
-                                  fsType:
-                                    description: Filesystem type to mount. Must be
-                                      a filesystem type supported by the host operating
-                                      system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                      inferred to be "ext4" if unspecified.
-                                    type: string
-                                  storagePolicyID:
-                                    description: Storage Policy Based Management (SPBM)
-                                      profile ID associated with the StoragePolicyName.
-                                    type: string
-                                  storagePolicyName:
-                                    description: Storage Policy Based Management (SPBM)
-                                      profile name.
-                                    type: string
-                                  volumePath:
-                                    description: Path that identifies vSphere volume
-                                      vmdk
-                                    type: string
-                                required:
-                                - volumePath
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      properties:
+                                        podAffinityTerm:
+                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                            - topologyKey
+                                          type: object
+                                        weight:
+                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                        - podAffinityTerm
+                                        - weight
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    items:
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    type: array
                                 type: object
-                            required:
-                            - name
+                              podAntiAffinity:
+                                description: podAntiAffinity describes pod anti-affinity scheduling rules.
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      properties:
+                                        podAffinityTerm:
+                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                            - topologyKey
+                                          type: object
+                                        weight:
+                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                        - podAffinityTerm
+                                        - weight
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    items:
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    type: array
+                                type: object
+                              tolerations:
+                                description: tolerations allow the pod to tolerate any taint that matches the triple <key,value,effect> using the matching operator.
+                                items:
+                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      type: string
+                                  type: object
+                                type: array
                             type: object
-                          type: array
-                      type: object
-                    type: array
-                type: object
-              developerMode:
-                description: developerMode determines if the cluster runs in developer-mode.
-                type: boolean
-              forceRedeploymentReason:
-                description: forceRedeploymentReason can be used to force a rolling
-                  update of all racks by providing a unique string.
-                type: string
-              genericUpgrade:
-                description: genericUpgrade allows to configure behavior of generic
-                  upgrade logic.
-                properties:
-                  failureStrategy:
-                    default: Retry
-                    description: failureStrategy specifies which logic is executed
-                      when upgrade failure happens. Currently only Retry is supported.
-                    type: string
-                  pollInterval:
-                    default: 1s
-                    description: pollInterval specifies how often upgrade logic polls
-                      on state updates. Increasing this value should lower number
-                      of requests sent to apiserver, but it may affect overall time
-                      spent during upgrade. DEPRECATED.
-                    type: string
-                type: object
-              imagePullSecrets:
-                description: imagePullSecrets is an optional list of references to
-                  secrets in the same namespace used for pulling Scylla and Agent
-                  images.
-                items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                type: array
-              network:
-                description: network holds the networking config.
-                properties:
-                  dnsPolicy:
-                    description: dnsPolicy defines how a pod's DNS will be configured.
-                    type: string
-                  hostNetworking:
-                    description: hostNetworking determines if scylla uses the host's
-                      network namespace. Setting this option avoids going through
-                      Kubernetes SDN and exposes scylla on node's IP.
-                    type: boolean
-                type: object
-              repairs:
-                description: repairs specify repair tasks in Scylla Manager. When
-                  Scylla Manager is not installed, these will be ignored.
-                items:
-                  properties:
-                    dc:
-                      description: dc is a list of datacenter glob patterns, e.g.
-                        'dc1', '!otherdc*' used to specify the DCs to include or exclude
-                        from backup.
-                      items:
-                        type: string
-                      type: array
-                    failFast:
-                      description: failFast indicates if a repair should be stopped
-                        on first error.
-                      type: boolean
-                    host:
-                      description: host specifies a host to repair. If empty, all
-                        hosts are repaired.
-                      type: string
-                    intensity:
-                      default: "1"
-                      description: intensity indicates how many token ranges (per
-                        shard) to repair in a single Scylla repair job. By default
-                        this is 1. If you set it to 0 the number of token ranges is
-                        adjusted to the maximum supported by node (see max_repair_ranges_in_parallel
-                        in Scylla logs). Valid values are 0 and integers >= 1. Higher
-                        values will result in increased cluster load and slightly
-                        faster repairs. Changing the intensity impacts repair granularity
-                        if you need to resume it, the higher the value the more work
-                        on resume. For Scylla clusters that *do not support row-level
-                        repair*, intensity can be a decimal between (0,1). In that
-                        case it specifies percent of shards that can be repaired in
-                        parallel on a repair master node. For Scylla clusters that
-                        are row-level repair enabled, setting intensity below 1 has
-                        the same effect as setting intensity 1.
-                      type: string
-                    interval:
-                      default: "0"
-                      description: interval represents a task schedule interval e.g.
-                        3d2h10m, valid units are d, h, m, s.
-                      type: string
-                    keyspace:
-                      description: keyspace is a list of keyspace/tables glob patterns,
-                        e.g. 'keyspace,!keyspace.table_prefix_*' used to include or
-                        exclude keyspaces from repair.
-                      items:
-                        type: string
-                      type: array
-                    name:
-                      description: name is a unique name of a task.
-                      type: string
-                    numRetries:
-                      default: 3
-                      description: numRetries indicates how many times a scheduled
-                        task will be retried before failing.
-                      format: int64
-                      type: integer
-                    parallel:
-                      default: 0
-                      description: 'parallel is the maximum number of Scylla repair
-                        jobs that can run at the same time (on different token ranges
-                        and replicas). Each node can take part in at most one repair
-                        at any given moment. By default the maximum possible parallelism
-                        is used. The effective parallelism depends on a keyspace replication
-                        factor (RF) and the number of nodes. The formula to calculate
-                        it is as follows: number of nodes / RF, ex. for 6 node cluster
-                        with RF=3 the maximum parallelism is 2.'
-                      format: int64
-                      type: integer
-                    smallTableThreshold:
-                      default: 1GiB
-                      description: smallTableThreshold enable small table optimization
-                        for tables of size lower than given threshold. Supported units
-                        [B, MiB, GiB, TiB].
-                      type: string
-                    startDate:
-                      default: now
-                      description: startDate specifies the task start date expressed
-                        in the RFC3339 format or now[+duration], e.g. now+3d2h10m,
-                        valid units are d, h, m, s.
-                      type: string
-                  type: object
-                type: array
-              repository:
-                default: docker.io/scylladb/scylla
-                description: repository is the image repository to pull the Scylla
-                  image from.
-                type: string
-              scyllaArgs:
-                description: scyllaArgs will be appended to Scylla binary during startup.
-                  This is supported from 4.2.0 Scylla version.
-                type: string
-              sysctls:
-                description: 'sysctls holds the sysctl properties to be applied during
-                  initialization given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
-                items:
-                  type: string
-                type: array
-              version:
-                description: version is a version tag of Scylla to use.
-                type: string
-            type: object
-          status:
-            description: status is the current status of this scylla cluster.
-            properties:
-              backups:
-                description: backups reflects status of backup tasks.
-                items:
-                  properties:
-                    dc:
-                      description: dc is a list of datacenter glob patterns, e.g.
-                        'dc1,!otherdc*' used to specify the DCs to include or exclude
-                        from backup.
-                      items:
-                        type: string
-                      type: array
-                    error:
-                      description: error holds the backup task error, if any.
-                      type: string
-                    id:
-                      description: id is the identification number of the backup task.
-                      type: string
-                    interval:
-                      default: "0"
-                      description: interval represents a task schedule interval e.g.
-                        3d2h10m, valid units are d, h, m, s.
-                      type: string
-                    keyspace:
-                      description: keyspace is a list of keyspace/tables glob patterns,
-                        e.g. 'keyspace,!keyspace.table_prefix_*' used to include or
-                        exclude keyspaces from repair.
-                      items:
-                        type: string
-                      type: array
-                    location:
-                      description: 'location is a list of backup locations in the
-                        format [<dc>:]<provider>:<name> ex. s3:my-bucket. The <dc>:
-                        part is optional and is only needed when different datacenters
-                        are being used to upload data to different locations. <name>
-                        must be an alphanumeric string and may contain a dash and
-                        or a dot, but other characters are forbidden. The only supported
-                        storage <provider> at the moment are s3 and gcs.'
-                      items:
-                        type: string
-                      type: array
-                    name:
-                      description: name is a unique name of a task.
-                      type: string
-                    numRetries:
-                      default: 3
-                      description: numRetries indicates how many times a scheduled
-                        task will be retried before failing.
-                      format: int64
-                      type: integer
-                    rateLimit:
-                      description: 'rateLimit is a list of megabytes (MiB) per second
-                        rate limits expressed in the format [<dc>:]<limit>. The <dc>:
-                        part is optional and only needed when different datacenters
-                        need different upload limits. Set to 0 for no limit (default
-                        100).'
-                      items:
-                        type: string
-                      type: array
-                    retention:
-                      default: 3
-                      description: retention is the number of backups which are to
-                        be stored.
-                      format: int64
-                      type: integer
-                    snapshotParallel:
-                      description: 'snapshotParallel is a list of snapshot parallelism
-                        limits in the format [<dc>:]<limit>. The <dc>: part is optional
-                        and allows for specifying different limits in selected datacenters.
-                        If The <dc>: part is not set, the limit is global (e.g. ''dc1:2,5'')
-                        the runs are parallel in n nodes (2 in dc1) and n nodes in
-                        all the other datacenters.'
-                      items:
-                        type: string
-                      type: array
-                    startDate:
-                      default: now
-                      description: startDate specifies the task start date expressed
-                        in the RFC3339 format or now[+duration], e.g. now+3d2h10m,
-                        valid units are d, h, m, s.
-                      type: string
-                    uploadParallel:
-                      description: 'uploadParallel is a list of upload parallelism
-                        limits in the format [<dc>:]<limit>. The <dc>: part is optional
-                        and allows for specifying different limits in selected datacenters.
-                        If The <dc>: part is not set the limit is global (e.g. ''dc1:2,5'')
-                        the runs are parallel in n nodes (2 in dc1) and n nodes in
-                        all the other datacenters.'
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                type: array
-              managerId:
-                description: managerId contains ID under which cluster was registered
-                  in Scylla Manager.
-                type: string
-              observedGeneration:
-                description: observedGeneration is the most recent generation observed
-                  for this ScyllaCluster. It corresponds to the ScyllaCluster's generation,
-                  which is updated on mutation by the API Server.
-                format: int64
-                type: integer
-              racks:
-                additionalProperties:
-                  description: RackStatus is the status of a Scylla Rack
-                  properties:
-                    conditions:
-                      description: conditions are the latest available observations
-                        of a rack's state.
-                      items:
-                        description: RackCondition is an observation about the state
-                          of a rack.
-                        properties:
-                          status:
-                            description: status represent condition status.
+                          resources:
+                            description: resources the Scylla container will use.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          scyllaAgentConfig:
+                            description: Scylla config map name to customize scylla manager agent
                             type: string
-                          type:
-                            description: type holds the condition type.
+                          scyllaConfig:
+                            description: Scylla config map name to customize scylla.yaml
                             type: string
+                          storage:
+                            description: storage describes the underlying storage that Scylla will consume.
+                            properties:
+                              capacity:
+                                description: capacity describes the requested size of each persistent volume.
+                                type: string
+                              storageClassName:
+                                description: storageClassName is the name of a storageClass to request.
+                                type: string
+                            type: object
+                          volumeMounts:
+                            description: VolumeMounts to be added to Scylla container.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                          volumes:
+                            description: Volumes added to Scylla Pod.
+                            items:
+                              description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                              properties:
+                                awsElasticBlockStore:
+                                  description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    partition:
+                                      description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      type: boolean
+                                    volumeID:
+                                      description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      type: string
+                                  required:
+                                    - volumeID
+                                  type: object
+                                azureDisk:
+                                  description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                  properties:
+                                    cachingMode:
+                                      description: 'Host Caching mode: None, Read Only, Read Write.'
+                                      type: string
+                                    diskName:
+                                      description: The Name of the data disk in the blob storage
+                                      type: string
+                                    diskURI:
+                                      description: The URI the data disk in the blob storage
+                                      type: string
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    kind:
+                                      description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                      type: string
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                  required:
+                                    - diskName
+                                    - diskURI
+                                  type: object
+                                azureFile:
+                                  description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                  properties:
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretName:
+                                      description: the name of secret that contains Azure Storage Account Name and Key
+                                      type: string
+                                    shareName:
+                                      description: Share Name
+                                      type: string
+                                  required:
+                                    - secretName
+                                    - shareName
+                                  type: object
+                                cephfs:
+                                  description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                  properties:
+                                    monitors:
+                                      description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      items:
+                                        type: string
+                                      type: array
+                                    path:
+                                      description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                      type: string
+                                    readOnly:
+                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      type: boolean
+                                    secretFile:
+                                      description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      type: string
+                                    secretRef:
+                                      description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    user:
+                                      description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      type: string
+                                  required:
+                                    - monitors
+                                  type: object
+                                cinder:
+                                  description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      type: string
+                                    readOnly:
+                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      type: boolean
+                                    secretRef:
+                                      description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    volumeID:
+                                      description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      type: string
+                                  required:
+                                    - volumeID
+                                  type: object
+                                configMap:
+                                  description: ConfigMap represents a configMap that should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its keys must be defined
+                                      type: boolean
+                                  type: object
+                                csi:
+                                  description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                                  properties:
+                                    driver:
+                                      description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                      type: string
+                                    fsType:
+                                      description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                      type: string
+                                    nodePublishSecretRef:
+                                      description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    readOnly:
+                                      description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                      type: object
+                                  required:
+                                    - driver
+                                  type: object
+                                downwardAPI:
+                                  description: DownwardAPI represents downward API about the pod that should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: Items is a list of downward API volume file
+                                      items:
+                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select in the specified API version.
+                                                type: string
+                                            required:
+                                              - fieldPath
+                                            type: object
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to select'
+                                                type: string
+                                            required:
+                                              - resource
+                                            type: object
+                                        required:
+                                          - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                emptyDir:
+                                  description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  properties:
+                                    medium:
+                                      description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      type: string
+                                    sizeLimit:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                ephemeral:
+                                  description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time. \n This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled."
+                                  properties:
+                                    volumeClaimTemplate:
+                                      description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
+                                      properties:
+                                        metadata:
+                                          description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                          type: object
+                                        spec:
+                                          description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                          properties:
+                                            accessModes:
+                                              description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                              items:
+                                                type: string
+                                              type: array
+                                            dataSource:
+                                              description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) * An existing custom resource that implements data population (Alpha) In order to use custom resource types that implement data population, the AnyVolumeDataSource feature gate must be enabled. If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source.'
+                                              properties:
+                                                apiGroup:
+                                                  description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                  type: string
+                                                kind:
+                                                  description: Kind is the type of resource being referenced
+                                                  type: string
+                                                name:
+                                                  description: Name is the name of resource being referenced
+                                                  type: string
+                                              required:
+                                                - kind
+                                                - name
+                                              type: object
+                                            resources:
+                                              description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  type: object
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              description: A label query over volumes to consider for binding.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                            storageClassName:
+                                              description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                              type: string
+                                            volumeMode:
+                                              description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                              type: string
+                                            volumeName:
+                                              description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                              type: string
+                                          type: object
+                                      required:
+                                        - spec
+                                      type: object
+                                  type: object
+                                fc:
+                                  description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    lun:
+                                      description: 'Optional: FC target lun number'
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                      type: boolean
+                                    targetWWNs:
+                                      description: 'Optional: FC target worldwide names (WWNs)'
+                                      items:
+                                        type: string
+                                      type: array
+                                    wwids:
+                                      description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                flexVolume:
+                                  description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                                  properties:
+                                    driver:
+                                      description: Driver is the name of the driver to use for this volume.
+                                      type: string
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                      type: string
+                                    options:
+                                      additionalProperties:
+                                        type: string
+                                      description: 'Optional: Extra command options if any.'
+                                      type: object
+                                    readOnly:
+                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                      type: boolean
+                                    secretRef:
+                                      description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                  required:
+                                    - driver
+                                  type: object
+                                flocker:
+                                  description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                                  properties:
+                                    datasetName:
+                                      description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                      type: string
+                                    datasetUUID:
+                                      description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                      type: string
+                                  type: object
+                                gcePersistentDisk:
+                                  description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    partition:
+                                      description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      format: int32
+                                      type: integer
+                                    pdName:
+                                      description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      type: string
+                                    readOnly:
+                                      description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      type: boolean
+                                  required:
+                                    - pdName
+                                  type: object
+                                gitRepo:
+                                  description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                                  properties:
+                                    directory:
+                                      description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                      type: string
+                                    repository:
+                                      description: Repository URL
+                                      type: string
+                                    revision:
+                                      description: Commit hash for the specified revision.
+                                      type: string
+                                  required:
+                                    - repository
+                                  type: object
+                                glusterfs:
+                                  description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                  properties:
+                                    endpoints:
+                                      description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                      type: string
+                                    path:
+                                      description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                      type: string
+                                    readOnly:
+                                      description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                      type: boolean
+                                  required:
+                                    - endpoints
+                                    - path
+                                  type: object
+                                hostPath:
+                                  description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                                  properties:
+                                    path:
+                                      description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      type: string
+                                    type:
+                                      description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      type: string
+                                  required:
+                                    - path
+                                  type: object
+                                iscsi:
+                                  description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                  properties:
+                                    chapAuthDiscovery:
+                                      description: whether support iSCSI Discovery CHAP authentication
+                                      type: boolean
+                                    chapAuthSession:
+                                      description: whether support iSCSI Session CHAP authentication
+                                      type: boolean
+                                    fsType:
+                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    initiatorName:
+                                      description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                      type: string
+                                    iqn:
+                                      description: Target iSCSI Qualified Name.
+                                      type: string
+                                    iscsiInterface:
+                                      description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                      type: string
+                                    lun:
+                                      description: iSCSI Target Lun number.
+                                      format: int32
+                                      type: integer
+                                    portals:
+                                      description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                      items:
+                                        type: string
+                                      type: array
+                                    readOnly:
+                                      description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                      type: boolean
+                                    secretRef:
+                                      description: CHAP Secret for iSCSI target and initiator authentication
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    targetPortal:
+                                      description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                      type: string
+                                  required:
+                                    - iqn
+                                    - lun
+                                    - targetPortal
+                                  type: object
+                                name:
+                                  description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                nfs:
+                                  description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  properties:
+                                    path:
+                                      description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      type: string
+                                    readOnly:
+                                      description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      type: boolean
+                                    server:
+                                      description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      type: string
+                                  required:
+                                    - path
+                                    - server
+                                  type: object
+                                persistentVolumeClaim:
+                                  description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  properties:
+                                    claimName:
+                                      description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      type: string
+                                    readOnly:
+                                      description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                      type: boolean
+                                  required:
+                                    - claimName
+                                  type: object
+                                photonPersistentDisk:
+                                  description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                                  properties:
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    pdID:
+                                      description: ID that identifies Photon Controller persistent disk
+                                      type: string
+                                  required:
+                                    - pdID
+                                  type: object
+                                portworxVolume:
+                                  description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                  properties:
+                                    fsType:
+                                      description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    volumeID:
+                                      description: VolumeID uniquely identifies a Portworx volume
+                                      type: string
+                                  required:
+                                    - volumeID
+                                  type: object
+                                projected:
+                                  description: Items for all in one resources secrets, configmaps, and downward API
+                                  properties:
+                                    defaultMode:
+                                      description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    sources:
+                                      description: list of volume projections
+                                      items:
+                                        description: Projection that may be projected along with other supported volume types
+                                        properties:
+                                          configMap:
+                                            description: information about the configMap data to project
+                                            properties:
+                                              items:
+                                                description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: The key to project.
+                                                      type: string
+                                                    mode:
+                                                      description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                  type: object
+                                                type: array
+                                              name:
+                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap or its keys must be defined
+                                                type: boolean
+                                            type: object
+                                          downwardAPI:
+                                            description: information about the downwardAPI data to project
+                                            properties:
+                                              items:
+                                                description: Items is a list of DownwardAPIVolume file
+                                                items:
+                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                  properties:
+                                                    fieldRef:
+                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                      properties:
+                                                        apiVersion:
+                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                          type: string
+                                                        fieldPath:
+                                                          description: Path of the field to select in the specified API version.
+                                                          type: string
+                                                      required:
+                                                        - fieldPath
+                                                      type: object
+                                                    mode:
+                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                      properties:
+                                                        containerName:
+                                                          description: 'Container name: required for volumes, optional for env vars'
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          description: 'Required: resource to select'
+                                                          type: string
+                                                      required:
+                                                        - resource
+                                                      type: object
+                                                  required:
+                                                    - path
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          secret:
+                                            description: information about the secret data to project
+                                            properties:
+                                              items:
+                                                description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: The key to project.
+                                                      type: string
+                                                    mode:
+                                                      description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                  type: object
+                                                type: array
+                                              name:
+                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret or its key must be defined
+                                                type: boolean
+                                            type: object
+                                          serviceAccountToken:
+                                            description: information about the serviceAccountToken data to project
+                                            properties:
+                                              audience:
+                                                description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                type: string
+                                              expirationSeconds:
+                                                description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                format: int64
+                                                type: integer
+                                              path:
+                                                description: Path is the path relative to the mount point of the file to project the token into.
+                                                type: string
+                                            required:
+                                              - path
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                quobyte:
+                                  description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                  properties:
+                                    group:
+                                      description: Group to map volume access to Default is no group
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                      type: boolean
+                                    registry:
+                                      description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                      type: string
+                                    tenant:
+                                      description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                      type: string
+                                    user:
+                                      description: User to map volume access to Defaults to serivceaccount user
+                                      type: string
+                                    volume:
+                                      description: Volume is a string that references an already created Quobyte volume by name.
+                                      type: string
+                                  required:
+                                    - registry
+                                    - volume
+                                  type: object
+                                rbd:
+                                  description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                  properties:
+                                    fsType:
+                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                      type: string
+                                    image:
+                                      description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: string
+                                    keyring:
+                                      description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: string
+                                    monitors:
+                                      description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      items:
+                                        type: string
+                                      type: array
+                                    pool:
+                                      description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: string
+                                    readOnly:
+                                      description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: boolean
+                                    secretRef:
+                                      description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    user:
+                                      description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      type: string
+                                  required:
+                                    - image
+                                    - monitors
+                                  type: object
+                                scaleIO:
+                                  description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                  properties:
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                      type: string
+                                    gateway:
+                                      description: The host address of the ScaleIO API Gateway.
+                                      type: string
+                                    protectionDomain:
+                                      description: The name of the ScaleIO Protection Domain for the configured storage.
+                                      type: string
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    sslEnabled:
+                                      description: Flag to enable/disable SSL communication with Gateway, default false
+                                      type: boolean
+                                    storageMode:
+                                      description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                      type: string
+                                    storagePool:
+                                      description: The ScaleIO Storage Pool associated with the protection domain.
+                                      type: string
+                                    system:
+                                      description: The name of the storage system as configured in ScaleIO.
+                                      type: string
+                                    volumeName:
+                                      description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                      type: string
+                                  required:
+                                    - gateway
+                                    - secretRef
+                                    - system
+                                  type: object
+                                secret:
+                                  description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                    optional:
+                                      description: Specify whether the Secret or its keys must be defined
+                                      type: boolean
+                                    secretName:
+                                      description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      type: string
+                                  type: object
+                                storageos:
+                                  description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                  properties:
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    readOnly:
+                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    volumeName:
+                                      description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                      type: string
+                                    volumeNamespace:
+                                      description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                      type: string
+                                  type: object
+                                vsphereVolume:
+                                  description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                  properties:
+                                    fsType:
+                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    storagePolicyID:
+                                      description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                      type: string
+                                    storagePolicyName:
+                                      description: Storage Policy Based Management (SPBM) profile name.
+                                      type: string
+                                    volumePath:
+                                      description: Path that identifies vSphere volume vmdk
+                                      type: string
+                                  required:
+                                    - volumePath
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
                         type: object
                       type: array
-                    members:
-                      description: members is the current number of members requested
-                        in the specific Rack
-                      format: int32
-                      type: integer
-                    readyMembers:
-                      description: readyMembers is the number of ready members in
-                        the specific Rack
-                      format: int32
-                      type: integer
-                    replace_address_first_boot:
-                      additionalProperties:
-                        type: string
-                      description: 'FIXME: The json value should have been a camelCase
-                        string.        We need to deprecate this value and introduce
-                        a new one. replace_address_first_boot holds addresses which
-                        should be replaced by new nodes.'
-                      type: object
-                    stale:
-                      description: stale indicates if the current rack status is collected
-                        for a previous generation. stale should eventually become
-                        false when the appropriate controller writes a fresh status.
-                      type: boolean
-                    updatedMembers:
-                      description: updatedMembers is the number of members matching
-                        the current spec.
-                      format: int32
-                      type: integer
-                    version:
-                      description: version is the current version of Scylla in use.
-                      type: string
                   type: object
-                description: racks reflect status of cluster racks.
-                type: object
-              repairs:
-                description: repairs reflects status of repair tasks.
-                items:
+                developerMode:
+                  description: developerMode determines if the cluster runs in developer-mode.
+                  type: boolean
+                forceRedeploymentReason:
+                  description: forceRedeploymentReason can be used to force a rolling update of all racks by providing a unique string.
+                  type: string
+                genericUpgrade:
+                  description: genericUpgrade allows to configure behavior of generic upgrade logic.
                   properties:
-                    dc:
-                      description: dc is a list of datacenter glob patterns, e.g.
-                        'dc1', '!otherdc*' used to specify the DCs to include or exclude
-                        from backup.
-                      items:
-                        type: string
-                      type: array
-                    error:
-                      description: error holds the repair task error, if any.
+                    failureStrategy:
+                      default: Retry
+                      description: failureStrategy specifies which logic is executed when upgrade failure happens. Currently only Retry is supported.
                       type: string
-                    failFast:
-                      description: failFast indicates if a repair should be stopped
-                        on first error.
-                      type: boolean
-                    host:
-                      description: host specifies a host to repair. If empty, all
-                        hosts are repaired.
-                      type: string
-                    id:
-                      description: id is the identification number of the repair task.
-                      type: string
-                    intensity:
-                      default: "1"
-                      description: intensity indicates how many token ranges (per
-                        shard) to repair in a single Scylla repair job. By default
-                        this is 1. If you set it to 0 the number of token ranges is
-                        adjusted to the maximum supported by node (see max_repair_ranges_in_parallel
-                        in Scylla logs). Valid values are 0 and integers >= 1. Higher
-                        values will result in increased cluster load and slightly
-                        faster repairs. Changing the intensity impacts repair granularity
-                        if you need to resume it, the higher the value the more work
-                        on resume. For Scylla clusters that *do not support row-level
-                        repair*, intensity can be a decimal between (0,1). In that
-                        case it specifies percent of shards that can be repaired in
-                        parallel on a repair master node. For Scylla clusters that
-                        are row-level repair enabled, setting intensity below 1 has
-                        the same effect as setting intensity 1.
-                      type: string
-                    interval:
-                      default: "0"
-                      description: interval represents a task schedule interval e.g.
-                        3d2h10m, valid units are d, h, m, s.
-                      type: string
-                    keyspace:
-                      description: keyspace is a list of keyspace/tables glob patterns,
-                        e.g. 'keyspace,!keyspace.table_prefix_*' used to include or
-                        exclude keyspaces from repair.
-                      items:
-                        type: string
-                      type: array
-                    name:
-                      description: name is a unique name of a task.
-                      type: string
-                    numRetries:
-                      default: 3
-                      description: numRetries indicates how many times a scheduled
-                        task will be retried before failing.
-                      format: int64
-                      type: integer
-                    parallel:
-                      default: 0
-                      description: 'parallel is the maximum number of Scylla repair
-                        jobs that can run at the same time (on different token ranges
-                        and replicas). Each node can take part in at most one repair
-                        at any given moment. By default the maximum possible parallelism
-                        is used. The effective parallelism depends on a keyspace replication
-                        factor (RF) and the number of nodes. The formula to calculate
-                        it is as follows: number of nodes / RF, ex. for 6 node cluster
-                        with RF=3 the maximum parallelism is 2.'
-                      format: int64
-                      type: integer
-                    smallTableThreshold:
-                      default: 1GiB
-                      description: smallTableThreshold enable small table optimization
-                        for tables of size lower than given threshold. Supported units
-                        [B, MiB, GiB, TiB].
-                      type: string
-                    startDate:
-                      default: now
-                      description: startDate specifies the task start date expressed
-                        in the RFC3339 format or now[+duration], e.g. now+3d2h10m,
-                        valid units are d, h, m, s.
+                    pollInterval:
+                      default: 1s
+                      description: pollInterval specifies how often upgrade logic polls on state updates. Increasing this value should lower number of requests sent to apiserver, but it may affect overall time spent during upgrade. DEPRECATED.
                       type: string
                   type: object
-                type: array
-              upgrade:
-                description: upgrade reflects state of ongoing upgrade procedure.
-                properties:
-                  currentNode:
-                    description: currentNode node under upgrade. DEPRECATED.
+                imagePullSecrets:
+                  description: imagePullSecrets is an optional list of references to secrets in the same namespace used for pulling Scylla and Agent images.
+                  items:
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  type: array
+                network:
+                  description: network holds the networking config.
+                  properties:
+                    dnsPolicy:
+                      description: dnsPolicy defines how a pod's DNS will be configured.
+                      type: string
+                    hostNetworking:
+                      description: hostNetworking determines if scylla uses the host's network namespace. Setting this option avoids going through Kubernetes SDN and exposes scylla on node's IP.
+                      type: boolean
+                  type: object
+                repairs:
+                  description: repairs specify repair tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
+                  items:
+                    properties:
+                      dc:
+                        description: dc is a list of datacenter glob patterns, e.g. 'dc1', '!otherdc*' used to specify the DCs to include or exclude from backup.
+                        items:
+                          type: string
+                        type: array
+                      failFast:
+                        description: failFast indicates if a repair should be stopped on first error.
+                        type: boolean
+                      host:
+                        description: host specifies a host to repair. If empty, all hosts are repaired.
+                        type: string
+                      intensity:
+                        default: "1"
+                        description: intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
+                        type: string
+                      interval:
+                        default: "0"
+                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      keyspace:
+                        description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: name is a unique name of a task.
+                        type: string
+                      numRetries:
+                        default: 3
+                        description: numRetries indicates how many times a scheduled task will be retried before failing.
+                        format: int64
+                        type: integer
+                      parallel:
+                        default: 0
+                        description: 'parallel is the maximum number of Scylla repair jobs that can run at the same time (on different token ranges and replicas). Each node can take part in at most one repair at any given moment. By default the maximum possible parallelism is used. The effective parallelism depends on a keyspace replication factor (RF) and the number of nodes. The formula to calculate it is as follows: number of nodes / RF, ex. for 6 node cluster with RF=3 the maximum parallelism is 2.'
+                        format: int64
+                        type: integer
+                      smallTableThreshold:
+                        default: 1GiB
+                        description: smallTableThreshold enable small table optimization for tables of size lower than given threshold. Supported units [B, MiB, GiB, TiB].
+                        type: string
+                      startDate:
+                        default: now
+                        description: startDate specifies the task start date expressed in the RFC3339 format or now[+duration], e.g. now+3d2h10m, valid units are d, h, m, s.
+                        type: string
+                    type: object
+                  type: array
+                repository:
+                  default: docker.io/scylladb/scylla
+                  description: repository is the image repository to pull the Scylla image from.
+                  type: string
+                scyllaArgs:
+                  description: scyllaArgs will be appended to Scylla binary during startup. This is supported from 4.2.0 Scylla version.
+                  type: string
+                sysctls:
+                  description: 'sysctls holds the sysctl properties to be applied during initialization given as a list of key=value pairs. Example: fs.aio-max-nr=232323'
+                  items:
                     type: string
-                  currentRack:
-                    description: currentRack rack under upgrade. DEPRECATED.
-                    type: string
-                  dataSnapshotTag:
-                    description: dataSnapshotTag is the snapshot tag of data keyspaces.
-                    type: string
-                  fromVersion:
-                    description: fromVersion reflects from which version ScyllaCluster
-                      is being upgraded.
-                    type: string
-                  state:
-                    description: state reflects current upgrade state.
-                    type: string
-                  systemSnapshotTag:
-                    description: systemSnapshotTag is the snapshot tag of system keyspaces.
-                    type: string
-                  toVersion:
-                    description: toVersion reflects to which version ScyllaCluster
-                      is being upgraded.
-                    type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                version:
+                  description: version is a version tag of Scylla to use.
+                  type: string
+              type: object
+            status:
+              description: status is the current status of this scylla cluster.
+              properties:
+                backups:
+                  description: backups reflects status of backup tasks.
+                  items:
+                    properties:
+                      dc:
+                        description: dc is a list of datacenter glob patterns, e.g. 'dc1,!otherdc*' used to specify the DCs to include or exclude from backup.
+                        items:
+                          type: string
+                        type: array
+                      error:
+                        description: error holds the backup task error, if any.
+                        type: string
+                      id:
+                        description: id is the identification number of the backup task.
+                        type: string
+                      interval:
+                        default: "0"
+                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      keyspace:
+                        description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+                        items:
+                          type: string
+                        type: array
+                      location:
+                        description: 'location is a list of backup locations in the format [<dc>:]<provider>:<name> ex. s3:my-bucket. The <dc>: part is optional and is only needed when different datacenters are being used to upload data to different locations. <name> must be an alphanumeric string and may contain a dash and or a dot, but other characters are forbidden. The only supported storage <provider> at the moment are s3 and gcs.'
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: name is a unique name of a task.
+                        type: string
+                      numRetries:
+                        default: 3
+                        description: numRetries indicates how many times a scheduled task will be retried before failing.
+                        format: int64
+                        type: integer
+                      rateLimit:
+                        description: 'rateLimit is a list of megabytes (MiB) per second rate limits expressed in the format [<dc>:]<limit>. The <dc>: part is optional and only needed when different datacenters need different upload limits. Set to 0 for no limit (default 100).'
+                        items:
+                          type: string
+                        type: array
+                      retention:
+                        default: 3
+                        description: retention is the number of backups which are to be stored.
+                        format: int64
+                        type: integer
+                      snapshotParallel:
+                        description: 'snapshotParallel is a list of snapshot parallelism limits in the format [<dc>:]<limit>. The <dc>: part is optional and allows for specifying different limits in selected datacenters. If The <dc>: part is not set, the limit is global (e.g. ''dc1:2,5'') the runs are parallel in n nodes (2 in dc1) and n nodes in all the other datacenters.'
+                        items:
+                          type: string
+                        type: array
+                      startDate:
+                        default: now
+                        description: startDate specifies the task start date expressed in the RFC3339 format or now[+duration], e.g. now+3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      uploadParallel:
+                        description: 'uploadParallel is a list of upload parallelism limits in the format [<dc>:]<limit>. The <dc>: part is optional and allows for specifying different limits in selected datacenters. If The <dc>: part is not set the limit is global (e.g. ''dc1:2,5'') the runs are parallel in n nodes (2 in dc1) and n nodes in all the other datacenters.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                managerId:
+                  description: managerId contains ID under which cluster was registered in Scylla Manager.
+                  type: string
+                observedGeneration:
+                  description: observedGeneration is the most recent generation observed for this ScyllaCluster. It corresponds to the ScyllaCluster's generation, which is updated on mutation by the API Server.
+                  format: int64
+                  type: integer
+                racks:
+                  additionalProperties:
+                    description: RackStatus is the status of a Scylla Rack
+                    properties:
+                      conditions:
+                        description: conditions are the latest available observations of a rack's state.
+                        items:
+                          description: RackCondition is an observation about the state of a rack.
+                          properties:
+                            status:
+                              description: status represent condition status.
+                              type: string
+                            type:
+                              description: type holds the condition type.
+                              type: string
+                          type: object
+                        type: array
+                      members:
+                        description: members is the current number of members requested in the specific Rack
+                        format: int32
+                        type: integer
+                      readyMembers:
+                        description: readyMembers is the number of ready members in the specific Rack
+                        format: int32
+                        type: integer
+                      replace_address_first_boot:
+                        additionalProperties:
+                          type: string
+                        description: 'FIXME: The json value should have been a camelCase string.        We need to deprecate this value and introduce a new one. replace_address_first_boot holds addresses which should be replaced by new nodes.'
+                        type: object
+                      stale:
+                        description: stale indicates if the current rack status is collected for a previous generation. stale should eventually become false when the appropriate controller writes a fresh status.
+                        type: boolean
+                      updatedMembers:
+                        description: updatedMembers is the number of members matching the current spec.
+                        format: int32
+                        type: integer
+                      version:
+                        description: version is the current version of Scylla in use.
+                        type: string
+                    type: object
+                  description: racks reflect status of cluster racks.
+                  type: object
+                repairs:
+                  description: repairs reflects status of repair tasks.
+                  items:
+                    properties:
+                      dc:
+                        description: dc is a list of datacenter glob patterns, e.g. 'dc1', '!otherdc*' used to specify the DCs to include or exclude from backup.
+                        items:
+                          type: string
+                        type: array
+                      error:
+                        description: error holds the repair task error, if any.
+                        type: string
+                      failFast:
+                        description: failFast indicates if a repair should be stopped on first error.
+                        type: boolean
+                      host:
+                        description: host specifies a host to repair. If empty, all hosts are repaired.
+                        type: string
+                      id:
+                        description: id is the identification number of the repair task.
+                        type: string
+                      intensity:
+                        default: "1"
+                        description: intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
+                        type: string
+                      interval:
+                        default: "0"
+                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        type: string
+                      keyspace:
+                        description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: name is a unique name of a task.
+                        type: string
+                      numRetries:
+                        default: 3
+                        description: numRetries indicates how many times a scheduled task will be retried before failing.
+                        format: int64
+                        type: integer
+                      parallel:
+                        default: 0
+                        description: 'parallel is the maximum number of Scylla repair jobs that can run at the same time (on different token ranges and replicas). Each node can take part in at most one repair at any given moment. By default the maximum possible parallelism is used. The effective parallelism depends on a keyspace replication factor (RF) and the number of nodes. The formula to calculate it is as follows: number of nodes / RF, ex. for 6 node cluster with RF=3 the maximum parallelism is 2.'
+                        format: int64
+                        type: integer
+                      smallTableThreshold:
+                        default: 1GiB
+                        description: smallTableThreshold enable small table optimization for tables of size lower than given threshold. Supported units [B, MiB, GiB, TiB].
+                        type: string
+                      startDate:
+                        default: now
+                        description: startDate specifies the task start date expressed in the RFC3339 format or now[+duration], e.g. now+3d2h10m, valid units are d, h, m, s.
+                        type: string
+                    type: object
+                  type: array
+                upgrade:
+                  description: upgrade reflects state of ongoing upgrade procedure.
+                  properties:
+                    currentNode:
+                      description: currentNode node under upgrade. DEPRECATED.
+                      type: string
+                    currentRack:
+                      description: currentRack rack under upgrade. DEPRECATED.
+                      type: string
+                    dataSnapshotTag:
+                      description: dataSnapshotTag is the snapshot tag of data keyspaces.
+                      type: string
+                    fromVersion:
+                      description: fromVersion reflects from which version ScyllaCluster is being upgraded.
+                      type: string
+                    state:
+                      description: state reflects current upgrade state.
+                      type: string
+                    systemSnapshotTag:
+                      description: systemSnapshotTag is the snapshot tag of system keyspaces.
+                      type: string
+                    toVersion:
+                      description: toVersion reflects to which version ScyllaCluster is being upgraded.
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
**Description of your changes:**
This PR allows to generate deepcopy, clients, listers, informers and crds for multiple API versions. Needed by the future PRs that introduce new v1alpha1 types.

PoC in https://github.com/scylladb/scylla-operator/pull/782