### PR TITLE
Build docs on presubmits only for the current branch

### DIFF
--- a/.github/actions/docs/build/action.yaml
+++ b/.github/actions/docs/build/action.yaml
@@ -1,5 +1,9 @@
 name: "Build documentation and upload artifacts"
-description: 'Builds the docs and uploads artifacts'
+description: "Builds the docs and uploads artifacts"
+inputs:
+  build_target:
+    description: "Build target"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -9,7 +13,7 @@ runs:
       set -euExo pipefail
       shopt -s inherit_errexit
       
-      make -C ./docs/ multiversion SPHINXOPTS="--keep-going"
+      make -C ./docs/ '${{ inputs.build_target }}' SPHINXOPTS="--keep-going"
       
       if [[ ! -d ./docs/_build ]]; then
         echo "docs dir not found"

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -35,3 +35,5 @@ jobs:
 
     - name: Build
       uses: ./.github/actions/docs/build
+      with:
+        build_target: "dirhtml"

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -38,6 +38,8 @@ jobs:
 
     - name: Build
       uses: ./.github/actions/docs/build
+      with:
+        build_target: "multiversion"
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Follow up to #886. Presubmits for branches need to be independent.