### PR TITLE
E2E for cluster connection via Ingress 

### DIFF
--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -118,7 +118,10 @@ runs:
       
       user="$( id -u )"
       group="$( id -g )"
-      ingress_address="$( kubectl -n haproxy-ingress get svc haproxy-ingress --template='{{ .spec.clusterIP }}' )"
+      
+      ingress_class_name='haproxy'
+      ingress_custom_annotations='haproxy.org/ssl-passthrough=true'
+      ingress_controller_address="$( kubectl -n haproxy-ingress get svc haproxy-ingress --template='{{ .spec.clusterIP }}' ):9142"
       
       sudo timeout "$(( ${e2e_timeout_minutes} + 5 ))m" podman run --user="${user}:${group}" --rm \
       --entrypoint=/usr/bin/scylla-operator-tests \
@@ -131,7 +134,9 @@ runs:
       --flake-attempts="${flake_attempts}" \
       --timeout="${e2e_timeout_minutes}m" \
       --feature-gates='${{ inputs.featureGates }}' \
-      --override-ingress-address="${ingress_address}" \
+      --ingress-controller-address="${ingress_controller_address}" \
+      --ingress-controller-ingress-class-name="${ingress_class_name}" \
+      --ingress-controller-custom-annotations="${ingress_custom_annotations}" \
       ${{ inputs.extraArgs }}
   - name: Dump cluster state
     if: ${{ always() }}

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -9,16 +9,24 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
+type IngressControllerOptions struct {
+	Address           string
+	IngressClassName  string
+	CustomAnnotations map[string]string
+}
+
 type TestFrameworkOptions struct {
 	ArtifactsDir                 string
 	DeleteTestingNSPolicyUntyped string
 	DeleteTestingNSPolicy        framework.DeleteTestingNSPolicyType
+	IngressController            *IngressControllerOptions
 }
 
 func NewTestFrameworkOptions() TestFrameworkOptions {
 	return TestFrameworkOptions{
 		ArtifactsDir:                 "",
 		DeleteTestingNSPolicyUntyped: string(framework.DeleteTestingNSPolicyAlways),
+		IngressController:            &IngressControllerOptions{},
 	}
 }
 
@@ -32,6 +40,9 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 		},
 		", ",
 	)))
