### PR TITLE
Support scyllaArgs in Helm chart

### DIFF
--- a/helm/scylla/templates/scyllacluster.yaml
+++ b/helm/scylla/templates/scyllacluster.yaml
@@ -50,6 +50,9 @@ spec:
   exposeOptions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.scyllaArgs }}
+  scyllaArgs: {{ .Values.scyllaArgs }}
+  {{- end }}
   datacenter:
     name: {{ .Values.datacenter }}
     racks:

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -44,7 +44,6 @@ repairs: []
 
 # scyllaArgs will be appended to Scylla binary startup parameters.
 scyllaArgs: ""
-# --memory 1g
 
 # Name of datacenter
 datacenter: "us-east-1"

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -42,7 +42,7 @@ backups: []
 # Scylla Manager Repair task definition
 repairs: []
 
-# scyllaArgs will be appended to Scylla binary during startup. This is supported from 4.2.0 Scylla version.
+# scyllaArgs will be appended to Scylla binary startup parameters.
 scyllaArgs: ""
 # --memory 1g
 

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -42,6 +42,10 @@ backups: []
 # Scylla Manager Repair task definition
 repairs: []
 
+# scyllaArgs will be appended to Scylla binary during startup. This is supported from 4.2.0 Scylla version.
+scyllaArgs: ""
+# --memory 1g
+
 # Name of datacenter
 datacenter: "us-east-1"
 # List of racks


### PR DESCRIPTION
**Description of your changes:**
The Scylla Helm chart does not support `scyllaArgs` inputs (see https://github.com/scylladb/scylla-operator/issues/989). This PR introduces support for passing `scyllaArgs` values via Helm Chart.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/989
