### PR TITLE
Fix sysctl settings in kubernetes setup Action

### DIFF
--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -20,11 +20,10 @@ runs:
       sudo modprobe overlay
       sudo modprobe br_netfilter
       sudo swapoff -a
-      echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/90-kube.conf >/dev/null
+      echo 'net.ipv4.ip_forward = 1' | sudo tee -a  /etc/sysctl.d/90-kube.conf >/dev/null
       # We need to raise `fs.nr_open` as it limits how high can systemd units configure LimitNOFILE
-      echo 'fs.nr_open = 10485760' | sudo tee /etc/sysctl.d/90-kube.conf >/dev/null
-      echo 'fs.aio-max-nr = 10485760' | sudo tee /etc/sysctl.d/90-kube.conf >/dev/null
-      echo 'fs.nr_open = 10485760' | sudo tee /etc/sysctl.d/90-kube.conf >/dev/null
+      echo 'fs.nr_open = 10485760' | sudo tee -a /etc/sysctl.d/90-kube.conf >/dev/null
+      echo 'fs.aio-max-nr = 10485760' | sudo tee -a /etc/sysctl.d/90-kube.conf >/dev/null
       echo 'net.bridge.bridge-nf-call-iptables  = 1' | sudo tee -a /etc/sysctl.d/90-kube.conf >/dev/null
       echo 'net.bridge.bridge-nf-call-ip6tables = 1' | sudo tee -a /etc/sysctl.d/90-kube.conf >/dev/null
       


### PR DESCRIPTION
Couple of 'tee' weren't appending to a file but they were overwriting it preventing previous settings to be applied.
