### PR TITLE
Tune CI and adjust timeouts

### DIFF
--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -121,7 +121,7 @@ runs:
       group="$( id -g )"
       ingress_address="$( kubectl -n haproxy-ingress get svc haproxy-ingress --template='{{ .spec.clusterIP }}' )"
       
-      sudo podman run --user="${user}:${group}" --rm \
+      sudo timeout "$(( ${e2e_timeout_minutes} + 5 ))m" podman run --user="${user}:${group}" --rm \
       --entrypoint=/usr/bin/scylla-operator-tests \
       -v="${ARTIFACTS_DIR}:${ARTIFACTS_DIR}:rw" \
       -v="${HOME}/.kube/config:/kubeconfig:ro" -e='KUBECONFIG=/kubeconfig' \

--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -151,11 +151,16 @@ runs:
       set -euExo pipefail
       shopt -s inherit_errexit
       
+      sudo dmesg > dmesg
+      sudo free -h > free
+      sudo df -h > df
+      sudo mount > mount
+      sudo lsblk > lsblk
+      
       sudo podman info > podman.info
       sudo podman images -a > podman.images
       sudo crictl images > crictl.images
       sudo podman stats -a --no-stream --no-reset > podman.stats
-      free -h > free
       journalctl -u kubelet > kubelet.log
       journalctl -u crio > crio.log
       sudo iptables -L > iptables.log

--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -21,7 +21,7 @@ inputs:
   baseTimeoutMinutes:
     description: "Default timeout in minutes. Can be extended to accommodate for flake retries."
     required: false
-    default: 120
+    default: 60
 runs:
   using: "composite"
   steps:

--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -159,7 +159,7 @@ runs:
       journalctl -u kubelet > kubelet.log
       journalctl -u crio > crio.log
       sudo iptables -L > iptables.log
-      sysctl --all > sysctls.log
+      sudo sysctl --all > sysctls.log
       
       sudo tar -c --use-compress-program=lz4 -f ./kubernetes.tar.lz4 "/etc/kubernetes"
       

--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -192,3 +192,11 @@ runs:
             max:
               cpu: "1"
       EOF
+
+  - name: Make extra disk space
+    shell: bash
+    run: |
+      set -euExo pipefail
+      shopt -s inherit_errexit
+
+      sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc

--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -88,8 +88,20 @@ runs:
       cat << EOF | sudo tee /etc/ssl/certs/audit-policy.yaml > /dev/null
       apiVersion: audit.k8s.io/v1
       kind: Policy
+      omitStages:
+      - "RequestReceived"
       rules:
+      - level: Metadata
+        resources:
+        - group: ""
+          resources:
+          - "events"
       - level: RequestResponse
+        verbs:
+        - create
+        - update
+        - patch
+      - level: Metadata
       EOF
       
       cat << EOF | sudo tee /root/kubeadm-config.yaml > /dev/null

--- a/.github/actions/setup-local-volume-provisioner/action.yaml
+++ b/.github/actions/setup-local-volume-provisioner/action.yaml
@@ -17,6 +17,9 @@ runs:
       shopt -s inherit_errexit
       
       sudo mkdir /mnt/persistent-volumes
+      # /mnt has limited space in GH Actions, use /
+      sudo mkdir /persistent-volumes
+      sudo mount --bind /persistent-volumes /mnt/persistent-volumes
       
       for i in $( seq 1 "${{ inputs.numberOfPersistentVolumes }}" ); do
         sudo mkdir "/mnt/persistent-volumes/vol${i}" "/mnt/persistent-volumes/disk_vol${i}"


### PR DESCRIPTION
**Description of your changes:**
- Fixes a permission issue on `sysctl` dump
- Collects `dmesg`, `df`, `mount` and `lsblk`
- Enforces e2e timeout above the container layer in case something in between would get stuck or the program timeout didn't work
- Frees disk space on GH runners (SDK we don't need)
- Moves PVs from `/mnt` (very small) to `/`
- Defaults test timeout is now `60m` so it can fit even with flakes under the global `90m` GH actions timeout
- Reduces audit size and resource consumption by the kube-apiserver
