### PR TITLE
Add Status Conditions

### DIFF
--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -2138,6 +2138,50 @@ spec:
                         type: array
                     type: object
                   type: array
+                conditions:
+                  description: conditions hold conditions describing ScyllaCluster state. To determine whether a cluster rollout is finished, look for Available=True,Progressing=False,Degraded=False.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
                 managerId:
                   description: managerId contains ID under which cluster was registered in Scylla Manager.
                   type: string

--- a/pkg/api/scylla/v1/cluster_types.go
+++ b/pkg/api/scylla/v1/cluster_types.go
@@ -430,7 +430,17 @@ type ScyllaClusterStatus struct {
 
 	// upgrade reflects state of ongoing upgrade procedure.
 	Upgrade *UpgradeStatus `json:"upgrade,omitempty"`
+
+	// conditions hold conditions describing ScyllaCluster state.
+	// To determine whether a cluster rollout is finished, look for Available=True,Progressing=False,Degraded=False.
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
+
+const (
+	AvailableCondition   = "Available"
+	ProgressingCondition = "Progressing"
+	DegradedCondition    = "Degraded"
+)
 
 // UpgradeStatus contains the internal state of an ongoing upgrade procedure.
 // Do not rely on these internal values externally. They are meant for keeping an internal state

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -1852,6 +1852,50 @@ spec:
                         type: array
                     type: object
                   type: array
+                conditions:
+                  description: conditions hold conditions describing ScyllaCluster state. To determine whether a cluster rollout is finished, look for Available=True,Progressing=False,Degraded=False.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
                 managerId:
                   description: managerId contains ID under which cluster was registered in Scylla Manager.
                   type: string

--- a/pkg/api/scylla/v1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1/zz_generated.deepcopy.go
@@ -7,6 +7,7 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -584,6 +585,13 @@ func (in *ScyllaClusterStatus) DeepCopyInto(out *ScyllaClusterStatus) {
 		in, out := &in.Upgrade, &out.Upgrade
 		*out = new(UpgradeStatus)
 		**out = **in
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/controller/scyllacluster/conditions.go
+++ b/pkg/controller/scyllacluster/conditions.go
@@ -1,0 +1,19 @@
+package scyllacluster
+
+const (
+	serviceAccountControllerProgressingCondition = "ServiceAccountControllerProgressing"
+	serviceAccountControllerDegradedCondition    = "ServiceAccountControllerDegraded"
+	roleBindingControllerProgressingCondition    = "RoleBindingControllerProgressing"
+	roleBindingControllerDegradedCondition       = "RoleBindingControllerDegraded"
+	agentTokenControllerProgressingCondition     = "AgentTokenControllerProgressing"
+	agentTokenControllerDegradedCondition        = "AgentTokenControllerDegraded"
+	statefulSetControllerAvailableCondition      = "StatefulSetControllerAvailable"
+	statefulSetControllerProgressingCondition    = "StatefulSetControllerProgressing"
+	statefulSetControllerDegradedCondition       = "StatefulSetControllerDegraded"
+	serviceControllerProgressingCondition        = "ServiceControllerProgressing"
+	serviceControllerDegradedCondition           = "ServiceControllerDegraded"
+	pdbControllerProgressingCondition            = "PDBControllerProgressing"
+	pdbControllerDegradedCondition               = "PDBControllerDegraded"
+	ingressControllerProgressingCondition        = "IngressControllerProgressing"
+	ingressControllerDegradedCondition           = "IngressControllerDegraded"
+)

--- a/pkg/controller/scyllacluster/controller.go
+++ b/pkg/controller/scyllacluster/controller.go
@@ -49,9 +49,9 @@ const (
 )
 
 var (
-	keyFunc                  = cache.DeletionHandlingMetaNamespaceKeyFunc
-	controllerGVK            = scyllav1.GroupVersion.WithKind("ScyllaCluster")
-	statefulSetControllerGVK = appsv1.SchemeGroupVersion.WithKind("StatefulSet")
+	keyFunc                    = cache.DeletionHandlingMetaNamespaceKeyFunc
+	scyllaClusterControllerGVK = scyllav1.GroupVersion.WithKind("ScyllaCluster")
+	statefulSetControllerGVK   = appsv1.SchemeGroupVersion.WithKind("StatefulSet")
 )
 
 type Controller struct {
@@ -265,7 +265,7 @@ func (scc *Controller) resolveScyllaClusterController(obj metav1.Object) *scylla
 		return nil
 	}
 
-	if controllerRef.Kind != controllerGVK.Kind {
+	if controllerRef.Kind != scyllaClusterControllerGVK.Kind {
 		return nil
 	}
 
@@ -457,13 +457,13 @@ func (scc *Controller) deleteSecret(obj interface{}) {
 	scc.enqueueOwner(secret)
 }
 
-func (sac *Controller) addServiceAccount(obj interface{}) {
+func (scc *Controller) addServiceAccount(obj interface{}) {
 	sa := obj.(*corev1.ServiceAccount)
 	klog.V(4).InfoS("Observed addition of ServiceAccount", "ServiceAccount", klog.KObj(sa))
-	sac.enqueueOwner(sa)
+	scc.enqueueOwner(sa)
 }
 
-func (sac *Controller) updateServiceAccount(old, cur interface{}) {
+func (scc *Controller) updateServiceAccount(old, cur interface{}) {
 	oldSA := old.(*corev1.ServiceAccount)
 	currentSA := cur.(*corev1.ServiceAccount)
 
@@ -473,17 +473,17 @@ func (sac *Controller) updateServiceAccount(old, cur interface{}) {
 			utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldSA, err))
 			return
 		}
-		sac.deleteServiceAccount(cache.DeletedFinalStateUnknown{
+		scc.deleteServiceAccount(cache.DeletedFinalStateUnknown{
 			Key: key,
 			Obj: oldSA,
 		})
 	}
 
 	klog.V(4).InfoS("Observed update of ServiceAccount", "ServiceAccount", klog.KObj(oldSA))
-	sac.enqueueOwner(currentSA)
+	scc.enqueueOwner(currentSA)
 }
 
-func (sac *Controller) deleteServiceAccount(obj interface{}) {
+func (scc *Controller) deleteServiceAccount(obj interface{}) {
 	svc, ok := obj.(*corev1.ServiceAccount)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -498,16 +498,16 @@ func (sac *Controller) deleteServiceAccount(obj interface{}) {
 		}
 	}
 	klog.V(4).InfoS("Observed deletion of ServiceAccount", "ServiceAccount", klog.KObj(svc))
-	sac.enqueueOwner(svc)
+	scc.enqueueOwner(svc)
 }
 
-func (sac *Controller) addRoleBinding(obj interface{}) {
+func (scc *Controller) addRoleBinding(obj interface{}) {
 	roleBinding := obj.(*rbacv1.RoleBinding)
 	klog.V(4).InfoS("Observed addition of RoleBinding", "RoleBinding", klog.KObj(roleBinding))
-	sac.enqueueOwner(roleBinding)
+	scc.enqueueOwner(roleBinding)
 }
 
-func (sac *Controller) updateRoleBinding(old, cur interface{}) {
+func (scc *Controller) updateRoleBinding(old, cur interface{}) {
 	oldRoleBinding := old.(*rbacv1.RoleBinding)
 	currentRoleBinding := cur.(*rbacv1.RoleBinding)
 
@@ -517,17 +517,17 @@ func (sac *Controller) updateRoleBinding(old, cur interface{}) {
 			utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldRoleBinding, err))
 			return
 		}
-		sac.deleteRoleBinding(cache.DeletedFinalStateUnknown{
+		scc.deleteRoleBinding(cache.DeletedFinalStateUnknown{
 			Key: key,
 			Obj: oldRoleBinding,
 		})
 	}
 
 	klog.V(4).InfoS("Observed update of RoleBinding", "RoleBinding", klog.KObj(oldRoleBinding))
-	sac.enqueueOwner(currentRoleBinding)
+	scc.enqueueOwner(currentRoleBinding)
 }
 
-func (sac *Controller) deleteRoleBinding(obj interface{}) {
+func (scc *Controller) deleteRoleBinding(obj interface{}) {
 	roleBinding, ok := obj.(*rbacv1.RoleBinding)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -542,7 +542,7 @@ func (sac *Controller) deleteRoleBinding(obj interface{}) {
 		}
 	}
 	klog.V(4).InfoS("Observed deletion of RoleBinding", "RoleBinding", klog.KObj(roleBinding))
-	sac.enqueueOwner(roleBinding)
+	scc.enqueueOwner(roleBinding)
 }
 
 func (scc *Controller) addPod(obj interface{}) {

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -50,7 +50,7 @@ func IdentityService(c *scyllav1.ScyllaCluster) *corev1.Service {
 			Namespace: c.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(c, controllerGVK),
+				*metav1.NewControllerRef(c, scyllaClusterControllerGVK),
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -99,7 +99,7 @@ func MemberService(sc *scyllav1.ScyllaCluster, rackName, name string, oldService
 			Name:      name,
 			Namespace: sc.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(sc, controllerGVK),
+				*metav1.NewControllerRef(sc, scyllaClusterControllerGVK),
 			},
 			Labels: labels,
 		},
@@ -199,7 +199,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 			Namespace: c.Namespace,
 			Labels:    rackLabels,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(c, controllerGVK),
+				*metav1.NewControllerRef(c, scyllaClusterControllerGVK),
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -624,7 +624,7 @@ func MakePodDisruptionBudget(c *scyllav1.ScyllaCluster) *policyv1.PodDisruptionB
 			Name:      naming.PodDisruptionBudgetName(c),
 			Namespace: c.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(c, controllerGVK),
+				*metav1.NewControllerRef(c, scyllaClusterControllerGVK),
 			},
 			Labels: naming.ClusterLabels(c),
 		},
@@ -699,7 +699,7 @@ func MakeIngresses(c *scyllav1.ScyllaCluster, services map[string]*corev1.Servic
 					Labels:      labels,
 					Annotations: ip.ingressOptions.Annotations,
 					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(c, controllerGVK),
+						*metav1.NewControllerRef(c, scyllaClusterControllerGVK),
 					},
 				},
 				Spec: networkingv1.IngressSpec{
@@ -761,7 +761,7 @@ func MakeAgentAuthTokenSecret(c *scyllav1.ScyllaCluster, authToken string) (*cor
 			Name:      naming.AgentAuthTokenSecretName(c.Name),
 			Namespace: c.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(c, controllerGVK),
+				*metav1.NewControllerRef(c, scyllaClusterControllerGVK),
 			},
 			Labels: naming.ClusterLabels(c),
 		},
@@ -793,7 +793,7 @@ func MakeServiceAccount(sc *scyllav1.ScyllaCluster) *corev1.ServiceAccount {
 			Name:      naming.MemberServiceAccountNameForScyllaCluster(sc.Name),
 			Namespace: sc.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(sc, controllerGVK),
+				*metav1.NewControllerRef(sc, scyllaClusterControllerGVK),
 			},
 			Labels: naming.ClusterLabels(sc),
 		},
@@ -807,7 +807,7 @@ func MakeRoleBinding(sc *scyllav1.ScyllaCluster) *rbacv1.RoleBinding {
 			Name:      saName,
 			Namespace: sc.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(sc, controllerGVK),
+				*metav1.NewControllerRef(sc, scyllaClusterControllerGVK),
 			},
 			Labels: naming.ClusterLabels(sc),
 		},

--- a/pkg/controllerhelpers/core_test.go
+++ b/pkg/controllerhelpers/core_test.go
@@ -1,0 +1,360 @@
+package controllerhelpers
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFindStatusConditionsWithSuffix(t *testing.T) {
+	tt := []struct {
+		name       string
+		conditions []metav1.Condition
+		suffix     string
+		expected   []metav1.Condition
+	}{
+		{
+			name:       "won't panic with nil array",
+			conditions: nil,
+			suffix:     "",
+			expected:   nil,
+		},
+		{
+			name:   "finds matching elements",
+			suffix: "Progressing",
+			conditions: []metav1.Condition{
+				{
+					Type:    "FooProgressing",
+					Status:  metav1.ConditionTrue,
+					Reason:  "FooProgressingReason",
+					Message: "FooProgressing message",
+				},
+				{
+					Type:    "Progressing",
+					Status:  metav1.ConditionTrue,
+					Reason:  "ProgressingReason",
+					Message: "Progressing message",
+				},
+				{
+					Type:    "BarProgressing",
+					Status:  metav1.ConditionFalse,
+					Reason:  "BarProgressingReason",
+					Message: "BarProgressing message",
+				},
+			},
+			expected: []metav1.Condition{
+				{
+					Type:    "FooProgressing",
+					Status:  metav1.ConditionTrue,
+					Reason:  "FooProgressingReason",
+					Message: "FooProgressing message",
+				},
+				{
+					Type:    "BarProgressing",
+					Status:  metav1.ConditionFalse,
+					Reason:  "BarProgressingReason",
+					Message: "BarProgressing message",
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FindStatusConditionsWithSuffix(tc.conditions, tc.suffix)
+			if !apiequality.Semantic.DeepEqual(got, tc.expected) {
+				t.Errorf("expected and got differ: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}
+
+func TestAggregateStatusConditions(t *testing.T) {
+	tt := []struct {
+		name              string
+		conditions        []metav1.Condition
+		condition         metav1.Condition
+		expectedCondition metav1.Condition
+		expectedError     error
+	}{
+		{
+			name:       "won't panic with nil array",
+			conditions: nil,
+			condition: metav1.Condition{
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 42,
+			},
+			expectedCondition: metav1.Condition{
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 42,
+			},
+			expectedError: nil,
+		},
+		{
+			name:       "will error on unknown initial condition",
+			conditions: nil,
+			condition: metav1.Condition{
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: 42,
+			},
+			expectedCondition: metav1.Condition{},
+			expectedError:     errors.New(`unsupported default value "Unknown"`),
+		},
+		{
+			name: "positive condition with all true results in the initial condition",
+			conditions: []metav1.Condition{
+				{
+					Type:    "FooAvailable",
+					Status:  metav1.ConditionTrue,
+					Reason:  "FooAvailableReason",
+					Message: "FooAvailable ok",
+				},
+				{
+					Type:    "BarAvailable",
+					Status:  metav1.ConditionTrue,
+					Reason:  "BarAvailableReason",
+					Message: "BarAvailable ok",
+				},
+			},
+			condition: metav1.Condition{
+				Type:               "Available",
+				Status:             metav1.ConditionTrue,
+				Reason:             "AsExpected",
+				Message:            "AsExpected",
+				ObservedGeneration: 42,
+			},
+			expectedCondition: metav1.Condition{
+				Type:               "Available",
+				Status:             metav1.ConditionTrue,
+				Reason:             "AsExpected",
+				Message:            "AsExpected",
+				ObservedGeneration: 42,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "positive condition with true and unknown results in an unknown condition",
+			conditions: []metav1.Condition{
+				{
+					Type:    "FooAvailable",
+					Status:  metav1.ConditionTrue,
+					Reason:  "FooAvailableReason",
+					Message: "FooAvailable ok",
+				},
+				{
+					Type:    "BarAvailable",
+					Status:  metav1.ConditionTrue,
+					Reason:  "BarAvailableReason",
+					Message: "BarAvailable ok",
+				},
+				{
+					Type:    "UnknownAvailableFoo",
+					Status:  metav1.ConditionUnknown,
+					Reason:  "UnknownAvailableFooReason",
+					Message: "UnknownAvailableFoo message",
+				},
+				{
+					Type:    "UnknownAvailableBar",
+					Status:  metav1.ConditionUnknown,
+					Reason:  "UnknownAvailableBarReason",
+					Message: "UnknownAvailableBar message",
+				},
+			},
+			condition: metav1.Condition{
+				Type:               "Available",
+				Status:             metav1.ConditionTrue,
+				Reason:             "AsExpected",
+				Message:            "AsExpected",
+				ObservedGeneration: 42,
+			},
+			expectedCondition: metav1.Condition{
+				Type:               "Available",
+				Status:             metav1.ConditionUnknown,
+				Reason:             "UnknownAvailableFoo_UnknownAvailableFooReason,UnknownAvailableBar_UnknownAvailableBarReason",
+				Message:            "UnknownAvailableFoo: UnknownAvailableFoo message\nUnknownAvailableBar: UnknownAvailableBar message",
+				ObservedGeneration: 42,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "positive condition with some false aggregates the false states",
+			conditions: []metav1.Condition{
+				{
+					Type:    "FooAvailable",
+					Status:  metav1.ConditionFalse,
+					Reason:  "FooAvailableReason",
+					Message: "FooAvailable error",
+				},
+				{
+					Type:    "GoodAvailable",
+					Status:  metav1.ConditionTrue,
+					Reason:  "GoodAvailableReason",
+					Message: "GoodAvailable ok",
+				},
+				{
+					Type:    "UnknownAvailable",
+					Status:  metav1.ConditionTrue,
+					Reason:  "UnknownAvailableReason",
+					Message: "UnknownAvailable ok",
+				},
+				{
+					Type:    "BarAvailable",
+					Status:  metav1.ConditionFalse,
+					Reason:  "BarAvailableReason",
+					Message: "BarAvailable error",
+				},
+			},
+			condition: metav1.Condition{
+				Type:               "Available",
+				Status:             metav1.ConditionTrue,
+				Reason:             "AsExpected",
+				Message:            "AsExpected",
+				ObservedGeneration: 42,
+			},
+			expectedCondition: metav1.Condition{
+				Type:               "Available",
+				Status:             metav1.ConditionFalse,
+				Reason:             "FooAvailable_FooAvailableReason,BarAvailable_BarAvailableReason",
+				Message:            "FooAvailable: FooAvailable error\nBarAvailable: BarAvailable error",
+				ObservedGeneration: 42,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "negative condition with all false results in the initial condition",
+			conditions: []metav1.Condition{
+				{
+					Type:    "FooDegraded",
+					Status:  metav1.ConditionFalse,
+					Reason:  "FooDegradedReason",
+					Message: "FooDegraded ok",
+				},
+				{
+					Type:    "BarDegraded",
+					Status:  metav1.ConditionFalse,
+					Reason:  "BarDegradedReason",
+					Message: "BarDegraded ok",
+				},
+			},
+			condition: metav1.Condition{
+				Type:               "Degraded",
+				Status:             metav1.ConditionFalse,
+				Reason:             "AsExpected",
+				Message:            "AsExpected",
+				ObservedGeneration: 42,
+			},
+			expectedCondition: metav1.Condition{
+				Type:               "Degraded",
+				Status:             metav1.ConditionFalse,
+				Reason:             "AsExpected",
+				Message:            "AsExpected",
+				ObservedGeneration: 42,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "negative condition with false and unknown results in an unknown condition",
+			conditions: []metav1.Condition{
+				{
+					Type:    "FooDegraded",
+					Status:  metav1.ConditionFalse,
+					Reason:  "FooDegradedReason",
+					Message: "FooDegraded ok",
+				},
+				{
+					Type:    "BarDegraded",
+					Status:  metav1.ConditionFalse,
+					Reason:  "BarDegradedReason",
+					Message: "BarDegraded ok",
+				},
+				{
+					Type:    "UnknownDegradedFoo",
+					Status:  metav1.ConditionUnknown,
+					Reason:  "UnknownDegradedFooReason",
+					Message: "UnknownDegradedFoo message",
+				},
+				{
+					Type:    "UnknownDegradedBar",
+					Status:  metav1.ConditionUnknown,
+					Reason:  "UnknownDegradedBar reason",
+					Message: "UnknownDegradedBar message",
+				},
+			},
+			condition: metav1.Condition{
+				Type:               "Degraded",
+				Status:             metav1.ConditionFalse,
+				Reason:             "AsExpected",
+				Message:            "AsExpected",
+				ObservedGeneration: 42,
+			},
+			expectedCondition: metav1.Condition{
+				Type:               "Degraded",
+				Status:             metav1.ConditionUnknown,
+				Reason:             "UnknownDegradedFoo_UnknownDegradedFooReason,UnknownDegradedBar_UnknownDegradedBar reason",
+				Message:            "UnknownDegradedFoo: UnknownDegradedFoo message\nUnknownDegradedBar: UnknownDegradedBar message",
+				ObservedGeneration: 42,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "negative condition with some true aggregates the true states",
+			conditions: []metav1.Condition{
+				{
+					Type:    "FooDegraded",
+					Status:  metav1.ConditionTrue,
+					Reason:  "FooDegradedReason",
+					Message: "FooDegraded error",
+				},
+				{
+					Type:    "GoodDegraded",
+					Status:  metav1.ConditionFalse,
+					Reason:  "GoodDegradedReason",
+					Message: "GoodDegraded ok",
+				},
+				{
+					Type:    "UnknownDegraded",
+					Status:  metav1.ConditionFalse,
+					Reason:  "UnknownDegradedReason",
+					Message: "UnknownDegraded ok",
+				},
+				{
+					Type:    "BarDegraded",
+					Status:  metav1.ConditionTrue,
+					Reason:  "BarDegradedReason",
+					Message: "BarDegraded error",
+				},
+			},
+			condition: metav1.Condition{
+				Type:               "Degraded",
+				Status:             metav1.ConditionFalse,
+				Reason:             "AsExpected",
+				Message:            "AsExpected",
+				ObservedGeneration: 42,
+			},
+			expectedCondition: metav1.Condition{
+				Type:               "Degraded",
+				Status:             metav1.ConditionTrue,
+				Reason:             "FooDegraded_FooDegradedReason,BarDegraded_BarDegradedReason",
+				Message:            "FooDegraded: FooDegraded error\nBarDegraded: BarDegraded error",
+				ObservedGeneration: 42,
+			},
+			expectedError: nil,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AggregateStatusConditions(tc.conditions, tc.condition)
+
+			if !reflect.DeepEqual(err, tc.expectedError) {
+				t.Errorf("expected error %#v, got %#v", tc.expectedError, err)
+			}
+
+			if !apiequality.Semantic.DeepEqual(got, tc.expectedCondition) {
+				t.Errorf("expected and got differ: %s", cmp.Diff(tc.expectedCondition, got))
+			}
+		})
+	}
+}

--- a/pkg/helpers/status.go
+++ b/pkg/helpers/status.go
@@ -1,0 +1,29 @@
+package helpers
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func IsStatusConditionPresentAndTrue(conditions []metav1.Condition, conditionType string, generation int64) bool {
+	return IsStatusConditionPresentAndEqual(conditions, conditionType, metav1.ConditionTrue, generation)
+}
+
+func IsStatusConditionPresentAndFalse(conditions []metav1.Condition, conditionType string, generation int64) bool {
+	return IsStatusConditionPresentAndEqual(conditions, conditionType, metav1.ConditionFalse, generation)
+}
+
+func IsStatusConditionPresentAndEqual(conditions []metav1.Condition, conditionType string, status metav1.ConditionStatus, generation int64) bool {
+	for _, condition := range conditions {
+		if condition.Type != conditionType {
+			continue
+		}
+
+		if condition.ObservedGeneration != generation {
+			return false
+		}
+
+		return condition.Status == status
+	}
+
+	return false
+}

--- a/pkg/internalapi/conditions.go
+++ b/pkg/internalapi/conditions.go
@@ -1,0 +1,7 @@
+package internalapi
+
+const (
+	AsExpectedReason  = "AsExpected"
+	ErrorReason       = "Error"
+	ProgressingReason = "Progressing"
+)

--- a/pkg/resource/helpers.go
+++ b/pkg/resource/helpers.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"errors"
+	"reflect"
 
 	"github.com/scylladb/scylla-operator/pkg/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,4 +24,26 @@ func GetObjectGVK(object runtime.Object) (*schema.GroupVersionKind, error) {
 	}
 
 	return &kinds[0], nil
+}
+
+func GetObjectGVKOrUnknown(obj runtime.Object) *schema.GroupVersionKind {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if len(gvk.Kind) > 0 {
+		return &gvk
+	}
+
+	kinds, _, err := scheme.Scheme.ObjectKinds(obj)
+	if err != nil || len(kinds) == 0 {
+		t := reflect.TypeOf(obj)
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+		return &schema.GroupVersionKind{
+			Group:   "unknown",
+			Version: "unknown",
+			Kind:    t.Name(),
+		}
+	}
+
+	return &kinds[0]
 }

--- a/pkg/resourceapply/core.go
+++ b/pkg/resourceapply/core.go
@@ -52,7 +52,7 @@ func ApplyService(
 		} else {
 			ReportCreateEvent(recorder, requiredCopy, err)
 		}
-		return actual, true, err
+		return actual, err == nil, err
 	}
 
 	existingControllerRef := metav1.GetControllerOfNoCopy(existing)

--- a/pkg/util/errors/multiline.go
+++ b/pkg/util/errors/multiline.go
@@ -1,0 +1,90 @@
+package errors
+
+import (
+	"errors"
+	"strings"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type aggregate struct {
+	errList []error
+	sep     string
+}
+
+var _ utilerrors.Aggregate = &aggregate{}
+
+func NewAggregate(errList []error, sep string) error {
+	var errs []error
+
+	for _, err := range errList {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	if len(sep) == 0 {
+		sep = "\n"
+	}
+
+	return &aggregate{
+		errList: errs,
+		sep:     sep,
+	}
+}
+
+func NewMultilineAggregate(errList []error) error {
+	return NewAggregate(errList, "\n")
+}
+
+func (agg *aggregate) Error() string {
+	msgs := make([]string, 0, len(agg.errList))
+
+	for _, err := range agg.errList {
+		msgs = append(msgs, err.Error())
+	}
+
+	return strings.Join(msgs, "\n")
+}
+
+func (agg *aggregate) Errors() []error {
+	return agg.errList
+}
+
+func (agg *aggregate) Is(target error) bool {
+	return agg.visit(func(err error) bool {
+		return errors.Is(err, target)
+	})
+}
+
+func (agg *aggregate) visit(f func(err error) bool) bool {
+	for _, err := range agg.errList {
+		switch err := err.(type) {
+		case *aggregate:
+			match := err.visit(f)
+			if match {
+				return match
+			}
+
+		case utilerrors.Aggregate:
+			for _, nestedErr := range err.Errors() {
+				match := f(nestedErr)
+				if match {
+					return match
+				}
+			}
+
+		default:
+			match := f(err)
+			if match {
+				return match
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/util/errors/multiline_test.go
+++ b/pkg/util/errors/multiline_test.go
@@ -1,0 +1,45 @@
+package errors
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewAggregate(t *testing.T) {
+	tt := []struct {
+		name           string
+		errList        []error
+		sep            string
+		expectedString string
+	}{
+		{
+			name:           "nil list results in an empty string",
+			errList:        nil,
+			sep:            "\n",
+			expectedString: "",
+		},
+		{
+			name: "multiline error is correctly formatted",
+			errList: []error{
+				errors.New("foo"),
+				nil,
+				errors.New("bar"),
+			},
+			sep:            "\n",
+			expectedString: "foo\nbar",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewAggregate(tc.errList, tc.sep)
+
+			var gotString string
+			if got != nil {
+				gotString = got.Error()
+			}
+			if gotString != tc.expectedString {
+				t.Errorf("expected error %q, got %q", tc.expectedString, gotString)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description of your changes:**
This PR adds 3 main conditions that help users determine the ScyllaCluster status.
 - `Available` (whether all replicas are up)
 - `Progressing` (whether the controller is making changes to reach the desired state)
 - `Degraded` (whether the controller hit any issues)

A rollout is done when `Available==True`, `Progressing==False`, `Degraded==False`. This gives user an easy way to interpret the status and possibly use upstream tooling, like `kubectl wait --for=condition=`.

Conditions also allow determining the processing state and the errors manifested into degraded state without consulting operator logs (which only admins can do).

This is also needed for #1021 where it allows interpreting state for multiple controller that consume it's outputs.
