### PR TITLE
Workaround mkfs.xfs min size limits in newer versions

### DIFF
--- a/hack/test/gke/xfs-formatter/tune2fs_test.sh
+++ b/hack/test/gke/xfs-formatter/tune2fs_test.sh
@@ -26,8 +26,9 @@ trap 'err_handler "${LINENO}"' ERR
 tmp_file=$( mktemp )
 
 function setup_fs {
-  dd if=/dev/zero of="${tmp_file}" bs=4096 count=4096 
-  mkfs -t "${1}" "${tmp_file}" 
+  dd if=/dev/zero of="${tmp_file}" bs=4096 count=4096
+  # Enable small filesystems with these 3 extra vars - https://lore.kernel.org/all/Yv4i0gWiHTkfWB5m@yuki/T/
+  TEST_DIR=1 TEST_DEV=1 QA_CHECK_FS=1 mkfs -t "${1}" "${tmp_file}"
 }
 
 echo "${message_prefix}..testing invalid parameters." >&2


### PR DESCRIPTION
**Description of your changes:**
```
mkfs.xfs since v5.19.0-rc1 [1] refuses to create filesystems < 300 MB.
```
https://lore.kernel.org/all/Yv4i0gWiHTkfWB5m@yuki/T/

We'll set the extra variables (`TEST_DIR=1 TEST_DEV=1 QA_CHECK_FS=1`) to allow us still create small testing filesystems.

