### PR TITLE
[WIP] Bind mount operator binary into Scylla to speed up startup times

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -274,9 +274,10 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 							Image:           sidecarImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command: []string{
-								"/bin/sh",
-								"-c",
-								fmt.Sprintf("cp -a /usr/bin/scylla-operator %s", naming.SharedDirName),
+								"/usr/bin/mount",
+								"--bind",
+								"/usr/bin/scylla-operator",
+								fmt.Sprintf("%s/scylla-operator", naming.SharedDirName),
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{


### PR DESCRIPTION
**Description of your changes:**
It takes about 14s to copy the current operator binary into the scylla container. This has to be done on every pod start up. Using bind mount is immediate.

