### PR TITLE
Avoid watch cache when using UntilWithSync

### DIFF
--- a/pkg/cmd/operator/sidecar.go
+++ b/pkg/cmd/operator/sidecar.go
@@ -14,6 +14,7 @@ import (
 	sidecarcontroller "github.com/scylladb/scylla-operator/pkg/controller/sidecar"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/sidecar"
@@ -197,10 +198,10 @@ func (o *SidecarOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Com
 	// Wait for the service that holds identity for this scylla node.
 	serviceFieldSelector := fields.OneTermEqualSelector("metadata.name", o.ServiceName)
 	serviceLW := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = serviceFieldSelector.String()
 			return o.kubeClient.CoreV1().Services(o.Namespace).List(ctx, options)
-		},
+		}),
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = serviceFieldSelector.String()
 			return o.kubeClient.CoreV1().Services(o.Namespace).Watch(ctx, options)
@@ -231,10 +232,10 @@ func (o *SidecarOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Com
 	// Wait for this Pod to have ContainerID set.
 	podFieldSelector := fields.OneTermEqualSelector("metadata.name", o.ServiceName)
 	podLW := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = podFieldSelector.String()
 			return o.kubeClient.CoreV1().Pods(o.Namespace).List(ctx, options)
-		},
+		}),
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = podFieldSelector.String()
 			return o.kubeClient.CoreV1().Pods(o.Namespace).Watch(ctx, options)
@@ -285,10 +286,10 @@ func (o *SidecarOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Com
 		naming.ConfigMapTypeLabel: string(naming.NodeConfigDataConfigMapType),
 	}.AsSelector()
 	podLW = &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
 			options.LabelSelector = labelSelector.String()
 			return o.kubeClient.CoreV1().ConfigMaps(pod.Namespace).List(ctx, options)
-		},
+		}),
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.LabelSelector = labelSelector.String()
 			return o.kubeClient.CoreV1().ConfigMaps(pod.Namespace).Watch(ctx, options)

--- a/pkg/helpers/cache.go
+++ b/pkg/helpers/cache.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 ScyllaDB
+
+package helpers
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// UncachedListFunc wraps a List function and makes sure initial lists avoid watch cache on the apiserver.
+// This is important for caller that need top reason about "happened after" or similar cases.
+func UncachedListFunc(f func(options metav1.ListOptions) (runtime.Object, error)) func(options metav1.ListOptions) (runtime.Object, error) {
+	return func(options metav1.ListOptions) (runtime.Object, error) {
+		// Transform every RV="0" into RV="" that avoids watch cache.
+		// By default, informers use RV="0" that goes through watch cache.
+		// We need to avoid watch cache not to list older objects.
+		if options.ResourceVersion == "0" {
+			options.ResourceVersion = ""
+		}
+
+		return f(options)
+	}
+}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	o "github.com/onsi/gomega"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -29,10 +30,10 @@ import (
 func WaitForServiceAccount(ctx context.Context, c corev1client.CoreV1Interface, namespace, name string) (*corev1.ServiceAccount, error) {
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
 	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
 			return c.ServiceAccounts(namespace).List(ctx, options)
-		},
+		}),
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = fieldSelector
 			return c.ServiceAccounts(namespace).Watch(ctx, options)
@@ -67,10 +68,10 @@ func WaitForServiceAccount(ctx context.Context, c corev1client.CoreV1Interface, 
 func WaitForObjectDeletion(ctx context.Context, dynamicClient dynamic.Interface, resource schema.GroupVersionResource, namespace, name string, uid *types.UID) error {
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
 	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
 			return dynamicClient.Resource(resource).Namespace(namespace).List(ctx, options)
-		},
+		}),
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = fieldSelector
 			return dynamicClient.Resource(resource).Namespace(namespace).Watch(ctx, options)

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -172,10 +172,10 @@ type WaitForStateOptions struct {
 func WaitForObjectState[Object, ListObject runtime.Object](ctx context.Context, client listerWatcher[ListObject], name string, options WaitForStateOptions, condition func(obj Object) (bool, error), additionalConditions ...func(obj Object) (bool, error)) (Object, error) {
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
 	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
 			return client.List(ctx, options)
-		},
+		}),
 		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 			options.FieldSelector = fieldSelector
 			return client.Watch(ctx, options)


### PR DESCRIPTION
**Description of your changes:**
`UntilWithSync` is based on informers for controllers that use `LIST` call with `RV="0"` that can use watch cache on the apiserver. (Contrary to `RV=""` that avoids watch cache.) That way it can receive older events then the current state. Like when a test verifies that a ScyllaCluster has been modified, it can still receive an older version of that object and think it is immediately rolled out.

In the ListerWatcher we'll replace any list call to `RV="0"` with `RV=""` to avoid watch cache.

**Which issue is resolved by this Pull Request:**
A lot of flakes in different forms.
