### PR TITLE
edit scylla-manager version

### DIFF
--- a/examples/common/manager.yaml
+++ b/examples/common/manager.yaml
@@ -252,7 +252,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:2.3.0
+        image: docker.io/scylladb/scylla-manager:2.5.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager


### PR DESCRIPTION
i think manager and manager-agent version must be same
Otherwise, the following problems will occur

scylla-manager and scylla-manager-agent version missmatch
Error:
 172.20.15.206: list remote files at location 0318002618UTC_manifest.json.gz: giving up after 2 attempts: invalid character '\x1f' looking for beginning of value

and i fixed matched version solved it

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #
