### PR TITLE
Keep custom annotations on ServiceAccounts

### DIFF
--- a/pkg/controller/scyllacluster/sync_serviceaccounts.go
+++ b/pkg/controller/scyllacluster/sync_serviceaccounts.go
@@ -16,9 +16,10 @@ func (scc *Controller) syncServiceAccounts(
 	sc *scyllav1.ScyllaCluster,
 	serviceAccounts map[string]*corev1.ServiceAccount,
 ) error {
-	var err error
-
-	requiredServiceAccount := MakeServiceAccount(sc)
+	requiredServiceAccount, err := MakeServiceAccount(sc, serviceAccounts, scc.serviceAccountLister)
+	if err != nil {
+		return fmt.Errorf("can't make service account(s): %w", err)
+	}
 
 	// Delete any excessive ServiceAccounts.
 	// Delete has to be the fist action to avoid getting stuck on quota.

--- a/test/e2e/set/scyllacluster/scyllacluster_sa.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sa.go
@@ -35,6 +35,9 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sa, err := f.KubeClient().CoreV1().ServiceAccounts(f.Namespace()).Create(ctx, &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-member", sc.Name),
+				Annotations: map[string]string{
+					"user-annotation": "123",
+				},
 			},
 		}, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -85,6 +88,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		}, utils.WaitForStateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(sa.OwnerReferences).To(o.HaveLen(1))
+		o.Expect(sa.Annotations).To(o.HaveKeyWithValue("user-annotation", "123"))
 
 		framework.By("Waiting for the RoleBinding to be adopted")
 		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, sc)


### PR DESCRIPTION
Users may need to annotate ServiceAccount used by ScyllaCluster
to integrate with k8s provider services like IAM role management.
These shouldn't be removed by Operator during reconcilation

Fixes #932
