### PR TITLE
Fix incorrect webhook service name in helm chart

### DIFF
--- a/helm/scylla-operator/templates/webhookserver.service.yaml
+++ b/helm/scylla-operator/templates/webhookserver.service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: scylla-operator
-  name: scylla-operator-webhook
+  name: {{ include "scylla-operator.webhookServiceName" . }}
   labels:
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/instance: webhook-server


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

The service name in the helm chart for the webhook `Service` is hard-coded but calculated in every other location as `scylla-operator.webhookServiceName`. This PR just updates the `Service` to match everything else.

**Which issue is resolved by this Pull Request:**
Resolves #904
