### PR TITLE
Create NodeConfig DaemonSet even when optimizations are disabled

### DIFF
--- a/pkg/cmd/operator/nodeconfigdaemon.go
+++ b/pkg/cmd/operator/nodeconfigdaemon.go
@@ -220,6 +220,7 @@ func (o *NodeConfigDaemonOptions) Run(streams genericclioptions.IOStreams, cmd *
 		o.NodeConfigName,
 		types.UID(o.NodeConfigUID),
 		o.ScyllaImage,
+		o.DisableOptimizations,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create node config instance controller: %w", err)

--- a/pkg/controller/nodeconfig/resource.go
+++ b/pkg/controller/nodeconfig/resource.go
@@ -117,10 +117,6 @@ func makeNodeConfigClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 }
 
 func makeNodeConfigDaemonSet(nc *scyllav1alpha1.NodeConfig, operatorImage, scyllaImage string) *appsv1.DaemonSet {
-	if nc.Spec.DisableOptimizations {
-		return nil
-	}
-
 	labels := map[string]string{
 		"app.kubernetes.io/name":   naming.NodeConfigAppName,
 		naming.NodeConfigNameLabel: nc.Name,

--- a/pkg/controller/nodeconfigdaemon/controller.go
+++ b/pkg/controller/nodeconfigdaemon/controller.go
@@ -67,13 +67,14 @@ type Controller struct {
 	namespacedJobLister       batchv1listers.JobLister
 	selfPodLister             corev1listers.PodLister
 
-	namespace      string
-	podName        string
-	nodeName       string
-	nodeUID        types.UID
-	nodeConfigName string
-	nodeConfigUID  types.UID
-	scyllaImage    string
+	namespace            string
+	podName              string
+	nodeName             string
+	nodeUID              types.UID
+	nodeConfigName       string
+	nodeConfigUID        types.UID
+	scyllaImage          string
+	disableOptimizations bool
 
 	cachesToSync []cache.InformerSynced
 
@@ -98,6 +99,7 @@ func NewController(
 	nodeConfigName string,
 	nodeConfigUID types.UID,
 	scyllaImage string,
+	disableOptimizations bool,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -124,13 +126,14 @@ func NewController(
 		namespacedJobLister:       namespacedJobInformer.Lister(),
 		selfPodLister:             selfPodInformer.Lister(),
 
-		namespace:      namespace,
-		podName:        podName,
-		nodeName:       nodeName,
-		nodeUID:        nodeUID,
-		nodeConfigName: nodeConfigName,
-		nodeConfigUID:  nodeConfigUID,
-		scyllaImage:    scyllaImage,
+		namespace:            namespace,
+		podName:              podName,
+		nodeName:             nodeName,
+		nodeUID:              nodeUID,
+		nodeConfigName:       nodeConfigName,
+		nodeConfigUID:        nodeConfigUID,
+		scyllaImage:          scyllaImage,
+		disableOptimizations: disableOptimizations,
 
 		cachesToSync: []cache.InformerSynced{
 			nodeConfigInformer.Informer().HasSynced,


### PR DESCRIPTION
DaemonSet wasn't created when optimizations were disabled, it forbid cleaning up
the Job resources.
Dangling resources lead to continous reruning of optimizations on every Node
restart.