### PR TITLE
[v1.6] Bump Go to 1.17.2 in release script

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -17,7 +17,7 @@ on:
         required: true
 
 env:
-  go_version: 1.16
+  go_version: 1.17.2
   git_repo_path: ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator
   retention_days: 90
 


### PR DESCRIPTION
Minimum required version is 1.17.1, where release script used 1.16.x.