### PR TITLE
[WIP] Split sidecar out of the scylla container

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -229,7 +229,7 @@ jobs:
         -v="${HOME}/.kube/config:/kubeconfig:ro" -e='KUBECONFIG=/kubeconfig' \
         '${{ env.image_repo_ref }}:ci' \
         run all \
-        --parallelism=15 \
+        --parallelism=10 \
         --artifacts-dir="${ARTIFACTS_DIR}" \
         --flake-attempts="${flake_attempts}" \
         --timeout="${e2e_timeout_minutes}m"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -229,6 +229,7 @@ jobs:
         -v="${HOME}/.kube/config:/kubeconfig:ro" -e='KUBECONFIG=/kubeconfig' \
         '${{ env.image_repo_ref }}:ci' \
         run all \
+        --parallelism=15 \
         --artifacts-dir="${ARTIFACTS_DIR}" \
         --flake-attempts="${flake_attempts}" \
         --timeout="${e2e_timeout_minutes}m"

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -16,7 +16,7 @@ spec:
       - name: manager-rack
         members: 1
         storage:
-          capacity: 5Gi
+          capacity: 10Gi
         resources:
           limits:
             cpu: 200m

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -16,7 +16,7 @@ spec:
     - name: manager-rack
       members: 1
       storage:
-        capacity: 5Gi
+        capacity: 10Gi
       resources:
         limits:
           cpu: 1

--- a/deploy/operator/50_webhookserver.deployment.yaml
+++ b/deploy/operator/50_webhookserver.deployment.yaml
@@ -10,6 +10,9 @@ spec:
   replicas: 2
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+      maxSurge: 100%
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook-server

--- a/examples/common/manager.yaml
+++ b/examples/common/manager.yaml
@@ -295,7 +295,7 @@ spec:
     - name: manager-rack
       members: 1
       storage:
-        capacity: 5Gi
+        capacity: 10Gi
       resources:
         limits:
           cpu: 1

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -2596,6 +2596,9 @@ spec:
   replicas: 2
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+      maxSurge: 100%
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook-server

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-openapi/validate v0.20.3
 	github.com/gocql/gocql v0.0.0-20211015133455-b225f9b53fa1
 	github.com/google/go-cmp v0.5.6
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
 	github.com/hashicorp/go-version v1.3.0
 	github.com/magiconair/properties v1.8.5
@@ -92,7 +93,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -469,6 +469,7 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -34,7 +34,7 @@ scylla:
   - name: manager-rack
     members: 1
     storage:
-      capacity: 5Gi
+      capacity: 10Gi
     resources:
       limits:
         cpu: 1

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -81,7 +81,7 @@ scylla:
   - name: manager-rack
     members: 1
     storage:
-      capacity: 5Gi
+      capacity: 10Gi
     resources:
       limits:
         cpu: 1

--- a/helm/scylla-operator/templates/webhookserver.deployment.yaml
+++ b/helm/scylla-operator/templates/webhookserver.deployment.yaml
@@ -10,6 +10,9 @@ spec:
   replicas: {{ .Values.webhookServerReplicas }}
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+      maxSurge: 100%
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook-server

