### PR TITLE
Replace Minikube's storage-provisioner with local-volume-provisioner

### DIFF
--- a/.github/actions/setup-minikube/action.yaml
+++ b/.github/actions/setup-minikube/action.yaml
@@ -41,7 +41,9 @@ runs:
       - level: RequestResponse
       EOF
 
-      sudo minikube start --wait=all --extra-config='apiserver.event-ttl=24h' --extra-config='apiserver.audit-policy-file=/etc/ssl/certs/audit-policy.yaml' --extra-config='apiserver.audit-log-path=/var/log/kube-apiserver-audit.log'
+      # Disable addons. We'll install storage provisioner on our own. 
+      # NOTE: Explicitly disable `storage-provisioner` and `default-storageclass` if you want to install addons.
+      sudo minikube start --wait=all --install-addons=false --extra-config='apiserver.event-ttl=24h' --extra-config='apiserver.audit-policy-file=/etc/ssl/certs/audit-policy.yaml' --extra-config='apiserver.audit-log-path=/var/log/kube-apiserver-audit.log'
 
       mkdir -p ~/.kube/
       sudo cat /root/.kube/config > ~/.kube/config

--- a/.github/actions/setup-minikube/manifests/local-storage-provisioner/00_namespace.yaml
+++ b/.github/actions/setup-minikube/manifests/local-storage-provisioner/00_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-storage-provisioner

--- a/.github/actions/setup-minikube/manifests/local-storage-provisioner/00_node.clusterrole.yaml
+++ b/.github/actions/setup-minikube/manifests/local-storage-provisioner/00_node.clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/.github/actions/setup-minikube/manifests/local-storage-provisioner/00_storageclass.yaml
+++ b/.github/actions/setup-minikube/manifests/local-storage-provisioner/00_storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-volumes
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete

--- a/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_clusterrolebinding.yaml
+++ b/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: local-storage-provisioner
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_configmap.yaml
+++ b/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: local-storage-provisioner
+data:
+  storageClassMap: |
+    local-volumes:
+       hostDir: /mnt/persistent-volumes/
+       mountDir: /mnt/persistent-volumes/
+       blockCleanerCommand:
+         - "/scripts/shred.sh"
+         - "2"
+       volumeMode: Filesystem
+       fsType: xfs
+       namePattern: "*"
+

--- a/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_daemonset.yaml
+++ b/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_daemonset.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: local-storage-provisioner
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+      - image: k8s.gcr.io/sig-storage/local-volume-provisioner@sha256:63859b69f9dfc0858e5d8746218e435c36e205c041fb6d8baf71ad132e24737f
+        imagePullPolicy: IfNotPresent
+        name: provisioner
+        securityContext:
+          privileged: true
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - mountPath: /etc/provisioner/config
+          name: provisioner-config
+          readOnly: true
+        - mountPath: /mnt/persistent-volumes/
+          name: k8s-local-pvs
+          mountPropagation: HostToContainer
+      volumes:
+      - name: provisioner-config
+        configMap:
+          name: local-provisioner-config
+      - name: k8s-local-pvs
+        hostPath:
+          path: /mnt/persistent-volumes/

--- a/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_node.clusterrolebinding.yaml
+++ b/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_node.clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: local-storage-provisioner
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_serviceaccount.yaml
+++ b/.github/actions/setup-minikube/manifests/local-storage-provisioner/10_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: local-storage-provisioner

--- a/.github/actions/setup-minikube/manifests/pv-setup/00_clusterrole.yaml
+++ b/.github/actions/setup-minikube/manifests/pv-setup/00_clusterrole.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pv-setup-daemonset
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create

--- a/.github/actions/setup-minikube/manifests/pv-setup/00_namespace.yaml
+++ b/.github/actions/setup-minikube/manifests/pv-setup/00_namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pv-setup
+

