### PR TITLE
Fix NodeConfig e2e flake and correct resourcequotas resource name in test machinery

### DIFF
--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -82,7 +82,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 			framework.Failf("Can't delete ResourceQuota %q: %v", naming.ManualRef(naming.ScyllaOperatorNodeTuningNamespace, resourceQuotaName), err)
 		}
 		if !apierrors.IsNotFound(err) {
-			err = framework.WaitForObjectDeletion(context.Background(), f.DynamicAdminClient(), corev1.SchemeGroupVersion.WithResource("resourcequota"), naming.ScyllaOperatorNodeTuningNamespace, resourceQuotaName, nil)
+			err = framework.WaitForObjectDeletion(context.Background(), f.DynamicAdminClient(), corev1.SchemeGroupVersion.WithResource(corev1.ResourceQuotas.String()), naming.ScyllaOperatorNodeTuningNamespace, resourceQuotaName, nil)
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}
 	})
@@ -190,7 +190,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for a ConfigMap to indicate blocking NodeConfig")
-		ctx1, ctx1Cancel := context.WithTimeout(ctx, apiCallTimeout)
+		ctx1, ctx1Cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer ctx1Cancel()
 		podName := fmt.Sprintf("%s-%d", naming.StatefulSetNameForRack(sc.Spec.Datacenter.Racks[0], sc), 0)
 		pod, err := utils.WaitForPodState(ctx1, f.KubeClient().CoreV1().Pods(sc.Namespace), podName, utils.WaitForStateOptions{}, func(p *corev1.Pod) (bool, error) {


### PR DESCRIPTION
**Description of your changes:**
Fixes a [spurious unstructured error in e2e](https://github.com/scylladb/scylla-operator/actions/runs/3050721115/jobs/4918176918#step:12:1308) and a timeout too short for an active wait.
```
    E0914 07:30:44.268519      15 cache/reflector.go:140] k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: Failed to watch *unstructured.Unstructured: failed to list *unstructured.Unstructured: the server could not find the requested resource
    W0914 07:30:45.366082      15 cache/reflector.go:424] k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
    E0914 07:30:45.366101      15 cache/reflector.go:140] k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: Failed to watch *unstructured.Unstructured: failed to list *unstructured.Unstructured: the server could not find the requested resource
    W0914 07:30:47.195222      15 cache/reflector.go:424] k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
...
```
The issue was a wrong resource name `resourcequota` (should be `resourcequotas`).
