### PR TITLE
Tune nodes immediately when tuning DaemonSet is scheduled 

### DIFF
--- a/pkg/controller/nodeconfigdaemon/controller.go
+++ b/pkg/controller/nodeconfigdaemon/controller.go
@@ -156,6 +156,9 @@ func NewController(
 		DeleteFunc: snc.deleteJob,
 	})
 
+	// Start right away, Scylla might not be scheduled yet, but Node can already be tuned.
+	snc.enqueue()
+
 	return snc, nil
 }
 

--- a/pkg/controller/nodeconfigdaemon/resource.go
+++ b/pkg/controller/nodeconfigdaemon/resource.go
@@ -33,7 +33,7 @@ func makePerftuneJobForNode(controllerRef *metav1.OwnerReference, namespace, nod
 	}
 
 	annotations := map[string]string{
-		naming.NodeConfigJobForNodeKey: string(nodeUID),
+		naming.NodeConfigJobForNodeKey: nodeName,
 	}
 
 	job := &batchv1.Job{

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -55,7 +55,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		preconditionSuccessful = true
 
 		g.By("Verifying there is at least one scylla node")
-		matchingNodes, err := utils.GetMatchingNodesForNodeConfig(ctx, f.KubeAdminClient().CoreV1(), ncTemplate)
+		matchingNodes, err = utils.GetMatchingNodesForNodeConfig(ctx, f.KubeAdminClient().CoreV1(), ncTemplate)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(matchingNodes).NotTo(o.HaveLen(0))
 		framework.Infof("There are %d scylla nodes", len(matchingNodes))


### PR DESCRIPTION
Previously controller was waiting for Scylla Pod to be scheduled on the same Node.
This wasn't in sync with e2e logic verifying it, but unfortunately due to a bug, it wasn't even checked.

E2E test verifying it was relying on suite-scoped variable containing a list of Nodes which are subject for optimizations. But because this variable was shadowed in place where it was computed, test was using an empty default slice. 
Assert compared length of this slice with number of scheduled jobs, which "thanks" to shadowing was passing even though no jobs were created.