### PR TITLE
Add missing symlink to ScyllaDBMonitoring CRD in helm CRDs

### DIFF
--- a/helm/scylla-operator/crds/00_scylla.scylladb.com_scylladbmonitorings.yaml
+++ b/helm/scylla-operator/crds/00_scylla.scylladb.com_scylladbmonitorings.yaml
@@ -1,0 +1,1 @@
+../../../pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbmonitorings.yaml


### PR DESCRIPTION
**Description of your changes:**
Add missing symlink to ScyllaDBMonitoring CRD in helm CRDs.
