### PR TITLE
Don't act on scylla pods that are being deleted in nodeconfigpod controller

### DIFF
--- a/pkg/controller/nodeconfigpod/sync.go
+++ b/pkg/controller/nodeconfigpod/sync.go
@@ -85,6 +85,10 @@ func (ncpc *Controller) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("can't list pods: %w", err)
 	}
 
+	if pod.DeletionTimestamp != nil {
+		return nil
+	}
+
 	configMaps, err := ncpc.getConfigMaps(ctx, pod)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Description of your changes:**
No controller is allowed to act on objects that are being deleted. We have missed that in `nodeconfigpod` controller.

**Which issue is resolved by this Pull Request:**
@rzetelskik found out that in his cluster scylla pods couldn't be foreground deleted because the controller was always recreating the tuning CM that depends on the Pod.

@rzetelskik please pick the commit and test it in your PR.