### PR TITLE
Use local NVMe storage class in EKS example

### DIFF
--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -26,6 +26,7 @@ spec:
     - name: a
       members: 1
       storage:
+        storageClassName: local-raid-disks
         capacity: 1800G
       resources:
         limits:
@@ -48,6 +49,7 @@ spec:
     - name: b
       members: 1
       storage:
+        storageClassName: local-raid-disks
         capacity: 1800G
       resources:
         limits:
@@ -70,6 +72,7 @@ spec:
     - name: c
       members: 1
       storage:
+        storageClassName: local-raid-disks
         capacity: 1800G
       resources:
         limits:


### PR DESCRIPTION
The EKS provisioning example defaults to provisioning i3.2xlarge machines, but cluster.yaml has no references to which storageClass to use when deploying a scyllaCluster resource.

Update the example as currently present within the GKE example (which uses the very same storageClass).