### PR TITLE
Make manager and operator namespaces configurable

### DIFF
--- a/helm/scylla-manager/templates/controller_deployment.yaml
+++ b/helm/scylla-manager/templates/controller_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scylla-manager-controller
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-manager.controllerLabels" . | nindent 4 }}
 spec:

--- a/helm/scylla-manager/templates/controller_pdb.yaml
+++ b/helm/scylla-manager/templates/controller_pdb.yaml
@@ -2,7 +2,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-manager-controller
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:

--- a/helm/scylla-manager/templates/controller_serviceaccount.yaml
+++ b/helm/scylla-manager/templates/controller_serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-manager.controllerServiceAccountName" . }}
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-manager.controllerLabels" . | nindent 4 }}
   {{- with .Values.controllerServiceAccount.annotations }}

--- a/helm/scylla-manager/templates/manager_configmap.yaml
+++ b/helm/scylla-manager/templates/manager_configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scylla-manager-config
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
 data:
   scylla-manager.yaml: |-
     http: :5080

--- a/helm/scylla-manager/templates/manager_deployment.yaml
+++ b/helm/scylla-manager/templates/manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scylla-manager
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
 spec:

--- a/helm/scylla-manager/templates/manager_service.yaml
+++ b/helm/scylla-manager/templates/manager_service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
   name: scylla-manager
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: api

--- a/helm/scylla-manager/templates/manager_serviceaccount.yaml
+++ b/helm/scylla-manager/templates/manager_serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-manager.serviceAccountName" . }}
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/scylla-manager/templates/manager_servicemonitor.yaml
+++ b/helm/scylla-manager/templates/manager_servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: scylla-manager
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
 spec:
   jobLabel: "app"
   selector:

--- a/helm/scylla-operator/templates/certificate.yaml
+++ b/helm/scylla-operator/templates/certificate.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "scylla-operator.certificateName" . }}
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - {{ include "scylla-operator.webhookServiceName" . }}.scylla-operator.svc

--- a/helm/scylla-operator/templates/issuer.yaml
+++ b/helm/scylla-operator/templates/issuer.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: scylla-operator-selfsigned-issuer
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 {{- end }}

--- a/helm/scylla-operator/templates/operator.deployment.yaml
+++ b/helm/scylla-operator/templates/operator.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scylla-operator
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-operator.labels" . | nindent 4 }}
 spec:

--- a/helm/scylla-operator/templates/operator.pdb.yaml
+++ b/helm/scylla-operator/templates/operator.pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-operator
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:

--- a/helm/scylla-operator/templates/operator.serviceaccount.yaml
+++ b/helm/scylla-operator/templates/operator.serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-operator.serviceAccountName" . }}
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/scylla-operator/templates/webhookserver.deployment.yaml
+++ b/helm/scylla-operator/templates/webhookserver.deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   name: webhook-server
   labels:
     app.kubernetes.io/name: webhook-server

--- a/helm/scylla-operator/templates/webhookserver.pdb.yaml
+++ b/helm/scylla-operator/templates/webhookserver.pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-server
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:

--- a/helm/scylla-operator/templates/webhookserver.service.yaml
+++ b/helm/scylla-operator/templates/webhookserver.service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   name: scylla-operator-webhook
   labels:
     app.kubernetes.io/name: webhook-server

--- a/helm/scylla-operator/templates/webhookserver.serviceaccount.yaml
+++ b/helm/scylla-operator/templates/webhookserver.serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   name: webhook-server
   labels:
     app.kubernetes.io/name: webhook-server


### PR DESCRIPTION
According to [the discussion](https://github.com/helm/helm/issues/5465) on best practices for k8s namespaces in helm, it is preferred to use `{{ .Release.Namespace }}` instead of hard coded namespaces for helm templates.

In the `scylla` chart, this style is already used. This PR extends the usage of `{{ .Release.Namespace }}` to the charts `scylla-manager` and `scylla-operator`. This enables users to deploy custom namespaces, e.g. one namespace which hosts the entire ScyllaDB tool stack.
