### PR TITLE
Collect e2e container logs from all namespaces

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -252,7 +252,7 @@ jobs:
         sudo tar -c --use-compress-program=lz4 -f ./kubernetes.tar.lz4 "/etc/kubernetes"
 
         mkdir container-logs
-        for ns in kube-system; do
+        for ns in $( kubectl get namespaces --template='{{ range .items }}{{ println .metadata.name }}{{ end }}' ); do
           mkdir "container-logs/${ns}"
           for cid in $( sudo crictl ps --label="io.kubernetes.pod.namespace=${ns}" -a -q ); do
             cname=$( sudo crictl inspect -o go-template --template='{{ .status.metadata.name }}' "${cid}" )


### PR DESCRIPTION
**Description of your changes:**
When a scylla pod is deleted (to be replaced), we lose all logs. We can do our best at least get them from CRI, if not purged already.