--- a/pkg/arg/arg.go
+++ b/pkg/arg/arg.go
@@ -1,0 +1,107 @@
+package arg
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/utils/pointer"
+)
+
+func IntFromBool(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+type Arg struct {
+	Flag  string
+	Value *string
+}
+
+func (a *Arg) String() string {
+	if a == nil {
+		return ""
+	}
+
+	if a.Value == nil {
+		return a.Flag
+	}
+
+	return fmt.Sprintf("%s=%s", a.Flag, *a.Value)
+}
+
+type Args []*Arg
+
+func NewArgs() Args {
+	return Args{}
+}
+
+func (a *Args) AddArg(flag string) {
+	*a = append(*a, &Arg{
+		Flag: flag,
+	})
+}
+
+func (a *Args) AddArgWithIntValue(flag string, value int) {
+	*a = append(*a, &Arg{
+		Flag:  flag,
+		Value: pointer.String(strconv.Itoa(value)),
+	})
+}
+
+func (a *Args) AddArgWithStringValue(flag string, value string) {
+	*a = append(*a, &Arg{
+		Flag:  flag,
+		Value: &value,
+	})
+}
+
+/*
+// Find finds the last matching flag.
+func (a *Args) Find(flag string) (*Arg, error) {
+	var res *Arg
+	for _, arg := range *a {
+		if arg.flag == flag {
+			res = &arg
+		}
+	}
+
+	if res == nil {
+		return nil, fmt.Errorf("flag %q not found", flag)
+	}
+
+	return res, nil
+}
+
+// FindValue finds the last matching flag value.
+func (a *Args) FindValue(flag string) (string, error) {
+	arg, err := a.Find(flag)
+	if err != nil {
+		return "", err
+	}
+	if arg.value == nil {
+		return "", fmt.Errorf("flag %q doesn't have a value set", flag)
+	}
+
+	return *arg.value, nil
+}
+*/
+
+func (a *Args) ArgStrings() []string {
+	res := make([]string, 0, len(*a))
+	for _, arg := range *a {
+		if arg == nil {
+			continue
+		}
+
+		res = append(res, arg.String())
+	}
+
+	return res
+}
+
+func (a *Args) String() string {
+	return strings.Join(a.ArgStrings(), " ")
+}

--- a/pkg/arg/arg_test.go
+++ b/pkg/arg/arg_test.go
@@ -1,0 +1,57 @@
+package arg
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewArgsFromSlice(t *testing.T) {
+	tt := []struct {
+		name        string
+		args        []string
+		expected    Args
+		expectedErr error
+	}{
+		{
+			name:        "nil args succeed",
+			args:        nil,
+			expected:    Args{},
+			expectedErr: nil,
+		},
+		{
+			name:        "empty args succeed",
+			args:        []string{},
+			expected:    Args{},
+			expectedErr: nil,
+		},
+		{
+			name: "repeated args succeed",
+			args: []string{
+				"--no-arg",
+				"--with-arg=wa",
+				"--complex=cv",
+			},
+			expected: Args{
+				{
+					Flag:  "--no-arg",
+					Value: nil,
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NewArgsFromSlice(tc.args)
+			if !reflect.DeepEqual(err, tc.expectedErr) {
+				t.Fatalf("expected and real error differ: %s", cmp.Diff(tc.expectedErr, err))
+			}
+
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Fatalf("expected and real result differ: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}

--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -16,7 +16,9 @@ func NewOperatorCommand(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.AddCommand(NewOperatorCmd(streams))
 	cmd.AddCommand(NewWebhookCmd(streams))
-	cmd.AddCommand(NewSidecarCmd(streams))
+	cmd.AddCommand(NewScyllaStarterCmd(streams))
+	cmd.AddCommand(NewScyllaProbesCmd(streams))
+	cmd.AddCommand(NewScyllaSidecarCmd(streams))
 	cmd.AddCommand(NewManagerControllerCmd(streams))
 	cmd.AddCommand(NewNodeConfigCmd(streams))
 

--- a/pkg/cmd/operator/scyllaprobes.go
+++ b/pkg/cmd/operator/scyllaprobes.go
@@ -1,0 +1,204 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/scyllaprobes"
+	"github.com/scylladb/scylla-operator/pkg/signals"
+	"github.com/scylladb/scylla-operator/pkg/version"
+	"github.com/spf13/cobra"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+)
+
+type ScyllaProbesOptions struct {
+	genericclioptions.ClientConfig
+	genericclioptions.InClusterReflection
+
+	ServiceName string
+
+	kubeClient kubernetes.Interface
+}
+
+func NewScyllaProbesOptions(streams genericclioptions.IOStreams) *ScyllaProbesOptions {
+	clientConfig := genericclioptions.NewClientConfig("scylla-probes")
+	clientConfig.QPS = 2
+	clientConfig.Burst = 5
+
+	return &ScyllaProbesOptions{
+		ClientConfig:        clientConfig,
+		InClusterReflection: genericclioptions.InClusterReflection{},
+	}
+}
+
+func NewScyllaProbesCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewScyllaProbesOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "serve-scylla-probes",
+		Short: "Run a server that translates standard probes for scylla.",
+		Long:  `Run a server that translates standard probes for scylla`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate()
+			if err != nil {
+				return err
+			}
+
+			err = o.Complete()
+			if err != nil {
+				return err
+			}
+
+			err = o.Run(streams, cmd)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	o.ClientConfig.AddFlags(cmd)
+	o.InClusterReflection.AddFlags(cmd)
+
+	cmd.Flags().StringVarP(&o.ServiceName, "service-name", "", o.ServiceName, "Name of the service corresponding to the managed node.")
+
+	return cmd
+}
+
+func (o *ScyllaProbesOptions) Validate() error {
+	var errs []error
+
+	errs = append(errs, o.ClientConfig.Validate())
+	errs = append(errs, o.InClusterReflection.Validate())
+
+	if len(o.ServiceName) == 0 {
+		errs = append(errs, fmt.Errorf("service-name can't be empty"))
+	} else {
+		serviceNameValidationErrs := apimachineryvalidation.NameIsDNS1035Label(o.ServiceName, false)
+		if len(serviceNameValidationErrs) != 0 {
+			errs = append(errs, fmt.Errorf("invalid service name %q: %v", o.ServiceName, serviceNameValidationErrs))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func (o *ScyllaProbesOptions) Complete() error {
+	err := o.ClientConfig.Complete()
+	if err != nil {
+		return err
+	}
+
+	err = o.InClusterReflection.Complete()
+	if err != nil {
+		return err
+	}
+
+	o.kubeClient, err = kubernetes.NewForConfig(o.ProtoConfig)
+	if err != nil {
+		return fmt.Errorf("can't build kubernetes clientset: %w", err)
+	}
+
+	return nil
+}
+
+func (o *ScyllaProbesOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Command) error {
+	klog.Infof("%s version %s", cmd.Name(), version.Get())
+	cliflag.PrintFlags(cmd.Flags())
+
+	stopCh := signals.StopChannel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	singleServiceKubeInformers := informers.NewSharedInformerFactoryWithOptions(
+		o.kubeClient,
+		12*time.Hour,
+		informers.WithNamespace(o.Namespace),
+		informers.WithTweakListOptions(
+			func(options *metav1.ListOptions) {
+				options.FieldSelector = fields.OneTermEqualSelector("metadata.name", o.ServiceName).String()
+			},
+		),
+	)
+
+	singleServiceInformer := singleServiceKubeInformers.Core().V1().Services()
+
+	prober := scyllaprobes.NewProber(
+		o.Namespace,
+		o.ServiceName,
+		singleServiceInformer.Lister(),
+	)
+
+	// Start informers.
+	singleServiceKubeInformers.Start(ctx.Done())
+
+	klog.V(2).InfoS("Waiting for single service informer caches to sync")
+	if !cache.WaitForCacheSync(ctx.Done(), singleServiceInformer.Informer().HasSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	// Run probes.
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", naming.ProbePort),
+		Handler: nil,
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		ok := cache.WaitForNamedCacheSync("Prober", ctx.Done(), singleServiceInformer.Informer().HasSynced)
+		if !ok {
+			return
+		}
+
+		klog.InfoS("Starting Prober server")
+		defer klog.InfoS("Prober server shut down")
+
+		http.HandleFunc(naming.LivenessProbePath, prober.Healthz)
+		http.HandleFunc(naming.ReadinessProbePath, prober.Readyz)
+
+		err := server.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			klog.Fatal("ListenAndServe failed: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+
+	klog.InfoS("Shutting down Prober server")
+	defer klog.InfoS("Shut down Prober server")
+
+	shutdownCtx, shutdownCtxCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer shutdownCtxCancel()
+	err := server.Shutdown(shutdownCtx)
+	if err != nil {
+		klog.ErrorS(err, "Shutting down Prober server")
+	}
+
+	return nil
+}

--- a/pkg/cmd/operator/scyllasidecar.go
+++ b/pkg/cmd/operator/scyllasidecar.go
@@ -1,0 +1,177 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	scyllaversionedclient "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
+	sidecarcontroller "github.com/scylladb/scylla-operator/pkg/controller/sidecar"
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/signals"
+	"github.com/scylladb/scylla-operator/pkg/version"
+	"github.com/spf13/cobra"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+)
+
+type ScyllaSidecarOptions struct {
+	genericclioptions.ClientConfig
+	genericclioptions.InClusterReflection
+
+	ServiceName string
+	CPUCount    int
+
+	kubeClient   kubernetes.Interface
+	scyllaClient scyllaversionedclient.Interface
+}
+
+func NewScyllaSidecarOptions(streams genericclioptions.IOStreams) *ScyllaSidecarOptions {
+	clientConfig := genericclioptions.NewClientConfig("scylla-sidecar")
+	clientConfig.QPS = 2
+	clientConfig.Burst = 5
+
+	return &ScyllaSidecarOptions{
+		ClientConfig:        clientConfig,
+		InClusterReflection: genericclioptions.InClusterReflection{},
+	}
+}
+
+func NewScyllaSidecarCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewScyllaSidecarOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "run-scylla-sidecar",
+		Short: "Run the scylla sidecar.",
+		Long:  `Run the scylla sidecar.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate()
+			if err != nil {
+				return err
+			}
+
+			err = o.Complete()
+			if err != nil {
+				return err
+			}
+
+			err = o.Run(streams, cmd)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	o.ClientConfig.AddFlags(cmd)
+	o.InClusterReflection.AddFlags(cmd)
+
+	cmd.Flags().StringVarP(&o.ServiceName, "service-name", "", o.ServiceName, "Name of the service corresponding to the managed node.")
+
+	return cmd
+}
+
+func (o *ScyllaSidecarOptions) Validate() error {
+	var errs []error
+
+	errs = append(errs, o.ClientConfig.Validate())
+	errs = append(errs, o.InClusterReflection.Validate())
+
+	if len(o.ServiceName) == 0 {
+		errs = append(errs, fmt.Errorf("service-name can't be empty"))
+	} else {
+		serviceNameValidationErrs := apimachineryvalidation.NameIsDNS1035Label(o.ServiceName, false)
+		if len(serviceNameValidationErrs) != 0 {
+			errs = append(errs, fmt.Errorf("invalid service name %q: %v", o.ServiceName, serviceNameValidationErrs))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func (o *ScyllaSidecarOptions) Complete() error {
+	err := o.ClientConfig.Complete()
+	if err != nil {
+		return err
+	}
+
+	err = o.InClusterReflection.Complete()
+	if err != nil {
+		return err
+	}
+
+	o.kubeClient, err = kubernetes.NewForConfig(o.ProtoConfig)
+	if err != nil {
+		return fmt.Errorf("can't build kubernetes clientset: %w", err)
+	}
+
+	o.scyllaClient, err = scyllaversionedclient.NewForConfig(o.RestConfig)
+	if err != nil {
+		return fmt.Errorf("can't build scylla clientset: %w", err)
+	}
+
+	return nil
+}
+
+func (o *ScyllaSidecarOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Command) error {
+	klog.Infof("%s version %s", cmd.Name(), version.Get())
+	cliflag.PrintFlags(cmd.Flags())
+
+	stopCh := signals.StopChannel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	singleServiceKubeInformers := informers.NewSharedInformerFactoryWithOptions(
+		o.kubeClient,
+		12*time.Hour,
+		informers.WithNamespace(o.Namespace),
+		informers.WithTweakListOptions(
+			func(options *metav1.ListOptions) {
+				options.FieldSelector = fields.OneTermEqualSelector("metadata.name", o.ServiceName).String()
+			},
+		),
+	)
+
+	singleServiceInformer := singleServiceKubeInformers.Core().V1().Services()
+
+	sc, err := sidecarcontroller.NewController(
+		o.Namespace,
+		o.ServiceName,
+		o.kubeClient,
+		singleServiceInformer,
+	)
+	if err != nil {
+		return fmt.Errorf("can't create scylla sidecar controller: %w", err)
+	}
+
+	// Start informers.
+	singleServiceKubeInformers.Start(ctx.Done())
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sc.Run(ctx)
+	}()
+
+	<-ctx.Done()
+
+	return nil
+}

--- a/pkg/cmd/operator/scyllastarter.go
+++ b/pkg/cmd/operator/scyllastarter.go
@@ -513,5 +513,5 @@ func (o *ScyllaStarterOptions) Run(streams genericclioptions.IOStreams, cmd *cob
 	// Exec into Scylla.
 	const scyllaPath = "/usr/bin/scylla"
 	klog.V(2).InfoS("Starting scylla", "Command", scyllaPath, "Args", scyllaArgs)
-	return syscall.Exec(scyllaPath, scyllaArgs, scyllaEnv)
+	return syscall.Exec(scyllaPath, append([]string{scyllaPath}, scyllaArgs...), scyllaEnv)
 }

--- a/pkg/cmd/operator/scyllastarter.go
+++ b/pkg/cmd/operator/scyllastarter.go
@@ -475,7 +475,6 @@ func (o *ScyllaStarterOptions) Run(streams genericclioptions.IOStreams, cmd *cob
 
 	if ioPropertiesPresent {
 		klog.InfoS("Found IO properties file, skipping io tuning", "Path", config.ScyllaIOPropertiesPath)
-		return nil
 	} else {
 		// TODO: scylla_io_setup loads precomputed IO properties for machine types which is not desirable
 		//       for us and we need to replace it wit lower level calls. Currently that's broken, and

--- a/pkg/cmd/operator/scyllastarter.go
+++ b/pkg/cmd/operator/scyllastarter.go
@@ -475,6 +475,7 @@ func (o *ScyllaStarterOptions) Run(streams genericclioptions.IOStreams, cmd *cob
 
 	if ioPropertiesPresent {
 		klog.InfoS("Found IO properties file, skipping io tuning", "Path", config.ScyllaIOPropertiesPath)
+		// FIXME: add io-properties file argument so it's picked up. (We don't cache the flags in /etc.)
 	} else {
 		// TODO: scylla_io_setup loads precomputed IO properties for machine types which is not desirable
 		//       for us and we need to replace it wit lower level calls. Currently that's broken, and

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -429,10 +429,13 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 								"/usr/bin/bash",
 								"-euExo",
 								"pipefail",
-								"-O",
-								"inherit_errexit",
+								// Old scylla images have bash < 4.4 that doesn't have this. Enable when we support only 4.6+.
+								// "-O",
+								// "inherit_errexit",
 								"-c",
 								`
+shopt -s inherit_errexit 2>/dev/null || true
+
 cat <<EOF > /etc/scylla.d/housekeeping.cfg
 [housekeeping]
 check-version: False

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -123,10 +123,6 @@ func memberServicePorts(cluster *scyllav1.ScyllaCluster) []corev1.ServicePort {
 			Port: 7001,
 		},
 		{
-			Name: "jmx-monitoring",
-			Port: 7199,
-		},
-		{
 			Name: "cql",
 			Port: 9042,
 		},
@@ -488,7 +484,17 @@ exec bash -x /scylla-housekeeping-service.sh
 								"-l",
 								"/opt/scylladb/jmx",
 								"-ja",
-								"0.0.0.0",
+								"$(POD_IP)",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "POD_IP",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "status.podIP",
+										},
+									},
+								},
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
@@ -655,10 +661,6 @@ func containerPorts(c *scyllav1.ScyllaCluster) []corev1.ContainerPort {
 		{
 			Name:          "tls-intra-node",
 			ContainerPort: 7001,
-		},
-		{
-			Name:          "jmx",
-			ContainerPort: 7199,
 		},
 		{
 			Name:          "prometheus",

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -498,7 +498,7 @@ exec bash -x /scylla-housekeeping-service.sh
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceCPU:    resource.MustParse("30m"),
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -727,16 +727,28 @@ func containerPorts(c *scyllav1.ScyllaCluster) []corev1.ContainerPort {
 			ContainerPort: c.Spec.Alternator.Port,
 		})
 	} else {
-		ports = append(ports, corev1.ContainerPort{
-			Name:          "cql",
-			ContainerPort: 9042,
-		}, corev1.ContainerPort{
-			Name:          "cql-ssl",
-			ContainerPort: 9142,
-		}, corev1.ContainerPort{
-			Name:          "thrift",
-			ContainerPort: 9160,
-		})
+		ports = append(ports,
+			corev1.ContainerPort{
+				Name:          "cql",
+				ContainerPort: 9042,
+			},
+			corev1.ContainerPort{
+				Name:          "cql-shard-aware",
+				ContainerPort: 19042,
+			},
+			corev1.ContainerPort{
+				Name:          "cql-ssl-sa",
+				ContainerPort: 19142,
+			},
+			corev1.ContainerPort{
+				Name:          "cql-ssl",
+				ContainerPort: 9142,
+			},
+			corev1.ContainerPort{
+				Name:          "thrift",
+				ContainerPort: 9160,
+			},
+		)
 	}
 
 	return ports

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -578,7 +578,7 @@ exec bash -x /scylla-housekeeping-service.sh
 									corev1.ResourceMemory: resource.MustParse("20Mi"),
 								},
 							},
-							// TODO: wire probes at leas to informers or something.
+							// TODO: wire probes at least to informers or something.
 						},
 					},
 					ServiceAccountName: naming.MemberServiceAccountNameForScyllaCluster(c.Name),

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -1,0 +1,128 @@
+// Copyright (C) 2022 ScyllaDB
+
+package proc
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+var (
+	pidRegex           = regexp.MustCompile("^[0-9]+$")
+	scyllaCommandRegex = regexp.MustCompile("^*/scylla$")
+)
+
+type ProcessInfo struct {
+	Pid uint64
+}
+
+func (pi *ProcessInfo) ReadCmdline() ([]string, error) {
+	cmdlinePath := fmt.Sprintf("/proc/%d/cmdline", pi.Pid)
+	bytes, err := os.ReadFile(cmdlinePath)
+	if err != nil {
+		return nil, fmt.Errorf("can't read file %q: %w", cmdlinePath, err)
+	}
+
+	return strings.Split(string(bytes), "\x00"), nil
+}
+
+func ListProcesses() ([]*ProcessInfo, error) {
+	f, err := os.Open("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("can't to open /proc: %w", err)
+	}
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			klog.ErrorS(err, "Can't close /proc file")
+		}
+	}()
+
+	files, err := f.Readdirnames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("can't read dir content: %w", err)
+	}
+
+	var processes []*ProcessInfo
+	for _, f := range files {
+		if !pidRegex.Match([]byte(f)) {
+			continue
+		}
+
+		pid, err := strconv.ParseUint(f, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("can't parse file name %q: %w", f, err)
+		}
+
+		processes = append(processes, &ProcessInfo{
+			Pid: pid,
+		})
+	}
+
+	return processes, nil
+}
+
+func FindProcessesMatchingCommand(r *regexp.Regexp) ([]*ProcessInfo, error) {
+	procInfos, err := ListProcesses()
+	if err != nil {
+		return nil, fmt.Errorf("can't list processes: %w", err)
+	}
+
+	var processes []*ProcessInfo
+	for _, pi := range procInfos {
+		cmdLine, err := pi.ReadCmdline()
+		if err != nil {
+			return nil, fmt.Errorf("can't read cmdline for process %d: %w", pi.Pid, err)
+		}
+
+		if len(cmdLine) == 0 {
+			return nil, fmt.Errorf("cmdline for process %d is empty: %w", pi.Pid, err)
+		}
+
+		command := cmdLine[0]
+		if r.MatchString(command) {
+			processes = append(processes, pi)
+		}
+	}
+
+	return processes, nil
+}
+
+func SignalScylla(signal os.Signal) error {
+	procInfos, err := FindProcessesMatchingCommand(scyllaCommandRegex)
+	if err != nil {
+		return fmt.Errorf("can't find processes: %w", err)
+	}
+
+	switch len(procInfos) {
+	case 0:
+		return errors.New("no scylla process found")
+	case 1:
+		break
+	default:
+		klog.Warning("Found more then one scylla process!")
+	}
+
+	// FIXME: parallelize for execution guarantee.
+	for _, pi := range procInfos {
+		p, err := os.FindProcess(int(pi.Pid))
+		if err != nil {
+			return fmt.Errorf("can't find process %q: %w", pi.Pid, err)
+		}
+
+		klog.InfoS("Sending signal to Scylla", "Signal", signal, "PID", pi.Pid)
+		err = p.Signal(signal)
+		if err != nil {
+			return fmt.Errorf("can't find process %q: %w", pi.Pid, err)
+		}
+		klog.InfoS("Signal to Scylla was sent", "Signal", signal, "PID", pi.Pid)
+	}
+
+	return nil
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 ScyllaDB
+
+package proc
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestFindProcessesMatchingCommand(t *testing.T) {
+	selfCmd := os.Args[0]
+	t.Logf("self command: %s", selfCmd)
+
+	selfPid := os.Getpid()
+	t.Logf("self pid: %d", selfPid)
+
+	selfCmdRegex := regexp.MustCompile(regexp.QuoteMeta(selfCmd))
+	procInfos, err := FindProcessesMatchingCommand(selfCmdRegex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(procInfos) != 1 {
+		t.Errorf("expected 1 proc info, got %d", len(procInfos))
+	}
+
+	gotPid := procInfos[0].Pid
+	if int(gotPid) != selfPid {
+		t.Errorf("expected pid %d, got %d", selfPid, gotPid)
+	}
+}

--- a/pkg/scyllaclient/client.go
+++ b/pkg/scyllaclient/client.go
@@ -3,6 +3,7 @@ package scyllaclient
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"runtime"
@@ -104,7 +105,7 @@ func (c *Client) Status(ctx context.Context, host string) (NodeStatusInfoSlice, 
 	// Get all hosts
 	resp, err := c.scyllaOps.StorageServiceHostIDGet(&scyllaOperations.StorageServiceHostIDGetParams{Context: ctx})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can't get StorageServiceHostID: %w", err)
 	}
 
 	all := make([]NodeStatusInfo, len(resp.Payload))
@@ -117,13 +118,14 @@ func (c *Client) Status(ctx context.Context, host string) (NodeStatusInfoSlice, 
 	for i := range all {
 		all[i].Datacenter, err = c.HostDatacenter(ctx, all[i].Addr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("can't get HostDatacenter for %q: %w", all[i].Addr, err)
 		}
 	}
 
 	// Get live nodes
 	live, err := c.scyllaOps.GossiperEndpointLiveGet(&scyllaOperations.GossiperEndpointLiveGetParams{Context: ctx})
 	if err != nil {
+		return nil, fmt.Errorf("can't get GossiperEndpointLive: %w", err)
 		return nil, err
 	}
 	setNodeStatus(all, NodeStatusUp, live.Payload)
@@ -131,21 +133,21 @@ func (c *Client) Status(ctx context.Context, host string) (NodeStatusInfoSlice, 
 	// Get joining nodes
 	joining, err := c.scyllaOps.StorageServiceNodesJoiningGet(&scyllaOperations.StorageServiceNodesJoiningGetParams{Context: ctx})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can't get StorageServiceNodesJoining: %w", err)
 	}
 	setNodeState(all, NodeStateJoining, joining.Payload)
 
 	// Get leaving nodes
 	leaving, err := c.scyllaOps.StorageServiceNodesLeavingGet(&scyllaOperations.StorageServiceNodesLeavingGetParams{Context: ctx})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can't get StorageServiceNodesLeaving: %w", err)
 	}
 	setNodeState(all, NodeStateLeaving, leaving.Payload)
 
 	// Get moving nodes
 	moving, err := c.scyllaOps.StorageServiceNodesMovingGet(&scyllaOperations.StorageServiceNodesMovingGetParams{Context: ctx})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can't get StorageServiceNodesMoving: %w", err)
 	}
 	setNodeState(all, NodeStateMoving, moving.Payload)
 

--- a/pkg/scyllaclient/client.go
+++ b/pkg/scyllaclient/client.go
@@ -126,7 +126,6 @@ func (c *Client) Status(ctx context.Context, host string) (NodeStatusInfoSlice, 
 	live, err := c.scyllaOps.GossiperEndpointLiveGet(&scyllaOperations.GossiperEndpointLiveGetParams{Context: ctx})
 	if err != nil {
 		return nil, fmt.Errorf("can't get GossiperEndpointLive: %w", err)
-		return nil, err
 	}
 	setNodeStatus(all, NodeStatusUp, live.Payload)
 

--- a/pkg/scyllaclient/status_test.go
+++ b/pkg/scyllaclient/status_test.go
@@ -1,0 +1,40 @@
+package scyllaclient
+
+import (
+	"fmt"
+	"testing"
+
+	openapiruntime "github.com/go-openapi/runtime"
+)
+
+func TestStatusCodeOf(t *testing.T) {
+	tt := []struct {
+		name         string
+		err          error
+		expectedCode int
+	}{
+		{
+			name: "OpenAPI error",
+			err: &openapiruntime.APIError{
+				Code: 401,
+			},
+			expectedCode: 401,
+		},
+		{
+			name: "W wrapped OpenAPI error",
+			err: fmt.Errorf("foo: %w", &openapiruntime.APIError{
+				Code: 401,
+			}),
+			expectedCode: 401,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StatusCodeOf(tc.err)
+
+			if got != tc.expectedCode {
+				t.Errorf("expected %d, got %d", tc.expectedCode, got)
+			}
+		})
+	}
+}

--- a/pkg/scyllaprobes/probes.go
+++ b/pkg/scyllaprobes/probes.go
@@ -1,4 +1,4 @@
-package sidecar
+package scyllaprobes
 
 import (
 	"context"

--- a/pkg/scyllaprobes/probes.go
+++ b/pkg/scyllaprobes/probes.go
@@ -98,6 +98,7 @@ func (p *Prober) Readyz(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	klog.V(4).InfoS("readyz probe", "nodeAddress", nodeAddress)
 
 	for _, s := range nodeStatuses {
 		klog.V(4).InfoS("readyz probe: node state", "Node", s.Addr, "Status", s.Status, "State", s.State)

--- a/pkg/semver/version.go
+++ b/pkg/semver/version.go
@@ -18,11 +18,11 @@ package semver
 
 import (
 	"github.com/blang/semver"
+	"k8s.io/klog/v2"
 )
 
 var (
 	ScyllaVersionThatSupportsArgs                    = semver.MustParse("4.2.0")
-	ScyllaVersionThatSupportsDisablingIOTuning       = semver.MustParse("4.3.0")
 	ScyllaVersionThatSupportsDisablingWritebackCache = semver.MustParse("2021.0.0")
 )
 
@@ -37,6 +37,9 @@ func NewScyllaVersion(v string) ScyllaVersion {
 	if err != nil {
 		return ScyllaVersion{unknown: true}
 	}
+
+	klog.V(2).InfoS("Scylla version detected", "version", version)
+
 	return ScyllaVersion{version: version, unknown: false}
 }
 

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -271,7 +271,7 @@ func (s *ScyllaConfig) generateCommand(ctx context.Context) ([]string, []string,
 		"pipefail",
 		"-c",
 		`
-python3 << EOF
+python3 - $@ << EOF
 import os
 import sys
 import scyllasetup
@@ -292,7 +292,7 @@ except Exception:
 	logging.exception('failed!')
 EOF
 
-/opt/scylladb/supervisor/scylla-server.sh -- $@
+/opt/scylladb/supervisor/scylla-server.sh
 `,
 	}
 	for key, value := range args {

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -292,7 +292,7 @@ except Exception:
 	logging.exception('failed!')
 EOF
 
-/opt/scylladb/supervisor/scylla-server.sh
+bash -x /opt/scylladb/supervisor/scylla-server.sh
 `,
 	}
 	for key, value := range args {
@@ -302,6 +302,8 @@ EOF
 			command = append(command, fmt.Sprintf("--%s=%s", key, *value))
 		}
 	}
+
+	klog.V(4).InfoS("Scylla command", "Command", command)
 
 	return command, os.Environ(), nil
 }

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/google/shlex"
 	"github.com/magiconair/properties"
 	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-operator/pkg/arg"
 	scyllaversionedclient "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/semver"
@@ -21,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 )
 
 const (
@@ -29,7 +29,7 @@ const (
 	configDirScyllaD                    = "/etc/scylla.d"
 	scyllaYAMLPath                      = configDirScylla + "/" + naming.ScyllaConfigName
 	scyllaYAMLConfigMapPath             = naming.ScyllaConfigDirName + "/" + naming.ScyllaConfigName
-	scyllaIOPropertiesPath              = configDirScyllaD + "/" + naming.ScyllaIOPropertiesName
+	ScyllaIOPropertiesPath              = configDirScyllaD + "/" + naming.ScyllaIOPropertiesName
 	scyllaRackDCPropertiesPath          = configDirScylla + "/" + naming.ScyllaRackDCPropertiesName
 	scyllaRackDCPropertiesConfigMapPath = naming.ScyllaConfigDirName + "/" + naming.ScyllaRackDCPropertiesName
 )
@@ -54,41 +54,21 @@ func NewScyllaConfig(m *identity.Member, kubeClient kubernetes.Interface, scylla
 	}
 }
 
-func (s *ScyllaConfig) Setup(ctx context.Context) ([]string, []string, error) {
-	klog.Info("Setting up iotune cache")
-	if err := setupIOTuneCache(); err != nil {
-		return nil, nil, fmt.Errorf("can't setup iotune cache: %w", err)
-	}
-
-	klog.Info("Setting up scylla.yaml")
-	if err := s.setupScyllaYAML(scyllaYAMLPath, scyllaYAMLConfigMapPath); err != nil {
-		return nil, nil, fmt.Errorf("can't setup scylla.yaml: %w", err)
-	}
-
-	klog.Info("Setting up cassandra-rackdc.properties")
-	if err := s.setupRackDCProperties(); err != nil {
-		return nil, nil, fmt.Errorf("can't setup rackdc properties file: %w", err)
-	}
-
-	klog.Info("Generating Scylla arguments")
-	return s.generateCommand(ctx)
-}
-
-// setupScyllaYAML edits the default scylla.yaml file with our custom options.
+// SetupScyllaYAML edits the default scylla.yaml file with our custom options.
 // We only edit the options that are not available to configure via the
 // entrypoint script flags. Those options are:
 // - cluster_name
 // - rpc_address
 // - endpoint_snitch
-func (s *ScyllaConfig) setupScyllaYAML(configFilePath, configMapPath string) error {
+func (s *ScyllaConfig) SetupScyllaYAML() error {
 	// Read default scylla.yaml
-	configFileBytes, err := ioutil.ReadFile(configFilePath)
+	configFileBytes, err := ioutil.ReadFile(scyllaYAMLPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to open scylla.yaml")
 	}
 
 	// Read config map scylla.yaml
-	configMapBytes, err := ioutil.ReadFile(configMapPath)
+	configMapBytes, err := ioutil.ReadFile(scyllaYAMLConfigMapPath)
 	if err != nil {
 		klog.InfoS("no scylla.yaml config map available")
 	}
@@ -114,14 +94,14 @@ func (s *ScyllaConfig) setupScyllaYAML(configFilePath, configMapPath string) err
 	}
 
 	// Write result to file
-	if err = ioutil.WriteFile(configFilePath, customConfigBytesBytes, os.ModePerm); err != nil {
+	if err = ioutil.WriteFile(scyllaYAMLPath, customConfigBytesBytes, os.ModePerm); err != nil {
 		return errors.Wrap(err, "error trying to write scylla.yaml")
 	}
 
 	return nil
 }
 
-func (s *ScyllaConfig) setupRackDCProperties() error {
+func (s *ScyllaConfig) SetupRackDCProperties() error {
 	suppliedProperties := loadProperties(s.scyllaRackDCPropertiesConfigMapPath)
 	rackDCProperties := createRackDCProperties(suppliedProperties, s.member.Datacenter, s.member.Rack)
 	f, err := os.Create(s.scyllaRackDCPropertiesPath)
@@ -159,148 +139,113 @@ func loadProperties(fileName string) *properties.Properties {
 
 var scyllaArgumentsRegexp = regexp.MustCompile(`--([^= ]+)(="[^"]+"|=\S+|\s+"[^"]+"|\s+[^\s-]+|\s+-?\d*\.?\d+[^\s-]+|)`)
 
-func convertScyllaArguments(scyllaArguments string) map[string]string {
-	output := make(map[string]string)
-	for _, value := range scyllaArgumentsRegexp.FindAllStringSubmatch(scyllaArguments, -1) {
-		if value[2] == "" {
-			output[value[1]] = ""
-		} else if value[2][0] == '=' {
-			output[value[1]] = strings.TrimSpace(value[2][1:])
-		} else {
-			output[value[1]] = strings.TrimSpace(value[2])
-		}
-	}
-	return output
-}
-
-func appendScyllaArguments(ctx context.Context, s *ScyllaConfig, scyllaArgs string, scyllaFinalArgs map[string]*string) {
-	for argName, argValue := range convertScyllaArguments(scyllaArgs) {
-		if existing := scyllaFinalArgs[argName]; existing == nil {
-			scyllaFinalArgs[argName] = pointer.StringPtr(strings.TrimSpace(argValue))
-		} else {
-			klog.Infof("ScyllaArgs: argument '%s' is ignored, it is already in the list", argName)
-		}
-	}
-}
-
-func (s *ScyllaConfig) generateCommand(ctx context.Context) ([]string, []string, error) {
-	m := s.member
-	// Get seeds
-	seedAddress, err := m.GetSeed(ctx, s.kubeClient.CoreV1())
-	if err != nil {
-		return nil, nil, fmt.Errorf("can't get seed address: %w", err)
-	}
-
-	// Check if we need to run in developer mode
-	devMode := "0"
-	cluster, err := s.scyllaClient.ScyllaV1().ScyllaClusters(s.member.Namespace).Get(ctx, s.member.Cluster, metav1.GetOptions{})
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "error getting cluster")
-	}
-	if cluster.Spec.DeveloperMode {
-		devMode = "1"
-	}
-
-	// Listen on all interfaces so users or a service mesh can use localhost.
-	// TODO: move some of these to the config.
-	argMap := map[string]*string{
-		"listen-address":            pointer.StringPtr("0.0.0.0"),
-		"broadcast-address":         &m.StaticIP,
-		"broadcast-rpc-address":     &m.StaticIP,
-		"seed-provider-parameters":  pointer.StringPtr(fmt.Sprintf("seeds=%s", seedAddress)),
-		"developer-mode":            &devMode,
-		"smp":                       pointer.StringPtr(strconv.Itoa(s.cpuCount)),
-		"log-to-syslog":             pointer.StringPtr("0"),
-		"log-to-stdout":             pointer.StringPtr("1"),
-		"prometheus-address":        pointer.StringPtr("0.0.0.0"),
-		"default-log-level":         pointer.StringPtr("info"),
-		"network-stack":             pointer.StringPtr("posix"),
-		"blocked-reactor-notify-ms": pointer.StringPtr("999999999"),
-	}
-	if m.Overprovisioned {
-		argMap["overprovisioned"] = nil
-	}
-	if cluster.Spec.Alternator.Enabled() {
-		argMap["alternator-address"] = pointer.StringPtr("0.0.0.0")
-		argMap["alternator-port"] = pointer.StringPtr(strconv.Itoa(int(cluster.Spec.Alternator.Port)))
-		if cluster.Spec.Alternator.WriteIsolation != "" {
-			argMap["alternator-write-isolation"] = pointer.StringPtr(cluster.Spec.Alternator.WriteIsolation)
-		}
-	}
-	// If node is being replaced
-	if addr, ok := m.ServiceLabels[naming.ReplaceLabel]; ok {
-		argMap["replace-address-first-boot"] = pointer.StringPtr(addr)
-	}
-	// See if we need to use cpu-pinning
-	// TODO: Add more checks to make sure this is valid.
-	// eg. parse the cpuset and check the number of cpus is the same as cpu limits
-	// Now we rely completely on the user to have the cpu policy correctly
-	// configured in the kubelet, otherwise scylla will crash.
-	if cluster.Spec.CpuSet {
-		cpusAllowed, err := getCPUsAllowedList("/proc/1/status")
-		if err != nil {
-			return nil, nil, errors.WithStack(err)
-		}
-		if err := s.validateCpuSet(ctx, cpusAllowed, s.cpuCount); err != nil {
-			return nil, nil, errors.WithStack(err)
-		}
-		argMap["cpuset"] = &cpusAllowed
-	}
-
-	version := semver.NewScyllaVersion(cluster.Spec.Version)
-
-	klog.InfoS("Scylla version detected", "version", version)
-
-	if len(cluster.Spec.ScyllaArgs) > 0 {
-		if !version.SupportFeatureUnsafe(semver.ScyllaVersionThatSupportsArgs) {
-			klog.InfoS("This scylla version does not support ScyllaArgs. ScyllaArgs is ignored", "version", cluster.Spec.Version)
-		} else {
-			appendScyllaArguments(ctx, s, cluster.Spec.ScyllaArgs, argMap)
-		}
-	}
-
-	if _, err := os.Stat(scyllaIOPropertiesPath); err == nil && version.SupportFeatureSafe(semver.ScyllaVersionThatSupportsDisablingIOTuning) {
-		klog.InfoS("Scylla IO properties are already set, skipping io tuning")
-		ioSetup := "0"
-		argMap["io-setup"] = &ioSetup
-		argMap["io-properties-file"] = pointer.StringPtr(scyllaIOPropertiesPath)
-	}
-
-	var sb strings.Builder
-	sb.WriteString("exec /usr/bin/scylla")
-	for key, value := range argMap {
-		if value == nil {
-			sb.WriteString(fmt.Sprintf(" --%s", key))
-		} else {
-			sb.WriteString(fmt.Sprintf(" --%s=%s", key, *value))
-		}
-	}
-
-	command := []string{
-		"/usr/bin/bash",
-		"-euExo",
-		"pipefail",
-		"-O",
-		"inherit_errexit",
-		"-c",
-		`
-# We need to setup /etc/scylla.d/dev-mode.conf for scylla_io_setup
-/opt/scylladb/scripts/scylla_dev_mode_setup --developer-mode="${DEVELOPER_MODE}"
-/opt/scylladb/scripts/scylla_io_setup
-
-/opt/scylladb/scripts/scylla_prepare
-` + sb.String(),
-	}
-
-	klog.V(4).InfoS("Scylla command", "Command", command)
-
+func (s *ScyllaConfig) GenerateScyllaEnv() []string {
 	osEnv := os.Environ()
 	env := make([]string, 0, len(osEnv)+1)
 	env = append(env, osEnv...)
 	env = append(env, "SCYLLA_HOME=/var/lib/scylla")
 	env = append(env, "SCYLLA_CONF=/etc/scylla")
+	return env
+}
 
-	return command, env, nil
+func (s *ScyllaConfig) GetScyllaUserArgs(ctx context.Context) ([]string, error) {
+	// TODO: cache it
+	cluster, err := s.scyllaClient.ScyllaV1().ScyllaClusters(s.member.Namespace).Get(ctx, s.member.Cluster, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting cluster")
+	}
+
+	version := semver.NewScyllaVersion(cluster.Spec.Version)
+	if !version.SupportFeatureUnsafe(semver.ScyllaVersionThatSupportsArgs) && len(cluster.Spec.ScyllaArgs) > 0 {
+		klog.InfoS("This scylla version does not support ScyllaArgs. ScyllaArgs is ignored", "version", cluster.Spec.Version)
+		return nil, nil
+	}
+
+	// This is an unfortunate API design (eventually we want to migrate it to `unsupportedScyllaArgs []string`).
+	// We need to parse the qouted arguments on our own :(
+	args, err := shlex.Split(cluster.Spec.ScyllaArgs)
+	if err != nil {
+		return nil, fmt.Errorf("can't split scylla args: %w", err)
+	}
+
+	return args, nil
+}
+
+func (s *ScyllaConfig) GenerateScyllaArgs(ctx context.Context) ([]string, error) {
+	m := s.member
+	// Get seeds
+	seedAddress, err := m.GetSeed(ctx, s.kubeClient.CoreV1())
+	if err != nil {
+		return nil, fmt.Errorf("can't get seed address: %w", err)
+	}
+
+	// Check if we need to run in developer mode
+	cluster, err := s.scyllaClient.ScyllaV1().ScyllaClusters(s.member.Namespace).Get(ctx, s.member.Cluster, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting cluster")
+	}
+
+	// Avoid a map to always write the arguments in a stable order.
+	// TODO: move some of these to the config.
+	args := arg.NewArgs()
+	// Listen on all interfaces so users or a service mesh can use localhost.
+	args.AddArgWithStringValue("--listen-address", "0.0.0.0")
+	args.AddArgWithStringValue("--broadcast-address", m.StaticIP)
+	args.AddArgWithStringValue("--broadcast-rpc-address", m.StaticIP)
+	args.AddArgWithStringValue("--seed-provider-parameters", fmt.Sprintf("seeds=%s", seedAddress))
+	args.AddArgWithIntValue("--developer-mode", arg.IntFromBool(cluster.Spec.DeveloperMode))
+	args.AddArgWithIntValue("--smp", s.cpuCount)
+	args.AddArgWithIntValue("--log-to-syslog", 0)
+	args.AddArgWithIntValue("--log-to-stdout", 1)
+	args.AddArgWithStringValue("--prometheus-address", "0.0.0.0")
+	args.AddArgWithStringValue("--default-log-level", "info")
+	args.AddArgWithStringValue("--network-stack", "posix")
+	args.AddArgWithIntValue("--blocked-reactor-notify-ms", 999999999)
+
+	if m.Overprovisioned {
+		args.AddArg("--overprovisioned")
+	}
+	if cluster.Spec.Alternator.Enabled() {
+		args.AddArgWithStringValue("--alternator-address", "0.0.0.0")
+		args.AddArgWithIntValue("--alternator-port", int(cluster.Spec.Alternator.Port))
+		if cluster.Spec.Alternator.WriteIsolation != "" {
+			args.AddArgWithStringValue("--alternator-write-isolation", cluster.Spec.Alternator.WriteIsolation)
+		}
+	}
+	// If node is being replaced
+	if addr, ok := m.ServiceLabels[naming.ReplaceLabel]; ok {
+		args.AddArgWithStringValue("--replace-address-first-boot", addr)
+	}
+
+	// if _, err := os.Stat(scyllaIOPropertiesPath); err == nil && version.SupportFeatureSafe(semver.ScyllaVersionThatSupportsDisablingIOTuning) {
+	// 	klog.InfoS("Scylla IO properties are already set, skipping io tuning")
+	// 	ioSetup := "0"
+	// 	ab.AddArgWithIntValue("--cpuset", cpusAllowed)
+	// 	argMap["io-setup"] = &ioSetup
+	// 	argMap["io-properties-file"] = pointer.StringPtr(scyllaIOPropertiesPath)
+	// }
+
+	// 	command := []string{
+	// 		"/usr/bin/bash",
+	// 		"-euExo",
+	// 		"pipefail",
+	// 		"-O",
+	// 		"inherit_errexit",
+	// 		"-c",
+	// 		`
+	// # We need to setup /etc/scylla.d/dev-mode.conf for scylla_io_setup
+	// /opt/scylladb/scripts/scylla_dev_mode_setup --developer-mode="${DEVELOPER_MODE}"
+	//
+	// #todo cpuset conf file
+	// /opt/scylladb/scripts/scylla_io_setup
+	//
+	// /opt/scylladb/scripts/scylla_prepare
+	// exec /usr/bin/scylla ` + ab.String() + userArgs,
+	// 	}
+
+	// klog.V(4).InfoS("Scylla command", "Command", command)
+
+	return args.ArgStrings(), nil
 }
 
 func (s *ScyllaConfig) validateCpuSet(ctx context.Context, cpusAllowed string, shards int) error {
@@ -315,20 +260,51 @@ func (s *ScyllaConfig) validateCpuSet(ctx context.Context, cpusAllowed string, s
 	return nil
 }
 
-func setupIOTuneCache() error {
-	if _, err := os.Stat(scyllaIOPropertiesPath); err != nil {
+func (s *ScyllaConfig) GetCpusetArg(ctx context.Context) (*arg.Arg, error) {
+	cluster, err := s.scyllaClient.ScyllaV1().ScyllaClusters(s.member.Namespace).Get(ctx, s.member.Cluster, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting cluster")
+	}
+
+	// See if we need to use cpu-pinning
+	// TODO: Add more checks to make sure this is valid.
+	// eg. parse the cpuset and check the number of cpus is the same as cpu limits
+	// Now we rely completely on the user to have the cpu policy correctly
+	// configured in the kubelet, otherwise scylla will crash.
+	if !cluster.Spec.CpuSet {
+		return nil, nil
+	}
+
+	cpusAllowed, err := getCPUsAllowedList("/proc/1/status")
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	err = s.validateCpuSet(ctx, cpusAllowed, s.cpuCount)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &arg.Arg{
+		Flag:  "--cpuset",
+		Value: &cpusAllowed,
+	}, nil
+}
+
+func SetupIOTuneCache() error {
+	if _, err := os.Stat(ScyllaIOPropertiesPath); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("can't stat file %q: %w", scyllaIOPropertiesPath, err)
+			return fmt.Errorf("can't stat file %q: %w", ScyllaIOPropertiesPath, err)
 		}
 
 		cachePath := path.Join(naming.DataDir, naming.ScyllaIOPropertiesName)
-		if err := os.Symlink(cachePath, scyllaIOPropertiesPath); err != nil {
-			return fmt.Errorf("can't create symlink from %q to %q: %w", scyllaIOPropertiesPath, cachePath, err)
+		if err := os.Symlink(cachePath, ScyllaIOPropertiesPath); err != nil {
+			return fmt.Errorf("can't create symlink from %q to %q: %w", ScyllaIOPropertiesPath, cachePath, err)
 		}
 
-		klog.V(2).Info("Initialized IOTune benchmark cache", "path", scyllaIOPropertiesPath, "cachePath", cachePath)
+		klog.V(2).Info("Initialized IOTune benchmark cache", "path", ScyllaIOPropertiesPath, "cachePath", cachePath)
 	} else {
-		klog.V(2).Info("Found cached IOTune benchmark results", "path", scyllaIOPropertiesPath)
+		klog.V(2).Info("Found cached IOTune benchmark results", "path", ScyllaIOPropertiesPath)
 	}
 
 	return nil

--- a/pkg/sidecar/config/config_test.go
+++ b/pkg/sidecar/config/config_test.go
@@ -6,12 +6,27 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/magiconair/properties"
 	"github.com/scylladb/scylla-operator/pkg/sidecar/identity"
 )
+
+func convertScyllaArguments(scyllaArguments string) map[string]string {
+	output := make(map[string]string)
+	for _, value := range scyllaArgumentsRegexp.FindAllStringSubmatch(scyllaArguments, -1) {
+		if value[2] == "" {
+			output[value[1]] = ""
+		} else if value[2][0] == '=' {
+			output[value[1]] = strings.TrimSpace(value[2][1:])
+		} else {
+			output[value[1]] = strings.TrimSpace(value[2])
+		}
+	}
+	return output
+}
 
 func TestCreateRackDCProperties(t *testing.T) {
 	tests := map[string]struct {
@@ -158,7 +173,7 @@ func TestScyllaYamlMerging(t *testing.T) {
 		defer os.Remove(configMapYamlPath)
 
 		sc := &ScyllaConfig{member: &identity.Member{Cluster: "cluster-name"}}
-		if err := sc.setupScyllaYAML(scyllaYamlPath, configMapYamlPath); err != nil {
+		if err := sc.SetupScyllaYAML(); err != nil {
 			t.Error(err)
 		}
 

--- a/test/e2e/set/scyllacluster/datainserter.go
+++ b/test/e2e/set/scyllacluster/datainserter.go
@@ -143,6 +143,10 @@ func (di *DataInserter) createSession(ctx context.Context, sc *scyllav1.ScyllaCl
 	clusterConfig := gocql.NewCluster(hosts...)
 	clusterConfig.Timeout = 3 * time.Second
 	clusterConfig.ConnectTimeout = 3 * time.Second
+	clusterConfig.RetryPolicy = &gocql.SimpleRetryPolicy{
+		// In CI Scylla should always be up and any failures should manifest into the test state.
+		NumRetries: 0,
+	}
 
 	session, err := gocqlx.WrapSession(clusterConfig.CreateSession())
 	if err != nil {

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -453,7 +453,7 @@ func RunEphemeralContainerAndWaitForCompletion(ctx context.Context, client corev
 		"ephemeralcontainers",
 	)
 	if err != nil {
-		return nil, fmt.Errorf("can't path pod %q to add ephemeral container: %w", podName, err)
+		return nil, fmt.Errorf("can't patch pod %q to add ephemeral container: %w", podName, err)
 	}
 
 	return WaitForPodState(

--- a/vendor/github.com/google/shlex/COPYING
+++ b/vendor/github.com/google/shlex/COPYING
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/shlex/README
+++ b/vendor/github.com/google/shlex/README
@@ -1,0 +1,2 @@
+go-shlex is a simple lexer for go that supports shell-style quoting,
+commenting, and escaping.

--- a/vendor/github.com/google/shlex/shlex.go
+++ b/vendor/github.com/google/shlex/shlex.go
@@ -1,0 +1,416 @@
+/*
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package shlex implements a simple lexer which splits input in to tokens using
+shell-style rules for quoting and commenting.
+
+The basic use case uses the default ASCII lexer to split a string into sub-strings:
+
+  shlex.Split("one \"two three\" four") -> []string{"one", "two three", "four"}
+
+To process a stream of strings:
+
+  l := NewLexer(os.Stdin)
+  for ; token, err := l.Next(); err != nil {
+  	// process token
+  }
+
+To access the raw token stream (which includes tokens for comments):
+
+  t := NewTokenizer(os.Stdin)
+  for ; token, err := t.Next(); err != nil {
+	// process token
+  }
+
+*/
+package shlex
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// TokenType is a top-level token classification: A word, space, comment, unknown.
+type TokenType int
+
+// runeTokenClass is the type of a UTF-8 character classification: A quote, space, escape.
+type runeTokenClass int
+
+// the internal state used by the lexer state machine
+type lexerState int
+
+// Token is a (type, value) pair representing a lexographical token.
+type Token struct {
+	tokenType TokenType
+	value     string
+}
+
+// Equal reports whether tokens a, and b, are equal.
+// Two tokens are equal if both their types and values are equal. A nil token can
+// never be equal to another token.
+func (a *Token) Equal(b *Token) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.tokenType != b.tokenType {
+		return false
+	}
+	return a.value == b.value
+}
+
+// Named classes of UTF-8 runes
+const (
+	spaceRunes            = " \t\r\n"
+	escapingQuoteRunes    = `"`
+	nonEscapingQuoteRunes = "'"
+	escapeRunes           = `\`
+	commentRunes          = "#"
+)
+
+// Classes of rune token
+const (
+	unknownRuneClass runeTokenClass = iota
+	spaceRuneClass
+	escapingQuoteRuneClass
+	nonEscapingQuoteRuneClass
+	escapeRuneClass
+	commentRuneClass
+	eofRuneClass
+)
+
+// Classes of lexographic token
+const (
+	UnknownToken TokenType = iota
+	WordToken
+	SpaceToken
+	CommentToken
+)
+
+// Lexer state machine states
+const (
+	startState           lexerState = iota // no runes have been seen
+	inWordState                            // processing regular runes in a word
+	escapingState                          // we have just consumed an escape rune; the next rune is literal
+	escapingQuotedState                    // we have just consumed an escape rune within a quoted string
+	quotingEscapingState                   // we are within a quoted string that supports escaping ("...")
+	quotingState                           // we are within a string that does not support escaping ('...')
+	commentState                           // we are within a comment (everything following an unquoted or unescaped #
+)
+
+// tokenClassifier is used for classifying rune characters.
+type tokenClassifier map[rune]runeTokenClass
+
+func (typeMap tokenClassifier) addRuneClass(runes string, tokenType runeTokenClass) {
+	for _, runeChar := range runes {
+		typeMap[runeChar] = tokenType
+	}
+}
+
+// newDefaultClassifier creates a new classifier for ASCII characters.
+func newDefaultClassifier() tokenClassifier {
+	t := tokenClassifier{}
+	t.addRuneClass(spaceRunes, spaceRuneClass)
+	t.addRuneClass(escapingQuoteRunes, escapingQuoteRuneClass)
+	t.addRuneClass(nonEscapingQuoteRunes, nonEscapingQuoteRuneClass)
+	t.addRuneClass(escapeRunes, escapeRuneClass)
+	t.addRuneClass(commentRunes, commentRuneClass)
+	return t
+}
+
+// ClassifyRune classifiees a rune
+func (t tokenClassifier) ClassifyRune(runeVal rune) runeTokenClass {
+	return t[runeVal]
+}
+
+// Lexer turns an input stream into a sequence of tokens. Whitespace and comments are skipped.
+type Lexer Tokenizer
+
+// NewLexer creates a new lexer from an input stream.
+func NewLexer(r io.Reader) *Lexer {
+
+	return (*Lexer)(NewTokenizer(r))
+}
+
+// Next returns the next word, or an error. If there are no more words,
+// the error will be io.EOF.
+func (l *Lexer) Next() (string, error) {
+	for {
+		token, err := (*Tokenizer)(l).Next()
+		if err != nil {
+			return "", err
+		}
+		switch token.tokenType {
+		case WordToken:
+			return token.value, nil
+		case CommentToken:
+			// skip comments
+		default:
+			return "", fmt.Errorf("Unknown token type: %v", token.tokenType)
+		}
+	}
+}
+
+// Tokenizer turns an input stream into a sequence of typed tokens
+type Tokenizer struct {
+	input      bufio.Reader
+	classifier tokenClassifier
+}
+
+// NewTokenizer creates a new tokenizer from an input stream.
+func NewTokenizer(r io.Reader) *Tokenizer {
+	input := bufio.NewReader(r)
+	classifier := newDefaultClassifier()
+	return &Tokenizer{
+		input:      *input,
+		classifier: classifier}
+}
+
+// scanStream scans the stream for the next token using the internal state machine.
+// It will panic if it encounters a rune which it does not know how to handle.
+func (t *Tokenizer) scanStream() (*Token, error) {
+	state := startState
+	var tokenType TokenType
+	var value []rune
+	var nextRune rune
+	var nextRuneType runeTokenClass
+	var err error
+
+	for {
+		nextRune, _, err = t.input.ReadRune()
+		nextRuneType = t.classifier.ClassifyRune(nextRune)
+
+		if err == io.EOF {
+			nextRuneType = eofRuneClass
+			err = nil
+		} else if err != nil {
+			return nil, err
+		}
+
+		switch state {
+		case startState: // no runes read yet
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						return nil, io.EOF
+					}
+				case spaceRuneClass:
+					{
+					}
+				case escapingQuoteRuneClass:
+					{
+						tokenType = WordToken
+						state = quotingEscapingState
+					}
+				case nonEscapingQuoteRuneClass:
+					{
+						tokenType = WordToken
+						state = quotingState
+					}
+				case escapeRuneClass:
+					{
+						tokenType = WordToken
+						state = escapingState
+					}
+				case commentRuneClass:
+					{
+						tokenType = CommentToken
+						state = commentState
+					}
+				default:
+					{
+						tokenType = WordToken
+						value = append(value, nextRune)
+						state = inWordState
+					}
+				}
+			}
+		case inWordState: // in a regular word
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case spaceRuneClass:
+					{
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case escapingQuoteRuneClass:
+					{
+						state = quotingEscapingState
+					}
+				case nonEscapingQuoteRuneClass:
+					{
+						state = quotingState
+					}
+				case escapeRuneClass:
+					{
+						state = escapingState
+					}
+				default:
+					{
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case escapingState: // the rune after an escape character
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						err = fmt.Errorf("EOF found after escape character")
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				default:
+					{
+						state = inWordState
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case escapingQuotedState: // the next rune after an escape character, in double quotes
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						err = fmt.Errorf("EOF found after escape character")
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				default:
+					{
+						state = quotingEscapingState
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case quotingEscapingState: // in escaping double quotes
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						err = fmt.Errorf("EOF found when expecting closing quote")
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case escapingQuoteRuneClass:
+					{
+						state = inWordState
+					}
+				case escapeRuneClass:
+					{
+						state = escapingQuotedState
+					}
+				default:
+					{
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case quotingState: // in non-escaping single quotes
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						err = fmt.Errorf("EOF found when expecting closing quote")
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case nonEscapingQuoteRuneClass:
+					{
+						state = inWordState
+					}
+				default:
+					{
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case commentState: // in a comment
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case spaceRuneClass:
+					{
+						if nextRune == '\n' {
+							state = startState
+							token := &Token{
+								tokenType: tokenType,
+								value:     string(value)}
+							return token, err
+						} else {
+							value = append(value, nextRune)
+						}
+					}
+				default:
+					{
+						value = append(value, nextRune)
+					}
+				}
+			}
+		default:
+			{
+				return nil, fmt.Errorf("Unexpected state: %v", state)
+			}
+		}
+	}
+}
+
+// Next returns the next token in the stream.
+func (t *Tokenizer) Next() (*Token, error) {
+	return t.scanStream()
+}
+
+// Split partitions a string into a slice of strings.
+func Split(s string) ([]string, error) {
+	l := NewLexer(strings.NewReader(s))
+	subStrings := make([]string, 0)
+	for {
+		word, err := l.Next()
+		if err != nil {
+			if err == io.EOF {
+				return subStrings, nil
+			}
+			return subStrings, err
+		}
+		subStrings = append(subStrings, word)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,6 +297,9 @@ github.com/google/go-cmp/cmp/internal/value
 ## explicit; go 1.12
 github.com/google/gofuzz
 github.com/google/gofuzz/bytesource
+# github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+## explicit; go 1.13
+github.com/google/shlex
 # github.com/google/uuid v1.3.0
 ## explicit
 github.com/google/uuid


### PR DESCRIPTION
**Description of your changes:**
This PR starts the process of removing processes out of the `scylla` container. The reason is twofold - it goes against a good container architecture to run multiple processes inside one container and running additional stuff in the same cpu slice can steel the core from scylla which manifests it latency bumps. From our debugging the scylla-operator process was the main offender causing the bumps but in followup PRs, and in cooperation with scylla devs, we should get rid of the `supervisord` running multiple processes in the container.

Requires:
- [ ] https://github.com/scylladb/scylla-operator/pull/967

Fixes #620