### PR TITLE
Fallback image builds to cgroupfs to workaround ubuntu systemd issues

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -121,7 +121,7 @@ jobs:
         set -x
         # Avoid podman permission error on Ubuntu 20.04 by using it as root, although it shouldn't be needed.
         # Use --format=docker to support SHELL instruction in the Dockerfile. (SHELL didn't make it to OCI spec.)
-        sudo podman build --format=docker --squash --network=none -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
+        sudo podman --cgroup-manager=cgroupfs build --format=docker --squash --network=none -f ./Dockerfile -t '${{ env.image_repo_ref }}:ci' .
         sudo podman images '${{ env.image_repo_ref }}:ci'
         sudo podman save '${{ env.image_repo_ref }}:ci' | lz4 - ~/operatorimage.tar.lz4
     - name: Upload image artifact


### PR DESCRIPTION
Probably an update to Ubuntu used in GH Action caused an incompatibility with systemd, this fallbacks the builds to use cgroupsfs driver.
```
sudo podman build --format=docker --squash --network=none -f ./Dockerfile -t docker.io/scylladb/scylla-operator:ci .
[1/2] STEP 1/4: FROM quay.io/scylladb/scylla-operator-images:golang-1.18 AS builder
Trying to pull quay.io/scylladb/scylla-operator-images:golang-1.18...
Getting image source signatures
Copying blob sha256:39e8f2bce4d379dbf41efb9b4d97[16](https://github.com/scylladb/scylla-operator/runs/7303784489?check_suite_focus=true#step:5:17)99a3a3230206c631dfa1a4[17](https://github.com/scylladb/scylla-operator/runs/7303784489?check_suite_focus=true#step:5:18)889020ebd2
Copying blob sha256:f16f8d7f144ed9ce72c778a3e2f9d8ed2f78fca4817558d3ae6ff703f11572ef
Copying blob sha256:3baef123bea3e48e294956fbfce69efc3a0243b37f503c606adbf7beca9de94a
Copying blob sha256:3baef123bea3e48e294956fbfce69efc3a0243b37f503c606adbf7beca9de94a
Copying blob sha256:39e8f2bce4d379dbf41efb9b4d971699a3a3230206c631dfa1a417889020ebd2
Copying blob sha256:f16f8d7f144ed9ce72c778a3e2f9d8ed2f78fca4817558d3ae6ff703f11572ef
Copying config sha256:7033c7f5331bf027ff480f2d8d5[24](https://github.com/scylladb/scylla-operator/runs/7303784489?check_suite_focus=true#step:5:25)ea293f0c363d01aee0d291cd87d6afe940d
Writing manifest to image destination
Storing signatures
[1/2] STEP 2/4: WORKDIR /go/src/github.com/scylladb/scylla-operator
[1/2] STEP 3/4: COPY . .
[1/2] STEP 4/4: RUN make build --warn-undefined-variables
error running container: error from /usr/bin/crun creating container for [/usr/bin/bash -euExo pipefail -O inherit_errexit -c make build --warn-undefined-variables]: sd-bus call: Connection reset by peer
: exit status 1
[2/2] STEP 1/6: FROM quay.io/scylladb/scylla-operator-images:base-ubuntu
Error: error building at STEP "RUN make build --warn-undefined-variables": error while running runtime: exit status 1
Error: Process completed with exit code 1[25](https://github.com/scylladb/scylla-operator/runs/7303784489?check_suite_focus=true#step:5:26).
```