### PR TITLE
Add imagePullSecrets support in Scylla helm chart

### DIFF
--- a/helm/scylla/templates/scyllacluster.yaml
+++ b/helm/scylla/templates/scyllacluster.yaml
@@ -12,6 +12,10 @@ spec:
   {{- if .Values.agentImage.repository }}
   agentRepository: {{ .Values.agentImage.repository }}
   {{- end }}
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if .Values.alternator.enabled }}
   alternator:
     port: {{ .Values.alternator.port }}

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -42,6 +42,9 @@ backups: []
 # Scylla Manager Repair task definition
 repairs: []
 
+# ImagePullSecrets used for pulling Scylla and Agent images
+imagePullSecrets: []
+
 # Name of datacenter
 datacenter: "us-east-1"
 # List of racks


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This will enable the users to make use of custom private image registry secrets.
**Which issue is resolved by this Pull Request:**
Resolves #1212 
