### PR TITLE
Use direct localhost connection to Scylla in sidecar

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -279,7 +279,6 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 							Command: []string{
 								path.Join(naming.SharedDirName, "scylla-operator"),
 								"sidecar",
-								fmt.Sprintf("--secret-name=%s", naming.AgentAuthTokenSecretName(c.Name)),
 								"--service-name=$(SERVICE_NAME)",
 								"--cpu-count=$(CPU_COUNT)",
 								// TODO: make it configurable

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -510,7 +510,6 @@ func TestStatefulSetForRack(t *testing.T) {
 								Command: []string{
 									"/mnt/shared/scylla-operator",
 									"sidecar",
-									"--secret-name=basic-auth-token",
 									"--service-name=$(SERVICE_NAME)",
 									"--cpu-count=$(CPU_COUNT)",
 									"--loglevel=2",

--- a/pkg/controller/sidecar/controller.go
+++ b/pkg/controller/sidecar/controller.go
@@ -38,12 +38,9 @@ var (
 type Controller struct {
 	namespace   string
 	serviceName string
-	secretName  string
-	hostAddr    string
 
 	kubeClient          kubernetes.Interface
 	singleServiceLister corev1listers.ServiceLister
-	secretLister        corev1listers.SecretLister
 
 	cachesToSync []cache.InformerSynced
 
@@ -56,11 +53,8 @@ type Controller struct {
 func NewController(
 	namespace,
 	serviceName string,
-	secretName string,
-	hostAddr string,
 	kubeClient kubernetes.Interface,
 	singleServiceInformer corev1informers.ServiceInformer,
-	secretInformer corev1informers.SecretInformer,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -96,16 +90,12 @@ func NewController(
 	scc := &Controller{
 		namespace:   namespace,
 		serviceName: serviceName,
-		secretName:  secretName,
-		hostAddr:    hostAddr,
 
 		kubeClient:          kubeClient,
 		singleServiceLister: singleServiceInformer.Lister(),
-		secretLister:        secretInformer.Lister(),
 
 		cachesToSync: []cache.InformerSynced{
 			singleServiceInformer.Informer().HasSynced,
-			secretInformer.Informer().HasSynced,
 		},
 
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "scyllasidecar-controller"}),

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -81,6 +81,7 @@ const (
 	ReadinessProbePath = "/readyz"
 	LivenessProbePath  = "/healthz"
 	ProbePort          = 8080
+	ScyllaAPIPort      = 10000
 
 	OperatorEnvVarPrefix = "SCYLLA_OPERATOR_"
 )

--- a/pkg/scyllaclient/client.go
+++ b/pkg/scyllaclient/client.go
@@ -24,7 +24,7 @@ import (
 )
 
 type Client struct {
-	config Config
+	config *Config
 	logger log.Logger
 
 	scyllaOps *scyllaOperations.Client
@@ -34,7 +34,7 @@ type Client struct {
 	dcCache map[string]string
 }
 
-func NewClient(config Config, logger log.Logger) (*Client, error) {
+func NewClient(config *Config, logger log.Logger) (*Client, error) {
 	/*if err := config.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid config")
 	}*/

--- a/pkg/scyllaclient/config.go
+++ b/pkg/scyllaclient/config.go
@@ -47,8 +47,8 @@ type BackoffConfig struct {
 }
 
 // DefaultConfig returns a Config initialized with default values.
-func DefaultConfig(authToken string, hosts ...string) Config {
-	return Config{
+func DefaultConfig(authToken string, hosts ...string) *Config {
+	return &Config{
 		AuthToken: authToken,
 		Hosts:     hosts,
 		Port:      "10001",
@@ -71,7 +71,7 @@ func DefaultConfig(authToken string, hosts ...string) Config {
 }
 
 // Validate checks if all the fields are properly set.
-func (c Config) Validate() error {
+func (c *Config) Validate() error {
 	var err error
 	if len(c.Hosts) == 0 {
 		err = multierr.Append(err, errors.New("missing hosts"))

--- a/pkg/scyllaclient/retry.go
+++ b/pkg/scyllaclient/retry.go
@@ -30,7 +30,7 @@ type retryableOperation struct {
 }
 
 // retryable wraps parent and adds retry capabilities.
-func retryable(transport runtime.ClientTransport, config Config, logger log.Logger) runtime.ClientTransport {
+func retryable(transport runtime.ClientTransport, config *Config, logger log.Logger) runtime.ClientTransport {
 	return retryableTransport{
 		transport:         transport,
 		config:            config.Backoff,


### PR DESCRIPTION
Previously readiness and liveness probes were routed thorugh
scylla-manage-agent which has much lower resources than Scylla
and it could throtthle probes causing timeouts.
Eliminating routing through agent decouples Scylla lifetime from agent.

Fixes #869