### PR TITLE
Fix sidecar readyz probe for IPv6 addresses

### DIFF
--- a/pkg/sidecar/probes.go
+++ b/pkg/sidecar/probes.go
@@ -112,13 +112,13 @@ func (p *Prober) Readyz(w http.ResponseWriter, req *http.Request) {
 	for _, s := range nodeStatuses {
 		klog.V(4).InfoS("readyz probe: node state", "Node", s.Addr, "Status", s.Status, "State", s.State)
 
-		sAddrIp := net.ParseIP(s.Addr)
-		if sAddrIp == nil {
+		sAddrIP := net.ParseIP(s.Addr)
+		if sAddrIP == nil {
 			klog.Warningf("readyz probe: failed to parse node address for Node=%s", s.Addr)
 			continue
 		}
 
-		if nodeAddressIP.Equal(sAddrIp) && s.IsUN() {
+		if nodeAddressIP.Equal(sAddrIP) && s.IsUN() {
 			transportEnabled, err := scyllaClient.IsNativeTransportEnabled(ctx, localhost)
 			if err != nil {
 				w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

`fdbc:7863:fdbf:0:0:0:0:6b7c` should be considered equal to `fdbc:7863:fdbf::6b7c`. Without this change, the operator sidecar would never declare the node healthy since it would never find an IP match when looking at node statuses.

**Which issue is resolved by this Pull Request:**
Resolves #
