### PR TITLE
Fix decommissioning of drained nodes

### DIFF
--- a/.github/actions/setup-minikube/action.yaml
+++ b/.github/actions/setup-minikube/action.yaml
@@ -15,12 +15,12 @@ runs:
     run: |
       set -x
       sudo apt-get install -y --no-install-recommends conntrack
-      sudo curl -s --fail -L https://storage.googleapis.com/minikube/releases/v1.24.0/minikube-linux-amd64 -o /usr/local/bin/minikube
+      sudo curl -s --fail -L https://storage.googleapis.com/minikube/releases/v1.25.2/minikube-linux-amd64 -o /usr/local/bin/minikube
       sudo chmod +x /usr/local/bin/minikube
 
-      sudo curl -s --fail -L "https://dl.k8s.io/release/v1.22.2/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
+      sudo curl -s --fail -L "https://dl.k8s.io/release/v1.23.0/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
       sudo chmod +x /usr/local/bin/kubectl
-      sudo curl -s --fail -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.22.0/crictl-v1.22.0-linux-amd64.tar.gz | tar -f - -xz -C /usr/local/bin crictl
+      sudo curl -s --fail -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.23.0/crictl-v1.23.0-linux-amd64.tar.gz | tar -f - -xz -C /usr/local/bin crictl
   - name: Configure minikube
     shell: bash
     run: |
@@ -61,6 +61,24 @@ runs:
         echo 'Waiting for apiserver to come up.'
         sleep 1
       done
+
+      # Hotfix pods/ephemeralcontainers perms needed by e2e tests
+      # (Upstream fix in https://github.com/kubernetes/kubernetes/pull/109332)
+      kubectl apply --server-side -f - <<EOF
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: scylladb-e2e:hotfixes
+          labels:
+            rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods/ephemeralcontainers
+          verbs:
+          - patch
+      EOF
 
       kubectl -n kube-system rollout status --timeout=5m deployment.apps/coredns
 

--- a/pkg/controller/sidecar/sync.go
+++ b/pkg/controller/sidecar/sync.go
@@ -48,6 +48,7 @@ func (c *Controller) decommissionNode(ctx context.Context, svc *corev1.Service) 
 			return fmt.Errorf("can't restart scylla node: %w", err)
 		}
 		klog.InfoS("Successfully restarted scylla.")
+		c.queue.AddAfter(c.key, requeueWaitDuration)
 		return nil
 
 	case scyllaclient.OperationalModeNormal:

--- a/pkg/controllerhelpers/core.go
+++ b/pkg/controllerhelpers/core.go
@@ -75,14 +75,24 @@ func IsOrphanedPV(pv *corev1.PersistentVolume, nodes []*corev1.Node) (bool, erro
 	return true, nil
 }
 
