### PR TITLE
Add resource version to e2e messages waiting for ScyllaCluster rollout

### DIFF
--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -255,7 +255,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 
 		verifyNodeConfig(ctx, f.KubeAdminClient(), nc)
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		ctx4, ctx4Cancel := utils.ContextForRollout(ctx, sc)
 		defer ctx4Cancel()
 		sc, err = utils.WaitForScyllaClusterState(ctx4, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_auth.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_auth.go
@@ -38,7 +38,7 @@ var _ = g.Describe("ScyllaCluster authentication", func() {
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_evictions.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_evictions.go
@@ -30,7 +30,7 @@ var _ = g.Describe("ScyllaCluster evictions", func() {
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -36,7 +36,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV", func() {
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
@@ -114,7 +114,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV", func() {
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx4, waitCtx4Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx4Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx4, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
@@ -37,7 +37,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		originalSC := sc.DeepCopy()
 		originalSC.ResourceVersion = ""
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -34,7 +34,7 @@ var _ = g.Describe("ScyllaCluster replace", func() {
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -35,7 +35,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to rollout")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
@@ -62,7 +62,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
 		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(3))
 
-		framework.By("Waiting for the ScyllaCluster to rollout")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx2Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx2, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
@@ -88,7 +88,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(2))
 
-		framework.By("Waiting for the ScyllaCluster to rollout")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx3, waitCtx3Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx3Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
@@ -146,7 +146,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(1))
 
-		framework.By("Waiting for the ScyllaCluster to rollout")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx5, waitCtx5Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx5Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx5, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
@@ -165,7 +165,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(3))
 
-		framework.By("Waiting for the ScyllaCluster to rollout")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx6, waitCtx6Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx6Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx6, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
@@ -51,7 +51,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
@@ -35,7 +35,7 @@ var _ = g.Describe("ScyllaCluster sysctl", func() {
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_updates.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_updates.go
@@ -44,7 +44,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
@@ -55,7 +55,7 @@ var _ = g.Describe("ScyllaCluster upgrades", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(sc.Spec.Version).To(o.Equal(e.initialVersion))
 
-			framework.By("Waiting for the ScyllaCluster to deploy")
+			framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 			waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 			defer waitCtx1Cancel()
 			sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)

--- a/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
@@ -30,7 +30,7 @@ var _ = g.Describe("ScyllaCluster webhook", func() {
 		validSC := scyllafixture.BasicScyllaCluster.ReadOrFail()
 		validSC.Name = names.SimpleNameGenerator.GenerateName(validSC.GenerateName)
 
-		framework.By("rejecting a creation of ScyllaCluster with duplicated racks")
+		framework.By("Rejecting a creation of ScyllaCluster with duplicated racks")
 		duplicateRacksSC := validSC.DeepCopy()
 		duplicateRacksSC.Spec.Datacenter.Racks = append(duplicateRacksSC.Spec.Datacenter.Racks, *duplicateRacksSC.Spec.Datacenter.Racks[0].DeepCopy())
 		_, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, duplicateRacksSC, metav1.CreateOptions{})
@@ -54,7 +54,7 @@ var _ = g.Describe("ScyllaCluster webhook", func() {
 			Code: 422,
 		}}))
 
-		framework.By("rejecting a creation of ScyllaCluster with invalid intensity in repair task spec")
+		framework.By("Rejecting a creation of ScyllaCluster with invalid intensity in repair task spec")
 		invalidIntensitySC := validSC.DeepCopy()
 		invalidIntensitySC.Spec.Repairs = append(invalidIntensitySC.Spec.Repairs, scyllav1.RepairTaskSpec{
 			Intensity: "100Mib",
@@ -80,11 +80,11 @@ var _ = g.Describe("ScyllaCluster webhook", func() {
 			Code: 422,
 		}}))
 
-		framework.By("accepting a creation of valid ScyllaCluster")
+		framework.By("Accepting a creation of valid ScyllaCluster")
 		validSC, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, validSC, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", validSC.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, validSC)
 		defer waitCtx1Cancel()
 		validSC, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), validSC.Namespace, validSC.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
@@ -99,7 +99,7 @@ var _ = g.Describe("ScyllaCluster webhook", func() {
 
 		verifyScyllaCluster(ctx, f.KubeClient(), validSC, di)
 
-		framework.By("rejecting an update of ScyllaCluster's repo")
+		framework.By("Rejecting an update of ScyllaCluster's repo")
 		_, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(validSC.Namespace).Patch(
 			ctx,
 			validSC.Name,
@@ -127,7 +127,7 @@ var _ = g.Describe("ScyllaCluster webhook", func() {
 			Code: 422,
 		}}))
 
-		framework.By("rejecting an update of ScyllaCluster's dcName")
+		framework.By("Rejecting an update of ScyllaCluster's dcName")
 		_, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(validSC.Namespace).Patch(
 			ctx,
 			validSC.Name,

--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -47,7 +47,7 @@ var _ = g.Describe("Scylla Manager integration", func() {
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Waiting for the ScyllaCluster to deploy")
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
 		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
 		defer waitCtx1Cancel()
 		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)


### PR DESCRIPTION
**Description of your changes:**
This PR adds resource version to e2e messages waiting for ScyllaCluster rollout. This will help with debugging flakes when reasoning about order of events or looking up objects in audit log.
