### PR TITLE
Wait for scylla nodes to have a full quorum before testing CQL in e2e tests

### DIFF
--- a/test/e2e/set/scyllacluster/datainserter.go
+++ b/test/e2e/set/scyllacluster/datainserter.go
@@ -3,7 +3,6 @@
 package scyllacluster
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -12,23 +11,18 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/gocqlx/v2/table"
-	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
-	"github.com/scylladb/scylla-operator/test/e2e/utils"
-	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/uuid"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 const nRows = 10
 
 type DataInserter struct {
-	client            corev1client.CoreV1Interface
 	session           *gocqlx.Session
 	keyspace          string
 	table             *table.Table
 	data              []*TestData
-	replicationFactor int32
+	replicationFactor int
 }
 
 type TestData struct {
@@ -36,12 +30,8 @@ type TestData struct {
 	Data string `db:"data"`
 }
 
-func NewDataInserter(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster, replicationFactor int32) (*DataInserter, error) {
-	if replicationFactor < 1 {
-		return nil, fmt.Errorf("replication factor can't be set to less than 1")
-	}
-
-	keyspace := strings.Replace(string(uuid.NewUUID()), "-", "", -1)
+func NewDataInserter(hosts []string) (*DataInserter, error) {
+	keyspace := utilrand.String(8)
 	table := table.New(table.Metadata{
 		Name:    fmt.Sprintf(`"%s"."test"`, keyspace),
 		Columns: []string{"id", "data"},
@@ -49,37 +39,41 @@ func NewDataInserter(ctx context.Context, client corev1client.CoreV1Interface, s
 	})
 	data := make([]*TestData, 0, nRows)
 	for i := 0; i < nRows; i++ {
-		data = append(data, &TestData{Id: i, Data: rand.String(32)})
+		data = append(data, &TestData{Id: i, Data: utilrand.String(32)})
 	}
 
 	di := &DataInserter{
-		client:            client,
 		keyspace:          keyspace,
 		table:             table,
 		data:              data,
-		replicationFactor: replicationFactor,
+		replicationFactor: len(hosts),
 	}
 
-	var err error
-	di.session, err = di.createSession(ctx, sc)
+	err := di.SetClientEndpoints(hosts)
 	if err != nil {
-		return nil, fmt.Errorf("can't create session: %w", err)
+		return nil, fmt.Errorf("can't set client endpoints: %w", err)
 	}
 
 	return di, nil
 }
 
 func (di *DataInserter) Close() {
-	di.session.Close()
+	if di.session != nil {
+		di.session.Close()
+	}
 }
 
-// UpdateClientEndpoints closes an existing session and opens a new one.
+// SetClientEndpoints creates a new session and closes a previous session if it existed.
 // In case an error was returned, DataInserter can no Longer be used.
-func (di *DataInserter) UpdateClientEndpoints(ctx context.Context, sc *scyllav1.ScyllaCluster) error {
-	di.session.Close()
+func (di *DataInserter) SetClientEndpoints(hosts []string) error {
+	di.Close()
 
-	var err error
-	di.session, err = di.createSession(ctx, sc)
+	if len(hosts) == 0 {
+		return fmt.Errorf("at least one enpoint is required")
+	}
+
+	framework.Infof("Creating CQL session (hosts=%q)", strings.Join(hosts, ", "))
+	err := di.createSession(hosts)
 	if err != nil {
 		return fmt.Errorf("can't create session: %w", err)
 	}
@@ -88,18 +82,26 @@ func (di *DataInserter) UpdateClientEndpoints(ctx context.Context, sc *scyllav1.
 }
 
 func (di *DataInserter) Insert() error {
-	framework.By("Inserting data with RF=%d", di.replicationFactor)
-
-	err := di.session.ExecStmt(fmt.Sprintf(`CREATE KEYSPACE "%s" WITH replication = {'class' : 'NetworkTopologyStrategy','replication_factor' : %d}`, di.keyspace, di.replicationFactor))
+	framework.Infof("Creating keyspace %q with RF %d", di.keyspace, di.replicationFactor)
+	err := di.session.ExecStmt(fmt.Sprintf(
+		`CREATE KEYSPACE %q WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': %d}`,
+		di.keyspace,
+		di.replicationFactor,
+	))
 	if err != nil {
 		return fmt.Errorf("can't create keyspace: %w", err)
 	}
 
-	err = di.session.ExecStmt(fmt.Sprintf("CREATE TABLE %s (id int primary key, data text)", di.table.Name()))
+	framework.Infof("Creating table %s", di.table.Name())
+	err = di.session.ExecStmt(fmt.Sprintf(
+		`CREATE TABLE %s (id int primary key, data text)`,
+		di.table.Name(),
+	))
 	if err != nil {
 		return fmt.Errorf("can't create table: %w", err)
 	}
 
+	framework.Infof("Inserting data into table %s", di.table.Name())
 	for _, t := range di.data {
 		q := di.session.Query(di.table.Insert()).BindStruct(t)
 		err = q.ExecRelease()
@@ -112,12 +114,10 @@ func (di *DataInserter) Insert() error {
 }
 
 func (di *DataInserter) Read() ([]*TestData, error) {
-	framework.By("Reading data with RF=%d", di.replicationFactor)
+	framework.Infof("Reading data from table %s", di.table.Name())
 
-	di.session.SetConsistency(gocql.All)
-
-	var res []*TestData
 	q := di.session.Query(di.table.SelectAll()).BindStruct(&TestData{})
+	var res []*TestData
 	err := q.SelectRelease(&res)
 	if err != nil {
 		return nil, fmt.Errorf("can't select data: %w", err)
@@ -134,20 +134,21 @@ func (di *DataInserter) GetExpected() []*TestData {
 	return di.data
 }
 
-func (di *DataInserter) createSession(ctx context.Context, sc *scyllav1.ScyllaCluster) (*gocqlx.Session, error) {
-	hosts, err := utils.GetHosts(ctx, di.client, sc)
-	if err != nil {
-		return nil, fmt.Errorf("can't get hosts: %w", err)
-	}
-
+func (di *DataInserter) createSession(hosts []string) error {
 	clusterConfig := gocql.NewCluster(hosts...)
 	clusterConfig.Timeout = 3 * time.Second
 	clusterConfig.ConnectTimeout = 3 * time.Second
+	// Set a small reconnect interval to avoid flakes, if not reconnected in time.
+	clusterConfig.ReconnectInterval = 500 * time.Millisecond
 
 	session, err := gocqlx.WrapSession(clusterConfig.CreateSession())
 	if err != nil {
-		return nil, fmt.Errorf("can't create gocqlx session: %w", err)
+		return fmt.Errorf("can't create gocqlx session: %w", err)
 	}
 
-	return &session, nil
+	session.SetConsistency(gocql.All)
+
+	di.session = &session
+
+	return nil
 }

--- a/test/e2e/set/scyllacluster/scyllacluster_evictions.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_evictions.go
@@ -36,14 +36,11 @@ var _ = g.Describe("ScyllaCluster evictions", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		di, err := NewDataInserter(ctx, f.KubeClient().CoreV1(), sc, utils.GetMemberCount(sc))
-		o.Expect(err).NotTo(o.HaveOccurred())
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(2))
+		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
-
-		err = di.Insert()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
 
 		framework.By("Allowing the first pod to be evicted")
 		e := &policyv1beta1.Eviction{

--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -55,7 +55,12 @@ var _ = g.Describe("ScyllaCluster Ingress", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), sc, nil)
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(1))
+		di := insertAndVerifyCQLData(ctx, hosts)
+		defer di.Close()
 
 		framework.By("Verifying AnyNode Ingresses")
 		services, err := f.KubeClient().CoreV1().Services(sc.Namespace).List(ctx, metav1.ListOptions{

--- a/test/e2e/set/scyllacluster/scyllacluster_hostid.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_hostid.go
@@ -38,14 +38,11 @@ var _ = g.Describe("ScyllaCluster HostID", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		di, err := NewDataInserter(ctx, f.KubeClient().CoreV1(), sc, utils.GetMemberCount(sc))
-		o.Expect(err).NotTo(o.HaveOccurred())
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(2))
+		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
-
-		err = di.Insert()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
 
 		framework.By("Verifying annotations")
 		scyllaClient, _, err := utils.GetScyllaClient(ctx, f.KubeClient().CoreV1(), sc)

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -42,14 +42,11 @@ var _ = g.Describe("ScyllaCluster Orphaned PV", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		di, err := NewDataInserter(ctx, f.KubeClient().CoreV1(), sc, utils.GetMemberCount(sc))
-		o.Expect(err).NotTo(o.HaveOccurred())
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(3))
+		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
-
-		err = di.Insert()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
 
 		framework.By("Simulating a PV on node that's gone")
 		stsName := naming.StatefulSetNameForRack(sc.Spec.Datacenter.Racks[0], sc)
@@ -120,6 +117,14 @@ var _ = g.Describe("ScyllaCluster Orphaned PV", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx4, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		oldHosts := hosts
+		hosts = getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(len(oldHosts)))
+		o.Expect(hosts).NotTo(o.ConsistOf(oldHosts))
+		err = di.SetClientEndpoints(hosts)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		verifyCQLData(ctx, di)
 	})
 })

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -40,14 +40,11 @@ var _ = g.Describe("ScyllaCluster replace", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		di, err := NewDataInserter(ctx, f.KubeClient().CoreV1(), sc, utils.GetMemberCount(sc))
-		o.Expect(err).NotTo(o.HaveOccurred())
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(2))
+		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
-
-		err = di.Insert()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
 
 		framework.By("Replacing a node #0")
 		pod, err := f.KubeClient().CoreV1().Pods(f.Namespace()).Get(
@@ -87,6 +84,14 @@ var _ = g.Describe("ScyllaCluster replace", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		oldHosts := hosts
+		hosts = getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(len(oldHosts)))
+		o.Expect(hosts).NotTo(o.ConsistOf(oldHosts))
+		err = di.SetClientEndpoints(hosts)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		verifyCQLData(ctx, di)
 	})
 })

--- a/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
@@ -57,8 +57,10 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		hosts, err := utils.GetHosts(ctx, f.KubeClient().CoreV1(), sc)
-		o.Expect(err).NotTo(o.HaveOccurred())
+		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(1))
+		di := insertAndVerifyCQLData(ctx, hosts)
+		defer di.Close()
 
 		connections := make(map[uint16]string)
 		var connectionsMut sync.Mutex

--- a/test/e2e/set/scyllacluster/scyllacluster_updates.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_updates.go
@@ -40,6 +40,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		framework.By("Creating a ScyllaCluster")
 		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
 		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(1))
 
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -50,14 +51,11 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		di, err := NewDataInserter(ctx, f.KubeClient().CoreV1(), sc, utils.GetMemberCount(sc))
-		o.Expect(err).NotTo(o.HaveOccurred())
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(1))
+		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
-
-		err = di.Insert()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
 
 		framework.By("Changing pod resources")
 		oldResources := *sc.Spec.Datacenter.Racks[0].Resources.DeepCopy()
@@ -99,6 +97,10 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx2, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+		o.Expect(hosts).To(o.ConsistOf(getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)))
+		verifyCQLData(ctx, di)
+
 		framework.By("Scaling the ScyllaCluster up to create a new replica")
 		oldMembers := sc.Spec.Datacenter.Racks[0].Members
 		newMebmers := oldMembers + 1
