### PR TITLE
Await schema agreement before verifying CQL data

### DIFF
--- a/test/e2e/set/scyllacluster/verify.go
+++ b/test/e2e/set/scyllacluster/verify.go
@@ -264,6 +264,9 @@ func getScyllaHostsAndWaitForFullQuorum(ctx context.Context, client corev1client
 }
 
 func verifyCQLData(ctx context.Context, di *utils.DataInserter) {
+	err := di.AwaitSchemaAgreement(ctx)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
 	framework.By("Verifying the data")
 	data, err := di.Read()
 	o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -3,6 +3,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -110,6 +111,17 @@ func (di *DataInserter) Insert() error {
 		}
 	}
 
+	return nil
+}
+
+func (di *DataInserter) AwaitSchemaAgreement(ctx context.Context) error {
+	framework.Infof("Awaiting schema agreement")
+	err := di.session.AwaitSchemaAgreement(ctx)
+	if err != nil {
+		return fmt.Errorf("can't await schema agreement: %w", err)
+	}
+
+	framework.Infof("Schema agreement reached")
 	return nil
 }
 


### PR DESCRIPTION
When cluster topology is changed, and cluster declares readiness, we verify whether data written before topology change is available. It may happen that test keyspace is not propagated at a time of reading, so a schema agreement check is added before data validation.

Fixes a flake from https://github.com/scylladb/scylla-operator/actions/runs/3757948428/jobs/6385771770