### PR TITLE
Fix crypto unit test not to capture loop variable

### DIFF
--- a/pkg/crypto/certcreators_test.go
+++ b/pkg/crypto/certcreators_test.go
@@ -74,6 +74,8 @@ func TestX509CertCreator_MakeCertificate(t *testing.T) {
 		},
 	}
 	for _, tc := range tt {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
**Description of your changes:**
go 1.20 vet found an issue for us in the test suite where we forgot to copy the loop variable. This PR fixes it.

**Which issue is resolved by this Pull Request:**
```
go vet ./...
# github.com/scylladb/scylla-operator/pkg/crypto
pkg/crypto/certcreators_test.go:80:22: loop variable tc captured by func literal
pkg/crypto/certcreators_test.go:80:57: loop variable tc captured by func literal
pkg/crypto/certcreators_test.go:81:31: loop variable tc captured by func literal
pkg/crypto/certcreators_test.go:82:63: loop variable tc captured by func literal
pkg/crypto/certcreators_test.go:108:7: loop variable tc captured by func literal
pkg/crypto/certcreators_test.go:125:32: loop variable tc captured by func literal
pkg/crypto/certcreators_test.go:131:34: loop variable tc captured by func literal
make: *** [Makefile:162: verify-govet] Error 1
```
