### PR TITLE
Force default resources in CI

### DIFF
--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -173,3 +173,22 @@ runs:
           verbs:
           - patch
       EOF
+      
+      # Force default resources
+      kubectl apply --server-side -f - <<EOF
+        apiVersion: v1
+        kind: LimitRange
+        metadata:
+          name: cpu-resource-constraint
+        spec:
+          limits:
+          - type: Container
+            default:
+              cpu: "1"
+              memory: 1Gi
+            defaultRequest:
+              cpu: 100m
+              memory: 100Mi
+            max:
+              cpu: "1"
+      EOF


### PR DESCRIPTION
**Description of your changes:**
Every resource created in CI should set its requests, this will make sure there is a default. Possibly, we could also use it to trace those resources down by raising the default value insanely high so it won't ever schedule.

**Which issue is resolved by this Pull Request:**
Flakes
