### PR TITLE
Reconcile metadata explicitly with apply

### DIFF
--- a/pkg/resourceapply/core.go
+++ b/pkg/resourceapply/core.go
@@ -45,6 +45,7 @@ func ApplyService(
 			return nil, false, err
 		}
 
+		resourcemerge.SanitizeObject(requiredCopy)
 		actual, err := client.Services(requiredCopy.Namespace).Create(ctx, requiredCopy, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
 			klog.V(2).InfoS("Already exists (stale cache)", "Service", klog.KObj(requiredCopy))
@@ -70,6 +71,8 @@ func ApplyService(
 	if existing.Annotations[naming.ManagedHash] == requiredCopy.Annotations[naming.ManagedHash] {
 		return existing, false, nil
 	}
+
+	resourcemerge.MergeMetadataInPlace(&requiredCopy.ObjectMeta, existing.ObjectMeta)
 
 	// Preserve allocated fields.
 	requiredCopy.Spec.ClusterIP = existing.Spec.ClusterIP
@@ -116,6 +119,7 @@ func ApplySecret(
 			return nil, false, err
 		}
 
+		resourcemerge.SanitizeObject(requiredCopy)
 		actual, err := client.Secrets(requiredCopy.Namespace).Create(ctx, requiredCopy, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
 			klog.V(2).InfoS("Already exists (stale cache)", "Secret", klog.KObj(requiredCopy))
@@ -141,6 +145,8 @@ func ApplySecret(
 	if existing.Annotations[naming.ManagedHash] == requiredCopy.Annotations[naming.ManagedHash] {
 		return existing, false, nil
 	}
+
+	resourcemerge.MergeMetadataInPlace(&requiredCopy.ObjectMeta, existing.ObjectMeta)
 
 	requiredCopy.ResourceVersion = existing.ResourceVersion
 	actual, err := client.Secrets(requiredCopy.Namespace).Update(ctx, requiredCopy, metav1.UpdateOptions{})
@@ -180,6 +186,7 @@ func ApplyConfigMap(
 			return nil, false, err
 		}
 
+		resourcemerge.SanitizeObject(requiredCopy)
 		actual, err := client.ConfigMaps(requiredCopy.Namespace).Create(ctx, requiredCopy, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
 			klog.V(2).InfoS("Already exists (stale cache)", "ConfigMap", klog.KObj(requiredCopy))
@@ -204,6 +211,8 @@ func ApplyConfigMap(
 	if existingHash == requiredHash {
 		return existing, false, nil
 	}
+
+	resourcemerge.MergeMetadataInPlace(&requiredCopy.ObjectMeta, existing.ObjectMeta)
 
 	// Honor the required RV if it was already set.
 	// Required objects set RV in case their input is based on a previous version of itself.
@@ -332,6 +341,7 @@ func ApplyNamespace(
 			return nil, false, err
 		}
 
+		resourcemerge.SanitizeObject(requiredCopy)
 		actual, err := client.Namespaces().Create(ctx, requiredCopy, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
 			klog.V(2).InfoS("Already exists (stale cache)", "Namespace", klog.KObj(requiredCopy))
@@ -356,6 +366,8 @@ func ApplyNamespace(
 	if existingHash == requiredHash {
 		return existing, false, nil
 	}
+
+	resourcemerge.MergeMetadataInPlace(&requiredCopy.ObjectMeta, existing.ObjectMeta)
 
 	// Honor the required RV if it was already set.
 	// Required objects set RV in case their input is based on a previous version of itself.

--- a/pkg/resourceapply/core_test.go
+++ b/pkg/resourceapply/core_test.go
@@ -339,6 +339,132 @@ func TestApplyService(t *testing.T) {
 			expectedErr:     fmt.Errorf(`service "default/test" isn't controlled by us`),
 			expectedEvents:  []string{`Warning UpdateServiceFailed Failed to update Service default/test: service "default/test" isn't controlled by us`},
 		},
+		{
+			name: "all label and annotation keys are kept when the hash matches",
+			existing: []runtime.Object{
+				func() *corev1.Service {
+					svc := newService()
+					svc.Annotations = map[string]string{
+						"a-1":  "a-alpha",
+						"a-2":  "a-beta",
+						"a-3-": "",
+					}
+					svc.Labels = map[string]string{
+						"l-1":  "l-alpha",
+						"l-2":  "l-beta",
+						"l-3-": "",
+					}
+					utilruntime.Must(SetHashAnnotation(svc))
+					svc.Annotations["a-1"] = "a-alpha-changed"
+					svc.Annotations["a-3"] = "a-resurrected"
+					svc.Annotations["a-custom"] = "custom-value"
+					svc.Labels["l-1"] = "l-alpha-changed"
+					svc.Labels["l-3"] = "l-resurrected"
+					svc.Labels["l-custom"] = "custom-value"
+					return svc
+				}(),
+			},
+			required: func() *corev1.Service {
+				svc := newService()
+				svc.Annotations = map[string]string{
+					"a-1":  "a-alpha",
+					"a-2":  "a-beta",
+					"a-3-": "",
+				}
+				svc.Labels = map[string]string{
+					"l-1":  "l-alpha",
+					"l-2":  "l-beta",
+					"l-3-": "",
+				}
+				return svc
+			}(),
+			forceOwnership: false,
+			expectedService: func() *corev1.Service {
+				svc := newService()
+				svc.Annotations = map[string]string{
+					"a-1":  "a-alpha",
+					"a-2":  "a-beta",
+					"a-3-": "",
+				}
+				svc.Labels = map[string]string{
+					"l-1":  "l-alpha",
+					"l-2":  "l-beta",
+					"l-3-": "",
+				}
+				utilruntime.Must(SetHashAnnotation(svc))
+				svc.Annotations["a-1"] = "a-alpha-changed"
+				svc.Annotations["a-3"] = "a-resurrected"
+				svc.Annotations["a-custom"] = "custom-value"
+				svc.Labels["l-1"] = "l-alpha-changed"
+				svc.Labels["l-3"] = "l-resurrected"
+				svc.Labels["l-custom"] = "custom-value"
+				return svc
+			}(),
+			expectedChanged: false,
+			expectedErr:     nil,
+			expectedEvents:  nil,
+		},
+		{
+			name: "only managed label and annotation keys are updated when the hash changes",
+			existing: []runtime.Object{
+				func() *corev1.Service {
+					svc := newService()
+					svc.Annotations = map[string]string{
+						"a-1":  "a-alpha",
+						"a-2":  "a-beta",
+						"a-3-": "a-resurrected",
+					}
+					svc.Labels = map[string]string{
+						"l-1":  "l-alpha",
+						"l-2":  "l-beta",
+						"l-3-": "l-resurrected",
+					}
+					utilruntime.Must(SetHashAnnotation(svc))
+					svc.Annotations["a-1"] = "a-alpha-changed"
+					svc.Annotations["a-custom"] = "a-custom-value"
+					svc.Labels["l-1"] = "l-alpha-changed"
+					svc.Labels["l-custom"] = "l-custom-value"
+					return svc
+				}(),
+			},
+			required: func() *corev1.Service {
+				svc := newService()
+				svc.Annotations = map[string]string{
+					"a-1":  "a-alpha-x",
+					"a-2":  "a-beta-x",
+					"a-3-": "",
+				}
+				svc.Labels = map[string]string{
+					"l-1":  "l-alpha-x",
+					"l-2":  "l-beta-x",
+					"l-3-": "",
+				}
+				return svc
+			}(),
+			forceOwnership: true,
+			expectedService: func() *corev1.Service {
+				svc := newService()
+				svc.Annotations = map[string]string{
+					"a-1":  "a-alpha-x",
+					"a-2":  "a-beta-x",
+					"a-3-": "",
+				}
+				svc.Labels = map[string]string{
+					"l-1":  "l-alpha-x",
+					"l-2":  "l-beta-x",
+					"l-3-": "",
+				}
+				utilruntime.Must(SetHashAnnotation(svc))
+				delete(svc.Annotations, "a-3-")
+				svc.Annotations["a-custom"] = "a-custom-value"
+				delete(svc.Labels, "l-3-")
+				svc.Labels["l-custom"] = "l-custom-value"
+				return svc
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents:  []string{"Normal ServiceUpdated Service default/test updated"},
+		},
 	}
 
 	for _, tc := range tt {
@@ -746,6 +872,132 @@ func TestApplySecret(t *testing.T) {
 			expectedChanged: false,
 			expectedErr:     fmt.Errorf(`secret "default/test" isn't controlled by us`),
 			expectedEvents:  []string{`Warning UpdateSecretFailed Failed to update Secret default/test: secret "default/test" isn't controlled by us`},
+		},
+		{
+			name: "all label and annotation keys are kept when the hash matches",
+			existing: []runtime.Object{
+				func() *corev1.Secret {
+					secret := newSecret()
+					secret.Annotations = map[string]string{
+						"a-1":  "a-alpha",
+						"a-2":  "a-beta",
+						"a-3-": "",
+					}
+					secret.Labels = map[string]string{
+						"l-1":  "l-alpha",
+						"l-2":  "l-beta",
+						"l-3-": "",
+					}
+					utilruntime.Must(SetHashAnnotation(secret))
+					secret.Annotations["a-1"] = "a-alpha-changed"
+					secret.Annotations["a-3"] = "a-resurrected"
+					secret.Annotations["a-custom"] = "custom-value"
+					secret.Labels["l-1"] = "l-alpha-changed"
+					secret.Labels["l-3"] = "l-resurrected"
+					secret.Labels["l-custom"] = "custom-value"
+					return secret
+				}(),
+			},
+			required: func() *corev1.Secret {
+				secret := newSecret()
+				secret.Annotations = map[string]string{
+					"a-1":  "a-alpha",
+					"a-2":  "a-beta",
+					"a-3-": "",
+				}
+				secret.Labels = map[string]string{
+					"l-1":  "l-alpha",
+					"l-2":  "l-beta",
+					"l-3-": "",
+				}
+				return secret
+			}(),
+			forceOwnership: false,
+			expectedSecret: func() *corev1.Secret {
+				secret := newSecret()
+				secret.Annotations = map[string]string{
+					"a-1":  "a-alpha",
+					"a-2":  "a-beta",
+					"a-3-": "",
+				}
+				secret.Labels = map[string]string{
+					"l-1":  "l-alpha",
+					"l-2":  "l-beta",
+					"l-3-": "",
+				}
+				utilruntime.Must(SetHashAnnotation(secret))
+				secret.Annotations["a-1"] = "a-alpha-changed"
+				secret.Annotations["a-3"] = "a-resurrected"
+				secret.Annotations["a-custom"] = "custom-value"
+				secret.Labels["l-1"] = "l-alpha-changed"
+				secret.Labels["l-3"] = "l-resurrected"
+				secret.Labels["l-custom"] = "custom-value"
+				return secret
+			}(),
+			expectedChanged: false,
+			expectedErr:     nil,
+			expectedEvents:  nil,
+		},
+		{
+			name: "only managed label and annotation keys are updated when the hash changes",
+			existing: []runtime.Object{
+				func() *corev1.Secret {
+					secret := newSecret()
+					secret.Annotations = map[string]string{
+						"a-1":  "a-alpha",
+						"a-2":  "a-beta",
+						"a-3-": "a-resurrected",
+					}
+					secret.Labels = map[string]string{
+						"l-1":  "l-alpha",
+						"l-2":  "l-beta",
+						"l-3-": "l-resurrected",
+					}
+					utilruntime.Must(SetHashAnnotation(secret))
+					secret.Annotations["a-1"] = "a-alpha-changed"
+					secret.Annotations["a-custom"] = "a-custom-value"
+					secret.Labels["l-1"] = "l-alpha-changed"
+					secret.Labels["l-custom"] = "l-custom-value"
+					return secret
+				}(),
+			},
+			required: func() *corev1.Secret {
+				secret := newSecret()
+				secret.Annotations = map[string]string{
+					"a-1":  "a-alpha-x",
+					"a-2":  "a-beta-x",
+					"a-3-": "",
+				}
+				secret.Labels = map[string]string{
+					"l-1":  "l-alpha-x",
+					"l-2":  "l-beta-x",
+					"l-3-": "",
+				}
+				return secret
+			}(),
+			forceOwnership: true,
+			expectedSecret: func() *corev1.Secret {
+				secret := newSecret()
+				secret.Annotations = map[string]string{
+					"a-1":  "a-alpha-x",
+					"a-2":  "a-beta-x",
+					"a-3-": "",
+				}
+				secret.Labels = map[string]string{
+					"l-1":  "l-alpha-x",
+					"l-2":  "l-beta-x",
+					"l-3-": "",
+				}
+				utilruntime.Must(SetHashAnnotation(secret))
+				delete(secret.Annotations, "a-3-")
+				secret.Annotations["a-custom"] = "a-custom-value"
+				delete(secret.Labels, "l-3-")
+				secret.Labels["l-custom"] = "l-custom-value"
+				return secret
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents:  []string{"Normal SecretUpdated Secret default/test updated"},
 		},
 	}
 
@@ -1205,7 +1457,7 @@ func TestApplyServiceAccount(t *testing.T) {
 				}
 				return sa
 			}(),
-			forceOwnership: true,
+			forceOwnership: false,
 			expectedSA: func() *corev1.ServiceAccount {
 				sa := newSAWithControllerRef()
 				sa.Annotations = map[string]string{
@@ -1652,6 +1904,130 @@ func TestApplyConfigMap(t *testing.T) {
 			expectedErr:     fmt.Errorf(`configmap "default/test" isn't controlled by us`),
 			expectedEvents:  []string{`Warning UpdateConfigMapFailed Failed to update ConfigMap default/test: configmap "default/test" isn't controlled by us`},
 		},
+		{
+			name: "all label and annotation keys are kept when the hash matches",
+			existing: []runtime.Object{
+				func() *corev1.ConfigMap {
+					cm := newConfigMap()
+					cm.Annotations = map[string]string{
+						"a-1":  "a-alpha",
+						"a-2":  "a-beta",
+						"a-3-": "",
+					}
+					cm.Labels = map[string]string{
+						"l-1":  "l-alpha",
+						"l-2":  "l-beta",
+						"l-3-": "",
+					}
+					utilruntime.Must(SetHashAnnotation(cm))
+					cm.Annotations["a-1"] = "a-alpha-changed"
+					cm.Annotations["a-3"] = "a-resurrected"
+					cm.Annotations["a-custom"] = "custom-value"
+					cm.Labels["l-1"] = "l-alpha-changed"
+					cm.Labels["l-3"] = "l-resurrected"
+					cm.Labels["l-custom"] = "custom-value"
+					return cm
+				}(),
+			},
+			required: func() *corev1.ConfigMap {
+				cm := newConfigMap()
+				cm.Annotations = map[string]string{
+					"a-1":  "a-alpha",
+					"a-2":  "a-beta",
+					"a-3-": "",
+				}
+				cm.Labels = map[string]string{
+					"l-1":  "l-alpha",
+					"l-2":  "l-beta",
+					"l-3-": "",
+				}
+				return cm
+			}(),
+			expectedCM: func() *corev1.ConfigMap {
+				cm := newConfigMap()
+				cm.Annotations = map[string]string{
+					"a-1":  "a-alpha",
+					"a-2":  "a-beta",
+					"a-3-": "",
+				}
+				cm.Labels = map[string]string{
+					"l-1":  "l-alpha",
+					"l-2":  "l-beta",
+					"l-3-": "",
+				}
+				utilruntime.Must(SetHashAnnotation(cm))
+				cm.Annotations["a-1"] = "a-alpha-changed"
+				cm.Annotations["a-3"] = "a-resurrected"
+				cm.Annotations["a-custom"] = "custom-value"
+				cm.Labels["l-1"] = "l-alpha-changed"
+				cm.Labels["l-3"] = "l-resurrected"
+				cm.Labels["l-custom"] = "custom-value"
+				return cm
+			}(),
+			expectedChanged: false,
+			expectedErr:     nil,
+			expectedEvents:  nil,
+		},
+		{
+			name: "only managed label and annotation keys are updated when the hash changes",
+			existing: []runtime.Object{
+				func() *corev1.ConfigMap {
+					cm := newConfigMap()
+					cm.Annotations = map[string]string{
+						"a-1":  "a-alpha",
+						"a-2":  "a-beta",
+						"a-3-": "a-resurrected",
+					}
+					cm.Labels = map[string]string{
+						"l-1":  "l-alpha",
+						"l-2":  "l-beta",
+						"l-3-": "l-resurrected",
+					}
+					utilruntime.Must(SetHashAnnotation(cm))
+					cm.Annotations["a-1"] = "a-alpha-changed"
+					cm.Annotations["a-custom"] = "a-custom-value"
+					cm.Labels["l-1"] = "l-alpha-changed"
+					cm.Labels["l-custom"] = "l-custom-value"
+					return cm
+				}(),
+			},
+			required: func() *corev1.ConfigMap {
+				cm := newConfigMap()
+				cm.Annotations = map[string]string{
+					"a-1":  "a-alpha-x",
+					"a-2":  "a-beta-x",
+					"a-3-": "",
+				}
+				cm.Labels = map[string]string{
+					"l-1":  "l-alpha-x",
+					"l-2":  "l-beta-x",
+					"l-3-": "",
+				}
+				return cm
+			}(),
+			expectedCM: func() *corev1.ConfigMap {
+				configMap := newConfigMap()
+				configMap.Annotations = map[string]string{
+					"a-1":  "a-alpha-x",
+					"a-2":  "a-beta-x",
+					"a-3-": "",
+				}
+				configMap.Labels = map[string]string{
+					"l-1":  "l-alpha-x",
+					"l-2":  "l-beta-x",
+					"l-3-": "",
+				}
+				utilruntime.Must(SetHashAnnotation(configMap))
+				delete(configMap.Annotations, "a-3-")
+				configMap.Annotations["a-custom"] = "a-custom-value"
+				delete(configMap.Labels, "l-3-")
+				configMap.Labels["l-custom"] = "l-custom-value"
+				return configMap
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents:  []string{"Normal ConfigMapUpdated ConfigMap default/test updated"},
+		},
 	}
 
 	for _, tc := range tt {
@@ -1975,6 +2351,132 @@ func TestApplyNamespace(t *testing.T) {
 			expectedChanged:           false,
 			expectedErr:               fmt.Errorf(`namespace "test" isn't controlled by us`),
 			expectedEvents:            []string{`Warning UpdateNamespaceFailed Failed to update Namespace test: namespace "test" isn't controlled by us`},
+		},
+		{
+			name: "all label and annotation keys are kept when the hash matches",
+			existing: []runtime.Object{
+				func() *corev1.Namespace {
+					ns := newNS()
+					ns.Annotations = map[string]string{
+						"a-1":  "a-alpha",
+						"a-2":  "a-beta",
+						"a-3-": "",
+					}
+					ns.Labels = map[string]string{
+						"l-1":  "l-alpha",
+						"l-2":  "l-beta",
+						"l-3-": "",
+					}
+					utilruntime.Must(SetHashAnnotation(ns))
+					ns.Annotations["a-1"] = "a-alpha-changed"
+					ns.Annotations["a-3"] = "a-resurrected"
+					ns.Annotations["a-custom"] = "custom-value"
+					ns.Labels["l-1"] = "l-alpha-changed"
+					ns.Labels["l-3"] = "l-resurrected"
+					ns.Labels["l-custom"] = "custom-value"
+					return ns
+				}(),
+			},
+			allowMissingControllerRef: true,
+			required: func() *corev1.Namespace {
+				ns := newNS()
+				ns.Annotations = map[string]string{
+					"a-1":  "a-alpha",
+					"a-2":  "a-beta",
+					"a-3-": "",
+				}
+				ns.Labels = map[string]string{
+					"l-1":  "l-alpha",
+					"l-2":  "l-beta",
+					"l-3-": "",
+				}
+				return ns
+			}(),
+			expectedNS: func() *corev1.Namespace {
+				ns := newNS()
+				ns.Annotations = map[string]string{
+					"a-1":  "a-alpha",
+					"a-2":  "a-beta",
+					"a-3-": "",
+				}
+				ns.Labels = map[string]string{
+					"l-1":  "l-alpha",
+					"l-2":  "l-beta",
+					"l-3-": "",
+				}
+				utilruntime.Must(SetHashAnnotation(ns))
+				ns.Annotations["a-1"] = "a-alpha-changed"
+				ns.Annotations["a-3"] = "a-resurrected"
+				ns.Annotations["a-custom"] = "custom-value"
+				ns.Labels["l-1"] = "l-alpha-changed"
+				ns.Labels["l-3"] = "l-resurrected"
+				ns.Labels["l-custom"] = "custom-value"
+				return ns
+			}(),
+			expectedChanged: false,
+			expectedErr:     nil,
+			expectedEvents:  nil,
+		},
+		{
+			name: "only managed label and annotation keys are updated when the hash changes",
+			existing: []runtime.Object{
+				func() *corev1.Namespace {
+					ns := newNS()
+					ns.Annotations = map[string]string{
+						"a-1":  "a-alpha",
+						"a-2":  "a-beta",
+						"a-3-": "a-resurrected",
+					}
+					ns.Labels = map[string]string{
+						"l-1":  "l-alpha",
+						"l-2":  "l-beta",
+						"l-3-": "l-resurrected",
+					}
+					utilruntime.Must(SetHashAnnotation(ns))
+					ns.Annotations["a-1"] = "a-alpha-changed"
+					ns.Annotations["a-custom"] = "a-custom-value"
+					ns.Labels["l-1"] = "l-alpha-changed"
+					ns.Labels["l-custom"] = "l-custom-value"
+					return ns
+				}(),
+			},
+			allowMissingControllerRef: true,
+			required: func() *corev1.Namespace {
+				ns := newNS()
+				ns.Annotations = map[string]string{
+					"a-1":  "a-alpha-x",
+					"a-2":  "a-beta-x",
+					"a-3-": "",
+				}
+				ns.Labels = map[string]string{
+					"l-1":  "l-alpha-x",
+					"l-2":  "l-beta-x",
+					"l-3-": "",
+				}
+				return ns
+			}(),
+			expectedNS: func() *corev1.Namespace {
+				ns := newNS()
+				ns.Annotations = map[string]string{
+					"a-1":  "a-alpha-x",
+					"a-2":  "a-beta-x",
+					"a-3-": "",
+				}
+				ns.Labels = map[string]string{
+					"l-1":  "l-alpha-x",
+					"l-2":  "l-beta-x",
+					"l-3-": "",
+				}
+				utilruntime.Must(SetHashAnnotation(ns))
+				delete(ns.Annotations, "a-3-")
+				ns.Annotations["a-custom"] = "a-custom-value"
+				delete(ns.Labels, "l-3-")
+				ns.Labels["l-custom"] = "l-custom-value"
+				return ns
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents:  []string{"Normal NamespaceUpdated Namespace test updated"},
 		},
 	}
 

--- a/pkg/resourcemerge/objectmerger.go
+++ b/pkg/resourcemerge/objectmerger.go
@@ -1,0 +1,55 @@
+package resourcemerge
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func isRemovalKey(k string) bool {
+	return strings.HasSuffix(k, "-")
+}
+
+func toRemovalKey(k string) string {
+	return k + "-"
+}
+
+func cleanRemovalKeys(m map[string]string) map[string]string {
+	for k := range m {
+		if isRemovalKey(k) {
+			delete(m, k)
+		}
+	}
+
+	return m
+}
+
+func SanitizeObject(obj metav1.Object) {
+	cleanRemovalKeys(obj.GetAnnotations())
+	cleanRemovalKeys(obj.GetLabels())
+}
+
+// MergeMapInPlaceWithoutRemovalKeys merges keys from existing into the required object.
+func MergeMapInPlaceWithoutRemovalKeys(required *map[string]string, existing map[string]string) {
+	for existingKey, existingValue := range existing {
+		// Don't copy removed keys.
+		_, isRemoved := (*required)[toRemovalKey(existingKey)]
+		if isRemoved {
+			continue
+		}
+
+		// Copy only keys not present in the required object.
+		_, found := (*required)[existingKey]
+		if !found {
+			(*required)[existingKey] = existingValue
+		}
+	}
+
+	cleanRemovalKeys(*required)
+}
+
+// MergeMetadataInPlace merges metadata from existing into the required.
+func MergeMetadataInPlace(required *metav1.ObjectMeta, existing metav1.ObjectMeta) {
+	MergeMapInPlaceWithoutRemovalKeys(&required.Annotations, existing.Annotations)
+	MergeMapInPlaceWithoutRemovalKeys(&required.Labels, existing.Labels)
+}

--- a/pkg/resourcemerge/objectmerger_test.go
+++ b/pkg/resourcemerge/objectmerger_test.go
@@ -1,0 +1,361 @@
+package resourcemerge
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsRemovalKey(t *testing.T) {
+	tt := []struct {
+		name     string
+		key      string
+		expected bool
+	}{
+		{
+			name:     "regular key",
+			key:      "foo",
+			expected: false,
+		},
+		{
+			name:     "regular key containing a dash",
+			key:      "foo-bar",
+			expected: false,
+		},
+		{
+			name:     "removal key",
+			key:      "foo-bar-",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isRemovalKey(tc.key)
+
+			if got != tc.expected {
+				t.Errorf("expected %t, got %t", tc.expected, got)
+			}
+		})
+	}
+}
+
+func FuzzToRemovalKey(f *testing.F) {
+	testCases := []string{
+		"foo",
+		"foo-",
+		"scylla-operator.scylladb.com/foo-bar",
+	}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, k string) {
+		t.Logf("key: %q", k)
+		rk := toRemovalKey(k)
+
+		if !isRemovalKey(rk) {
+			t.Errorf("%q isn't a removal key", rk)
+		}
+	})
+}
+
+func TestCleanRemovalKeys(t *testing.T) {
+	tt := []struct {
+		name     string
+		m        map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "nil map",
+			m:        nil,
+			expected: nil,
+		},
+		{
+			name:     "empty map",
+			m:        map[string]string{},
+			expected: map[string]string{},
+		},
+		{
+			name: "removal keys are cleaned",
+			m: map[string]string{
+				"foo":  "alpha",
+				"foo-": "beta",
+				"bar-": "gama",
+			},
+			expected: map[string]string{
+				"foo": "alpha",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cleanRemovalKeys(tc.m)
+
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("expected and got differs: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}
+
+func TestSanitizeObject(t *testing.T) {
+	tt := []struct {
+		name     string
+		obj      *metav1.ObjectMeta
+		expected *metav1.ObjectMeta
+	}{
+		{
+			name: "object with nils",
+			obj: &metav1.ObjectMeta{
+				Annotations: nil,
+				Labels:      nil,
+			},
+			expected: &metav1.ObjectMeta{
+				Annotations: nil,
+				Labels:      nil,
+			},
+		},
+		{
+			name: "mixed values",
+			obj: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"a-foo":  "a-alpha",
+					"a-bar-": "a-beta",
+				},
+				Labels: map[string]string{
+					"l-foo":  "l-alpha",
+					"l-bar-": "l-beta",
+				},
+			},
+			expected: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"a-foo": "a-alpha",
+				},
+				Labels: map[string]string{
+					"l-foo": "l-alpha",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.obj.DeepCopy()
+			SanitizeObject(got)
+
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("expected and got differs: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}
+
+func TestMergeMapInPlaceWithoutRemovalKeys(t *testing.T) {
+	tt := []struct {
+		name           string
+		required       map[string]string
+		existing       map[string]string
+		expected       map[string]string
+		expectPanicErr error
+	}{
+		{
+			name:     "nil required map panics",
+			required: nil,
+			existing: map[string]string{
+				"bar": "beta",
+			},
+			expected:       nil,
+			expectPanicErr: fmt.Errorf("assignment to entry in nil map"),
+		},
+		{
+			name: "no existing map",
+			required: map[string]string{
+				"foo": "alpha",
+			},
+			existing: nil,
+			expected: map[string]string{
+				"foo": "alpha",
+			},
+		},
+		{
+			name: "removal key is removed",
+			required: map[string]string{
+				"foo":  "alpha",
+				"bar-": "",
+			},
+			existing: map[string]string{
+				"foo": "alpha",
+				"bar": "beta",
+			},
+			expected: map[string]string{
+				"foo": "alpha",
+			},
+		},
+		{
+			name: "removal keys are not copied",
+			required: map[string]string{
+				"foo":  "alpha",
+				"bar-": "",
+			},
+			existing: map[string]string{
+				"foo":    "alpha",
+				"bar-":   "beta",
+				"extra-": "gama",
+			},
+			expected: map[string]string{
+				"foo": "alpha",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil && tc.expectPanicErr != nil {
+					t.Errorf("expected panic error %q, got none", tc.expectPanicErr.Error())
+				}
+				if r != nil && tc.expectPanicErr.Error() != r.(error).Error() {
+					t.Errorf("expected panic error %q, got %q", tc.expectPanicErr.Error(), r.(error).Error())
+
+				}
+			}()
+
+			var got map[string]string
+			if tc.required != nil {
+				got = make(map[string]string, len(tc.required))
+				for k, v := range tc.required {
+					got[k] = v
+				}
+			}
+			MergeMapInPlaceWithoutRemovalKeys(&got, tc.existing)
+
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("expected and got differs: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}
+
+func TestMergeMetadataInPlace(t *testing.T) {
+	tt := []struct {
+		name     string
+		required *metav1.ObjectMeta
+		existing metav1.ObjectMeta
+		expected metav1.ObjectMeta
+	}{
+		{
+			name: "nil maps",
+			required: &metav1.ObjectMeta{
+				Annotations: nil,
+				Labels:      nil,
+			},
+			existing: metav1.ObjectMeta{
+				Annotations: nil,
+				Labels:      nil,
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: nil,
+				Labels:      nil,
+			},
+		},
+		{
+			name: "removal keys are removed",
+			required: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"a-1":  "foo",
+					"a-2-": "",
+				},
+				Labels: map[string]string{
+					"l-1":  "bar",
+					"l-2-": "",
+				},
+			},
+			existing: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"a-1": "foo",
+					"a-2": "old",
+				},
+				Labels: map[string]string{
+					"l-1": "bar",
+					"l-2": "old",
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"a-1": "foo",
+				},
+				Labels: map[string]string{
+					"l-1": "bar",
+				},
+			},
+		},
+		{
+			name: "new fields are added",
+			required: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"a-1": "foo",
+				},
+				Labels: map[string]string{
+					"l-1": "bar",
+				},
+			},
+			existing: metav1.ObjectMeta{
+				Annotations: nil,
+				Labels:      nil,
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"a-1": "foo",
+				},
+				Labels: map[string]string{
+					"l-1": "bar",
+				},
+			},
+		},
+		{
+			name: "unmanaged keys are kept",
+			required: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"a-1": "foo",
+				},
+				Labels: map[string]string{
+					"l-1": "bar",
+				},
+			},
+			existing: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"user-annotation": "ua",
+				},
+				Labels: map[string]string{
+					"user-label": "ul",
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"a-1":             "foo",
+					"user-annotation": "ua",
+				},
+				Labels: map[string]string{
+					"l-1":        "bar",
+					"user-label": "ul",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.required.DeepCopy()
+			MergeMetadataInPlace(got, tc.existing)
+
+			if !reflect.DeepEqual(*got, tc.expected) {
+				t.Errorf("expected and got differs: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description of your changes:**
We need to keep user's annotations and labels when we reconcile. Previously this was managed by distinguishing a prefix but that has its own downsides:
- We can't handle our own historical keys that don't have our prefix
- Apply will clear our own annotation if they come from a different controller (like the side car)
The new approach:
- Explicitly prunes keys by appending `-` to the required key
```yaml
# Existing object
annotations:
  "managed-1": "alpha"
  "managed-2": "beta"
  "custom": "gama"
```
```yaml
# Required object
annotations:
  "managed-1": "alpha"
  "managed-2-": ""
```
```yaml
# Result
annotations:
  "managed-1": "alpha"
  "custom": "gama"
```
- Keeps all annotations and labels that are not specified in the required object or having a removal key specified there
- Applies required annotations only when the required object has changed (allows to test changing even our own annotations and labels)

TODO:
- [x] Extend this to all apply functions (but let's agree on the approach before I do that)

/cc @zimnx @rzetelskik 
