### PR TITLE
Extend e2e tests with quorum monitoring

### DIFF
--- a/pkg/cmd/operator/sidecar.go
+++ b/pkg/cmd/operator/sidecar.go
@@ -391,6 +391,7 @@ func (o *SidecarOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Com
 
 		http.HandleFunc(naming.LivenessProbePath, prober.Healthz)
 		http.HandleFunc(naming.ReadinessProbePath, prober.Readyz)
+		http.HandleFunc(naming.InternalNodeStatusesPath, prober.InternalNodeStatuses)
 
 		err := server.ListenAndServe()
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -148,6 +148,10 @@ func servicePorts(cluster *scyllav1.ScyllaCluster) []corev1.ServicePort {
 			Port: 9100,
 		},
 		{
+			Name: "prober",
+			Port: naming.ProbePort,
+		},
+		{
 			Name: portNameCQL,
 			Port: 9042,
 		},

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -92,6 +92,10 @@ func TestMemberService(t *testing.T) {
 			Port: 9100,
 		},
 		{
+			Name: "prober",
+			Port: 8080,
+		},
+		{
 			Name: "cql",
 			Port: 9042,
 		},

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -100,10 +100,11 @@ const (
 
 	DataDir = "/var/lib/scylla"
 
-	ReadinessProbePath = "/readyz"
-	LivenessProbePath  = "/healthz"
-	ProbePort          = 8080
-	ScyllaAPIPort      = 10000
+	ReadinessProbePath       = "/readyz"
+	LivenessProbePath        = "/healthz"
+	InternalNodeStatusesPath = "/internal_node_statuses"
+	ProbePort                = 8080
+	ScyllaAPIPort            = 10000
 
 	OperatorEnvVarPrefix = "SCYLLA_OPERATOR_"
 )

--- a/pkg/sidecar/probes.go
+++ b/pkg/sidecar/probes.go
@@ -2,12 +2,18 @@ package sidecar
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
+	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	corev1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -59,6 +65,30 @@ func (p *Prober) getNodeAddress() (string, error) {
 	return controllerhelpers.GetScyllaIPFromService(svc)
 }
 
+func GetInternalNodeStatuses(ctx context.Context, addr string) (scyllaclient.NodeStatusInfoSlice, error) {
+	statuses := scyllaclient.NodeStatusInfoSlice{}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
+	if err != nil {
+		return statuses, fmt.Errorf("can't create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := http.DefaultClient
+	res, err := client.Do(req)
+	if err != nil {
+		return statuses, fmt.Errorf("can't send a request: %w", err)
+	}
+	defer res.Body.Close()
+
+	err = json.NewDecoder(res.Body).Decode(&statuses)
+	if err != nil {
+		return statuses, fmt.Errorf("can't decode json: %w", err)
+	}
+
+	return statuses, nil
+}
+
 func (p *Prober) Readyz(w http.ResponseWriter, req *http.Request) {
 	ctx, ctxCancel := context.WithTimeout(req.Context(), p.timeout)
 	defer ctxCancel()
@@ -100,27 +130,105 @@ func (p *Prober) Readyz(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	klog.V(4).InfoS("readyz probe: node statuses", "Statuses", nodeStatuses)
+
+	// Check for self UN and isNativeTransportEnabled first.
+	selfStatusFound := false
 	for _, s := range nodeStatuses {
-		klog.V(4).InfoS("readyz probe: node state", "Node", s.Addr, "Status", s.Status, "State", s.State)
+		if s.Addr != nodeAddress {
+			continue
+		}
 
-		if s.Addr == nodeAddress && s.IsUN() {
-			transportEnabled, err := scyllaClient.IsNativeTransportEnabled(ctx, localhost)
-			if err != nil {
-				w.WriteHeader(http.StatusServiceUnavailable)
-				klog.ErrorS(err, "readyz probe: can't get scylla native transport", "Service", p.serviceRef(), "Node", s.Addr)
-				return
-			}
+		selfStatusFound = true
 
-			klog.V(4).InfoS("readyz probe: node state", "Node", s.Addr, "NativeTransportEnabled", transportEnabled)
-			if transportEnabled {
-				w.WriteHeader(http.StatusOK)
-				return
+		if !s.IsUN() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			klog.V(2).InfoS("readyz probe: node is not UN", "Service", p.serviceRef(), "Node", s.Addr)
+			return
+		}
+
+		transportEnabled, err := scyllaClient.IsNativeTransportEnabled(ctx, localhost)
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			klog.ErrorS(err, "readyz probe: can't get scylla native transport", "Service", p.serviceRef(), "Node", s.Addr)
+			return
+		}
+
+		if !transportEnabled {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			klog.V(2).InfoS("readyz probe: scylla native transport is not enabled", "Service", p.serviceRef(), "Node", s.Addr)
+			return
+		}
+	}
+
+	if !selfStatusFound {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		klog.V(2).InfoS("readyz probe: node's own status is missing", "Service", p.serviceRef())
+		return
+	}
+
+	receivedStatuses := make(map[string]scyllaclient.NodeStatusInfoSlice)
+	receivedStatuses[nodeAddress] = nodeStatuses
+
+	notUNMap := make(map[string]bool)
+	for _, s := range nodeStatuses {
+		if !s.IsUN() {
+			notUNMap[s.Addr] = true
+		}
+	}
+
+	if len(notUNMap) > 1 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		klog.V(2).InfoS("readyz probe: node considers more than one peer not UN", "Service", p.serviceRef(), "Statuses", nodeStatuses)
+		return
+	}
+
+	errs := make([]error, 0)
+	for _, s := range nodeStatuses {
+		if s.Addr == nodeAddress {
+			continue
+		}
+
+		if notUNMap[s.Addr] {
+			continue
+		}
+
+		statusURL := url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort(s.Addr, strconv.Itoa(naming.ProbePort)),
+			Path:   naming.InternalNodeStatusesPath,
+		}
+		statuses, err := GetInternalNodeStatuses(ctx, statusURL.String())
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't get statuses from node %s: %w", s.Addr, err))
+			break
+		}
+
+		klog.V(4).InfoS("readyz probe: received statuses", "Node", s.Addr, "Statuses", statuses)
+		receivedStatuses[s.Addr] = statuses
+
+		for _, rs := range statuses {
+			if !rs.IsUN() {
+				notUNMap[rs.Addr] = true
 			}
 		}
 	}
 
-	klog.V(2).InfoS("readyz probe: node is not ready", "Service", p.serviceRef())
-	w.WriteHeader(http.StatusServiceUnavailable)
+	err = apierrors.NewAggregate(errs)
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		klog.ErrorS(err, "readyz probe: can't gather statuses from peers", "Service", p.serviceRef(), "Err", err)
+		return
+	}
+
+	if len(notUNMap) > 1 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		klog.V(2).InfoS("readyz probe: more than one node considered not UN by peers", "Service", p.serviceRef(), "Statuses", receivedStatuses)
+		return
+	}
+
+	klog.V(2).InfoS("readyz probe: node is ready", "Service", p.serviceRef())
+	w.WriteHeader(http.StatusOK)
 }
 
 func (p *Prober) Healthz(w http.ResponseWriter, req *http.Request) {
@@ -157,4 +265,34 @@ func (p *Prober) Healthz(w http.ResponseWriter, req *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+func (p *Prober) InternalNodeStatuses(w http.ResponseWriter, req *http.Request) {
+	ctx, ctxCancel := context.WithTimeout(req.Context(), p.timeout)
+	defer ctxCancel()
+
+	scyllaClient, err := controllerhelpers.NewScyllaClientForLocalhost()
+	if err != nil {
+		klog.ErrorS(err, "internal_node_statuses: can't get scylla client", "Service", p.serviceRef())
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer scyllaClient.Close()
+
+	nodeStatuses, err := scyllaClient.Status(ctx, localhost)
+	if err != nil {
+		klog.ErrorS(err, "internal_node_statuses: can't get scylla node status", "Service", p.serviceRef())
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	payload, err := json.Marshal(nodeStatuses)
+	if err != nil {
+		klog.ErrorS(err, "internal_node_statuses: can't marshall node statuses", "Service", p.serviceRef())
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(payload)
 }

--- a/test/e2e/utils/quorummonitor.go
+++ b/test/e2e/utils/quorummonitor.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 ScyllaDB
+
+package utils
+
+import (
+	"context"
+
+	"github.com/gocql/gocql"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+)
+
+type QuorumMonitor struct {
+	*DataInserter
+}
+
+func NewQuorumMonitor(hosts []string) (*QuorumMonitor, error) {
+	di, err := NewDataInserter(hosts, false, WithClusterConfigModifier(clusterConfigModifier), WithReadConsistency(gocql.Quorum))
+	if err != nil {
+		return nil, err
+	}
+	return &QuorumMonitor{di}, nil
+}
+
+type quorumMonitorQueryObserver struct {
+}
+
+func (k quorumMonitorQueryObserver) ObserveQuery(_ context.Context, oq gocql.ObservedQuery) {
+	if oq.Err != nil {
+		framework.Warnf("Query failed. Host: %+v. Metrics: %+v. Err: %v.", oq.Host, oq.Metrics, oq.Err)
+	}
+}
+
+var queryObserver quorumMonitorQueryObserver
+
+func clusterConfigModifier(clusterConfig *gocql.ClusterConfig) *gocql.ClusterConfig {
+	clusterConfig.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
+	clusterConfig.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: 1}
+	clusterConfig.QueryObserver = queryObserver
+
+	return clusterConfig
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR introduces an extension of the E2E test suite which monitors whether quorum is achievable in applicable tests by periodically sending read queries with consistency QUORUM.

At the moment it's flaky and requires changing the implementation of our readiness probes with a more robust approach to topology changes before it can be considered for merging. See e.g. https://github.com/scylladb/scylla-operator/issues/1077.

**Which issue is resolved by this Pull Request:**
Resolves #1079 
