### PR TITLE
Update and pin Ubuntu to 22.04

### DIFF
--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -135,12 +135,14 @@ runs:
       kubeletCgroups: /system.slice/kubelet.service
       enforceNodeAllocatable:
       - pods
+      - system-reserved
       systemReservedCgroup: /system.slice
-      kubeReservedCgroup: /system.slice/kubelet.service
       systemReserved:
+        cpu: "200m"
         ephemeral-storage: 1Gi
       serializeImagePulls: false
       containerLogMaxSize: 50Mi
+      cpuManagerPolicy: static
       maxPods: 1024
       kubeAPIQPS: 30
       kubeAPIBurst: 50

--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -21,6 +21,10 @@ runs:
       sudo modprobe br_netfilter
       sudo swapoff -a
       echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/90-kube.conf >/dev/null
+      # We need to raise `fs.nr_open` as it limits how high can systemd units configure LimitNOFILE
+      echo 'fs.nr_open = 10485760' | sudo tee /etc/sysctl.d/90-kube.conf >/dev/null
+      echo 'fs.aio-max-nr = 10485760' | sudo tee /etc/sysctl.d/90-kube.conf >/dev/null
+      echo 'fs.nr_open = 10485760' | sudo tee /etc/sysctl.d/90-kube.conf >/dev/null
       echo 'net.bridge.bridge-nf-call-iptables  = 1' | sudo tee -a /etc/sysctl.d/90-kube.conf >/dev/null
       echo 'net.bridge.bridge-nf-call-ip6tables = 1' | sudo tee -a /etc/sysctl.d/90-kube.conf >/dev/null
       
@@ -31,6 +35,14 @@ runs:
     run: |
       set -euExo pipefail
       shopt -s inherit_errexit
+      
+      # Raise crio limits
+      sudo mkdir /etc/systemd/system/cri-o.service.d
+      cat << EOF | sudo tee /etc/systemd/system/cri-o.service.d/override.conf
+      [Service]
+      LimitNOFILE=10485760
+      LimitNPROC=10485760
+      EOF
       
       source /etc/os-release
       KUBERNETES_VERSION_SHORT=$( echo ${{ inputs.kubernetesVersion }} | cut -d'.' -f1-2 )
@@ -57,6 +69,7 @@ runs:
       cgroup_manager = "systemd"
       EOF
       
+      sudo systemctl daemon-reload
       sudo systemctl enable --now crio
 
   - name: Install kubernetes

--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -74,11 +74,13 @@ runs:
       echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
       sudo apt-get update
       
-      # Remove conflicting package
+      # Remove conflicting packages (also removes podman).
       sudo apt-get remove containernetworking-plugins
       
       sudo apt-get install -y --no-install-recommends kubelet="${KUBERNETES_PKG_VERSION}" kubeadm="${KUBERNETES_PKG_VERSION}" kubectl="${KUBERNETES_PKG_VERSION}"
 
+      # Podman got wiped by removing `containernetworking-plugins` so we have to install it from the new repo.
+      sudo apt-get install podman
   - name: Start Kubernetes
     shell: bash
     run: |

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   build-and-test:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -24,7 +24,7 @@ env:
 jobs:
   build-and-test:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
     - build-and-test
     steps:
@@ -76,7 +76,7 @@ jobs:
 
   failure-notifications:
     name: Failure notifications
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
     - build-and-test
     - deploy

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -42,7 +42,7 @@ defaults:
 jobs:
   verify:
     name: Verify
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
 
   verify-deps:
     name: Verify dependencies
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
   verify-vendorability:
     name: Verify vendorability
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     env:
       github_self_ref: 'github.com/${{ github.repository }}@${{ github.sha }}'
@@ -118,7 +118,7 @@ jobs:
 
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3
@@ -143,7 +143,7 @@ jobs:
 
   images:
     name: Build images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3
@@ -155,11 +155,9 @@ jobs:
       run: ./hack/ci-detect-tags.sh
     - name: Install podman
       run: |
-        set -x
-        # Install nativelly when we have Ubuntu >= 20.10
-        . /etc/os-release
-        echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-        curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+        set -euExo pipefail
+        shopt -s inherit_errexit
+        
         sudo apt-get update
         sudo apt-get -y install podman
     - name: Build image
@@ -180,7 +178,7 @@ jobs:
 
   charts:
     name: Build Helm charts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3
@@ -206,7 +204,7 @@ jobs:
 
   test-e2e-parallel:
     name: Test e2e parallel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: images
     timeout-minutes: 90
     steps:
@@ -223,7 +221,7 @@ jobs:
 
   test-e2e-serial:
     name: Test e2e serial
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: images
     timeout-minutes: 90
     steps:
@@ -240,7 +238,7 @@ jobs:
 
   test-e2e-parallel-alpha:
     name: Test e2e parallel (with alpha features)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: images
     timeout-minutes: 90
     steps:
@@ -258,7 +256,7 @@ jobs:
 
   test-e2e-serial-alpha:
     name: Test e2e serial (with alpha features)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: images
     timeout-minutes: 90
     steps:
@@ -279,7 +277,7 @@ jobs:
   # Dummy step for different promotion jobs to depend on
   success:
     name: All tests successfull
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
     - verify
     - verify-deps
@@ -299,7 +297,7 @@ jobs:
 
   promote:
     name: Promote artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [success]
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
@@ -361,7 +359,7 @@ jobs:
 
   failure-notifications:
     name: Failure notifications
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
     - success
     - promote

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   title:
     name: Verify PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Verify PR title
       run: |
@@ -54,7 +54,7 @@ jobs:
         fi
   labels:
     name: Verify PR labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Verify PR labels
       run: |
@@ -71,7 +71,7 @@ jobs:
   milestone:
     name: Verify PR milestone
     if: ${{ github.event.pull_request.base.ref == 'master' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -30,7 +30,7 @@ defaults:
 jobs:
   release-notes:
     name: Publish release notes
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/scylladb/scylla-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM quay.io/scylladb/scylla-operator-images:base-ubuntu
+FROM quay.io/scylladb/scylla-operator-images:base-ubuntu-22.04
 # sidecar-injection container and existing installations use binary from root,
 # we have to keep it there until we figure out how to properly upgrade them.
 COPY --from=builder /go/src/github.com/scylladb/scylla-operator/scylla-operator /usr/bin/


### PR DESCRIPTION
**Description of your changes:**
Update Ubuntu in the image and in the CI to 22.04. It also ping the version where it previously wasn't so we avoid compatibility surprises. As a bonus, we can install `podman` directly.

**Which issue is resolved by this Pull Request:**
Followup to https://github.com/scylladb/scylla-operator-images/issues/6

Requires:
- [x] https://github.com/scylladb/scylla-operator-images/pull/9
