### PR TITLE
Expose node-exporter metrics in Scylla Pods

### DIFF
--- a/examples/common/monitoring/scylla-service-monitor.yaml
+++ b/examples/common/monitoring/scylla-service-monitor.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: scylla
   endpoints:
+    - port: node-exporter
     - port: agent-prometheus
       metricRelabelings:
         # rename job label to 'manager_agent' due to hardcoded name

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -142,6 +142,10 @@ func memberServicePorts(cluster *scyllav1.ScyllaCluster) []corev1.ServicePort {
 			Name: "agent-api",
 			Port: 10001,
 		},
+		{
+			Name: "node-exporter",
+			Port: 9100,
+		},
 	}
 	if cluster.Spec.Alternator.Enabled() {
 		ports = append(ports, corev1.ServicePort{
@@ -494,6 +498,10 @@ func containerPorts(c *scyllav1.ScyllaCluster) []corev1.ContainerPort {
 		{
 			Name:          "prometheus",
 			ContainerPort: 9180,
+		},
+		{
+			Name:          "node-exporter",
+			ContainerPort: 9100,
 		},
 	}
 

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -91,6 +91,10 @@ func TestMemberService(t *testing.T) {
 			Port: 10001,
 		},
 		{
+			Name: "node-exporter",
+			Port: 9100,
+		},
+		{
 			Name: "thrift",
 			Port: 9160,
 		},
@@ -506,6 +510,10 @@ func TestStatefulSetForRack(t *testing.T) {
 									{
 										Name:          "prometheus",
 										ContainerPort: 9180,
+									},
+									{
+										Name:          "node-exporter",
+										ContainerPort: 9100,
 									},
 									{
 										Name:          "cql",


### PR DESCRIPTION
Scylla image by defualt runs node-exporter which is exposing useful
metrics our Scylla Monitoring expects. Previously they weren't exposed
on Pod level hence Prometheus wans't able to scrape them.