### PR TITLE
Limit CI parallelism

### DIFF
--- a/pkg/cmd/tests/tests_run.go
+++ b/pkg/cmd/tests/tests_run.go
@@ -47,7 +47,7 @@ var suites = ginkgotest.TestSuites{
 		Description: templates.LongDesc(`
 		Runs all tests.
 		`),
-		DefaultParallelism: 30,
+		DefaultParallelism: 15,
 	},
 	{
 		Name: "scylla-operator/conformance/parallel",
@@ -55,7 +55,7 @@ var suites = ginkgotest.TestSuites{
 		Tests that ensure an Scylla Operator is working properly.
 		`),
 		LabelFilter:        fmt.Sprintf("!%s", framework.SerialLabelName),
-		DefaultParallelism: 30,
+		DefaultParallelism: 15,
 	},
 	{
 		Name: "scylla-operator/conformance/serial",


### PR DESCRIPTION
**Description of your changes:**
So far 30 has been an artificial number we chose and there was always less tests - meaning that the CI was always mimitted just by the number of tests. It seems we are reaching the resource limits of our small machine, so let's checkpoint a number that used to historically work and reduce it if we see further contention.


**Which issue is resolved by this Pull Request:**
Flakes