### PR TITLE
Adjust rate limits and timeouts for e2e tests

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -42,6 +42,8 @@ for f in $( find "${deploy_dir}"/ -type f -name '*.yaml' ); do
     sed -i -E -e "s~docker.io/scylladb/scylla-operator(:|@sha256:)[^ ]*~${OPERATOR_IMAGE_REF}~" "${f}"
 done
 
+yq e --inplace '.spec.template.spec.containers[0].args += ["--qps=200", "--burst=400"]' "${deploy_dir}/operator/50_operator.deployment.yaml"
+
 kubectl_create -f "${deploy_dir}"/cert-manager.yaml
 
 # Wait for cert-manager

--- a/pkg/controller/scyllacluster/controller.go
+++ b/pkg/controller/scyllacluster/controller.go
@@ -44,9 +44,6 @@ import (
 
 const (
 	ControllerName = "ScyllaClusterController"
-	// maxSyncDuration enforces preemption. Do not raise the value! Controllers shouldn't actively wait,
-	// but rather use the queue.
-	maxSyncDuration = 40 * time.Second
 
 	artificialDelayForCachesToCatchUp = 10 * time.Second
 )
@@ -206,8 +203,6 @@ func (scc *Controller) processNextItem(ctx context.Context) bool {
 	}
 	defer scc.queue.Done(key)
 
-	ctx, cancel := context.WithTimeout(ctx, maxSyncDuration)
-	defer cancel()
 	err := scc.sync(ctx, key.(string))
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
 	err = utilerrors.Reduce(err)

--- a/test/e2e/utils/config.go
+++ b/test/e2e/utils/config.go
@@ -5,7 +5,11 @@ package utils
 import "time"
 
 const (
-	baseRolloutTimout  = 30 * time.Second
+	// syncTimeout is the maximum time the sync loop can last. In normal circumstances this is in the order
+	// of seconds but there are special cases we need to account for. Like when the sync loop generates new keys
+	// and signs certificates it can take several seconds. When the CI creates multiple clusters in parallel on
+	// a constrained CPU, one cert can easily take over 30s.
+	syncTimeout        = 2 * time.Minute
 	imagePullTimeout   = 4 * time.Minute
 	joinClusterTimeout = 3 * time.Minute
 

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -82,7 +82,7 @@ func IsNodeConfigDoneWithNodeTuningFunc(nodes []*corev1.Node) func(nc *scyllav1a
 }
 
 func RolloutTimeoutForScyllaCluster(sc *scyllav1.ScyllaCluster) time.Duration {
-	return baseRolloutTimout + time.Duration(GetMemberCount(sc))*memberRolloutTimeout
+	return syncTimeout + time.Duration(GetMemberCount(sc))*memberRolloutTimeout
 }
 
 func GetMemberCount(sc *scyllav1.ScyllaCluster) int32 {


### PR DESCRIPTION
**Description of your changes:**
- raises scyllacluster sync timeout
- raises rate limits for the operator when deployed to run e2e
- removes maxSyncDuration that has served it's purpose when tracing down long lived syncs but doesn't work well with the rate limitter

**Which issue is resolved by this Pull Request:**
Some flakes.

Extracted from #1021
