### PR TITLE
sidecar: fix parallel racks creation

### DIFF
--- a/pkg/sidecar/identity/member_test.go
+++ b/pkg/sidecar/identity/member_test.go
@@ -87,7 +87,7 @@ func TestMember_GetSeeds(t *testing.T) {
 			memberName: firstPod.Name,
 			memberIP:   firstService.Spec.ClusterIP,
 			objects:    []runtime.Object{firstPod, firstService, secondPod, secondService, thirdPod, thirdService},
-			expectSeed: secondService.Spec.ClusterIP,
+			expectSeed: firstService.Spec.ClusterIP,
 		},
 	}
 


### PR DESCRIPTION
**Problem:**
If multiple racks are present in the initial ScyllaCluster CRD multiple StatefulSet resources will be created.
This results in multiple Pods being created in parallel.

Since the logic for the first node only triggers when there are no other Pods it will instead now create a circular dependency between the StatefulSets as seed nodes.

**Description of your changes:**
This changes the logic that tries to find the "first created Pod" to also include itself and will allow a uniform seed list for each rack without circular dependencies.