### PR TITLE
Fix NodeConfigPod controller to exclusively enqueue and sync Scylla Pods

### DIFF
--- a/pkg/controller/nodeconfigpod/controller.go
+++ b/pkg/controller/nodeconfigpod/controller.go
@@ -165,7 +165,7 @@ func (ncpc *Controller) enqueueAllScyllaPodsOnNode(depth int, obj kubeinterfaces
 
 	klog.V(4).InfoSDepth(depth, "Enqueuing all pods on Node", "Pods", len(pods), "Node", klog.KObj(node))
 	for _, pod := range pods {
-		ncpc.handlers.EnqueueWithDepth(depth+1, pod, op)
+		ncpc.handlers.Enqueue(depth+1, pod, op)
 	}
 
 	return
@@ -212,7 +212,7 @@ func (ncpc *Controller) enqueueScyllaPod(depth int, obj kubeinterfaces.ObjectInt
 		return
 	}
 
-	ncpc.handlers.EnqueueWithDepth(depth+1, pod, op)
+	ncpc.handlers.Enqueue(depth+1, pod, op)
 }
 
 func (ncpc *Controller) addPod(obj interface{}) {

--- a/pkg/controller/nodeconfigpod/controller.go
+++ b/pkg/controller/nodeconfigpod/controller.go
@@ -147,6 +147,10 @@ func NewController(
 	return ncpc, nil
 }
 
+func (ncpc *Controller) enqueueScyllaPodFunc() controllerhelpers.EnqueueFuncType {
+	return ncpc.handlers.EnqueueWithFilterFunc(controllerhelpers.IsScyllaPod)
+}
+
 func (ncpc *Controller) enqueueAllScyllaPodsOnNode(depth int, obj kubeinterfaces.ObjectInterface, op controllerhelpers.HandlerOperationType) {
 	node := obj.(*corev1.Node)
 
@@ -199,26 +203,10 @@ func (ncpc *Controller) enqueueAllScyllaPodsForNodeConfig(depth int, obj kubeint
 	}
 }
 
-func (ncpc *Controller) enqueueScyllaPod(depth int, obj kubeinterfaces.ObjectInterface, op controllerhelpers.HandlerOperationType) {
-	pod := obj.(*corev1.Pod)
-
-	// TODO: extract and use a better label, verify the container
-	if pod.Labels == nil {
-		return
-	}
-
-	_, isScyllaPod := pod.Labels[naming.ClusterNameLabel]
-	if !isScyllaPod {
-		return
-	}
-
-	ncpc.handlers.Enqueue(depth+1, pod, op)
-}
-
 func (ncpc *Controller) addPod(obj interface{}) {
 	ncpc.handlers.HandleAdd(
 		obj.(*corev1.Pod),
-		ncpc.enqueueScyllaPod,
+		ncpc.enqueueScyllaPodFunc(),
 	)
 }
 
@@ -226,7 +214,7 @@ func (ncpc *Controller) updatePod(old, cur interface{}) {
 	ncpc.handlers.HandleUpdate(
 		old.(*corev1.Pod),
 		cur.(*corev1.Pod),
-		ncpc.enqueueScyllaPod,
+		ncpc.enqueueScyllaPodFunc(),
 		nil,
 	)
 }
@@ -234,7 +222,7 @@ func (ncpc *Controller) updatePod(old, cur interface{}) {
 func (ncpc *Controller) addConfigMap(obj interface{}) {
 	ncpc.handlers.HandleAdd(
 		obj.(*corev1.ConfigMap),
-		ncpc.handlers.EnqueueOwner,
+		ncpc.handlers.EnqueueOwnerFunc(ncpc.enqueueScyllaPodFunc()),
 	)
 }
 
@@ -242,7 +230,7 @@ func (ncpc *Controller) updateConfigMap(old, cur interface{}) {
 	ncpc.handlers.HandleUpdate(
 		old.(*corev1.ConfigMap),
 		cur.(*corev1.ConfigMap),
-		ncpc.handlers.EnqueueOwner,
+		ncpc.handlers.EnqueueOwnerFunc(ncpc.enqueueScyllaPodFunc()),
 		ncpc.deleteConfigMap,
 	)
 }
@@ -250,7 +238,7 @@ func (ncpc *Controller) updateConfigMap(old, cur interface{}) {
 func (ncpc *Controller) deleteConfigMap(obj interface{}) {
 	ncpc.handlers.HandleDelete(
 		obj,
-		ncpc.handlers.EnqueueOwner,
+		ncpc.handlers.EnqueueOwnerFunc(ncpc.enqueueScyllaPodFunc()),
 	)
 }
 

--- a/pkg/controller/nodeconfigpod/sync.go
+++ b/pkg/controller/nodeconfigpod/sync.go
@@ -39,6 +39,11 @@ func (ncpc *Controller) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("can't list pods: %w", err)
 	}
 
+	if !controllerhelpers.IsScyllaPod(pod) {
+		klog.Warningf("Non-Scylla Pod %q enqueued for sync by NodeConfigPod controller", klog.KObj(pod))
+		return nil
+	}
+
 	if pod.DeletionTimestamp != nil {
 		return nil
 	}

--- a/pkg/controller/scyllacluster/controller.go
+++ b/pkg/controller/scyllacluster/controller.go
@@ -362,7 +362,7 @@ func (scc *Controller) enqueueOwnerThroughStatefulSetOwner(depth int, obj kubein
 	}
 
 	klog.V(4).InfoS("Enqueuing owner of StatefulSet", "StatefulSet", klog.KObj(sc), "ScyllaCluster", klog.KObj(sc))
-	scc.handlers.EnqueueWithDepth(depth+1, sc, op)
+	scc.handlers.Enqueue(depth+1, sc, op)
 }
 
 func (scc *Controller) addService(obj interface{}) {

--- a/pkg/controllerhelpers/scylla.go
+++ b/pkg/controllerhelpers/scylla.go
@@ -218,3 +218,17 @@ func EnsureNodeConfigCondition(status *scyllav1alpha1.NodeConfigStatus, cond *sc
 
 	*existingCond = *cond
 }
+
+func IsScyllaPod(pod *corev1.Pod) bool {
+	// TODO: use a better label, verify the container
+	if pod.Labels == nil {
+		return false
+	}
+
+	_, ok := pod.Labels[naming.ClusterNameLabel]
+	if !ok {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
As described in https://github.com/scylladb/scylla-operator/issues/1119, currently the NodeConfigPod controller removes ownerReferences from *any* ConfigMap that has a controllerRef to *any* Pod. This is undesired as the controller shouldn't affect any resources that the operator doesn't manage. This PR adds a condition verifying whether the owner of the ConfigMap is a Scylla Pod.

**Which issue is resolved by this Pull Request:**
Resolves #1119
