### PR TITLE
Allow directly selecting member services for building CQL connections

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -31,11 +31,14 @@ const (
 )
 
 func HeadlessServiceForCluster(c *scyllav1.ScyllaCluster) *corev1.Service {
+	labels := naming.ClusterLabels(c)
+	labels[naming.ScyllaServiceTypeLabel] = string(naming.ScyllaServiceTypeIdentity)
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      naming.HeadlessServiceNameForCluster(c),
 			Namespace: c.Namespace,
-			Labels:    naming.ClusterLabels(c),
+			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(c, controllerGVK),
 			},
@@ -62,6 +65,7 @@ func MemberService(sc *scyllav1.ScyllaCluster, rackName, name string, oldService
 	labels := naming.ClusterLabels(sc)
 	labels[naming.DatacenterNameLabel] = sc.Spec.Datacenter.Name
 	labels[naming.RackNameLabel] = rackName
+	labels[naming.ScyllaServiceTypeLabel] = string(naming.ScyllaServiceTypeMember)
 
 	// Copy the old replace label, if present.
 	var replaceAddr string

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -55,6 +55,7 @@ func TestMemberService(t *testing.T) {
 			"scylla/cluster":               "basic",
 			"scylla/datacenter":            "dc",
 			"scylla/rack":                  "rack",
+			"scylla-operator.scylladb.com/scylla-service-type": "member",
 		}
 	}
 	basicPorts := []corev1.ServicePort{

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -27,12 +27,20 @@ const (
 	LabelValueFalse = "false"
 )
 
+type ScyllaServiceType string
+
+const (
+	ScyllaServiceTypeIdentity ScyllaServiceType = "identity"
+	ScyllaServiceTypeMember   ScyllaServiceType = "member"
+)
+
 // Generic Labels used on objects created by the operator.
 const (
 	ClusterNameLabel             = "scylla/cluster"
 	DatacenterNameLabel          = "scylla/datacenter"
 	RackNameLabel                = "scylla/rack"
 	ScyllaVersionLabel           = "scylla/scylla-version"
+	ScyllaServiceTypeLabel       = "scylla-operator.scylladb.com/scylla-service-type"
 	ManagedHash                  = "scylla-operator.scylladb.com/managed-hash"
 	NodeConfigJobForNodeUIDLabel = "scylla-operator.scylladb.com/node-config-job-for-node-uid"
 	NodeConfigJobTypeLabel       = "scylla-operator.scylladb.com/node-config-job-type"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR introduces `scylla-operator.scylladb.com/scylla-service-type` label to Scylla Services, which allows for distinguishing between `member` and `identity` (headless) Services.
