### PR TITLE
Handle multiple tags for the same commit on promotion

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -80,6 +80,9 @@ jobs:
       with:
         path: ${{ env.git_repo_path }}
         fetch-depth: 0
+    - name: Setup git tags
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      run: ./hack/ci-detect-tags.sh
     - name: Setup go
       uses: actions/setup-go@v2
       with:
@@ -101,6 +104,9 @@ jobs:
       with:
         path: ${{ env.git_repo_path }}
         fetch-depth: 0  # also fetch tags
+    - name: Setup git tags
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      run: ./hack/ci-detect-tags.sh
     - name: Install podman
       run: |
         set -x
@@ -135,6 +141,9 @@ jobs:
       with:
         path: ${{ env.git_repo_path }}
         fetch-depth: 0  # also fetch tags
+    - name: Setup git tags
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      run: ./hack/ci-detect-tags.sh
     - name: Create artifacts dir
       env:
         ARTIFACTS_DIR: ${{ runner.temp }}/e2e-artifacts
@@ -254,6 +263,9 @@ jobs:
         path: ${{ env.git_repo_path }}
         # Helm Chart version needs to be semantic, we need tags in checked out repo to determine latest one.
         fetch-depth: 0
+    - name: Setup git tags
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      run: ./hack/ci-detect-tags.sh
     - name: Setup go
       uses: actions/setup-go@v2
       with:
@@ -262,14 +274,14 @@ jobs:
       if: ${{ github.event_name != 'schedule' }}
       run: |
         source ./hack/lib/tag-from-gh-ref.sh
-        IMAGE_TAG=$( tag_from_gh_ref "${GITHUB_REF}" )
-        echo "IMAGE_TAG=${IMAGE_TAG}" | tee -a ${GITHUB_ENV}
+        CI_IMAGE_TAG=$( tag_from_gh_ref "${GITHUB_REF}" )
+        echo "CI_IMAGE_TAG=${CI_IMAGE_TAG}" | tee -a ${GITHUB_ENV}
     - name: Determine promotion tag for scheduled job
       if: ${{ github.event_name == 'schedule' }}
       run: |
-        IMAGE_TAG=nightly
-        echo "IMAGE_TAG=${IMAGE_TAG}" | tee -a ${GITHUB_ENV}
-        echo "HELM_CHART_VERSION_SUFFIX=-${IMAGE_TAG}" | tee -a ${GITHUB_ENV}
+        CI_IMAGE_TAG=nightly
+        echo "CI_IMAGE_TAG=${CI_IMAGE_TAG}" | tee -a ${GITHUB_ENV}
+        echo "HELM_CHART_VERSION_SUFFIX=-${CI_IMAGE_TAG}" | tee -a ${GITHUB_ENV}
     - uses: actions/download-artifact@v2
       with:
         name: operatorimage.tar.lz4
@@ -289,8 +301,8 @@ jobs:
     - name: Promote image
       run: |
         set -x
-        docker tag '${{ env.image_repo_ref }}:ci' '${{ env.image_repo_ref }}:${{ env.IMAGE_TAG }}'
-        docker push '${{ env.image_repo_ref }}:${{ env.IMAGE_TAG }}'
+        docker tag '${{ env.image_repo_ref }}:ci' '${{ env.image_repo_ref }}:${{ env.CI_IMAGE_TAG }}'
+        docker push '${{ env.image_repo_ref }}:${{ env.CI_IMAGE_TAG }}'
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@master
       with:
@@ -298,7 +310,7 @@ jobs:
     - name: Publish Helm Chart
       env:
         HELM_CHANNEL: latest
-        HELM_APP_VERSION: ${{ env.IMAGE_TAG }}
+        HELM_APP_VERSION: ${{ env.CI_IMAGE_TAG }}
       run: make helm-publish
 
   failure-notifications:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: build
 
-SHELL :=/bin/bash -euEo pipefail
+SHELL :=/bin/bash -euEo pipefail -O inherit_errexit
 
 IMAGE_TAG ?= latest
 IMAGE_REF ?= docker.io/scylladb/scylla-operator:$(IMAGE_TAG)
@@ -10,11 +10,12 @@ CODEGEN_HEADER_FILE ?=/dev/null
 CODEGEN_APIS_PACKAGE ?=$(GO_PACKAGE)/pkg/api
 CODEGEN_GROUPS_VERSIONS ?="scyllaclusters/v1"
 
+MAKE_REQUIRED_MIN_VERSION:=4.2 # for SHELLSTATUS
 GO_REQUIRED_MIN_VERSION ?=1.16
 
-GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown')
-GIT_TAG_SHORT ?=$(shell git describe --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown')
-GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
+GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*')$(if $(filter $(.SHELLSTATUS),0),,$(error git describe failed))
+GIT_TAG_SHORT ?=$(shell git describe --tags --abbrev=7 --match 'v[0-9]*')$(if $(filter $(.SHELLSTATUS),0),,$(error git describe failed))
+GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)$(if $(filter $(.SHELLSTATUS),0),,$(error git rev-parse failed))
 GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 
 GO ?=go
@@ -67,7 +68,7 @@ define version-ldflags
 -X $(1).gitTreeState="$(GIT_TREE_STATE)" \
 -X $(1).buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"
 endef
-GO_LD_FLAGS ?=-ldflags "$(call version-ldflags,$(GO_PACKAGE)/pkg/version) $(GO_LD_EXTRA_FLAGS)"
+GO_LD_FLAGS ?=-ldflags '$(strip $(call version-ldflags,$(GO_PACKAGE)/pkg/version) $(GO_LD_EXTRA_FLAGS))'
 
 # TODO: look into how to make these local to the targets
 export DOCKER_BUILDKIT :=1
@@ -90,6 +91,9 @@ $(if $(strip $(call is_equal_or_higher_version,$($(2)),$(3))),,$(error `$(1)` is
 )
 endef
 
+ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
+$(call require_minimal_version,make,MAKE_REQUIRED_MIN_VERSION,$(MAKE_VERSION))
+endif
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(GO_VERSION))
 endif

--- a/hack/ci-detect-tags.sh
+++ b/hack/ci-detect-tags.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright (C) 2021 ScyllaDB
+#
+# This script will set appropriate tag variables in the CI environment.
+# Multiple tags can point to one commit which makes `git describe` ambiguous
+# for the purposes of promotion. Like when vX.Y.Z-beta.0 and vX.Y.Z-rc.0 point
+# to the same commit. Git describe could return any of those and even if it would
+# return the newest, the job order is not determined either. And jobs can be rerun
+# which would make the beta job promoting to rc.0.
+set -euExo pipefail
+shopt -s inherit_errexit
+
+parent_dir=$( dirname "${BASH_SOURCE[0]}" )
+source "${parent_dir}/lib/tag-from-gh-ref.sh"
+
+tag=$( tag_from_gh_ref "${GITHUB_REF}" )
+git_sha=$( git rev-parse --short=7 "HEAD^{commit}" )
+
+echo "GIT_TAG=${tag}-0-g${git_sha}" | tee -a ${GITHUB_ENV}
+echo "GIT_TAG_SHORT=${tag}" | tee -a ${GITHUB_ENV}


### PR DESCRIPTION
**Description of your changes:**
Multiple tags can point to one commit which makes `git describe` ambiguous for the purposes of promotion. Like when vX.Y.Z-beta.0 and vX.Y.Z-rc.0 point to the same commit. Git describe could return any of those and even if it would return the newest, the job order is not determined either. And jobs can be rerun which would make the beta job promoting to rc.0.

**Which issue is resolved by this Pull Request:**
Helm chart promotion.
