### PR TITLE
Close idle connections to scylla API when done using them

### DIFF
--- a/pkg/controller/scyllacluster/sync_statefulsets.go
+++ b/pkg/controller/scyllacluster/sync_statefulsets.go
@@ -150,6 +150,7 @@ func (scc *Controller) beforeUpgrade(ctx context.Context, sc *scyllav1.ScyllaClu
 	if err != nil {
 		return true, err
 	}
+	defer scyllaClient.Close()
 
 	klog.V(4).InfoS("Checking schema agreement", "ScyllaCluster", klog.KObj(sc))
 	hasSchemaAgreement, err := scyllaClient.HasSchemaAgreement(ctx)
@@ -188,6 +189,7 @@ func (scc *Controller) afterUpgrade(ctx context.Context, sc *scyllav1.ScyllaClus
 	if err != nil {
 		return err
 	}
+	defer scyllaClient.Close()
 
 	// Clear system backup.
 	err = scc.removeSnapshot(ctx, scyllaClient, hosts, []string{sc.Status.Upgrade.SystemSnapshotTag})
@@ -234,6 +236,7 @@ func (scc *Controller) beforeNodeUpgrade(ctx context.Context, sc *scyllav1.Scyll
 	if err != nil {
 		return true, err
 	}
+	defer scyllaClient.Close()
 
 	om, err := scyllaClient.OperationMode(ctx, host)
 	if err != nil {
@@ -313,6 +316,7 @@ func (scc *Controller) afterNodeUpgrade(ctx context.Context, sc *scyllav1.Scylla
 	if err != nil {
 		return err
 	}
+	defer scyllaClient.Close()
 
 	// Clear data backup.
 	err = scc.removeSnapshot(ctx, scyllaClient, []string{host}, []string{sc.Status.Upgrade.DataSnapshotTag})

--- a/pkg/controller/sidecar/controller.go
+++ b/pkg/controller/sidecar/controller.go
@@ -264,6 +264,7 @@ func (c *Controller) getHostID(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("can't create a new ScyllaClient for localhost: %w", err)
 	}
+	defer scyllaClient.Close()
 
 	v, err = scyllaClient.GetLocalHostId(ctx, localhost, false)
 	if err != nil {

--- a/pkg/controller/sidecar/sync.go
+++ b/pkg/controller/sidecar/sync.go
@@ -26,6 +26,7 @@ func (c *Controller) decommissionNode(ctx context.Context, svc *corev1.Service) 
 	if err != nil {
 		return err
 	}
+	defer scyllaClient.Close()
 
 	opMode, err := scyllaClient.OperationMode(ctx, localhost)
 	if err != nil {

--- a/pkg/scyllaclient/client.go
+++ b/pkg/scyllaclient/client.go
@@ -29,6 +29,7 @@ type Client struct {
 
 	scyllaOps *scyllaOperations.Client
 	transport http.RoundTripper
+	pool      hostpool.HostPool
 
 	mu      sync.RWMutex
 	dcCache map[string]string
@@ -69,8 +70,15 @@ func NewClient(config *Config, logger log.Logger) (*Client, error) {
 		logger:    logger,
 		scyllaOps: scyllaOps,
 		transport: transport,
+		pool:      pool,
 		dcCache:   make(map[string]string),
 	}, nil
+}
+
+func (c *Client) Close() {
+	if c.pool != nil {
+		c.pool.Close()
+	}
 }
 
 // HostDatacenter looks up the datacenter that the given host belongs to.

--- a/pkg/sidecar/probes.go
+++ b/pkg/sidecar/probes.go
@@ -83,6 +83,7 @@ func (p *Prober) Readyz(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer scyllaClient.Close()
 
 	// Contact Scylla to learn about the status of the member
 	nodeStatuses, err := scyllaClient.Status(ctx, localhost)
@@ -145,6 +146,7 @@ func (p *Prober) Healthz(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer scyllaClient.Close()
 
 	// Check if Scylla API is reachable
 	_, err = scyllaClient.Ping(ctx, localhost)

--- a/test/e2e/set/scyllacluster/scyllacluster_auth.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_auth.go
@@ -169,6 +169,7 @@ func getScyllaClientStatus(ctx context.Context, hosts []string, authToken string
 
 	client, err := scyllaclient.NewClient(cfg, log.NopLogger)
 	o.Expect(err).NotTo(o.HaveOccurred())
+	defer client.Close()
 
 	return client.Status(ctx, hosts[0])
 }

--- a/test/e2e/set/scyllacluster/scyllacluster_hostid.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_hostid.go
@@ -50,6 +50,7 @@ var _ = g.Describe("ScyllaCluster HostID", func() {
 		framework.By("Verifying annotations")
 		scyllaClient, _, err := utils.GetScyllaClient(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
+		defer scyllaClient.Close()
 
 		svcs, err := f.KubeClient().CoreV1().Services(sc.Namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: utils.GetMemberServiceSelector(sc.Name).String(),

--- a/test/e2e/set/scyllacluster/verify.go
+++ b/test/e2e/set/scyllacluster/verify.go
@@ -119,6 +119,8 @@ func verifyScyllaCluster(ctx context.Context, kubeClient kubernetes.Interface, s
 	// TODO: Use scylla client to check at least "UN"
 	scyllaClient, hosts, err := utils.GetScyllaClient(ctx, kubeClient.CoreV1(), sc)
 	o.Expect(err).NotTo(o.HaveOccurred())
+	defer scyllaClient.Close()
+
 	o.Expect(hosts).To(o.HaveLen(memberCount))
 
 	status, err := scyllaClient.Status(ctx, "")


### PR DESCRIPTION
ScyllaClient keep idle connections for future reuse, but in our case
client is trashed after every use.
ScyllaClient was extended with Close function allowing for cleanup of
underlying host pool.

Fixes #1016
