### PR TITLE
Support custom annotations for webhookserver in helm

### DIFF
--- a/helm/scylla-operator/templates/webhookserver.deployment.yaml
+++ b/helm/scylla-operator/templates/webhookserver.deployment.yaml
@@ -16,6 +16,10 @@ spec:
       app.kubernetes.io/instance: webhook-server
   template:
     metadata:
+    {{- with .Values.webhookServerPodAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       labels:
         app.kubernetes.io/name: webhook-server
         app.kubernetes.io/instance: webhook-server

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -64,6 +64,9 @@ webhookServerNodeSelector: { }
 # Tolerations for Webhook Server pods
 webhookServerTolerations: [ ]
 
+# Pod annotations for the webhook deployment
+webhookServerPodAnnotations: {}
+
 # Affinity for Webhook Server pods
 webhookServerAffinity:
   podAntiAffinity:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
We use EKS and hybrid cni with multus-cni: aws-vpc-cni and flannel. Since the k8s apiserver wants to access the webhook service, we need to make the webhook to use aws-vpc-cni by adding an annotation

**Which issue is resolved by this Pull Request:**
NA