### PR TITLE
Bring back ServiceAccount template in Scylla Helm chart

### DIFF
--- a/helm/scylla/templates/_helpers.tpl
+++ b/helm/scylla/templates/_helpers.tpl
@@ -34,7 +34,10 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "scylla.labels" -}}
-{{ include "scylla.selectorLabels" . }}
+scylla/cluster: {{ include "scylla.fullname" . }}
+app: scylla
+app.kubernetes.io/name: scylla
+app.kubernetes.io/managed-by: scylla-operator
 {{- end }}
 
 {{/*
@@ -45,9 +48,3 @@ app.kubernetes.io/name: {{ include "scylla.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "scylla.serviceAccountName" -}}
-{{- printf "%s-%s" (include "scylla.fullname" .) "member" }}
-{{- end }}

--- a/helm/scylla/templates/serviceaccount.yaml
+++ b/helm/scylla/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if (and .Values.serviceAccount.create .Values.serviceAccount.annotations) -}}
+# Even though Scylla Operator creates and manages Service Account used by ScyllaClusters
+# we have to keep it here to keep backward compatibility of setting custom annotations via helm chart.
+# Operator will adopt it anyways on creation and updates.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ printf "%s-member" (include "scylla.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "scylla.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
Even though Scylla Operator creates and manages Service Account
used by ScyllaClusters we have to keep it in Scylla Helm chart
to keep backward compatibility of setting custom annotations.
Operator will adopt and reconcile it anyways on creation and updates.

Fixes #936
