### PR TITLE
Freeze docutils dependency version to 0.17

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -15,6 +15,7 @@ sphinx-autobuild = "0.7.1"
 Sphinx = "2.4.4"
 sphinx-multiversion-scylla = "~0.2.6"
 sphinx-markdown-tables = "0.0.15"
+docutils = "0.17"
 
 [tool.poetry.dev-dependencies]
 pytest = "5.2"


### PR DESCRIPTION
Related issue https://github.com/scylladb/scylla-operator/pull/807

The GitHub Action failed because the dependency [docutils was recently updated](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-18-2021-10-26) with breaking changes. 

This PR sets the docutils version to 0.17. You can merge this PR, or merge instead https://github.com/scylladb/scylla-operator/pull/815. The new version of the theme already sets  ``docutils < 0.18``.

