### PR TITLE
Use shared images

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -121,7 +121,7 @@ jobs:
         set -x
         # Avoid podman permission error on Ubuntu 20.04 by using it as root, although it shouldn't be needed.
         # Use --format=docker to support SHELL instruction in the Dockerfile. (SHELL didn't make it to OCI spec.)
-        sudo podman build --format=docker --squash -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
+        sudo podman build --format=docker --squash --network=none -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
         sudo podman images '${{ env.image_repo_ref }}:ci'
         sudo podman save '${{ env.image_repo_ref }}:ci' | lz4 - ~/operatorimage.tar.lz4
     - name: Upload image artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,9 @@
-# TODO: extract builder and base image into its own repo for reuse and to speed up builds
-FROM docker.io/library/ubuntu:20.04 AS builder
-SHELL ["/bin/bash", "-euEo", "pipefail", "-c"]
-ENV GOPATH=/go \
-    GOROOT=/usr/local/go \
-# Enable madvdontneed=1, for golang < 1.16 https://github.com/golang/go/issues/42330
-    GODEBUG=madvdontneed=1
-ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
-RUN apt-get update; \
-    apt-get install -y --no-install-recommends make git curl gzip ca-certificates jq; \
-    apt-get clean; \
-    curl --fail -L https://storage.googleapis.com/golang/go1.18.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+FROM quay.io/scylladb/scylla-operator-images:golang-1.18 AS builder
 WORKDIR /go/src/github.com/scylladb/scylla-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM docker.io/library/ubuntu:20.04
-SHELL ["/bin/bash", "-euEo", "pipefail", "-c"]
+FROM quay.io/scylladb/scylla-operator-images:base-ubuntu
 # sidecar-injection container and existing installations use binary from root,
 # we have to keep it there until we figure out how to properly upgrade them.
 COPY --from=builder /go/src/github.com/scylladb/scylla-operator/scylla-operator /usr/bin/


### PR DESCRIPTION
**Description of your changes:**
Using shared images will speedup image build significantly and also avoids "live" installing distribution packages that do flake on network / repo availability. This also gives us the chance to finally enforce offline builds.

Master branch:
```
podman build --format=docker --squash   .  34,37s user 15,64s system 96% cpu 52,061 total
```

This PR:
```
podman build --format=docker --squash   .  23,09s user 8,82s system 268% cpu 11,868 total
```