### PR TITLE
Disable shadawareness E2E giving false positives

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
@@ -28,6 +28,10 @@ var _ = g.Describe("ScyllaCluster", func() {
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should allow to build connection pool using shard aware ports", func() {
+		g.Skip("Shardawareness doesn't work on setups NATting traffic, and our CI does it when traffic is going through ClusterIPs." +
+			"It's shall be reenabled once we switch client-node communication to PodIPs.",
+		)
+
 		const (
 			nonShardAwarePort = 9042
 			shardAwarePort    = 19042


### PR DESCRIPTION
Both on CI and on local environments traffic between test binary and
Scylla Pods is NATed. This test give false positives
because we were checking whether driver attempted to connect to shard aware port,
but it wasn't checking whether it acutally succeeded.
It wasn't spotted because message about wrong shard assignment is
printed out by the driver to stdout and no error is reported anywhere.
Gocql doesn't expose any way of checking if shardaware ports are used
successfully.

False positive is fixed by #1038 but it requires client-node communication using 
PodIPs which we don't currenly have.