### PR TITLE
Mark NodeConfig as blocking if container wasn't tuned yet

### DIFF
--- a/pkg/controller/nodeconfigdaemon/sync_jobs.go
+++ b/pkg/controller/nodeconfigdaemon/sync_jobs.go
@@ -150,7 +150,7 @@ func (ncdc *Controller) makeJobForContainers(ctx context.Context) (*batchv1.Job,
 	for i := range localScyllaPods {
 		scyllaPod := localScyllaPods[i]
 
-		if scyllaPod.Status.QOSClass != corev1.PodQOSGuaranteed {
+		if !controllerhelpers.IsPodTunable(scyllaPod) {
 			klog.V(4).Infof("Pod %q isn't a subject for optimizations", naming.ObjRef(scyllaPod))
 			continue
 		}

--- a/pkg/controller/nodeconfigdaemon/tune.go
+++ b/pkg/controller/nodeconfigdaemon/tune.go
@@ -25,7 +25,7 @@ const defaultCgroupMountpoint = "/sys/fs/cgroup"
 func getIRQCPUs(ctx context.Context, criClient cri.Client, scyllaPods []*corev1.Pod, hostFullCpuset cpuset.CPUSet, cgroupMountpoint string) (cpuset.CPUSet, error) {
 	scyllaCPUs := cpuset.CPUSet{}
 	for _, scyllaPod := range scyllaPods {
-		if scyllaPod.Status.QOSClass != corev1.PodQOSGuaranteed {
+		if !controllerhelpers.IsPodTunable(scyllaPod) {
 			continue
 		}
 

--- a/pkg/controller/nodeconfigpod/sync_configmaps.go
+++ b/pkg/controller/nodeconfigpod/sync_configmaps.go
@@ -71,6 +71,10 @@ func (ncpc *Controller) makeConfigMap(ctx context.Context, pod *corev1.Pod) (*co
 				continue
 			}
 
+			if !controllerhelpers.IsPodTunable(pod) {
+				continue
+			}
+
 			if controllerhelpers.IsNodeTunedForContainer(nc, node.Name, containerID) {
 				continue
 			}

--- a/pkg/controllerhelpers/scylla.go
+++ b/pkg/controllerhelpers/scylla.go
@@ -186,7 +186,17 @@ func IsNodeTunedForContainer(nc *scyllav1alpha1.NodeConfig, nodeName string, con
 		return false
 	}
 
-	return true
+	for _, cid := range ns.TunedContainers {
+		if cid == containerID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsPodTunable(pod *corev1.Pod) bool {
+	return pod.Status.QOSClass == corev1.PodQOSGuaranteed
 }
 
 func IsNodeTuned(ncnss []scyllav1alpha1.NodeConfigNodeStatus, nodeName string) bool {

--- a/test/e2e/fixture/scylla/optimized.scyllacluster.yaml
+++ b/test/e2e/fixture/scylla/optimized.scyllacluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  generateName: optimized-
+spec:
+  version: 4.6.3
+  agentVersion: 2.6.3
+  developerMode: true
+  datacenter:
+    name: us-east-1
+    racks:
+    - name: us-east-1a
+      members: 1
+      storage:
+        capacity: 100Mi
+      agentResources:
+        limits:
+          cpu: 50m
+          memory: 200Mi
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi

--- a/test/e2e/fixture/scylla/registry.go
+++ b/test/e2e/fixture/scylla/registry.go
@@ -13,6 +13,9 @@ var (
 	//go:embed "basic.scyllacluster.yaml"
 	BasicScyllaCluster ScyllaClusterBytes
 
+	//go:embed "optimized.scyllacluster.yaml"
+	OptimizedScyllaCluster ScyllaClusterBytes
+
 	//go:embed "nodeconfig.yaml"
 	NodeConfig NodeConfigBytes
 )


### PR DESCRIPTION
Function which determined if container is tuned or not did not take into
account nodeConfig status containing list of tuned containers.
NodeConfig which tuned Node but not any container was considered as
non-blocking. E2E test verifying optimizations was passing even for
cluster which wasn't tunable.