+	cmd.PersistentFlags().StringVarP(&o.IngressController.Address, "ingress-controller-address", "", o.IngressController.Address, "Overrides destination address when sending testing data to applications behind ingresses.")
+	cmd.PersistentFlags().StringVarP(&o.IngressController.IngressClassName, "ingress-controller-ingress-class-name", "", o.IngressController.IngressClassName, "Ingress class name under which ingress controller is registered")
+	cmd.PersistentFlags().StringToStringVarP(&o.IngressController.CustomAnnotations, "ingress-controller-custom-annotations", "", o.IngressController.CustomAnnotations, "Custom annotations required by the ingress controller")
 }
 
 func (o *TestFrameworkOptions) Validate() error {

--- a/pkg/cmd/tests/tests_run.go
+++ b/pkg/cmd/tests/tests_run.go
@@ -74,22 +74,21 @@ type RunOptions struct {
 	genericclioptions.ClientConfig
 	TestFrameworkOptions
 
-	Timeout                time.Duration
-	Quiet                  bool
-	ShowProgress           bool
-	FlakeAttempts          int
-	FailFast               bool
-	LabelFilter            string
-	FocusStrings           []string
-	SkipStrings            []string
-	RandomSeed             int64
-	DryRun                 bool
-	Color                  bool
-	OverrideIngressAddress string
-	Parallelism            int
-	ParallelShard          int
-	ParallelServerAddress  string
-	ParallelLogLevel       int32
+	Timeout               time.Duration
+	Quiet                 bool
+	ShowProgress          bool
+	FlakeAttempts         int
+	FailFast              bool
+	LabelFilter           string
+	FocusStrings          []string
+	SkipStrings           []string
+	RandomSeed            int64
+	DryRun                bool
+	Color                 bool
+	Parallelism           int
+	ParallelShard         int
+	ParallelServerAddress string
+	ParallelLogLevel      int32
 
 	SelectedSuite *ginkgotest.TestSuite
 }
@@ -163,7 +162,6 @@ func NewRunCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().Int64VarP(&o.RandomSeed, randomSeedFlagKey, "", o.RandomSeed, "Seed for the test suite.")
 	cmd.Flags().BoolVarP(&o.DryRun, "dry-run", "", o.DryRun, "Doesn't execute the tests, only prints. Limited to serial execution.")
 	cmd.Flags().BoolVarP(&o.Color, "color", "", o.Color, "Colors the output.")
-	cmd.Flags().StringVarP(&o.OverrideIngressAddress, "override-ingress-address", "", o.OverrideIngressAddress, "This flag will override destination address when sending testing data to applications behind ingresses.")
 	cmd.Flags().IntVarP(&o.Parallelism, "parallelism", "", o.Parallelism, "Determines how many workers are going to run in parallel. If not specified or if zero, the default parallelism for the suite will be chosen.")
 	cmd.Flags().Int32Var(&o.ParallelLogLevel, "parallel-loglevel", o.ParallelLogLevel, "Set the level of log output for parallel processes (0-10).")
 	cmd.Flags().IntVarP(&o.ParallelShard, parallelShardFlagKey, "", o.ParallelShard, "")
@@ -260,10 +258,16 @@ func (o *RunOptions) run(ctx context.Context, streams genericclioptions.IOStream
 	const suite = "Scylla operator E2E tests"
 
 	framework.TestContext = &framework.TestContextType{
-		RestConfig:             o.RestConfig,
-		ArtifactsDir:           o.ArtifactsDir,
-		DeleteTestingNSPolicy:  o.DeleteTestingNSPolicy,
-		OverrideIngressAddress: o.OverrideIngressAddress,
+		RestConfig:            o.RestConfig,
+		ArtifactsDir:          o.ArtifactsDir,
+		DeleteTestingNSPolicy: o.DeleteTestingNSPolicy,
+	}
+	if o.IngressController != nil {
+		framework.TestContext.IngressController = &framework.IngressController{
+			Address:           o.IngressController.Address,
+			IngressClassName:  o.IngressController.IngressClassName,
+			CustomAnnotations: o.IngressController.CustomAnnotations,
+		}
 	}
 
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()

--- a/test/e2e/fixture/scylla/scylladbmonitoring.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbmonitoring.yaml.tmpl
@@ -13,11 +13,15 @@ spec:
       exposeOptions:
         webInterface:
           ingress:
-            ingressClassName: haproxy
+            {{- with .ingressClassName }}
+            ingressClassName: {{ . }}
+            {{- end }}
             dnsDomains:
             - "{{ .name }}-prometheus.{{ .namespace }}.apps.cluster.scylladb.com"
+            {{- with .ingressCustomAnnotations }}
             annotations:
-              haproxy-ingress.github.io/ssl-passthrough: "true"
+              {{- . | toYAML | nindent 14 }}
+            {{- end }}
       storage:
         volumeClaimTemplate:
           spec:
@@ -28,8 +32,10 @@ spec:
       exposeOptions:
         webInterface:
           ingress:
-            ingressClassName: haproxy
+            ingressClassName: {{ .ingressClassName }}
             dnsDomains:
             - "{{ .name }}-grafana.{{ .namespace }}.apps.cluster.scylladb.com"
+            {{- with .ingressCustomAnnotations }}
             annotations:
-              haproxy-ingress.github.io/ssl-passthrough: "true"
+              {{- . | toYAML | nindent 14 }}
+            {{- end }}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -74,11 +74,11 @@ func (f *Framework) Username() string {
 }
 
 func (f *Framework) GetIngressAddress(hostname string) string {
-	if len(TestContext.OverrideIngressAddress) == 0 {
+	if TestContext.IngressController == nil || len(TestContext.IngressController.Address) == 0 {
 		return hostname
 	}
 
-	return TestContext.OverrideIngressAddress
+	return TestContext.IngressController.Address
 }
 
 func (f *Framework) FieldManager() string {

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -16,9 +16,15 @@ var (
 	DeleteTestingNSPolicyNever     DeleteTestingNSPolicyType = "Never"
 )
 
+type IngressController struct {
+	IngressClassName  string
+	Address           string
+	CustomAnnotations map[string]string
+}
+
 type TestContextType struct {
-	RestConfig             *restclient.Config
-	ArtifactsDir           string
-	DeleteTestingNSPolicy  DeleteTestingNSPolicyType
-	OverrideIngressAddress string
+	RestConfig            *restclient.Config
+	ArtifactsDir          string
+	DeleteTestingNSPolicy DeleteTestingNSPolicyType
+	IngressController     *IngressController
 }

--- a/test/e2e/set/scyllacluster/verify.go
+++ b/test/e2e/set/scyllacluster/verify.go
@@ -291,8 +291,9 @@ func verifyCQLData(ctx context.Context, di *utils.DataInserter) {
 	o.Expect(data).To(o.Equal(di.GetExpected()))
 }
 
-func insertAndVerifyCQLData(ctx context.Context, hosts []string) *utils.DataInserter {
-	di, err := utils.NewDataInserter(hosts)
+func insertAndVerifyCQLData(ctx context.Context, hosts []string, options ...utils.DataInserterOption) *utils.DataInserter {
+	framework.By("Inserting data")
+	di, err := utils.NewDataInserter(hosts, options...)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	insertAndVerifyCQLDataUsingDataInserter(ctx, di)

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
@@ -50,11 +50,16 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Creating a ScyllaDBMonitoring")
-		sm, _, err := scyllafixture.ScyllaDBMonitoringTemplate.RenderObject(map[string]string{
+		renderArgs := map[string]any{
 			"name":              sc.Name,
 			"namespace":         sc.Namespace,
 			"scyllaClusterName": sc.Name,
-		})
+		}
+		if framework.TestContext.IngressController != nil {
+			renderArgs["ingressClassName"] = framework.TestContext.IngressController.IngressClassName
+			renderArgs["ingressCustomAnnotations"] = framework.TestContext.IngressController.CustomAnnotations
+		}
+		sm, _, err := scyllafixture.ScyllaDBMonitoringTemplate.RenderObject(renderArgs)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		sm, err = f.ScyllaClient().ScyllaV1alpha1().ScyllaDBMonitorings(sc.Namespace).Create(

--- a/vendor/github.com/gocql/gocql/scyllacloud/cluster.go
+++ b/vendor/github.com/gocql/gocql/scyllacloud/cluster.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2021 ScyllaDB
+
+package scyllacloud
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/gocql/gocql"
+	"sigs.k8s.io/yaml"
+)
+
+func NewCloudCluster(bundlePath string) (*gocql.ClusterConfig, error) {
+	connConf := &ConnectionConfig{}
+
+	bundleFile, err := os.ReadFile(bundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("can't open bundle path: %w", err)
+	}
+
+	if err := yaml.Unmarshal(bundleFile, connConf); err != nil {
+		return nil, fmt.Errorf("can't decode bundle file at %q: %w", bundlePath, err)
+	}
+
+	if _, ok := connConf.Contexts[connConf.CurrentContext]; !ok {
+		return nil, fmt.Errorf("current context points to unknown context")
+	}
+
+	confContext := connConf.Contexts[connConf.CurrentContext]
+
+	if _, ok := connConf.AuthInfos[confContext.AuthInfoName]; !ok {
+		return nil, fmt.Errorf("context %q auth info points to unknown authinfo", connConf.CurrentContext)
+	}
+
+	if _, ok := connConf.Datacenters[confContext.DatacenterName]; !ok {
+		return nil, fmt.Errorf("context %q datacenter points to unknown datacenter", connConf.CurrentContext)
+	}
+
+	authInfo := connConf.AuthInfos[confContext.AuthInfoName]
+
+	caPool, err := connConf.GetRootCAPool()
+	if err != nil {
+		return nil, fmt.Errorf("can't create root CA pool: %w", err)
+	}
+
+	cc := gocql.NewCluster(connConf.GetInitialContactPoints()...)
+	cc.Port = 443
+
+	// SslOpts are used only by establishing connection to initial contact points.
+	// Skip verifying TLS if any of DC requires it.
+	insecureSkipVerify := false
+	for _, dc := range connConf.Datacenters {
+		if dc.InsecureSkipTLSVerify {
+			insecureSkipVerify = true
+			break
+		}
+	}
+
+	cc.SslOpts = &gocql.SslOptions{
+		// Set to false, always use value from tls.Config.
+		EnableHostVerification: false,
+		Config: &tls.Config{
+			RootCAs: caPool,
+			GetClientCertificate: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				return connConf.GetClientCertificate()
+			},
+			InsecureSkipVerify: insecureSkipVerify,
+		},
+	}
+
+	dialer := cc.Dialer
+	if dialer == nil {
+		dialer = &net.Dialer{}
+	}
+
+	cc.HostDialer = NewSniHostDialer(connConf, dialer)
+	cc.Authenticator = gocql.PasswordAuthenticator{Password: authInfo.Password, Username: authInfo.Username}
+
+	if connConf.Parameters != nil {
+		if connConf.Parameters.DefaultConsistency != "" {
+			if !validateConsistency(connConf.Parameters.DefaultConsistency, allowedConsistencies) {
+				return nil, fmt.Errorf("invalid value of default consistency %q, values can be one of: %v", connConf.Parameters.DefaultConsistency, allowedConsistencies)
+			}
+			if err := cc.Consistency.UnmarshalText([]byte(connConf.Parameters.DefaultConsistency)); err != nil {
+				return nil, fmt.Errorf("unmarshal default consistency: %w", err)
+			}
+		}
+		if connConf.Parameters.DefaultSerialConsistency != "" {
+			if !validateConsistency(connConf.Parameters.DefaultSerialConsistency, allowedSerialConsistencies) {
+				return nil, fmt.Errorf("invalid value of default serial consistency %q, values can be one of: %v", connConf.Parameters.DefaultSerialConsistency, allowedSerialConsistencies)
+			}
+			if err := cc.SerialConsistency.UnmarshalText([]byte(connConf.Parameters.DefaultSerialConsistency)); err != nil {
+				return nil, fmt.Errorf("unmarshal default serial consistency: %w", err)
+			}
+		}
+	}
+
+	return cc, nil
+}
+
+func validateConsistency(c ConsistencyString, allowed []ConsistencyString) bool {
+	for _, ac := range allowed {
+		if ac == c {
+			return true
+		}
+	}
+	return false
+}
+
+var allowedSerialConsistencies = []ConsistencyString{
+	DefaultSerialConsistency,
+	DefaultLocalSerialConsistency,
+}
+var allowedConsistencies = []ConsistencyString{
+	DefaultThreeConsistency,
+	DefaultOneConsistency,
+	DefaultTwoConsistency,
+	DefaultAnyConsistency,
+	DefaultQuorumConsistency,
+	DefaultAllConsistency,
+	DefaultLocalQuorumConsistency,
+	DefaultEachQuorumConsistency,
+	DefaultLocalOneConsistency,
+}

--- a/vendor/github.com/gocql/gocql/scyllacloud/config.go
+++ b/vendor/github.com/gocql/gocql/scyllacloud/config.go
@@ -1,0 +1,244 @@
+package scyllacloud
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+type ConnectionConfig struct {
+	// Kind is a string value representing the REST resource this object represents.
+	// Servers may infer this from the endpoint the client submits requests to.
+	// In CamelCase.
+	// +optional
+	Kind string `json:"kind,omitempty"`
+	// APIVersion defines the versioned schema of this representation of an object.
+	// Servers should convert recognized schemas to the latest internal value, and
+	// may reject unrecognized values.
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
+	// Datacenters is a map of referencable names to datacenter configs.
+	Datacenters map[string]*Datacenter `json:"datacenters"`
+	// AuthInfos is a map of referencable names to authentication configs.
+	AuthInfos map[string]*AuthInfo `json:"authInfos"`
+	// Contexts is a map of referencable names to context configs.
+	Contexts map[string]*Context `json:"contexts"`
+	// CurrentContext is the name of the context that you would like to use by default.
+	CurrentContext string `json:"currentContext"`
+	// Parameters is a struct containing common driver configuration parameters.
+	// +optional
+	Parameters *Parameters `json:"parameters,omitempty"`
+}
+
+type AuthInfo struct {
+	// ClientCertificateData contains PEM-encoded data from a client cert file for TLS. Overrides ClientCertificatePath.
+	// +optional
+	ClientCertificateData []byte `json:"clientCertificateData,omitempty"`
+	// ClientCertificatePath is the path to a client cert file for TLS.
+	// +optional
+	ClientCertificatePath string `json:"clientCertificatePath,omitempty"`
+	// ClientKeyData contains PEM-encoded data from a client key file for TLS. Overrides ClientKeyPath.
+	// +optional
+	ClientKeyData []byte `json:"clientKeyData,omitempty"`
+	// ClientKeyPath is the path to a client key file for TLS.
+	// +optional
+	ClientKeyPath string `json:"clientKeyPath,omitempty"`
+	// Username is the username for basic authentication to the Scylla cluster.
+	// +optional
+	Username string `json:"username,omitempty"`
+	// Password is the password for basic authentication to the Scylla cluster.
+	// +optional	`
+	Password string `json:"password,omitempty"`
+}
+
+type Datacenter struct {
+	// CertificateAuthorityPath is the path to a cert file for the certificate authority.
+	// +optional
+	CertificateAuthorityPath string `json:"certificateAuthorityPath,omitempty"`
+	// CertificateAuthorityData contains PEM-encoded certificate authority certificates. Overrides CertificateAuthority.
+	// +optional
+	CertificateAuthorityData []byte `json:"certificateAuthorityData,omitempty"`
+	// Server is the initial contact point of the Scylla cluster.
+	// Example: https://hostname:port
+	Server string `json:"server"`
+	// TLSServerName is used to check server certificates. If TLSServerName is empty, the hostname used to contact the server is used.
+	// +optional
+	TLSServerName string `json:"tlsServerName,omitempty"`
+	// NodeDomain the domain suffix that is concatenated with host_id of the node driver wants to connect to.
+	// Example: host_id.<nodeDomain>
+	NodeDomain string `json:"nodeDomain"`
+	// InsecureSkipTLSVerify skips the validity check for the server's certificate. This will make your HTTPS connections insecure.
+	// +optional
+	InsecureSkipTLSVerify bool `json:"insecureSkipTlsVerify,omitempty"`
+	// ProxyURL is the URL to the proxy to be used for all requests made by this
+	// client. URLs with "http", "https", and "socks5" schemes are supported. If
+	// this configuration is not provided or the empty string, the client
+	// attempts to construct a proxy configuration from http_proxy and
+	// https_proxy environment variables. If these environment variables are not
+	// set, the client does not attempt to proxy requests.
+	// +optional
+	ProxyURL string `json:"proxyUrl,omitempty"`
+}
+
+type Context struct {
+	// DatacenterName is the name of the datacenter for this context.
+	DatacenterName string `json:"datacenterName"`
+	// AuthInfoName is the name of the authInfo for this context.
+	AuthInfoName string `json:"authInfoName"`
+}
+
+type Parameters struct {
+	// DefaultConsistency is the default consistency level used for user queries.
+	// +optional
+	DefaultConsistency ConsistencyString `json:"defaultConsistency,omitempty"`
+	// DefaultSerialConsistency is the default consistency level for the serial part of user queries.
+	// +optional
+	DefaultSerialConsistency ConsistencyString `json:"defaultSerialConsistency,omitempty"`
+}
+
+type ConsistencyString string
+
+// just AnyConsistency etc is better, but there's already SerialConsistency defined elsewhere.
+const (
+	DefaultAnyConsistency         ConsistencyString = "ANY"
+	DefaultOneConsistency         ConsistencyString = "ONE"
+	DefaultTwoConsistency         ConsistencyString = "TWO"
+	DefaultThreeConsistency       ConsistencyString = "THREE"
+	DefaultQuorumConsistency      ConsistencyString = "QUORUM"
+	DefaultAllConsistency         ConsistencyString = "ALL"
+	DefaultLocalQuorumConsistency ConsistencyString = "LOCAL_QUORUM"
+	DefaultEachQuorumConsistency  ConsistencyString = "EACH_QUORUM"
+	DefaultSerialConsistency      ConsistencyString = "SERIAL"
+	DefaultLocalSerialConsistency ConsistencyString = "LOCAL_SERIAL"
+	DefaultLocalOneConsistency    ConsistencyString = "LOCAL_ONE"
+)
+
+func (cc *ConnectionConfig) GetRootCAPool() (*x509.CertPool, error) {
+	caPool := x509.NewCertPool()
+
+	for dcName, dc := range cc.Datacenters {
+		if len(dc.CertificateAuthorityData) == 0 && len(dc.CertificateAuthorityPath) == 0 {
+			return nil, fmt.Errorf("datacenter %q does not include certificate authority", dcName)
+		}
+
+		caData, err := cc.getDataOrReadFile(dc.CertificateAuthorityData, dc.CertificateAuthorityPath)
+		if err != nil {
+			return nil, fmt.Errorf("can't read datacenter %q certificate authority file from %q: %w", dcName, dc.CertificateAuthorityPath, err)
+		}
+
+		caPool.AppendCertsFromPEM(caData)
+	}
+
+	return caPool, nil
+}
+
+func (cc *ConnectionConfig) GetDatacenterCAPool(datacenterName string) (*x509.CertPool, error) {
+	dc, ok := cc.Datacenters[datacenterName]
+	if !ok {
+		return nil, fmt.Errorf("datacenter %q not found in cloud connection config", datacenterName)
+	}
+
+	caPool := x509.NewCertPool()
+
+	if len(dc.CertificateAuthorityData) == 0 && len(dc.CertificateAuthorityPath) == 0 {
+		return nil, fmt.Errorf("datacenter %q does not include certificate authority", datacenterName)
+	}
+
+	caData, err := cc.getDataOrReadFile(dc.CertificateAuthorityData, dc.CertificateAuthorityPath)
+	if err != nil {
+		return nil, fmt.Errorf("can't read datacenter %q certificate authority file from %q: %w", datacenterName, dc.CertificateAuthorityPath, err)
+	}
+	caPool.AppendCertsFromPEM(caData)
+
+	return caPool, nil
+}
+
+func (cc *ConnectionConfig) GetInitialContactPoints() []string {
+	hosts := make([]string, 0, len(cc.Datacenters))
+	for _, dc := range cc.Datacenters {
+		hosts = append(hosts, dc.Server)
+	}
+	return hosts
+}
+
+func (cc *ConnectionConfig) getDataOrReadFile(data []byte, path string) ([]byte, error) {
+	if len(data) == 0 {
+		return os.ReadFile(path)
+	}
+
+	return data, nil
+}
+
+func (cc *ConnectionConfig) GetCurrentDatacenterConfig() (*Datacenter, error) {
+	contextConf, err := cc.GetCurrentContextConfig()
+	if err != nil {
+		return nil, fmt.Errorf("can't get current context config: %w", err)
+	}
+
+	if len(contextConf.DatacenterName) == 0 {
+		return nil, fmt.Errorf("datacenterName in current context can't be empty")
+	}
+
+	dcConf, ok := cc.Datacenters[contextConf.DatacenterName]
+	if !ok {
+		return nil, fmt.Errorf("datacenter %q does not exists", contextConf.DatacenterName)
+	}
+
+	return dcConf, nil
+}
+
+func (cc *ConnectionConfig) GetCurrentContextConfig() (*Context, error) {
+	if len(cc.CurrentContext) == 0 {
+		return nil, fmt.Errorf("current context can't be empty")
+	}
+
+	contextConf, ok := cc.Contexts[cc.CurrentContext]
+	if !ok {
+		return nil, fmt.Errorf("context %q does not exists", cc.CurrentContext)
+	}
+
+	return contextConf, nil
+}
+
+func (cc *ConnectionConfig) GetCurrentAuthInfo() (*AuthInfo, error) {
+	contextConf, err := cc.GetCurrentContextConfig()
+	if err != nil {
+		return nil, fmt.Errorf("can't get current context config: %w", err)
+	}
+
+	if len(contextConf.AuthInfoName) == 0 {
+		return nil, fmt.Errorf("authInfo in current context can't be empty")
+	}
+
+	authInfo, ok := cc.AuthInfos[contextConf.AuthInfoName]
+	if !ok {
+		return nil, fmt.Errorf("authInfo %q does not exists", contextConf.AuthInfoName)
+	}
+
+	return authInfo, nil
+}
+
+func (cc *ConnectionConfig) GetClientCertificate() (*tls.Certificate, error) {
+	authInfo, err := cc.GetCurrentAuthInfo()
+	if err != nil {
+		return nil, fmt.Errorf("can't get current auth info: %w", err)
+	}
+
+	clientCert, err := cc.getDataOrReadFile(authInfo.ClientCertificateData, authInfo.ClientCertificatePath)
+	if err != nil {
+		return nil, fmt.Errorf("can't read client certificate: %w", err)
+	}
+
+	clientKey, err := cc.getDataOrReadFile(authInfo.ClientKeyData, authInfo.ClientKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("can't read client key: %w", err)
+	}
+
+	cert, err := tls.X509KeyPair(clientCert, clientKey)
+	if err != nil {
+		return nil, fmt.Errorf("can't create x509 pair: %w", err)
+	}
+
+	return &cert, nil
+}

--- a/vendor/github.com/gocql/gocql/scyllacloud/hostdialer.go
+++ b/vendor/github.com/gocql/gocql/scyllacloud/hostdialer.go
@@ -1,0 +1,139 @@
+// Copyright (C) 2021 ScyllaDB
+
+package scyllacloud
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/gocql/gocql"
+	"golang.org/x/net/proxy"
+)
+
+// SniHostDialer is able to dial particular host through SNI proxy.
+// TLS Config is build from ConnectionConfig based on datacenter where given node belongs.
+// SNI is constructed from host_id of a node, and NodeDomain taken from cloud config.
+type SniHostDialer struct {
+	connConfig *ConnectionConfig
+	dialer     gocql.Dialer
+}
+
+func NewSniHostDialer(connConfig *ConnectionConfig, dialer gocql.Dialer) *SniHostDialer {
+	return &SniHostDialer{
+		connConfig: connConfig,
+		dialer:     dialer,
+	}
+}
+
+func (s *SniHostDialer) DialHost(ctx context.Context, host *gocql.HostInfo) (*gocql.DialedHost, error) {
+	hostID := host.HostID()
+	if len(hostID) == 0 {
+		return s.dialInitialContactPoint(ctx)
+	}
+
+	dcName := host.DataCenter()
+	dcConf, ok := s.connConfig.Datacenters[dcName]
+	if !ok {
+		return nil, fmt.Errorf("datacenter %q configuration not found in connection bundle", dcName)
+	}
+
+	dialer := s.dialer
+
+	if len(dcConf.ProxyURL) != 0 {
+		u, err := url.Parse(dcConf.ProxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("can't parse proxy URL %q: %w", dcConf.ProxyURL, err)
+		}
+
+		d, err := proxy.FromURL(u, proxyDialerFunc(func(network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, addr)
+		}))
+		if err != nil {
+			return nil, fmt.Errorf("can't create proxy dialer: %w", err)
+		}
+
+		dialer = d.(proxy.ContextDialer)
+	}
+
+	sni := fmt.Sprintf("%s.%s", host.HostID(), dcConf.NodeDomain)
+	clientCertificate, err := s.connConfig.GetClientCertificate()
+	if err != nil {
+		return nil, fmt.Errorf("can't get client certificate from configuration: %w", err)
+	}
+
+	ca, err := s.connConfig.GetDatacenterCAPool(dcName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get root CA from configuration: %w", err)
+	}
+
+	return s.connect(ctx, dialer, dcConf.Server, &tls.Config{
+		ServerName:         sni,
+		RootCAs:            ca,
+		InsecureSkipVerify: dcConf.InsecureSkipTLSVerify,
+		Certificates:       []tls.Certificate{*clientCertificate},
+	})
+}
+
+func (s *SniHostDialer) dialInitialContactPoint(ctx context.Context) (*gocql.DialedHost, error) {
+	insecureSkipVerify := false
+	for _, dc := range s.connConfig.Datacenters {
+		if dc.InsecureSkipTLSVerify {
+			insecureSkipVerify = true
+			break
+		}
+	}
+
+	clientCertificate, err := s.connConfig.GetClientCertificate()
+	if err != nil {
+		return nil, fmt.Errorf("can't get client certificate from configuration: %w", err)
+	}
+
+	ca, err := s.connConfig.GetRootCAPool()
+	if err != nil {
+		return nil, fmt.Errorf("can't get root CA from configuration: %w", err)
+	}
+
+	dcConf, err := s.connConfig.GetCurrentDatacenterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("can't get current datacenter config: %w", err)
+	}
+
+	serverName := dcConf.NodeDomain
+	if len(serverName) == 0 {
+		serverName = dcConf.Server
+	}
+
+	return s.connect(ctx, s.dialer, dcConf.Server, &tls.Config{
+		ServerName:         serverName,
+		RootCAs:            ca,
+		InsecureSkipVerify: insecureSkipVerify,
+		Certificates:       []tls.Certificate{*clientCertificate},
+	})
+}
+
+func (s *SniHostDialer) connect(ctx context.Context, dialer gocql.Dialer, server string, tlsConfig *tls.Config) (*gocql.DialedHost, error) {
+	conn, err := dialer.DialContext(ctx, "tcp", server)
+	if err != nil {
+		return nil, fmt.Errorf("can't connect to %q: %w", server, err)
+	}
+
+	tconn := tls.Client(conn, tlsConfig)
+	if err := tconn.HandshakeContext(ctx); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("can't finish TLS handshake with server %q SNI %q: %w", server, tlsConfig.ServerName, err)
+	}
+
+	return &gocql.DialedHost{
+		Conn:            tconn,
+		DisableCoalesce: true,
+	}, nil
+}
+
+type proxyDialerFunc func(network, addr string) (net.Conn, error)
+
+func (d proxyDialerFunc) Dial(network, addr string) (net.Conn, error) {
+	return d(network, addr)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -327,6 +327,7 @@ github.com/gocql/gocql
 github.com/gocql/gocql/internal/lru
 github.com/gocql/gocql/internal/murmur
 github.com/gocql/gocql/internal/streams
+github.com/gocql/gocql/scyllacloud
 # github.com/godbus/dbus/v5 v5.1.0
 ## explicit; go 1.12
 github.com/godbus/dbus/v5


### PR DESCRIPTION
E2E test validating whether clients can connect to ScyllaDB cluster via CQL Connection Config using Ingresses.

Test binary is extended with three parameters:
* `--ingress-controller-address` - address allowing to connect to deployed proxy.
* `--ingress-controller-ingress-class-name` - must match the deployed ingress controller class.
* `--ingress-controller-custom-annotations` - haproxy requires special annotation to enable passthrough mode, it can be configured via this parameter.

Fixes #1015 