### PR TITLE
helm: allow setting custom CA when not using CertManager

### DIFF
--- a/helm/scylla-operator/templates/validatingwebhook.yaml
+++ b/helm/scylla-operator/templates/validatingwebhook.yaml
@@ -2,11 +2,16 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
+  {{- if .Values.webhook.createSelfSignedCertificate }}
     cert-manager.io/inject-ca-from: scylla-operator/{{ include "scylla-operator.certificateName" . }}
+  {{- end }}
   name: scylla-operator
 webhooks:
 - name: webhook.scylla.scylladb.com
   clientConfig:
+  {{- if not .Values.webhook.createSelfSignedCertificate }}
+    caBundle: {{ required "If self signed certificate is turned off, you need to provide caBundle for validating webhook" .Values.webhook.caBundle  | quote }}
+  {{- end }}
     service:
       name: {{ include "scylla-operator.webhookServiceName" . }}
       namespace: scylla-operator

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -41,6 +41,10 @@ webhook:
   # Name of a secret containing custom certificate
   # If not set and createSelfSignedCertificate is true, a name is generated using fullname
   certificateSecretName: ""
+  # If createSelfSignedCertificate=false, you need to supply your own certificate and also
+  # provide CA for the API server, so that it accepts your certificate. The value holds base64-encoded
+  # CA in PEM format.
+  caBundle: ""
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
If helm chart user disables CertManager integration, setting custom CA bundle is required.

Otherwise the whole feature doesn't make sense, because you won't be able to deploy resources, the validation during `kubectl apply` will fail with:

```
Error: Internal error occurred: failed calling webhook "webhook.scylla.scylladb.com": could not get REST client: unable to load root certificates: unable to parse bytes as PEM block

```

