### PR TITLE
Fix command go-template in monitoring docs

### DIFF
--- a/docs/source/monitoring.md
+++ b/docs/source/monitoring.md
@@ -160,7 +160,7 @@ $ INGRESS_PORT=443
 When you are running in a real cluster there is usually a cloud LoadBalancer or a bare metal alternative providing you with an externally reachable IP address.
 
 ```console
-$ INGRESS_IP="$( kubectl -n=haproxy-ingress get service/haproxy-ingress --template='{{ ( index .loadBalancer.ingress 0 ).ip }}' )"
+$ INGRESS_IP="$( kubectl -n=haproxy-ingress get service/haproxy-ingress --template='{{ ( index .status.loadBalancer.ingress 0 ).ip }}' )"
 ```
 
 ##### Ingress NodePort


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
One of the commands in the Monitoring section of the documentation has a broken go-template resulting in the following error:
```
error: error executing template "{{ ( index .loadBalancer.ingress 0 ).ip }}": template: output:1:5: executing "output" at <index .loadBalancer.ingress 0>: error calling index: index of untyped nil
```
It must have gone unnoticed when applying review remarks to https://github.com/scylladb/scylla-operator/pull/1161. This PR fixes the template to read the correct field.

