### PR TITLE
Don't use "any" prefix for LB CQL service

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -715,7 +715,7 @@ func MakeIngresses(c *scyllav1.ScyllaCluster, services map[string]*corev1.Servic
 	type params struct {
 		ingressNameSuffix     string
 		portName              string
-		identitySubdomainFunc func(string) string
+		protocolSubdomainFunc func(string) string
 		memberSubdomainFunc   func(string, string) string
 		ingressOptions        *scyllav1.IngressOptions
 	}
@@ -725,7 +725,7 @@ func MakeIngresses(c *scyllav1.ScyllaCluster, services map[string]*corev1.Servic
 		ingressParams = append(ingressParams, params{
 			ingressNameSuffix:     "cql",
 			portName:              portNameCQLSSL,
-			identitySubdomainFunc: naming.GetCQLAnySubDomain,
+			protocolSubdomainFunc: naming.GetCQLProtocolSubDomain,
 			memberSubdomainFunc:   naming.GetCQLHostIDSubDomain,
 			ingressOptions:        c.Spec.ExposeOptions.CQL.Ingress,
 		})
@@ -741,7 +741,7 @@ func MakeIngresses(c *scyllav1.ScyllaCluster, services map[string]*corev1.Servic
 			switch naming.ScyllaServiceType(service.Labels[naming.ScyllaServiceTypeLabel]) {
 			case naming.ScyllaServiceTypeIdentity:
 				for _, domain := range c.Spec.DNSDomains {
-					hosts = append(hosts, ip.identitySubdomainFunc(domain))
+					hosts = append(hosts, ip.protocolSubdomainFunc(domain))
 				}
 				labels[naming.ScyllaIngressTypeLabel] = string(naming.ScyllaIngressTypeAnyNode)
 

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -1153,7 +1153,7 @@ func TestMakeIngresses(t *testing.T) {
 						IngressClassName: pointer.String("cql-ingress-class"),
 						Rules: []networkingv1.IngressRule{
 							{
-								Host: "any.cql.public.scylladb.com",
+								Host: "cql.public.scylladb.com",
 								IngressRuleValue: networkingv1.IngressRuleValue{
 									HTTP: &networkingv1.HTTPIngressRuleValue{
 										Paths: []networkingv1.HTTPIngressPath{
@@ -1174,7 +1174,7 @@ func TestMakeIngresses(t *testing.T) {
 								},
 							},
 							{
-								Host: "any.cql.private.scylladb.com",
+								Host: "cql.private.scylladb.com",
 								IngressRuleValue: networkingv1.IngressRuleValue{
 									HTTP: &networkingv1.HTTPIngressRuleValue{
 										Paths: []networkingv1.HTTPIngressPath{

--- a/pkg/controller/scyllacluster/sync_certs.go
+++ b/pkg/controller/scyllacluster/sync_certs.go
@@ -137,10 +137,10 @@ func (scc *Controller) syncCerts(
 		hostIDs = append(hostIDs, hostID)
 	}
 
-	// For every cluster domain we'll create the "any.nodes" subdomain and "UUID" subdomains for every node.
+	// For every cluster domain we'll create "cql" subdomain and "UUID.cql" subdomains for every node.
 	var servingDNSNames []string
 	for _, domain := range sc.Spec.DNSDomains {
-		servingDNSNames = append(servingDNSNames, naming.GetCQLAnySubDomain(domain))
+		servingDNSNames = append(servingDNSNames, naming.GetCQLProtocolSubDomain(domain))
 
 		for _, hostID := range hostIDs {
 			servingDNSNames = append(servingDNSNames, naming.GetCQLHostIDSubDomain(hostID, domain))

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -140,3 +140,9 @@ const (
 const (
 	ScyllaRuntimeConfigKey string = "ScyllaRuntimeConfig"
 )
+
+type ProtocolDNSLabel string
+
+const (
+	CQLProtocolDNSLabel = "cql"
+)

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -188,10 +188,14 @@ func GetScyllaClusterLocalServingCertName(scName string) string {
 	return fmt.Sprintf("%s-local-serving-certs", scName)
 }
 
-func GetCQLAnySubDomain(domain string) string {
-	return fmt.Sprintf("any.cql.%s", domain)
+func GetProtocolSubDomain(protocol, domain string) string {
+	return fmt.Sprintf("%s.%s", protocol, domain)
+}
+
+func GetCQLProtocolSubDomain(domain string) string {
+	return GetProtocolSubDomain(CQLProtocolDNSLabel, domain)
 }
 
 func GetCQLHostIDSubDomain(hostID, domain string) string {
-	return fmt.Sprintf("%s.cql.%s", hostID, domain)
+	return fmt.Sprintf("%s.%s", hostID, GetCQLProtocolSubDomain(domain))
 }

--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -86,8 +86,8 @@ var _ = g.Describe("ScyllaCluster Ingress", func() {
 			sc.Spec.ExposeOptions.CQL.Ingress.IngressClassName,
 			&services.Items[0],
 			[]string{
-				"any.cql.private.nodes.scylladb.com",
-				"any.cql.public.nodes.scylladb.com",
+				"cql.private.nodes.scylladb.com",
+				"cql.public.nodes.scylladb.com",
 			},
 			"cql-ssl",
 		)

--- a/test/e2e/set/scyllacluster/scyllacluster_tls.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_tls.go
@@ -169,7 +169,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 				var sniHosts []string
 				for _, domain := range sc.Spec.DNSDomains {
-					sniHosts = append(sniHosts, fmt.Sprintf("any.cql.%s", domain))
+					sniHosts = append(sniHosts, fmt.Sprintf("cql.%s", domain))
 
 					for _, nodeID := range nodeIDs {
 						sniHosts = append(sniHosts, fmt.Sprintf("%s.cql.%s", nodeID, domain))


### PR DESCRIPTION
**Description of your changes:**
The CQL load balanced service (`any.cql.nodeDomain`) doesn't logically belong at the same level as the `host_id` subdomains. Although highly unlikely, they could possibly conflict. Using `cql.nodeDomain` will avoid conflicts and put it on a different level. It will allow us to drop `tlsServerName` field from CQLClientConfig (aka "bundle") as it can be now covered by only one field, `nodeDomain` - to be eventually renamed to `clusterDomain`, `serviceDomain` or something more descriptive.

In the end, sending all traffic to `any.cql.nodeDomain` (with ServerName set to `host_id.cql.nodeDomain`) feels a bit weird. This gets fixed by using the service like `server: cql.nodeDomain` where all traffic goes to.

Default destination
```
server: cql.<sc_name>.<sc_namespace>.<router_domain>:9142
nodeDomain: cql.<sc_name>.<sc_namespace>.<router_domain>
```
Explicit destination
```
server: 172.16.42.42:9142
nodeDomain: cql.<sc_name>.<sc_namespace>.<router_domain>
```