### PR TITLE
[v1.8] Bump Go version in release pipeline

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -17,7 +17,7 @@ on:
         required: true
 
 env:
-  go_version: 1.17.5
+  go_version: 1.19
   git_repo_path: ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator
   retention_days: 90
 


### PR DESCRIPTION
Fixes the failure of pipeline publishing release notes: https://github.com/scylladb/scylla-operator/actions/runs/3822431869/jobs/6502569259

Backport of #1136 