### PR TITLE
Increase task sync timeout in e2e tests

### DIFF
--- a/test/e2e/utils/config.go
+++ b/test/e2e/utils/config.go
@@ -14,7 +14,7 @@ const (
 	memberRolloutTimeout = 30*time.Second + imagePullTimeout + joinClusterTimeout
 
 	baseManagerSyncTimeout = 3 * time.Minute
-	managerTaskSyncTimeout = 30 * time.Second
+	managerTaskSyncTimeout = 90 * time.Second
 
 	nodeConfigRolloutTimeout = 3 * time.Minute
 )


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
As I wasn't able to find possible errors while reading the artifacts logs or running the tests locally, my proposal is to increase sync timeout for tasks and see if failures reappear.
Increased timeout value is based on my experience with new manager controller. 

**Which issue is resolved by this Pull Request:**
Resolves #1031