--- a/.github/actions/setup-minikube/manifests/pv-setup/10_clusterrolebinding.yaml
+++ b/.github/actions/setup-minikube/manifests/pv-setup/10_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pv-setup-daemonset
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pv-setup-daemonset
+subjects:
+- kind: ServiceAccount
+  name: pv-setup-daemonset
+  namespace: pv-setup

--- a/.github/actions/setup-minikube/manifests/pv-setup/10_daemonset.yaml
+++ b/.github/actions/setup-minikube/manifests/pv-setup/10_daemonset.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: pv-setup
+  namespace: pv-setup
+  labels:
+    app: pv-setup
+spec:
+  selector:
+    matchLabels:
+      app: pv-setup
+  template:
+    metadata:
+      labels:
+        app: pv-setup
+    spec:
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      serviceAccountName: pv-setup
+      containers:
+      - name: pv-setup
+        image: quay.io/scylladb/scylla-operator-images:node-setup
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/bin/bash"
+        - "-euExo"
+        - "pipefail"
+        - "-O"
+        - "inherit_errexit"
+        - "-c"
+        - |
+          mkdir -p /host/var/persistent-volumes/
+          if [[ ! -f "/host/var/persistent-volumes/persistent-volume-image.xfs" ]]; then
+            dd if=/dev/zero of=/host/var/persistent-volumes/persistent-volume-image.xfs bs=1024 count=0 seek=10485760
+          fi
+          
+          if [[ $( blkid -o value -s TYPE "/host/var/persistent-volumes/persistent-volume-image.xfs" ) != "xfs" ]]; then
+            mkfs -t xfs /host/var/persistent-volumes/persistent-volume-image.xfs
+          fi
+            
+          mkdir -p /host/mnt/persistent-volumes/
+          for d in $(seq -f "pv-%05g" 1 30); do
+            if [[ ! -d "/host/mnt/persistent-volumes/${d}" ]]; then
+              mkdir "/host/mnt/persistent-volumes/${d}"
+            fi
+            ( mount | grep "/host/mnt/persistent-volumes/${d} " 2>/dev/null 1>&2 ) || \
+            mount --bind "/host/mnt/persistent-volumes/${d}"{,}
+          done
+          
+          sleep infinity
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: hostfs
+          mountPath: /host
+          mountPropagation: Bidirectional
+      volumes:
+      - name: hostfs
+        hostPath:
+          path: /

--- a/.github/actions/setup-minikube/manifests/pv-setup/10_serviceaccount.yaml
+++ b/.github/actions/setup-minikube/manifests/pv-setup/10_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pv-setup
+  namespace: pv-setup

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -197,6 +197,16 @@ jobs:
         go install github.com/mikefarah/yq/v4@v4.6.1
     - name: Setup minikube
       uses: ./go/src/github.com/scylladb/scylla-operator/.github/actions/setup-minikube
+    - name: Set up volume provisioner
+      run: |
+        set -euExo pipefail
+        shopt -s inherit_errexit
+        
+        kubectl -n pv-setup create -f ./.github/actions/setup-minikube/manifests/pv-setup/
+        kubectl -n pv-setup rollout status --timeout 5m daemonset.apps/pv-setup
+    
+        kubectl -n local-storage-provisioner create -f ./.github/actions/setup-minikube/manifests/local-storage-provisioner/
+        kubectl -n local-storage-provisioner rollout status --timeout 5m daemonset.apps/local-volume-provisioner
     - name: Deploy scylla-operator
       run: |
         set -x


### PR DESCRIPTION
**Description of your changes:**
Currently our CI is using Minikube's `storage-provisioner` for volume provisioning. However, `storage-provisioner` controller logic is broken and has recently caused some flaky behaviour in our e2e test suite (for details see #974). To mitigate the issue, this pull request replaces `storage-provisioner` with `local-volume-provisioner`, which "dynamically" provisions volumes from a preliminarily created set of arbitrary size.

**Which issue is resolved by this Pull Request:**
Resolves #974
