### PR TITLE
Remove redundant sleep from e2e upgrade test

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
@@ -5,7 +5,6 @@ package scyllacluster
 import (
 	"context"
 	"fmt"
-	"time"
 
 	g "github.com/onsi/ginkgo"
 	gt "github.com/onsi/ginkgo/extensions/table"
@@ -77,9 +76,6 @@ var _ = g.Describe("ScyllaCluster upgrades", func() {
 			)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(sc.Spec.Version).To(o.Equal(e.updatedVersion))
-
-			// FIXME: Remove when we have observedGeneration. Until then this is racy.
-			time.Sleep(10 * time.Second)
 
 			framework.By("Waiting for the ScyllaCluster to re-deploy")
 			waitCtx2, waitCtx2Cancel := contextForRollout(ctx, sc)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Remove redundant sleep from e2e upgrade test. Checking for observedGeneration has already been introduced in #684.

**Which issue is resolved by this Pull Request:**
Resolves:
