### PR TITLE
Fix ownerRefs for nodeconfigpod controller

### DIFF
--- a/pkg/controller/nodeconfigpod/controller.go
+++ b/pkg/controller/nodeconfigpod/controller.go
@@ -44,7 +44,7 @@ const (
 
 var (
 	keyFunc       = cache.DeletionHandlingMetaNamespaceKeyFunc
-	controllerGVK = corev1.SchemeGroupVersion.WithKind("pods")
+	controllerGVK = corev1.SchemeGroupVersion.WithKind("Pod")
 )
 
 type Controller struct {

--- a/pkg/controller/nodeconfigpod/resource_test.go
+++ b/pkg/controller/nodeconfigpod/resource_test.go
@@ -1,0 +1,66 @@
+package nodeconfigpod
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestMakeConfigMap(t *testing.T) {
+	tt := []struct {
+		name     string
+		pod      *corev1.Pod
+		data     map[string]string
+		expected *corev1.ConfigMap
+	}{
+		{
+			name: "basic",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+					UID:       "42",
+				},
+			},
+			data: map[string]string{
+				"key": "value",
+			},
+			expected: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "nodeconfig-podinfo-42",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "v1",
+							Kind:               "Pod",
+							Name:               "bar",
+							UID:                "42",
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Bool(true),
+						},
+					},
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":       "42",
+						"scylla-operator.scylladb.com/config-map-type": "NodeConfigData",
+					},
+				},
+				Data: map[string]string{
+					"key": "value",
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := makeConfigMap(tc.pod, tc.data)
+
+			if !apiequality.Semantic.DeepEqual(tc.expected, got) {
+				t.Errorf("expected and gotten ConfigMaps differ: \n%s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}

--- a/pkg/resourceapply/core.go
+++ b/pkg/resourceapply/core.go
@@ -53,7 +53,7 @@ func ApplyService(
 	}
 
 	existingControllerRef := metav1.GetControllerOfNoCopy(existing)
-	if !equality.Semantic.DeepEqual(existingControllerRef, requiredControllerRef) {
+	if existingControllerRef == nil || existingControllerRef.UID != requiredControllerRef.UID {
 		if existingControllerRef == nil && forceOwnership {
 			klog.V(2).InfoS("Forcing apply to claim the Service", "Service", naming.ObjRef(requiredCopy))
 		} else {
@@ -124,7 +124,7 @@ func ApplySecret(
 	}
 
 	existingControllerRef := metav1.GetControllerOfNoCopy(existing)
-	if !equality.Semantic.DeepEqual(existingControllerRef, requiredControllerRef) {
+	if existingControllerRef == nil || existingControllerRef.UID != requiredControllerRef.UID {
 		if existingControllerRef == nil && forceOwnership {
 			klog.V(2).InfoS("Forcing apply to claim the Secret", "Secret", naming.ObjRef(requiredCopy))
 		} else {
@@ -188,7 +188,7 @@ func ApplyConfigMap(
 	}
 
 	existingControllerRef := metav1.GetControllerOfNoCopy(existing)
-	if !equality.Semantic.DeepEqual(existingControllerRef, requiredControllerRef) {
+	if existingControllerRef == nil || existingControllerRef.UID != requiredControllerRef.UID {
 		// This is not the place to handle adoption.
 		err := fmt.Errorf("configmap %q isn't controlled by us", naming.ObjRef(requiredCopy))
 		ReportUpdateEvent(recorder, requiredCopy, err)

--- a/pkg/resourceapply/core_test.go
+++ b/pkg/resourceapply/core_test.go
@@ -276,6 +276,29 @@ func TestApplyService(t *testing.T) {
 			expectedEvents:  []string{"Normal ServiceUpdated Service default/test updated"},
 		},
 		{
+			name: "update succeeds to replace ownerRef kind",
+			existing: []runtime.Object{
+				func() *corev1.Service {
+					svc := newService()
+					svc.OwnerReferences[0].Kind = "WrongKind"
+					utilruntime.Must(SetHashAnnotation(svc))
+					return svc
+				}(),
+			},
+			required: func() *corev1.Service {
+				svc := newService()
+				return svc
+			}(),
+			expectedService: func() *corev1.Service {
+				svc := newService()
+				utilruntime.Must(SetHashAnnotation(svc))
+				return svc
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents:  []string{"Normal ServiceUpdated Service default/test updated"},
+		},
+		{
 			name: "update fails if the existing object is owned by someone else",
 			existing: []runtime.Object{
 				func() *corev1.Service {
@@ -618,10 +641,10 @@ func TestApplySecret(t *testing.T) {
 			name: "update fails if the existing object has no ownerRef",
 			existing: []runtime.Object{
 				func() *corev1.Secret {
-					sts := newSecret()
-					sts.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(sts))
-					return sts
+					secret := newSecret()
+					secret.OwnerReferences = nil
+					utilruntime.Must(SetHashAnnotation(secret))
+					return secret
 				}(),
 			},
 			required: func() *corev1.Secret {
@@ -638,10 +661,10 @@ func TestApplySecret(t *testing.T) {
 			name: "forced update succeeds if the existing object has no ownerRef",
 			existing: []runtime.Object{
 				func() *corev1.Secret {
-					sts := newSecret()
-					sts.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(sts))
-					return sts
+					secret := newSecret()
+					secret.OwnerReferences = nil
+					utilruntime.Must(SetHashAnnotation(secret))
+					return secret
 				}(),
 			},
 			required: func() *corev1.Secret {
@@ -653,6 +676,29 @@ func TestApplySecret(t *testing.T) {
 			expectedSecret: func() *corev1.Secret {
 				secret := newSecret()
 				secret.Labels["foo"] = "bar"
+				utilruntime.Must(SetHashAnnotation(secret))
+				return secret
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents:  []string{"Normal SecretUpdated Secret default/test updated"},
+		},
+		{
+			name: "update succeeds to replace ownerRef kind",
+			existing: []runtime.Object{
+				func() *corev1.Secret {
+					secret := newSecret()
+					secret.OwnerReferences[0].Kind = "WrongKind"
+					utilruntime.Must(SetHashAnnotation(secret))
+					return secret
+				}(),
+			},
+			required: func() *corev1.Secret {
+				secret := newSecret()
+				return secret
+			}(),
+			expectedSecret: func() *corev1.Secret {
+				secret := newSecret()
 				utilruntime.Must(SetHashAnnotation(secret))
 				return secret
 			}(),
@@ -1327,10 +1373,10 @@ func TestApplyConfigMap(t *testing.T) {
 			name: "update fails if the existing object has no ownerRef",
 			existing: []runtime.Object{
 				func() *corev1.ConfigMap {
-					sts := newConfigMap()
-					sts.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(sts))
-					return sts
+					cm := newConfigMap()
+					cm.OwnerReferences = nil
+					utilruntime.Must(SetHashAnnotation(cm))
+					return cm
 				}(),
 			},
 			required: func() *corev1.ConfigMap {
@@ -1342,6 +1388,29 @@ func TestApplyConfigMap(t *testing.T) {
 			expectedChanged: false,
 			expectedErr:     fmt.Errorf(`configmap "default/test" isn't controlled by us`),
 			expectedEvents:  []string{`Warning UpdateConfigMapFailed Failed to update ConfigMap default/test: configmap "default/test" isn't controlled by us`},
+		},
+		{
+			name: "update succeeds to replace ownerRef kind",
+			existing: []runtime.Object{
+				func() *corev1.ConfigMap {
+					cm := newConfigMap()
+					cm.OwnerReferences[0].Kind = "WrongKind"
+					utilruntime.Must(SetHashAnnotation(cm))
+					return cm
+				}(),
+			},
+			required: func() *corev1.ConfigMap {
+				cm := newConfigMap()
+				return cm
+			}(),
+			expectedCM: func() *corev1.ConfigMap {
+				cm := newConfigMap()
+				utilruntime.Must(SetHashAnnotation(cm))
+				return cm
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents:  []string{"Normal ConfigMapUpdated ConfigMap default/test updated"},
 		},
 		{
 			name: "update fails if the existing object is owned by someone else",

--- a/pkg/resourceapply/policy.go
+++ b/pkg/resourceapply/policy.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	policyv1beta1client "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
@@ -55,7 +54,7 @@ func ApplyPodDisruptionBudget(
 	}
 
 	existingControllerRef := metav1.GetControllerOfNoCopy(existing)
-	if !equality.Semantic.DeepEqual(existingControllerRef, requiredControllerRef) {
+	if existingControllerRef == nil || existingControllerRef.UID != requiredControllerRef.UID {
 		if existingControllerRef == nil && forceOwnership {
 			klog.V(2).InfoS("Forcing apply to claim the PodDisruptionBudget", "PodDisruptionBudget", naming.ObjRef(requiredCopy))
 		} else {

--- a/pkg/resourceapply/policy_test.go
+++ b/pkg/resourceapply/policy_test.go
@@ -272,6 +272,29 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 			expectedEvents:  []string{"Normal PodDisruptionBudgetUpdated PodDisruptionBudget default/test updated"},
 		},
 		{
+			name: "update succeeds to replace ownerRef kind",
+			existing: []runtime.Object{
+				func() *policyv1beta1.PodDisruptionBudget {
+					pdb := newPDB()
+					pdb.OwnerReferences[0].Kind = "WrongKind"
+					utilruntime.Must(SetHashAnnotation(pdb))
+					return pdb
+				}(),
+			},
+			required: func() *policyv1beta1.PodDisruptionBudget {
+				pdb := newPDB()
+				return pdb
+			}(),
+			expectedPDB: func() *policyv1beta1.PodDisruptionBudget {
+				pdb := newPDB()
+				utilruntime.Must(SetHashAnnotation(pdb))
+				return pdb
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents:  []string{"Normal PodDisruptionBudgetUpdated PodDisruptionBudget default/test updated"},
+		},
+		{
 			name: "update fails if the existing object is owned by someone else",
 			existing: []runtime.Object{
 				func() *policyv1beta1.PodDisruptionBudget {

--- a/pkg/resourceapply/rbac_test.go
+++ b/pkg/resourceapply/rbac_test.go
@@ -278,8 +278,8 @@ func TestApplyClusterRole(t *testing.T) {
 			required:                  newCr(),
 			expectedCr:                nil,
 			expectedChanged:           false,
-			expectedErr:               fmt.Errorf(`clusterrole "test" isn't controlled by us`),
-			expectedEvents:            []string{`Warning UpdateClusterRoleFailed Failed to update ClusterRole test: clusterrole "test" isn't controlled by us`},
+			expectedErr:               fmt.Errorf(`clusterrole "test" is controlled by someone else`),
+			expectedEvents:            []string{`Warning UpdateClusterRoleFailed Failed to update ClusterRole test: clusterrole "test" is controlled by someone else`},
 		},
 	}
 
@@ -646,8 +646,8 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 			required:                  newCrb(),
 			expectedCrb:               nil,
 			expectedChanged:           false,
-			expectedErr:               fmt.Errorf(`clusterrolebinding "test" isn't controlled by us`),
-			expectedEvents:            []string{`Warning UpdateClusterRoleBindingFailed Failed to update ClusterRoleBinding test: clusterrolebinding "test" isn't controlled by us`},
+			expectedErr:               fmt.Errorf(`clusterrolebinding "test" is controlled by someone else`),
+			expectedEvents:            []string{`Warning UpdateClusterRoleBindingFailed Failed to update ClusterRoleBinding test: clusterrolebinding "test" is controlled by someone else`},
 		},
 	}
 


### PR DESCRIPTION
**Description of your changes:**
We have accidentally used Resource name instead of Kind in the nodeconfigpod controller. That creates invalid ownerRefs and prevents GC from executing a cascade delete because such Kind doesn't exist. This PR fixes that and adds the logic that allows us to apply a new ownerRef as long as the UID matches. (We got lucky this time.)

**Which issue is resolved by this Pull Request:**
Resolves #881 
