### PR TITLE
Point all traffic targeting default backend to correct port

### DIFF
--- a/examples/third-party/haproxy-ingress/10_ingress-default-backend.svc.yaml
+++ b/examples/third-party/haproxy-ingress/10_ingress-default-backend.svc.yaml
@@ -9,8 +9,8 @@ spec:
   - name: https
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8080
   - name: cql-ssl
     port: 9142
     protocol: TCP
-    targetPort: 443
+    targetPort: 8080


### PR DESCRIPTION
Turns out when connection to default backend cannot be established, haproxy does a hard reset after 20mins. After fixing it, haproxy hasn't restarted during 4h of load.

Fixes #1171