### PR TITLE
Don't GC events during CI runs

### DIFF
--- a/.github/actions/setup-minikube/action.yaml
+++ b/.github/actions/setup-minikube/action.yaml
@@ -32,7 +32,7 @@ runs:
       - level: Request
       EOF
 
-      sudo minikube start --wait=all --extra-config=apiserver.audit-policy-file=/etc/ssl/certs/audit-policy.yaml --extra-config=apiserver.audit-log-path=/var/log/minikube/kube-apiserver-audit.log
+      sudo minikube start --wait=all --extra-config='apiserver.event-ttl=24h' --extra-config='apiserver.audit-policy-file=/etc/ssl/certs/audit-policy.yaml' --extra-config='apiserver.audit-log-path=/var/log/minikube/kube-apiserver-audit.log'
 
       mkdir -p ~/.kube/
       sudo cat /root/.kube/config > ~/.kube/config


### PR DESCRIPTION
**Description of your changes:**
By default, events are deleted after 1h, we need them to stay for the duration of the CI run. 24 hours should be more than enough.

**Which issue is resolved by this Pull Request:**
Resolves #784 
