### PR TITLE
Increase TerminationGracePeriodSeconds of Scylla pods

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -396,7 +396,8 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 						PodAffinity:     placement.PodAffinity,
 						PodAntiAffinity: placement.PodAntiAffinity,
 					},
-					ImagePullSecrets: c.Spec.ImagePullSecrets,
+					ImagePullSecrets:              c.Spec.ImagePullSecrets,
+					TerminationGracePeriodSeconds: pointer.Int64Ptr(900),
 				},
 			},
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -643,9 +643,10 @@ func TestStatefulSetForRack(t *testing.T) {
 								Resources: newBasicRack().Resources,
 							},
 						},
-						DNSPolicy:          "ClusterFirstWithHostNet",
-						ServiceAccountName: "basic-member",
-						Affinity:           &corev1.Affinity{},
+						DNSPolicy:                     "ClusterFirstWithHostNet",
+						ServiceAccountName:            "basic-member",
+						Affinity:                      &corev1.Affinity{},
+						TerminationGracePeriodSeconds: pointer.Int64Ptr(900),
 					},
 				},
 				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR increases TerminationGracePeriodSeconds of Scylla pods from default 30s to 900s to sync with scylla-server supervisord's timeout value introduced in https://github.com/scylladb/scylla/pull/9545. 

**Which issue is resolved by this Pull Request:**
Resolves #805 
