### PR TITLE
Bump prometheus-operator image tag to v0.51.2

### DIFF
--- a/examples/common/monitoring/values.yaml
+++ b/examples/common/monitoring/values.yaml
@@ -53,7 +53,7 @@ prometheusOperator:
     enabled: false
 
   image:
-    tag: v0.45.0
+    tag: v0.51.2
 
   # This might need to be increased for bigger deployments.
   resources:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR updates prometheus-operator image tag in helm files. At the moment, deploying the monitoring stack as per scylla-operator's instructions results in prometheus-operator error `flag provided but not defined: -config-reloader-cpu-request`.
