### PR TITLE
Fix PrometheusExposeOptions struct name in API definitions

### DIFF
--- a/pkg/api/scylla/v1alpha1/types_monitoring.go
+++ b/pkg/api/scylla/v1alpha1/types_monitoring.go
@@ -103,7 +103,7 @@ type PrometheusSpec struct {
 
 	// exposeOptions specifies options for exposing Prometheus UI.
 	// +optional
-	ExposeOptions *GrafanaExposeOptions `json:"exposeOptions,omitempty"`
+	ExposeOptions *PrometheusExposeOptions `json:"exposeOptions,omitempty"`
 
 	// storage describes the underlying storage that Prometheus will consume.
 	// +optional

--- a/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
@@ -403,7 +403,7 @@ func (in *PrometheusSpec) DeepCopyInto(out *PrometheusSpec) {
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.ExposeOptions != nil {
 		in, out := &in.ExposeOptions, &out.ExposeOptions
-		*out = new(GrafanaExposeOptions)
+		*out = new(PrometheusExposeOptions)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Storage != nil {


### PR DESCRIPTION
**Description of your changes:**
This fixes the wrong struct used in `scylladbmonitoring.spec.components.prometheus.exposeOptions`. Fortunately, at this point the structs are equivalent from the API perspective and we can switch them.

