### PR TITLE
Use annotations to mark node replacement address instead of labels

### DIFF
--- a/pkg/controller/orphanedpv/sync.go
+++ b/pkg/controller/orphanedpv/sync.go
@@ -148,7 +148,7 @@ func (opc *Controller) sync(ctx context.Context, key string) error {
 			ctx,
 			pi.ServiceName,
 			types.MergePatchType,
-			[]byte(fmt.Sprintf(`{"metadata": {"labels": {%q: ""} } }`, naming.ReplaceLabel)),
+			[]byte(fmt.Sprintf(`{"metadata": {"annotations": {%q: ""} } }`, naming.ReplaceAnnotation)),
 			metav1.PatchOptions{},
 		)
 		if err != nil {

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -74,11 +74,20 @@ func MemberService(sc *scyllav1.ScyllaCluster, rackName, name string, oldService
 
 	annotations := map[string]string{}
 
-	// Copy the old replace label, if present.
+	// Copy the old replace annotation, if present.
 	var replaceAddr string
 	var hasReplaceAnnotation bool
 	if oldService != nil {
 		replaceAddr, hasReplaceAnnotation = oldService.Annotations[naming.ReplaceAnnotation]
+
+		// Maintain backwards compatibility
+		replaceAddrLabel, hasReplaceLabel := oldService.Labels[naming.ReplaceAnnotation]
+		if hasReplaceLabel && !hasReplaceAnnotation {
+			// The annotation should take precendence over the label.
+			hasReplaceAnnotation = true
+			replaceAddr = replaceAddrLabel
+		}
+
 		if hasReplaceAnnotation {
 			annotations[naming.ReplaceAnnotation] = replaceAddr
 		}

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -157,12 +157,11 @@ func TestMemberService(t *testing.T) {
 			oldService: nil,
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = "10.0.0.1"
-						return labels
-					}(),
+					Name:   basicSVCName,
+					Labels: basicSVCLabels(),
+					Annotations: map[string]string{
+						naming.ReplaceAnnotation: "10.0.0.1",
+					},
 					OwnerReferences: basicSCOwnerRefs,
 				},
 				Spec: corev1.ServiceSpec{
@@ -188,19 +187,18 @@ func TestMemberService(t *testing.T) {
 			svcName:  basicSVCName,
 			oldService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						naming.ReplaceLabel: "10.0.0.1",
+					Annotations: map[string]string{
+						naming.ReplaceAnnotation: "10.0.0.1",
 					},
 				},
 			},
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = "10.0.0.1"
-						return labels
-					}(),
+					Name:   basicSVCName,
+					Labels: basicSVCLabels(),
+					Annotations: map[string]string{
+						naming.ReplaceAnnotation: "10.0.0.1",
+					},
 					OwnerReferences: basicSCOwnerRefs,
 				},
 				Spec: corev1.ServiceSpec{
@@ -218,19 +216,18 @@ func TestMemberService(t *testing.T) {
 			svcName:       basicSVCName,
 			oldService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						naming.ReplaceLabel: "10.0.0.1",
+					Annotations: map[string]string{
+						naming.ReplaceAnnotation: "10.0.0.1",
 					},
 				},
 			},
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = "10.0.0.1"
-						return labels
-					}(),
+					Name:   basicSVCName,
+					Labels: basicSVCLabels(),
+					Annotations: map[string]string{
+						naming.ReplaceAnnotation: "10.0.0.1",
+					},
 					OwnerReferences: basicSCOwnerRefs,
 				},
 				Spec: corev1.ServiceSpec{
@@ -248,19 +245,18 @@ func TestMemberService(t *testing.T) {
 			svcName:       basicSVCName,
 			oldService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						naming.ReplaceLabel: "",
+					Annotations: map[string]string{
+						naming.ReplaceAnnotation: "",
 					},
 				},
 			},
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = ""
-						return labels
-					}(),
+					Name:   basicSVCName,
+					Labels: basicSVCLabels(),
+					Annotations: map[string]string{
+						naming.ReplaceAnnotation: "",
+					},
 					OwnerReferences: basicSCOwnerRefs,
 				},
 				Spec: corev1.ServiceSpec{
@@ -286,19 +282,18 @@ func TestMemberService(t *testing.T) {
 			svcName:  basicSVCName,
 			oldService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						naming.ReplaceLabel: "",
+					Annotations: map[string]string{
+						naming.ReplaceAnnotation: "",
 					},
 				},
 			},
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = ""
-						return labels
-					}(),
+					Name:   basicSVCName,
+					Labels: basicSVCLabels(),
+					Annotations: map[string]string{
+						naming.ReplaceAnnotation: "",
+					},
 					OwnerReferences: basicSCOwnerRefs,
 				},
 				Spec: corev1.ServiceSpec{

--- a/pkg/controller/scyllacluster/sync_services.go
+++ b/pkg/controller/scyllacluster/sync_services.go
@@ -204,7 +204,7 @@ func (scc *Controller) syncServices(
 
 	// Replace members.
 	for _, svc := range services {
-		replaceAddr, ok := svc.Labels[naming.ReplaceLabel]
+		replaceAddr, ok := svc.Annotations[naming.ReplaceAnnotation]
 		if !ok {
 			continue
 		}
@@ -383,7 +383,7 @@ func (scc *Controller) syncServices(
 				if podReady {
 					scc.eventRecorder.Eventf(svc, corev1.EventTypeNormal, "FinishedReplacingNode", "New pod %s/%s is ready.", pod.Namespace, pod.Name)
 					svcCopy := svc.DeepCopy()
-					delete(svcCopy.Labels, naming.ReplaceLabel)
+					delete(svcCopy.Annotations, naming.ReplaceAnnotation)
 					controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, serviceControllerProgressingCondition, svcCopy, "update", sc.Generation)
 					_, err := scc.kubeClient.CoreV1().Services(svcCopy.Namespace).Update(ctx, svcCopy, metav1.UpdateOptions{})
 					resourceapply.ReportUpdateEvent(scc.eventRecorder, svc, err)

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -16,8 +16,8 @@ const (
 	// Values: {true, false}
 	DecommissionedLabel = "scylla/decommissioned"
 
-	// ReplaceLabel express the intent to replace pod under the specific member.
-	ReplaceLabel = "scylla/replace"
+	// ReplaceAnnotation express the intent to replace pod under the specific member.
+	ReplaceAnnotation = "scylla/replace"
 
 	// NodeMaintenanceLabel means that node is under maintenance.
 	// Readiness check will always fail when this label is added to member service.

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -245,6 +245,10 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		}
 	}
 	// If node is being replaced
+	// Maintain backwards compatibility
+	if addr, ok := m.ServiceLabels[naming.ReplaceAnnotation]; ok {
+		args["replace-address-first-boot"] = pointer.StringPtr(addr)
+	}
 	if addr, ok := m.ServiceAnnotations[naming.ReplaceAnnotation]; ok {
 		args["replace-address-first-boot"] = pointer.StringPtr(addr)
 	}

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -245,7 +245,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		}
 	}
 	// If node is being replaced
-	if addr, ok := m.ServiceLabels[naming.ReplaceLabel]; ok {
+	if addr, ok := m.ServiceAnnotations[naming.ReplaceAnnotation]; ok {
 		args["replace-address-first-boot"] = pointer.StringPtr(addr)
 	}
 	// See if we need to use cpu-pinning

--- a/pkg/sidecar/identity/member.go
+++ b/pkg/sidecar/identity/member.go
@@ -23,28 +23,30 @@ type Member struct {
 	// IP of the Pod
 	IP string
 	// ClusterIP of the member's Service
-	StaticIP      string
-	Rack          string
-	Datacenter    string
-	Cluster       string
-	ServiceLabels map[string]string
-	PodID         string
+	StaticIP           string
+	Rack               string
+	Datacenter         string
+	Cluster            string
+	ServiceLabels      map[string]string
+	ServiceAnnotations map[string]string
+	PodID              string
 
 	Overprovisioned bool
 }
 
 func NewMemberFromObjects(service *corev1.Service, pod *corev1.Pod) *Member {
 	return &Member{
-		Namespace:       service.Namespace,
-		Name:            service.Name,
-		IP:              pod.Status.PodIP,
-		StaticIP:        service.Spec.ClusterIP,
-		Rack:            pod.Labels[naming.RackNameLabel],
-		Datacenter:      pod.Labels[naming.DatacenterNameLabel],
-		Cluster:         pod.Labels[naming.ClusterNameLabel],
-		ServiceLabels:   service.Labels,
-		PodID:           string(pod.UID),
-		Overprovisioned: pod.Status.QOSClass != corev1.PodQOSGuaranteed,
+		Namespace:          service.Namespace,
+		Name:               service.Name,
+		IP:                 pod.Status.PodIP,
+		StaticIP:           service.Spec.ClusterIP,
+		Rack:               pod.Labels[naming.RackNameLabel],
+		Datacenter:         pod.Labels[naming.DatacenterNameLabel],
+		Cluster:            pod.Labels[naming.ClusterNameLabel],
+		ServiceLabels:      service.Labels,
+		ServiceAnnotations: service.Annotations,
+		PodID:              string(pod.UID),
+		Overprovisioned:    pod.Status.QOSClass != corev1.PodQOSGuaranteed,
 	}
 }
 

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -60,8 +60,8 @@ var _ = g.Describe("ScyllaCluster replace", func() {
 			pod.Name,
 			types.MergePatchType,
 			[]byte(fmt.Sprintf(
-				`{"metadata":{"labels": {"%s": ""}}}`,
-				naming.ReplaceLabel,
+				`{"metadata":{"annotations": {"%s": ""}}}`,
+				naming.ReplaceAnnotation,
 			)),
 			metav1.PatchOptions{},
 		)


### PR DESCRIPTION
**Description of your changes:**

In IPv6 clusters, node addresses contain `:`. This is not valid in K8S label values, so the operator is unable to replace a node in IPv6 clusters.

To fix this, instead of storing the replace address in a label on the service, store it in an annotation - K8S annotations do not have this restriction on their values.

This was tested by deploying the changes to an IPv6 cluster and verifying that node replacement works as intended.

**Which issue is resolved by this Pull Request:**
Resolves #
