### PR TITLE
Fix deploying multiple racks

### DIFF
--- a/.github/actions/setup-minikube/action.yaml
+++ b/.github/actions/setup-minikube/action.yaml
@@ -3,6 +3,13 @@ description: 'Installs minikube Kubernetes cluster'
 runs:
   using: "composite"
   steps:
+  - name: Configure system
+    shell: bash
+    run: |
+      set -euExo pipefail
+
+      echo 'fs.aio-max-nr = 10485760' | sudo tee /etc/sysctl.d/90-scylla.conf >/dev/null
+      sudo sysctl --system
   - name: Install minikube
     shell: bash
     run: |

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -210,7 +210,7 @@ jobs:
       run: |
         set -euExo pipefail
 
-        e2e_timeout_minutes=60
+        e2e_timeout_minutes=120
         flake_attempts=0
         if [[ -v 'FLAKE_ATTEMPTS' ]]; then
           flake_attempts="${FLAKE_ATTEMPTS}"

--- a/pkg/controller/scyllacluster/sync_statefulsets.go
+++ b/pkg/controller/scyllacluster/sync_statefulsets.go
@@ -355,7 +355,7 @@ func (scc *Controller) pruneStatefulSets(
 }
 
 // createMissingStatefulSets creates missing StatefulSets.
-// It return true if a statefulSet was created and an error.
+// It return true if done and an error.
 func (scc *Controller) createMissingStatefulSets(
 	ctx context.Context,
 	sc *scyllav1.ScyllaCluster,
@@ -365,36 +365,56 @@ func (scc *Controller) createMissingStatefulSets(
 	services map[string]*corev1.Service,
 ) (bool, error) {
 	var errs []error
-	stsCreated := false
-	for _, sts := range requiredStatefulSets {
+	anyChanged := false
+	for _, req := range requiredStatefulSets {
+		klog.V(4).InfoS("Processing required StatefulSet", "StatefulSet", klog.KObj(req))
 		// Check the adopted set.
-		_, found := statefulSets[sts.Name]
+		sts, found := statefulSets[req.Name]
 		if !found {
-			klog.V(2).InfoS("Creating missing StatefulSet", "StatefulSet", klog.KObj(sts))
-			updatedSts, changed, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, sts, false)
+			klog.V(2).InfoS("Creating missing StatefulSet", "StatefulSet", klog.KObj(req))
+			var changed bool
+			var err error
+			sts, changed, err = resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, req, false)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("can't create missing statefulset: %w", err))
 				continue
 			}
 			if changed {
-				stsCreated = true
+				anyChanged = true
 
-				rackName, ok := updatedSts.Labels[naming.RackNameLabel]
+				rackName, ok := sts.Labels[naming.RackNameLabel]
 				if !ok {
 					errs = append(errs, fmt.Errorf(
 						"can't determine rack name: statefulset %s is missing label %q",
-						naming.ObjRef(updatedSts),
+						naming.ObjRef(sts),
 						naming.RackNameLabel),
 					)
 					continue
 				}
 				oldRackStatus := sc.Status.Racks[rackName]
-				status.Racks[rackName] = *scc.calculateRackStatus(sc, rackName, updatedSts, &oldRackStatus, services)
+				status.Racks[rackName] = *scc.calculateRackStatus(sc, rackName, sts, &oldRackStatus, services)
 			}
+		} else {
+			// When we decommission a member there is a pod left that's not ready until we scale.
+			if req.Spec.Replicas != nil && sts.Spec.Replicas != nil &&
+				*req.Spec.Replicas != *sts.Spec.Replicas {
+				continue
+			}
+		}
+
+		// Wait for the StatefulSet to rollout. Racks can only bootstrap one by one.
+		rolledOut, err := controllerhelpers.IsStatefulSetRolledOut(sts)
+		if err != nil {
+			return false, err
+		}
+
+		if !rolledOut {
+			klog.V(4).InfoS("Waiting for StatefulSet rollout", "ScyllaCluster", klog.KObj(sc), "StatefulSet", klog.KObj(sts))
+			return false, nil
 		}
 	}
 
-	return stsCreated, utilerrors.NewAggregate(errs)
+	return !anyChanged, utilerrors.NewAggregate(errs)
 }
 
 func (scc *Controller) syncStatefulSets(
@@ -427,11 +447,11 @@ func (scc *Controller) syncStatefulSets(
 
 	// Before any update, make sure all StatefulSets are present.
 	// Create any that are missing.
-	stsCreated, err := scc.createMissingStatefulSets(ctx, sc, status, requiredStatefulSets, statefulSets, services)
+	done, err := scc.createMissingStatefulSets(ctx, sc, status, requiredStatefulSets, statefulSets, services)
 	if err != nil {
 		return status, fmt.Errorf("can't create StatefulSet(s): %w", err)
 	}
-	if stsCreated {
+	if !done {
 		// Wait for the informers to catch up.
 		// TODO: Add expectations, not to reconcile sooner then we see this new StatefulSet in our caches. (#682)
 		time.Sleep(artificialDelayForCachesToCatchUp)
@@ -797,11 +817,11 @@ func (scc *Controller) syncStatefulSets(
 		// Wait for the StatefulSet to rollout.
 		rolledOut, err := controllerhelpers.IsStatefulSetRolledOut(updatedSts)
 		if err != nil {
-			klog.V(4).InfoS("Waiting for StatefulSet rollout", "ScyllaCluster", klog.KObj(sc), "StatefulSet", klog.KObj(updatedSts))
 			return status, err
 		}
 
 		if !rolledOut {
+			klog.V(4).InfoS("Waiting for StatefulSet rollout", "ScyllaCluster", klog.KObj(sc), "StatefulSet", klog.KObj(updatedSts))
 			return status, nil
 		}
 	}

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -10,7 +10,7 @@ const (
 	upgradeFromScyllaVersion = "4.4.6"
 	upgradeToScyllaVersion   = "4.5.1"
 
-	testTimout = 15 * time.Minute
+	testTimout = 45 * time.Minute
 
 	memberRolloutTimeout = 3 * time.Minute
 	baseRolloutTimout    = 30 * time.Second

--- a/test/e2e/set/scyllacluster/helpers.go
+++ b/test/e2e/set/scyllacluster/helpers.go
@@ -35,7 +35,7 @@ import (
 )
 
 func rolloutTimeoutForScyllaCluster(sc *scyllav1.ScyllaCluster) time.Duration {
-	return baseRolloutTimout + time.Duration(getMemberCount(sc))*memberRolloutTimeout
+	return baseRolloutTimout + time.Duration(int32(len(sc.Spec.Datacenter.Racks))*getMemberCount(sc))*memberRolloutTimeout
 }
 
 func getMemberCount(sc *scyllav1.ScyllaCluster) int32 {


### PR DESCRIPTION
**Description of your changes:**
We have to wait for each Scylla rack to bootstrap before creating another one.

More contained change replacing https://github.com/scylladb/scylla-operator/pull/794

**Which issue is resolved by this Pull Request:**
Resolves #757 #755
