### PR TITLE
Make the hack gomod valid

### DIFF
--- a/hack/gke/systemd/go.mod
+++ b/hack/gke/systemd/go.mod
@@ -1,0 +1,1 @@
+module hack


### PR DESCRIPTION
**Description of your changes:**
IDEs like Goland try to `go list` all go.mod files in the project but fail when it's missing the module declaration. Every mod file should contain it.

**Which issue is resolved by this Pull Request:**
```
go: no module declaration in go.mod. To specify the module path:
	go mod edit -module=example.com/mod
```
