### PR TITLE
Account for image pull times when determining in e2e timeouts

### DIFF
--- a/test/e2e/utils/config.go
+++ b/test/e2e/utils/config.go
@@ -5,8 +5,13 @@ package utils
 import "time"
 
 const (
-	memberRolloutTimeout = 3 * time.Minute
-	baseRolloutTimout    = 30 * time.Second
+	baseRolloutTimout  = 30 * time.Second
+	imagePullTimeout   = 4 * time.Minute
+	joinClusterTimeout = 3 * time.Minute
+
+	// memberRolloutTimeout is the maximum amount of time it takes to start a scylla pod and become ready.
+	// It includes the time to pull the images, copy the necessary files (sidecar), join the cluster and similar.
+	memberRolloutTimeout = 30*time.Second + imagePullTimeout + joinClusterTimeout
 
 	baseManagerSyncTimeout = 3 * time.Minute
 	managerTaskSyncTimeout = 30 * time.Second

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -37,10 +37,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func rolloutTimeoutForScyllaCluster(sc *scyllav1.ScyllaCluster) time.Duration {
-	return baseRolloutTimout + time.Duration(int32(len(sc.Spec.Datacenter.Racks))*GetMemberCount(sc))*memberRolloutTimeout
-}
-
 func IsNodeConfigRolledOut(nc *scyllav1alpha1.NodeConfig) (bool, error) {
 	cond := controllerhelpers.FindNodeConfigCondition(nc.Status.Conditions, scyllav1alpha1.NodeConfigReconciledConditionType)
 	return nc.Status.ObservedGeneration >= nc.Generation &&


### PR DESCRIPTION
**Description of your changes:**
E2E runs are often failing at random tests because scylla won't become ready in time which it can't because most of the timeout for scylla rollout is spent on pulling the image, like in https://github.com/scylladb/scylla-operator/runs/4506379510?check_suite_focus=true
```
lastTimestamp: "2021-12-13T13:08:29Z"
message: Pulling image docker.io/scylladb/scylla:4.4.6"
```

```
lastTimestamp: "2021-12-13T13:10:50Z"
message: Successfully pulled image "docker.io/scylladb/scylla:4.4.6" in 2m21.545046062s
```
The PR accounts for the image pull times and sets the timeouts accordingly.