-func FindScyllaContainerStatus(pod *corev1.Pod) *corev1.ContainerStatus {
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name == naming.ScyllaContainerName {
-			return &cs
+func FindContainerStatus(pod *corev1.Pod, containerName string) *corev1.ContainerStatus {
+	for _, statusSet := range [][]corev1.ContainerStatus{
+		pod.Status.InitContainerStatuses,
+		pod.Status.ContainerStatuses,
+		pod.Status.EphemeralContainerStatuses,
+	} {
+		for _, cs := range statusSet {
+			if cs.Name == containerName {
+				return &cs
+			}
 		}
 	}
 
 	return nil
+}
+
+func FindScyllaContainerStatus(pod *corev1.Pod) *corev1.ContainerStatus {
+	return FindContainerStatus(pod, naming.ScyllaContainerName)
 }
 
 func IsScyllaContainerRunning(pod *corev1.Pod) bool {

--- a/pkg/helpers/mergepatch.go
+++ b/pkg/helpers/mergepatch.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 ScyllaDB
+
+package helpers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+func CreateTwoWayMergePatch[T runtime.Object](original, modified T) ([]byte, error) {
+	oldJson, err := json.Marshal(original)
+	if err != nil {
+		return nil, fmt.Errorf("can't marshal old object: %w", err)
+	}
+
+	newJson, err := json.Marshal(modified)
+	if err != nil {
+		return nil, fmt.Errorf("can't marshal new object: %w", err)
+	}
+
+	return strategicpatch.CreateTwoWayMergePatch(oldJson, newJson, modified)
+}

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -193,7 +193,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		ctx1, ctx1Cancel := context.WithTimeout(ctx, apiCallTimeout)
 		defer ctx1Cancel()
 		podName := fmt.Sprintf("%s-%d", naming.StatefulSetNameForRack(sc.Spec.Datacenter.Racks[0], sc), 0)
-		pod, err := utils.WaitForPodState(ctx1, f.KubeClient().CoreV1(), sc.Namespace, podName, func(p *corev1.Pod) (bool, error) {
+		pod, err := utils.WaitForPodState(ctx1, f.KubeClient().CoreV1().Pods(sc.Namespace), podName, func(p *corev1.Pod) (bool, error) {
 			return true, nil
 		}, utils.WaitForStateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -73,7 +73,7 @@ var _ = g.Describe("ScyllaCluster replace", func() {
 		framework.By("Waiting for the pod to be replaced")
 		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx2Cancel()
-		_, err = utils.WaitForPodState(waitCtx2, f.KubeClient().CoreV1(), pod.Namespace, pod.Name, func(p *corev1.Pod) (bool, error) {
+		_, err = utils.WaitForPodState(waitCtx2, f.KubeClient().CoreV1().Pods(pod.Namespace), pod.Name, func(p *corev1.Pod) (bool, error) {
 			return p.UID != pod.UID, nil
 		}, utils.WaitForStateOptions{TolerateDelete: true})
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -7,9 +7,14 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	"github.com/scylladb/scylla-operator/pkg/controller/scyllacluster"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -45,16 +50,17 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
 
-		framework.By("Scaling the ScyllaCluster to 2 replicas")
+		framework.By("Scaling the ScyllaCluster to 3 replicas")
 		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
 			ctx,
 			sc.Name,
 			types.JSONPatchType,
-			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 2}]`),
+			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 3}]`),
 			metav1.PatchOptions{},
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(2))
+		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(3))
 
 		framework.By("Waiting for the ScyllaCluster to rollout")
 		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, sc)
@@ -71,7 +77,65 @@ var _ = g.Describe("ScyllaCluster", func() {
 		err = di.Insert()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Scaling the ScyllaCluster back to 1 replica")
+		framework.By("Scaling the ScyllaCluster down to 2 replicas")
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace).Patch(
+			ctx,
+			sc.Name,
+			types.JSONPatchType,
+			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 2}]`),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(2))
+
+		framework.By("Waiting for the ScyllaCluster to rollout")
+		waitCtx3, waitCtx3Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx3Cancel()
+		sc, err = utils.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
+
+		podName := naming.StatefulSetNameForRack(sc.Spec.Datacenter.Racks[0], sc) + "-1"
+		svcName := podName
+		framework.By("Marking ScyllaCluster node #2 (%s) for maintenance", podName)
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					naming.NodeMaintenanceLabel: "",
+				},
+			},
+		}
+		patch, err := helpers.CreateTwoWayMergePatch(&corev1.Service{}, svc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		svc, err = f.KubeClient().CoreV1().Services(sc.Namespace).Patch(
+			ctx,
+			svcName,
+			types.StrategicMergePatchType,
+			patch,
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Manually draining ScyllaCluster node #2 (%s)", podName)
+		ec := &corev1.EphemeralContainer{
+			TargetContainerName: naming.ScyllaContainerName,
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:            "e2e-drain-scylla",
+				Image:           scyllacluster.ImageForCluster(sc),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         []string{"/usr/bin/nodetool", "drain"},
+				Args:            []string{},
+			},
+		}
+		pod, err := utils.RunEphemeralContainerAndWaitForCompletion(ctx, f.KubeClient().CoreV1().Pods(sc.Namespace), podName, ec)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		ephemeralContainerState := controllerhelpers.FindContainerStatus(pod, ec.Name)
+		o.Expect(ephemeralContainerState).NotTo(o.BeNil())
+		o.Expect(ephemeralContainerState.State.Terminated).NotTo(o.BeNil())
+		o.Expect(ephemeralContainerState.State.Terminated.ExitCode).To(o.BeEquivalentTo(0))
+
+		framework.By("Scaling the ScyllaCluster down to 1 replicas")
 		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
 			ctx,
 			sc.Name,
@@ -83,28 +147,28 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(1))
 
 		framework.By("Waiting for the ScyllaCluster to rollout")
-		waitCtx3, waitCtx3Cancel := utils.ContextForRollout(ctx, sc)
-		defer waitCtx3Cancel()
-		sc, err = utils.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.IsScyllaClusterRolledOut)
+		waitCtx5, waitCtx5Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx5Cancel()
+		sc, err = utils.WaitForScyllaClusterState(waitCtx5, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
 
-		framework.By("Scaling the ScyllaCluster back to 2 replicas to make sure there isn't an old (decommissioned) storage in place")
+		framework.By("Scaling the ScyllaCluster back to 3 replicas to make sure there isn't an old (decommissioned) storage in place")
 		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
 			ctx,
 			sc.Name,
 			types.JSONPatchType,
-			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 2}]`),
+			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 3}]`),
 			metav1.PatchOptions{},
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(2))
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(3))
 
 		framework.By("Waiting for the ScyllaCluster to rollout")
-		waitCtx4, waitCtx4Cancel := utils.ContextForRollout(ctx, sc)
-		defer waitCtx4Cancel()
-		sc, err = utils.WaitForScyllaClusterState(waitCtx4, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.IsScyllaClusterRolledOut)
+		waitCtx6, waitCtx6Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx6Cancel()
+		sc, err = utils.WaitForScyllaClusterState(waitCtx6, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)


### PR DESCRIPTION
**Description of your changes:**
Fixes decommissioning of drained nodes and adds e2e coverage. Previously, when the node was already drained, the decommissioning would get stuck in the sidecar until a change on the corresponding service would trigger a new sync.
