### PR TITLE
Add silent requeue mechanism in nodeconfigpod controller

### DIFF
--- a/pkg/controller/nodeconfigpod/sync_configmaps.go
+++ b/pkg/controller/nodeconfigpod/sync_configmaps.go
@@ -55,7 +55,7 @@ func (ncpc *Controller) makeConfigMap(ctx context.Context, pod *corev1.Pod) (*co
 
 	containerID, err := controllerhelpers.GetScyllaContainerID(pod)
 	if err != nil {
-		return nil, fmt.Errorf("can't get container id: %w", err)
+		return nil, controllerhelpers.NewRequeueError(fmt.Sprintf("can't get container id: %s", err))
 	}
 
 	src := &internalapi.SidecarRuntimeConfig{

--- a/pkg/controllerhelpers/error.go
+++ b/pkg/controllerhelpers/error.go
@@ -19,3 +19,8 @@ func NewRequeueError(reasons ...string) *RequeueError {
 func (e *RequeueError) Error() string {
 	return strings.Join(e.reasons, ", ")
 }
+
+func (e *RequeueError) Is(err error) bool {
+	_, ok := err.(*RequeueError)
+	return ok
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
When there was not scylla container on a pod, nodeconfig tuning couldn't succeed and was producing many errors. This fix will make the controller silently requeue until scylla container is deployed on a pod.


**Which issue is resolved by this Pull Request:**
Resolves #1033
