### PR TITLE
Fix panic in NoeConfig e2e

### DIFF
--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -199,6 +199,8 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		pod, err := utils.WaitForPodState(ctx1, f.KubeClient().CoreV1(), sc.Namespace, podName, func(p *corev1.Pod) (bool, error) {
 			return true, nil
 		}, utils.WaitForStateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		cmName := naming.GetTuningConfigMapNameForPod(pod)
 		ctx2, ctx2Cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer ctx2Cancel()


### PR DESCRIPTION
**Description of your changes:**
E2E was missing an error check.

**Which issue is resolved by this Pull Request:**
```
  Full Stack Trace
    github.com/scylladb/scylla-operator/pkg/naming.GetTuningConfigMapNameForPod(...)
    	github.com/scylladb/scylla-operator/pkg/naming/names.go:164
    github.com/scylladb/scylla-operator/test/e2e/set/nodeconfig.glob..func1.4()
    	github.com/scylladb/scylla-operator/test/e2e/set/nodeconfig/nodeconfig_optimizations.go:199 +0x979
```