### PR TITLE
Enforce cpu limits for scylla-operator in CI

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -44,8 +44,11 @@ for f in $( find "${deploy_dir}"/ -type f -name '*.yaml' ); do
     sed -i -E -e "s~docker.io/scylladb/scylla-operator(:|@sha256:)[^ ]*~${OPERATOR_IMAGE_REF}~" "${f}"
 done
 
-yq e --inplace '.spec.template.spec.containers[0].args += ["--qps=200", "--burst=400"]' "${deploy_dir}/operator/50_operator.deployment.yaml"
-yq e --inplace '.spec.template.spec.containers[0].args += ["--crypto-key-buffer-size-min=3", "--crypto-key-buffer-size-max=6", "--crypto-key-buffer-delay=2s"]' "${deploy_dir}/operator/50_operator.deployment.yaml"
+yq e --inplace '
+.spec.template.spec.containers[0].args += ["--qps=200", "--burst=400"] |
+.spec.template.spec.containers[0].args += ["--crypto-key-buffer-size-min=3", "--crypto-key-buffer-size-max=6", "--crypto-key-buffer-delay=2s"] |
+.spec.template.spec.containers[0].resources.limits = {"cpu": "200m", "memory": "100Mi"} |
+.' "${deploy_dir}/operator/50_operator.deployment.yaml"
 
 if [[ -n ${SCYLLA_OPERATOR_FEATURE_GATES+x} ]]; then
     yq e --inplace '.spec.template.spec.containers[0].args += "--feature-gates="+ strenv(SCYLLA_OPERATOR_FEATURE_GATES)' "${deploy_dir}/operator/50_operator.deployment.yaml"


### PR DESCRIPTION
**Description of your changes:**
Scylla-operator has peak CPU usage when generating certs. On our small CI node 2 cores for everything this may be the last drop so we should limit the peaks.

Given this will slow down cert generation we may decide to wait for #1202 but let's see if or how bad it actually is.

**Which issue is resolved by this Pull Request:**
Some flakes hopefully.