### PR TITLE
Fix node setup image in EKS example

### DIFF
--- a/examples/eks/node-setup-daemonset.yaml
+++ b/examples/eks/node-setup-daemonset.yaml
@@ -93,7 +93,7 @@ spec:
       serviceAccountName: node-setup-daemonset
       containers:
       - name: node-setup
-        image: scylladb/scylla-machine-image:k8s-aws-666.development-20201023.0c4dfa1
+        image: docker.io/scylladb/scylla-machine-image:k8s-aws-node-setup-0.0.2@sha256:f588fb9223ace917a1075974bc0d37813f540b3c05dfdd183b1849ec2f83c879
         imagePullPolicy: Always
         args:
           - --all


### PR DESCRIPTION
Image used by DaemonSet setting up the disks in EKS example got broken when repository of 4.1 Scylla was removed.
In order to unstuck users using it, new version was released disabling the removed repository.

Users which are affected by this should be aware that we are planning on deprecating this DaemonSet in favor of upcoming automated disk setup.

Fixes #1218

Requirements:

- [x] https://github.com/scylladb/scylla-machine-image/pull/442
- [x] Above image is published