### PR TITLE
Wait for haproxy-ingress to be ready when setting up the example

### DIFF
--- a/examples/third-party/haproxy-ingress/10_haproxy-ingress.deploy.yaml
+++ b/examples/third-party/haproxy-ingress/10_haproxy-ingress.deploy.yaml
@@ -43,6 +43,10 @@ spec:
           requests:
             cpu: 100m
             memory: 50M
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 1042
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
**Description of your changes:**
Without a readiness probe the haproxy deployment will go immediately ready which will unblock the corresponding `rollout status` but if it never starts up properly the liveness will kill it. At least reusing the liveness endpoint for readyness fixes the issue. (There is no dedicated `/readyz` :( )

**Which issue is resolved by this Pull Request:**
Flakes and bugs the manifested as failures for tests that use ingresses.
