### PR TITLE
Fix "job" labels in Grafana dashboards' queries

### DIFF
--- a/assets/monitoring/grafana/v1alpha1/dashboards.cm.yaml
+++ b/assets/monitoring/grafana/v1alpha1/dashboards.cm.yaml
@@ -4602,7 +4602,7 @@ data:
                             ]
                         },
                         "datasource": "prometheus",
-                        "definition": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                        "definition": "query_result(count(up{job=~\"$cluster|$^\"}) by (dc))",
                         "error": null,
                         "hide": 2,
                         "includeAll": true,
@@ -4610,7 +4610,7 @@ data:
                         "name": "count_dc",
                         "options": [],
                         "query": {
-                            "query": "query_result(count(up{job=\"scylla\"}) by (dc))",
+                            "query": "query_result(count(up{job=~\"$cluster|$^\"}) by (dc))",
                             "refId": "StandardVariableQuery"
                         },
                         "refresh": 2,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Currently there is a bug breaking our Grafana dashboards introduced in https://github.com/scylladb/scylla-operator/pull/1111. The "job" label in some of the PromQL queries is hardcoded to "scylla", while the ServiceMonitor manifests set it to the value of "scylla/cluster" labels of the identity Service.
https://github.com/scylladb/scylla-operator/blob/ee48da7fa9235eb8167f569c321123740c57252f/assets/monitoring/prometheus/v1/scylladb.servicemonitor.yaml#L8

For reference see https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor.

This PR fixes it by setting it to a `cluster` label defined in the ServiceMonitor: https://github.com/scylladb/scylla-operator/blob/ee48da7fa9235eb8167f569c321123740c57252f/assets/monitoring/prometheus/v1/scylladb.servicemonitor.yaml#L25. For reference see https://prometheus.io/docs/prometheus/latest/configuration/configuration/#service and https://prometheus.io/docs/prometheus/latest/configuration/configuration/#service.
 
