### PR TITLE
Raise loglevel in CI to V4

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -201,6 +201,12 @@ jobs:
       run: |
         set -x
         timeout 10m ./hack/ci-deploy.sh '${{ env.image_repo_ref }}:ci'
+        
+        # Raise loglevel in CI.
+        # TODO: Replace it with ScyllaOperatorConfig field when available.
+        kubectl -n scylla-operator patch deployment/scylla-operator --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--loglevel=4"}]'
+        kubectl -n scylla-operator rollout status deployment/scylla-operator
+        
         kubectl get pods -A
     - name: Tolerate flakes on promotion jobs
       if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
This raises loglevel in CI to V4 to better debug the current failures.
