### PR TITLE
Increase storage and set sysctls in Scylla Helm chart

### DIFF
--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -35,7 +35,8 @@ hostNetworking: false
 # Whether Scylla Operator should perform automatic cleanup of orphaned Pods
 automaticOrphanedNodeCleanup: false
 # Sysctl properties to be applied during initialization given as a list of key=value pairs
-sysctls: []
+sysctls:
+- "fs.aio-max-nr=2097152"
 
 # Scylla Manager Backups task definition
 backups: []
@@ -55,7 +56,7 @@ racks:
   members: 3
   # Storage definition
   storage:
-    capacity: 10Gi
+    capacity: 20Gi
   # Scylla container resource definition
   resources:
      limits:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Currently deploying a Scylla Helm chart with predefined values results in an error (see #906). This PR increases the storage capacity in values.yaml. To mitigate further errors, it also sets sysctls.

**Which issue is resolved by this Pull Request:**
Resolves #906 
