### PR TITLE
Replace deprecated GCP Auth with a dedicated GitHub action

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -347,10 +347,12 @@ jobs:
         set -x
         docker tag '${{ env.image_repo_ref }}:ci' '${{ env.image_repo_ref }}:${{ env.CI_IMAGE_TAG }}'
         docker push '${{ env.image_repo_ref }}:${{ env.CI_IMAGE_TAG }}'
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v1
       with:
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
     - name: Publish Helm Chart
       env:
         HELM_CHANNEL: latest


### PR DESCRIPTION
**Description of your changes:**
Fixes following warning in promotion jobs:
```
Promote artifacts:
"service_account_key" has been deprecated. Please switch to using google-github-actions/auth which supports both Workload Identity Federation and Service Account Key JSON authentication. For more details, see https://github.com/google-github-actions/setup-gcloud#authorization
```