### PR TITLE
Fix ApplyRoleBinding updates for immutable roleRef

### DIFF
--- a/pkg/resourceapply/rbac.go
+++ b/pkg/resourceapply/rbac.go
@@ -49,7 +49,20 @@ func ApplyRoleBindingWithControl(
 	required *rbacv1.RoleBinding,
 	options ApplyOptions,
 ) (*rbacv1.RoleBinding, bool, error) {
-	return ApplyGeneric[*rbacv1.RoleBinding](ctx, control, recorder, required, options)
+	return ApplyGenericWithHandlers[*rbacv1.RoleBinding](
+		ctx,
+		control,
+		recorder,
+		required,
+		options,
+		nil,
+		func(required *rbacv1.RoleBinding, existing *rbacv1.RoleBinding) string {
+			if !equality.Semantic.DeepEqual(existing.RoleRef, (*required).RoleRef) {
+				return "roleRef is immutable"
+			}
+			return ""
+		},
+	)
 }
 
 func ApplyRoleBinding(


### PR DESCRIPTION
**Description of your changes:**
Fixes `ApplyRoleBinding` to recreate the object on roleRef changes  because `rolebinding.spec.roleRef` is immutable.
Ref https://github.com/kubernetes/kubernetes/blob/0843c4dfcab93dd242044e51d6a2a21dc73d233e/pkg/apis/rbac/validation/validation.go#L165-L167

**Which issue is resolved by this Pull Request:**
Needed by #1111
