### PR TITLE
Allow configuring webhook resources in `scylla-operator` Helm chart

### DIFF
--- a/helm/scylla-operator/templates/webhookserver.deployment.yaml
+++ b/helm/scylla-operator/templates/webhookserver.deployment.yaml
@@ -60,9 +60,7 @@ spec:
           name: webhook-server
           protocol: TCP
         resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
+          {{- toYaml .Values.webhook.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /tmp/serving-certs
           name: cert

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -42,6 +42,11 @@ webhook:
   # If not set and createSelfSignedCertificate is true, a name is generated using fullname
   certificateSecretName: ""
 
+  resources:
+    requests:
+      cpu: 100m
+      memory: 20Mi
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Allow to configure webhook resource in `values.yaml`

