### PR TITLE
Allow overriding Scylla command line args

### DIFF
--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -184,11 +184,7 @@ func convertScyllaArguments(scyllaArguments string) map[string]string {
 
 func appendScyllaArguments(ctx context.Context, s *ScyllaConfig, scyllaArgs string, scyllaFinalArgs map[string]*string) {
 	for argName, argValue := range convertScyllaArguments(scyllaArgs) {
-		if existing := scyllaFinalArgs[argName]; existing == nil {
-			scyllaFinalArgs[argName] = pointer.StringPtr(strings.TrimSpace(argValue))
-		} else {
-			klog.Infof("ScyllaArgs: argument '%s' is ignored, it is already in the list", argName)
-		}
+		scyllaFinalArgs[argName] = pointer.StringPtr(strings.TrimSpace(argValue))
 	}
 }
 


### PR DESCRIPTION
**Description of your changes:**

Allow `scyllaArgs` to replace existing Scylla command line arguments. This is necessary to override the hardcoded `0.0.0.0` listen address to `::` when we want to use IPv6.

**Which issue is resolved by this Pull Request:**
Resolves #
