### PR TITLE
Add Dependabot to keep actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "kind/machinery"
+    commit-message:
+      prefix: "Update actions "
+      include: "scope"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
CI jobs were issuing a warnings about deprecated actions.
This PR will add Dependabot to keep them up to date. 

**Which issue is resolved by this Pull Request:**
Resolves #1063 
