### PR TITLE
Fix Scylla Monitoring support

### DIFF
--- a/docs/source/monitoring.md
+++ b/docs/source/monitoring.md
@@ -4,6 +4,16 @@ Both Prometheus, Grafana and AlertManager were configured with specific rules fo
 All of them will be available under the `scylla-monitoring` namespace.
 Customization can be done in `examples/common/monitoring/values.yaml`
 
+
+1. Download Scylla Monitoring
+
+   First you need to download Scylla Monitoring, which contains Grafana dashboards and custom Prometheus rules.
+   You can do this by running the following command:
+   ```
+   mkdir scylla-monitoring
+   curl -L https://github.com/scylladb/scylla-monitoring/tarball/branch-4.0 | tar -xzf - -C scylla-monitoring --strip-components=1
+   ```
+
 1. Add monitoring stack charts repository
    ```
    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
@@ -29,30 +39,23 @@ Customization can be done in `examples/common/monitoring/values.yaml`
     kubectl apply -f examples/common/monitoring/scylla-manager-service-monitor.yaml
     ```
 
-1. Download dashboards
-
-   First you need to download the dashboards to make them available in Grafana.
-   You can do this by running the following command:
-    ```
-    wget https://github.com/scylladb/scylla-monitoring/archive/scylla-monitoring-3.6.0.tar.gz
-    tar -xvf scylla-monitoring-3.6.0.tar.gz
-    ```
-
 1. Install dashboards
 
     Scylla Monitoring comes with pre generated dashboards suitable for multiple Scylla versions.
-    In this example we will use dashboards for Scylla 4.3, and Scylla Manager 2.2.
+    In this example we will use dashboards for Scylla 4.6, and Scylla Manager 3.0.
     Amend directory path to generated dashboards to version suitable for your deployment.
 
    Now the dashboards can be created like this:
