### PR TITLE
Use more workers by default to make the controller more responsive

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -46,7 +46,7 @@ func NewOperatorOptions(streams genericclioptions.IOStreams) *OperatorOptions {
 		InClusterReflection: genericclioptions.InClusterReflection{},
 		LeaderElection:      genericclioptions.NewLeaderElection(),
 
-		ConcurrentSyncs: 5,
+		ConcurrentSyncs: 50,
 		OperatorImage:   "",
 	}
 }


### PR DESCRIPTION
**Description of your changes:**
Raises a default controller worker count to 50.

While going through some of our e2e runs I've noticed that a lot of sync loops took almost exactly 10s. This likely stems from a statefulset bug workaround introduced in https://github.com/scylladb/scylla-operator/pull/697. These long sync loops were blocking the other objects from being processed so they could take more then 30s to react and flake our tests.

Raising the default number of workers makes it more responsive by default without having a big effect on memory consumption. This is still just a default and anyone can adjust the value based on their cluster size and the trade-off between cpu/memory and responsiveness.

**Which issue is resolved by this Pull Request:**
Fixes TLS tests flaking on #1021 that isn't merged yet so the flakes don't have a tracker yet. I assume more are gonna be linked after the fact as this is a common issue.
