### PR TITLE
Fix repository paths so it can be vendored

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -73,7 +73,7 @@ jobs:
       run: make verify-deps --warn-undefined-variables
 
   verify-vendorability:
-    name: Verify scylla-operator repo can be vendored by someone else
+    name: Verify vendorability
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-20.04
     env:
@@ -96,18 +96,18 @@ jobs:
         set -x
         pushd "$( mktemp -d )"
         
-        go mod init foo.com
-        go get "${github_self_ref}"
-        cat go.mod
-        
         cat > ./main.go <<EOF                                       
         package main
         import _ "github.com/scylladb/scylla-operator/pkg/scheme"
         func main() {}
         EOF
         
-        go mod tidy
+        go mod init foo.com
+        go mod edit -replace "github.com/scylladb/scylla-operator=${github_self_ref}"
         cat go.mod
+        
+        go mod tidy
+        cat go.{mod,sum}
         
         go mod vendor
         

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -72,6 +72,47 @@ jobs:
     - name: Verify dependencies
       run: make verify-deps --warn-undefined-variables
 
+  verify-vendorability:
+    name: Verify scylla-operator repo can be vendored by someone else
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-20.04
+    env:
+      github_self_ref: 'github.com/${{ github.repository }}@${{ github.sha }}'
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: ${{ env.git_repo_path }}
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.go_version }}
+    - name: Override repository ref on pull requests
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        echo "Initial github_self_ref=${github_self_ref}"
+        echo 'github_self_ref=github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}' | tee -a ${GITHUB_ENV}
+    - name: Verify vendorability
+      run: |
+        set -x
+        pushd "$( mktemp -d )"
+        
+        go mod init foo.com
+        go get "${github_self_ref}"
+        cat go.mod
+        
+        cat > ./main.go <<EOF                                       
+        package main
+        import _ "github.com/scylladb/scylla-operator/pkg/scheme"
+        func main() {}
+        EOF
+        
+        go mod tidy
+        cat go.mod
+        
+        go mod vendor
+        
+        go build ./...
+
   build-and-test:
     name: Build and test
     runs-on: ubuntu-20.04


### PR DESCRIPTION
**Description of your changes:**
Currently the repository can't be vendored because special character in a path that's not even a go subpackage. This PR fixes it and adds a test to prevent it from happening again.

**Which issue is resolved by this Pull Request:**
```
go mod tidy && go mod vendor
go: finding module for package github.com/scylladb/scylla-operator/pkg/scheme
go: downloading github.com/scylladb/scylla-operator v1.7.4
github.com/tnozicka/go-sni-proxy/cmd/sni-proxy imports
	github.com/scylladb/scylla-operator/pkg/scheme: create zip: hack/gke/systemd/mnt-raid\x2ddisks-disk0.mount: malformed file path "hack/gke/systemd/mnt-raid\\x2ddisks-disk0.mount": invalid char '\\'
```