### PR TITLE
Add silent requeue in manager controller for not found tokens 

### DIFF
--- a/pkg/controller/manager/sync.go
+++ b/pkg/controller/manager/sync.go
@@ -6,7 +6,8 @@ import (
 	"time"
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
-	helpers "github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -105,6 +106,12 @@ func (c *Controller) sync(ctx context.Context, key string) error {
 	}
 
 	if sc.DeletionTimestamp != nil {
+		return nil
+	}
+
+	if !controllerhelpers.IsScyllaClusterRolledOut(sc) {
+		klog.V(4).InfoS("Skipping sync - cluster is not yet rolled out", "ScyllaCluster", klog.KObj(sc))
+		// Exit and wait for cluster to roll out.
 		return nil
 	}
 

--- a/pkg/controllerhelpers/scylla.go
+++ b/pkg/controllerhelpers/scylla.go
@@ -7,6 +7,7 @@ import (
 	"github.com/scylladb/go-log"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 	"go.uber.org/zap"
@@ -217,4 +218,20 @@ func EnsureNodeConfigCondition(status *scyllav1alpha1.NodeConfigStatus, cond *sc
 	}
 
 	*existingCond = *cond
+}
+
+func IsScyllaClusterRolledOut(sc *scyllav1.ScyllaCluster) bool {
+	if !helpers.IsStatusConditionPresentAndTrue(sc.Status.Conditions, scyllav1.AvailableCondition, sc.Generation) {
+		return false
+	}
+
+	if !helpers.IsStatusConditionPresentAndFalse(sc.Status.Conditions, scyllav1.ProgressingCondition, sc.Generation) {
+		return false
+	}
+
+	if !helpers.IsStatusConditionPresentAndFalse(sc.Status.Conditions, scyllav1.DegradedCondition, sc.Generation) {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
- add secret handlers to manager controller
- silently requeue when cluster token has not been found yet

**Which issue is resolved by this Pull Request:**
Resolves #1031 
