### PR TITLE
Bump Scylla and Scylla Manager Agent versions

### DIFF
--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -39,8 +39,8 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 4.4.2
-  agentVersion: 2.3.0
+  version: 4.4.5
+  agentVersion: 2.5.1
   cpuset: true
   network:
     hostNetworking: true

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -41,8 +41,8 @@ metadata:
   name: simple-cluster
   namespace: scylla
 spec:
-  version: 4.2.0
-  agentVersion: 2.2.0
+  version: 4.4.5
+  agentVersion: 2.5.1
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -39,8 +39,8 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 4.2.0
-  agentVersion: 2.2.0
+  version: 4.4.5
+  agentVersion: 2.5.1
   cpuset: true
   sysctls:
     - "fs.aio-max-nr=2097152"

--- a/test/e2e/fixture/scyllacluster/basic.scyllacluster.yaml
+++ b/test/e2e/fixture/scyllacluster/basic.scyllacluster.yaml
@@ -3,8 +3,8 @@ kind: ScyllaCluster
 metadata:
   name: basic
 spec:
-  version: 4.4.2
-  agentVersion: 2.3.0
+  version: 4.4.5
+  agentVersion: 2.5.1
   developerMode: true
   datacenter:
     name: us-east-1

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	updateFromScyllaVersion  = "4.4.1"
-	updateToScyllaVersion    = "4.4.2"
-	upgradeFromScyllaVersion = "4.3.2"
-	upgradeToScyllaVersion   = "4.4.2"
+	updateFromScyllaVersion  = "4.4.4"
+	updateToScyllaVersion    = "4.4.5"
+	upgradeFromScyllaVersion = "4.3.6"
+	upgradeToScyllaVersion   = "4.4.5"
 
 	testTimout = 15 * time.Minute
 


### PR DESCRIPTION
Our examples use Scylla which is not supported anymore and is failing
to deploy due to additional parameters that are unknown in 4.2.0.

Scylla and Scylla Manager Agent versions are bumped to latest ones.