### PR TITLE
Drop migration workaround for manual ServiceAccounts

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -14,11 +14,9 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 )
@@ -789,45 +787,17 @@ func stringOrDefault(str, def string) string {
 	return def
 }
 
-func MakeServiceAccount(sc *scyllav1.ScyllaCluster, serviceAccounts map[string]*corev1.ServiceAccount, serviceAccountLister corev1listers.ServiceAccountLister) (*corev1.ServiceAccount, error) {
-	annotations := map[string]string{}
-	name := naming.MemberServiceAccountNameForScyllaCluster(sc.Name)
-
-	existing, found := serviceAccounts[name]
-	if !found {
-		// In 1.7.0 we started managing ServiceAccounts. Because previously these were created by users
-		// there's a high chance that they don't match our selector, hence are not available in serviceAccounts.
-		// Ref: https://github.com/scylladb/scylla-operator/issues/932
-		//
-		// Cache fetch happens only once - when SA is being adopted, or it's missing.
-		// It can be removed in 1.8.0 because all SAs will be already adopted, and they will match our selector.
-		// TODO: https://github.com/scylladb/scylla-operator/issues/934
-		var err error
-		existing, err = serviceAccountLister.ServiceAccounts(sc.Namespace).Get(name)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("can't get %s service account: %w", naming.ManualRef(sc.Namespace, name), err)
-		}
-	}
-
-	if existing != nil {
-		// We need to copy annotations stored in user SA because these may control integrations with k8s provider services
-		// like IAM management.
-		for k, v := range existing.Annotations {
-			annotations[k] = v
-		}
-	}
-
+func MakeServiceAccount(sc *scyllav1.ScyllaCluster) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      naming.MemberServiceAccountNameForScyllaCluster(sc.Name),
 			Namespace: sc.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(sc, controllerGVK),
 			},
-			Labels:      naming.ClusterLabels(sc),
-			Annotations: annotations,
+			Labels: naming.ClusterLabels(sc),
 		},
-	}, nil
+	}
 }
 
 func MakeRoleBinding(sc *scyllav1.ScyllaCluster) *rbacv1.RoleBinding {

--- a/pkg/controller/scyllacluster/sync_serviceaccounts.go
+++ b/pkg/controller/scyllacluster/sync_serviceaccounts.go
@@ -16,10 +16,9 @@ func (scc *Controller) syncServiceAccounts(
 	sc *scyllav1.ScyllaCluster,
 	serviceAccounts map[string]*corev1.ServiceAccount,
 ) error {
-	requiredServiceAccount, err := MakeServiceAccount(sc, serviceAccounts, scc.serviceAccountLister)
-	if err != nil {
-		return fmt.Errorf("can't make service account(s): %w", err)
-	}
+	var err error
+
+	requiredServiceAccount := MakeServiceAccount(sc)
 
 	// Delete any excessive ServiceAccounts.
 	// Delete has to be the fist action to avoid getting stuck on quota.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Leftovers of workaround for https://github.com/scylladb/scylla-operator/pull/933 has been deleted, as it is not needed anymore.

**Which issue is resolved by this Pull Request:**
Resolves #934 
