### PR TITLE
Fix loglevel type and change image tag in example helm values for Scylla Operator Chart

### DIFF
--- a/examples/helm/values.operator.yaml
+++ b/examples/helm/values.operator.yaml
@@ -1,9 +1,9 @@
 # Specify desired Scylla Operator image
 image:
-  tag: nightly
+  tag: latest
 
 # Change log level
-logLevel: info
+logLevel: 2
 
 # Resources allocated to Scylla Operator pods
 resources:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
The loglevel value set in the example custom values for Scylla Operator Chart is outdated. At the moment it is set to string `info` instead of an integer. It is no longer valid after #534 was merged.

If you try following the [Deploying Scylla stack using Helm Charts](https://operator.docs.scylladb.com/stable/helm.html) section from our documentation and try installing Scylla Operator with the custom values, you'll get the following error:
```
$ helm install scylla-operator scylla/scylla-operator --values examples/helm/values.operator.yaml --create-namespace --namespace scylla-operator

Error: values don't meet the specifications of the schema(s) in the following chart(s):
scylla-operator:
- logLevel: Invalid type. Expected: integer, given: string
```

This PR changes the value in the exemplary custom values to an integer. It also changes the overridden image tag to a more sane one.
