### PR TITLE
Fix checking for required min version of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $(if $(strip $(call is_equal_or_higher_version,$($(2)),$(3))),,$(error `$(1)` is
 )
 endef
 
-ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
+ifneq "$(MAKE_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,make,MAKE_REQUIRED_MIN_VERSION,$(MAKE_VERSION))
 endif
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR fixes a Makefile bug in checking for minimal required make version.