### PR TITLE
Fix GH action setting up Kubernetes

### DIFF
--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -49,7 +49,7 @@ runs:
       echo "deb [signed-by=/etc/apt/keyrings/libcontainers-crio-archive-keyring.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${KUBERNETES_VERSION_SHORT}/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable:cri-o:${KUBERNETES_VERSION_SHORT}.list
       
       sudo apt-get update
-      sudo apt-get install -y --no-install-recommends cri-o cri-o-runc
+      sudo apt-get install -y --no-install-recommends cri-o cri-o-runc conmon
       
       cat << EOF | sudo tee /etc/crio/crio.conf.d/02-cgroup-manager.conf
       [crio.runtime]

--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -143,7 +143,10 @@ runs:
       
       # master taint is deprecated in 1.24 and removed in 1.25
       # control-plane taint is added in 1.25
+      # kubectl returns an error if taint isn't there when we try to remove it, to overcome this we first taint it, and then untaint
+      kubectl taint nodes --selector node-role.kubernetes.io/control-plane= --overwrite node-role.kubernetes.io/control-plane:NoSchedule
       kubectl taint nodes --selector node-role.kubernetes.io/control-plane= node-role.kubernetes.io/control-plane-
+      kubectl taint nodes --selector node-role.kubernetes.io/control-plane= --overwrite node-role.kubernetes.io/master:NoSchedule
       kubectl taint nodes --selector node-role.kubernetes.io/control-plane= node-role.kubernetes.io/master-
       
       kubectl -n kube-system rollout status --timeout=5m deployment.apps/coredns

--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -75,7 +75,7 @@ runs:
       sudo apt-get update
       
       # Remove conflicting package
-      sudo apt remove containernetworking-plugins
+      sudo apt-get remove containernetworking-plugins
       
       sudo apt-get install -y --no-install-recommends kubelet="${KUBERNETES_PKG_VERSION}" kubeadm="${KUBERNETES_PKG_VERSION}" kubectl="${KUBERNETES_PKG_VERSION}"
 


### PR DESCRIPTION
Two issues were found with setup-kubernetes action when Kube 1.25 was used:
* kubelet exec probes wasn't working - due to old conmon
* control plane nodes couldn't be untained - master taint is removed in 1.25 and kubectl isn't idempotent