@@ -120,5 +122,14 @@ var _ = g.Describe("ScyllaCluster", func() {
 		defer waitCtx4Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx4, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		oldHosts := hosts
+		hosts = getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(oldHosts).To(o.HaveLen(int(oldMembers)))
+		o.Expect(hosts).To(o.HaveLen(int(newMebmers)))
+		o.Expect(hosts).To(o.ContainElements(oldHosts))
+		verifyCQLData(ctx, di)
 	})
 })

--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -53,14 +53,11 @@ var _ = g.Describe("Scylla Manager integration", func() {
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		di, err := NewDataInserter(ctx, f.KubeClient().CoreV1(), sc, utils.GetMemberCount(sc))
-		o.Expect(err).NotTo(o.HaveOccurred())
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(hosts).To(o.HaveLen(1))
+		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
-
-		err = di.Insert()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		verifyScyllaCluster(ctx, f.KubeClient(), sc, di)
 
 		framework.By("Waiting for the cluster sync with Scylla Manager")
 		registeredInManagerCond := func(sc *scyllav1.ScyllaCluster) (bool, error) {

--- a/test/e2e/set/scyllacluster/verify.go
+++ b/test/e2e/set/scyllacluster/verify.go
@@ -132,16 +132,16 @@ func getScyllaHostsAndWaitForFullQuorum(ctx context.Context, client corev1client
 	return hosts
 }
 
-func verifyCQLData(ctx context.Context, di *DataInserter) {
+func verifyCQLData(ctx context.Context, di *utils.DataInserter) {
 	framework.By("Verifying the data")
 	data, err := di.Read()
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(data).To(o.Equal(di.GetExpected()))
 }
 
-func insertAndVerifyCQLData(ctx context.Context, hosts []string) *DataInserter {
+func insertAndVerifyCQLData(ctx context.Context, hosts []string) *utils.DataInserter {
 	framework.By("Inserting data")
-	di, err := NewDataInserter(hosts)
+	di, err := utils.NewDataInserter(hosts)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	err = di.Insert()

--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2021 ScyllaDB
 
-package scyllacluster
+package utils
 
 import (
 	"fmt"


### PR DESCRIPTION
**Description of your changes:**
When a ScyllaCluster is considered rolled out it only means that every node reports itself as a UN. Before we can use CQL, the nodes have to agree that the other ones are UN as well. Because state propagation base on Gossip takes time (prefers AP), we have to explicitly wait for it to sync before using CQL. It's done by making sure all nodes report all the other nodes, including itself, as UN.

This work is is based on @rzetelskik findings, thanks!

This PR also enhances the DataInserter, make sure it uses full quorum for all operations and extends several test. (Previously it was using quorum for writes and full quorum for reads.)

**Which issue is resolved by this Pull Request:**
A few flakes for sure.
