### PR TITLE
Fix spelling in CRD documentation

### DIFF
--- a/docs/source/scylla_cluster_crd.md
+++ b/docs/source/scylla_cluster_crd.md
@@ -1,6 +1,6 @@
 # Scylla Cluster CRD
 
-Scylla database clusters can be created and configuring using the `clusters.scylla.scylladb.com` custom resource definition (CRD).
+Scylla database clusters can be created and configured using the `clusters.scylla.scylladb.com` custom resource definition (CRD).
 
 Please refer to the the [user guide walk-through](generic.md) for deployment instructions.
 This page will explain all the available configuration options on the Scylla CRD.


### PR DESCRIPTION
Line 3.
Spelling error corrected. "configuring" changed to "configured".

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #
