### PR TITLE
Bump gocql to scylladb/gocql@v1.7.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -148,4 +148,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/gocql/gocql => github.com/scylladb/gocql v1.7.1
+replace github.com/gocql/gocql => github.com/scylladb/gocql v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,8 @@ github.com/scylladb/go-reflectx v1.0.1 h1:b917wZM7189pZdlND9PbIJ6NQxfDPfBvUaQ7cj
 github.com/scylladb/go-reflectx v1.0.1/go.mod h1:rWnOfDIRWBGN0miMLIcoPt/Dhi2doCMZqwMCJ3KupFc=
 github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
-github.com/scylladb/gocql v1.7.1 h1:luZYytwSVdcDXnBh+zhXWzFbO+QPy6a7KyveyUpRnkQ=
-github.com/scylladb/gocql v1.7.1/go.mod h1:TA7opQwU+6t8LmGZr/oyudP4QhVj3ucqbtZ73Xu4ghY=
+github.com/scylladb/gocql v1.7.3 h1:tCZ44eA4SDC69SHgp1XUcEdWcXi5CQb+iaMOrpncwvI=
+github.com/scylladb/gocql v1.7.3/go.mod h1:TA7opQwU+6t8LmGZr/oyudP4QhVj3ucqbtZ73Xu4ghY=
 github.com/scylladb/gocqlx/v2 v2.7.0 h1:/w1VeJHCEAsg9eTculTvIS9eIe/VmEu0clhlH1CF7lc=
 github.com/scylladb/gocqlx/v2 v2.7.0/go.mod h1:jKhM0/LkEAhEOSwd10TCMQdlC5x8aEzK7cXjQcPyMJ0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/vendor/github.com/gocql/gocql/events.go
+++ b/vendor/github.com/gocql/gocql/events.go
@@ -240,8 +240,8 @@ func (s *Session) handleRemovedNode(ip net.IP, port int) {
 
 	// we remove all nodes but only add ones which pass the filter
 	host, ok := s.ring.getHostByIP(ip.String())
-	hostID := host.HostID()
 	if ok {
+		hostID := host.HostID()
 		s.ring.removeHost(hostID)
 
 		host.setState(NodeDown)

--- a/vendor/github.com/gocql/gocql/host_source_scylla.go
+++ b/vendor/github.com/gocql/gocql/host_source_scylla.go
@@ -1,0 +1,7 @@
+package gocql
+
+func (h *HostInfo) SetDatacenter(dc string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.dataCenter = dc
+}

--- a/vendor/github.com/gocql/gocql/scylla.go
+++ b/vendor/github.com/gocql/gocql/scylla.go
@@ -217,7 +217,6 @@ type scyllaConnPicker struct {
 	nrShards               int
 	msbIgnore              uint64
 	pos                    uint64
-	dialer                 Dialer
 	lastAttemptedShard     int
 	shardAwarePortDisabled bool
 
@@ -254,27 +253,11 @@ func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
 		shardAwareAddress:      shardAwareAddress,
 		nrShards:               conn.scyllaSupported.nrShards,
 		msbIgnore:              conn.scyllaSupported.msbIgnore,
-		dialer:                 makeDialerForScyllaConnPicker(conn),
 		lastAttemptedShard:     0,
 		shardAwarePortDisabled: conn.session.cfg.DisableShardAwarePort,
 
 		disableShardAwarePortUntil: new(atomic.Value),
 	}
-}
-
-func makeDialerForScyllaConnPicker(conn *Conn) Dialer {
-	cfg := conn.session.connCfg
-	dialer := cfg.Dialer
-	if dialer == nil {
-		d := &ScyllaShardAwareDialer{}
-		d.Timeout = cfg.ConnectTimeout
-		if cfg.Keepalive > 0 {
-			d.KeepAlive = cfg.Keepalive
-		}
-		dialer = d
-	}
-
-	return dialer
 }
 
 func (p *scyllaConnPicker) Pick(t token) *Conn {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -293,7 +293,7 @@ github.com/go-openapi/validate
 # github.com/gobuffalo/flect v0.2.2
 ## explicit; go 1.13
 github.com/gobuffalo/flect
-# github.com/gocql/gocql v1.2.1 => github.com/scylladb/gocql v1.7.1
+# github.com/gocql/gocql v1.2.1 => github.com/scylladb/gocql v1.7.3
 ## explicit; go 1.13
 github.com/gocql/gocql
 github.com/gocql/gocql/internal/lru
@@ -1265,4 +1265,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/gocql/gocql => github.com/scylladb/gocql v1.7.1
+# github.com/gocql/gocql => github.com/scylladb/gocql v1.7.3


### PR DESCRIPTION
New version contains a fix for nil pointer dereference, which broke recent CI run.