### PR TITLE
Update readiness immediatelly

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -366,8 +366,9 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 								// TODO: Lower the timeout when we fix probes. We have temporarily changed them from 5s
 								// to 30s to survive cluster overload.
 								// Relevant issue: https://github.com/scylladb/scylla-operator/issues/844
-								TimeoutSeconds: int32(30),
-								PeriodSeconds:  int32(10),
+								TimeoutSeconds:   int32(30),
+								FailureThreshold: int32(1),
+								PeriodSeconds:    int32(10),
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Port: intstr.FromInt(naming.ProbePort),

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -585,8 +585,9 @@ func TestStatefulSetForRack(t *testing.T) {
 									},
 								},
 								ReadinessProbe: &corev1.Probe{
-									TimeoutSeconds: int32(30),
-									PeriodSeconds:  int32(10),
+									TimeoutSeconds:   int32(30),
+									FailureThreshold: int32(1),
+									PeriodSeconds:    int32(10),
 									Handler: corev1.Handler{
 										HTTPGet: &corev1.HTTPGetAction{
 											Port: intstr.FromInt(8080),


### PR DESCRIPTION
**Description of your changes:**
If not specified, the FailureThreshold defaults to 3. Which means after readiness succeeds it takes 3 consecutive failed calls (30s - 90s) for it to go into `Ready: False`. This PR makes sure the first failed call sets readiness to false and better reflects the state.