-    ```
-    # Scylla dashboards
-    kubectl -n scylla-monitoring create configmap scylla-dashboards --from-file=scylla-monitoring-scylla-monitoring-3.6.0/grafana/build/ver_4.3
-    kubectl -n scylla-monitoring patch configmap scylla-dashboards  -p '{"metadata":{"labels":{"grafana_dashboard": "1"}}}'
+   ```
+   # Scylla dashboards
+   for f in scylla-monitoring/grafana/build/ver_4.6/*.json; do
+     kubectl -n scylla-monitoring create configmap scylla-dashboard-"$( basename "${f}" '.json' )" --from-file="${f}" --dry-run=client -o yaml | kubectl label -f- --dry-run=client -o yaml --local grafana_dashboard=1 | kubectl apply --server-side -f-
+   done
 
-    # Scylla Manager dashboards
-    kubectl -n scylla-monitoring create configmap scylla-manager-dashboards --from-file=scylla-monitoring-scylla-monitoring-3.6.0/grafana/build/manager_2.2
-    kubectl -n scylla-monitoring patch configmap scylla-manager-dashboards  -p '{"metadata":{"labels":{"grafana_dashboard": "1"}}}'
+   # Scylla Manager dashboards
+   for f in scylla-monitoring/grafana/build/manager_3.0/*.json; do
+     kubectl -n scylla-monitoring create configmap scylla-manager-dashboard-"$( basename "${f}" '.json' )" --from-file="${f}" --dry-run=client -o yaml | kubectl label -f- --dry-run=client -o yaml --local grafana_dashboard=1 | kubectl apply --server-side -f-
+   done
     ```
 
     Once Grafana sidecar picks up these dashboards they should be accessible in Grafana.

--- a/examples/common/monitoring/scylla-manager-service-monitor.yaml
+++ b/examples/common/monitoring/scylla-manager-service-monitor.yaml
@@ -4,10 +4,10 @@ metadata:
   name: scylla-manager-service-monitor
   namespace: scylla-manager
 spec:
-  jobLabel: "app"
+  jobLabel: "app.kubernetes.io/name"
   selector:
     matchLabels:
-      app: scylla-manager
+      app.kubernetes.io/name: scylla-manager
   endpoints:
     - port: metrics
       metricRelabelings:

--- a/examples/common/monitoring/scylla-service-monitor.yaml
+++ b/examples/common/monitoring/scylla-service-monitor.yaml
@@ -4,12 +4,12 @@ metadata:
   name: scylla-service-monitor
   namespace: scylla
 spec:
-  jobLabel: "app"
+  jobLabel: "app.kubernetes.io/name"
   targetLabels: ["scylla/cluster"]
   podTargetLabels: ["scylla/datacenter","scylla/rack"]
   selector:
     matchLabels:
-      app: scylla
+      app.kubernetes.io/name: scylla
   endpoints:
     - port: node-exporter
     - port: agent-prometheus

--- a/examples/common/monitoring/values.yaml
+++ b/examples/common/monitoring/values.yaml
@@ -32,7 +32,7 @@ grafana:
     # - scylla-plugin
 
   image:
-    tag: 7.3.5
+    tag: 9.0.2
 
 
   # This might need to be increased for bigger deployments.
@@ -53,7 +53,7 @@ prometheusOperator:
     enabled: false
 
   image:
-    tag: v0.51.2
+    tag: v0.57.0
 
   # This might need to be increased for bigger deployments.
   resources:
@@ -66,7 +66,7 @@ prometheusOperator:
 
 prometheus:
   image:
-    tag: v2.24.0
+    tag: v2.37.0
   # This might need to be increased for bigger deployments.
   resources:
     limits:


### PR DESCRIPTION
**Description of your changes:**
There's a bunch of issues with our Scylla Monitoring setup and related documentation.

1. Our docs suggest downloading scylla-monitoring-3.6.0 while 4.0.0 is already out.

2. Scylla Monitoring 3.9.0 introduced an additional dashboard, which caused all of the dashboards combined to go over maximum content size of a ConfigMap:
```
error: failed to create configmap: ConfigMap "scylla-dashboards" is invalid: []: Too long: must have at most 1048576 bytes
```

3. Grafana version set in `examples/common/monitoring/values.yaml` does not support/include some plugins used by the newer dashboards.
![Screenshot from 2022-07-18 13-47-36](https://user-images.githubusercontent.com/32443348/179504921-ae406583-620c-490d-99a9-e46ccc140ba5.png)

4. JobLabel/Selector in Scylla Manager's ServiceMonitor are outdated, which leads to Scylla Manager metrics not being picked up by Prometheus.
![image (3)](https://user-images.githubusercontent.com/32443348/179220255-38bfd1d1-4b2c-4e28-8d34-2ac829eca197.png)


5. Our documentation says nothing about setting up custom Prometheus rules included in Scylla Monitoring, which causes some (or, well, most) of the panels in our dashboards to stay empty.

![Screenshot from 2022-07-15 14-16-38](https://user-images.githubusercontent.com/32443348/179221202-635f6fad-5666-47a0-a886-89a2a557ec20.png)

This PR fixes the above issues by:
1. Updating the scylla-monitoring version in our docs.
2. Updating the docs with commands iterating over the dashboards and creating a separate ConfigMap for each, instead of creating one for the entire set. This, of course, doesn't protect us from a singular dashboard going over the limit, but that could be fixed by Scylla Monitoring when generating them. The script that generates dashboards allows for setting a size limit and splits if necessary. At the moment though no of the dashboards is above the CM's content size limit.
3. Updating Grafana, Prometheus and Prometheus Operator versions in `examples/common/monitoring/values.yaml`.
4. Fixing the selectors and jobLabels in examplary ServiceMonitors.
5. Updating the commands in our docs responsible for installing `kube-prometheus-stack` Helm chart with a `yq` command appending the custom Prometheus rules from Scylla Monitoring.

There's still some issues with Scylla Manager dashboard missing metrics, but it seems to be an issue with Scylla Monitoring. I'll discuss it with Amnon.

Requires: #1000, [scylladb/scylla-monitoring#1767](https://github.com/scylladb/scylla-monitoring/pull/1767) 
