### PR TITLE
Fix backup field name in scylla cluster spec documentation

### DIFF
--- a/docs/source/manager.md
+++ b/docs/source/manager.md
@@ -149,7 +149,7 @@ Add following task definition to Cluster spec:
     - name: "users repair"
       keyspace: ["users"]
       interval: "1d"
-  backup:
+  backups:
     - name: "weekly backup"
       location: ["s3:cluster-backups"]
       retention: 3


### PR DESCRIPTION
as per this doc https://operator.docs.scylladb.com/stable/scylla_cluster_crd.html, the correct key is backups

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #
