### PR TITLE
Tune kubelet config in CI

### DIFF
--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -125,6 +125,12 @@ runs:
       kubeReservedCgroup: /system.slice/kubelet.service
       systemReserved:
         ephemeral-storage: 1Gi
+      serializeImagePulls: false
+      containerLogMaxSize: 50Mi
+      maxPods: 50
+      kubeAPIQPS: 30
+      kubeAPIBurst: 50
+      hairpinMode: hairpin-veth
       EOF
       
       sudo kubeadm init --config=/root/kubeadm-config.yaml


### PR DESCRIPTION
**Description of your changes:**
This PR adjust a few kubelet options for our kubeadm CI setup to make it more stable and better performing. Also sets `hairpinMode` so to avoid ScyllaDB truncate issues.

