### PR TITLE
Refactor release notes publishing into a reusable GitHub Action 

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -1,0 +1,122 @@
+name: "Generate and publish release notes"
+description: 'Generate and publish release notes'
+inputs:
+  githubRepository:
+    description: "Name of repository which release notes should be generated and published in 'owner/repository' format"
+    required: true
+  githubRef:
+    description: "The fully-formed ref of the branch or tag for publishing a release"
+    required: true
+  githubToken:
+    description: "Token with access to pull permissions to scylladb/scylla-operator and release permissions to repository which release is published"
+    required: true
+  goVersion:
+    description: "Version of Go"
+    required: true
+  genReleaseNotesVersionRef:
+    description: "Version ref of gen-release-notes"
+    required: true
+runs:
+  using: "composite"
+  steps:
+  - name: Setup go
+    uses: actions/setup-go@v3
+    with:
+      go-version: ${{ inputs.goVersion }}
+  
+  - uses: actions/checkout@v3
+    with:
+      ref: ${{ inputs.genReleaseNotesVersionRef }}
+      repository: scylladb/scylla-operator
+      path: ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator
+      fetch-depth: 0
+  
+  - name: Install release notes generator
+    shell: bash
+    run: |
+      set -euExo pipefail
+      shopt -s inherit_errexit
+      
+      cd ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator
+      make build GO_BUILD_PACKAGES=./cmd/gen-release-notes --warn-undefined-variables
+      
+      echo "${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator" >> ${GITHUB_PATH}
+  
+  - uses: actions/checkout@v3
+    with:
+      repository: ${{ inputs.githubRepository }}
+      path: ${{ github.workspace }}/go/src/github.com/${{ inputs.githubRepository }}
+      fetch-depth: 0
+  
+  - name: Create release
+    working-directory: ${{ github.workspace }}/go/src/github.com/${{ inputs.githubRepository }}
+    shell: bash
+    run: |
+      set -euExo pipefail
+      shopt -s inherit_errexit
+      
+      source ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator/hack/lib/semver.sh
+      
+      current_tag='${{ inputs.githubRef }}'
+      [[ "${current_tag}" != "" ]]
+      echo "${current_tag}" | grep -E -e '^v[0-9]+\.[0-9]+\.[0-9]+(-(beta|rc).[0-9]+)?$'
+      
+      prerelease=$( echo "${current_tag}" | sed -E -e 's/^[^-]+(-(beta|rc)\..*)?$/\2/' )
+      case "${prerelease}" in
+        "beta" | "rc")
+          # Pre-releases diff to a closest pre-release of the same type.
+          tags=$( git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-'"${prerelease}"'.[0-9]+)?$' )
+          ;;
+      
+        "")
+          # Releases diff to a closest release.
+          tags=$( git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]$' )
+          ;;
+      
+        *)
+          exit 1
+          ;;
+      esac
+      
+      previous_tag="$( find_previous_semver "${tags}" "${current_tag}" )"
+      [[ "${previous_tag}" != "" ]]
+      
+      release_name="${current_tag#v}"
+      previous_release_name="${previous_tag#v}"
+      
+      gen-release-notes \
+      --start-ref="$( git merge-base "${current_tag}" "${previous_tag}" )" \
+      --end-ref="${current_tag}" \
+      --release-name="${release_name}" \
+      --previous-release-name="${previous_release_name}" \
+      --github-token="${{ inputs.githubToken }}" \
+      --repository="${{ inputs.githubRepository }}" \
+      --loglevel=2 > ~/release_notes.md
+      
+      data="$( jq -n \
+        --arg current_tag "${current_tag}" \
+        --arg github_ref "${{ inputs.githubRef }}" \
+        --arg release_name "${release_name}" \
+        --arg prerelease "${prerelease}" \
+        --arg body "$( cat ~/release_notes.md )" \
+        '{
+          "tag_name": $current_tag,
+          "name": $current_tag,
+          "draft": false,
+          "prerelease": $prerelease | test("^$") | not,
+          "body": $body
+      }' )"
+      curl --fail -X POST \
+      -H "Authorization: Bearer ${{ inputs.githubToken }}" \
+      -H "Accept: application/vnd.github.v3+json" \
+      https://api.github.com/repos/${{ inputs.githubRepository }}/releases \
+      --data "${data}"
+  
+  - name: Upload artifact
+    if: ${{ always() }}
+    uses: actions/upload-artifact@v3
+    with:
+      name: release_notes.md
+      path: ~/release_notes.md
+      if-no-files-found: error
+      retention-days: 90

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -19,95 +19,39 @@ on:
 
 env:
   go_version: '1.20'
-  git_repo_path: ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator
-  retention_days: 90
 
 defaults:
   run:
     shell: bash
-    working-directory: "./go/src/github.com/scylladb/scylla-operator"
 
 jobs:
   release-notes:
     name: Publish release notes
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-      with:
-        path: ${{ env.git_repo_path }}
-        fetch-depth: 0
-    - name: Setup go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ env.go_version }}
-    - name: Create release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Determine current tag
       run: |
         set -euExo pipefail
         shopt -s inherit_errexit
-
-        source ./hack/lib/semver.sh
-
+        
         if [[ -n '${{ github.event.inputs.tag }}' ]]; then
           current_tag='${{ github.event.inputs.tag }}'
         else
           current_tag="${GITHUB_REF#refs/*/}"
         fi
-        [[ "${current_tag}" != "" ]]
-        echo "${current_tag}" | grep -E -e '^v[0-9]+\.[0-9]+\.[0-9]+(-(beta|rc).[0-9]+)?$'
+        
+        echo "current_tag=${current_tag}" | tee -a ${GITHUB_ENV}
 
-        prerelease=$( echo "${current_tag}" | sed -E -e 's/^[^-]+(-(beta|rc)\..*)?$/\2/' )
-        case "${prerelease}" in
-          "beta" | "rc")
-            # Pre-releases diff to a closest pre-release of the same type.
-            tags=$( git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-'"${prerelease}"'.[0-9]+)?$' )
-            ;;
-
-          "")
-            # Releases diff to a closest release.
-            tags=$( git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]$' )
-            ;;
-
-          *)
-            exit 1
-            ;;
-        esac
-
-        previous_tag="$( find_previous_semver "${tags}" "${current_tag}" )"
-        [[ "${previous_tag}" != "" ]]
-
-        release_name="${current_tag#v}"
-        previous_release_name="${previous_tag#v}"
-        make build GO_BUILD_PACKAGES=./cmd/gen-release-notes --warn-undefined-variables
-        ./gen-release-notes --start-ref="$( git merge-base "${current_tag}" "${previous_tag}" )" \
-        --end-ref="${current_tag}" --release-name="${release_name}" --previous-release-name="${previous_release_name}" --github-token="${GITHUB_TOKEN}" \
-        --loglevel=2 > ~/release_notes.md
-
-        data="$( jq -n \
-          --arg current_tag "${current_tag}" \
-          --arg github_ref "${GITHUB_REF}" \
-          --arg release_name "${release_name}" \
-          --arg prerelease "${prerelease}" \
-          --arg body "$( cat ~/release_notes.md )" \
-          '{
-            "tag_name": $current_tag,
-            "name": $current_tag,
-            "draft": false,
-            "prerelease": $prerelease | test("^$") | not,
-            "body": $body
-        }' )"
-        curl --fail -X POST \
-        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github.v3+json" \
-        https://api.github.com/repos/scylladb/scylla-operator/releases \
-        --data "${data}"
-
-    - name: Upload artifact
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+    - uses: actions/checkout@v3
       with:
-        name: release_notes.md
-        path: ~/release_notes.md
-        if-no-files-found: error
-        retention-days: ${{ env.retention_days }}
+        path: ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator
+        fetch-depth: 0
+
+    - name: Generate and publish release notes
+      uses: ./go/src/github.com/scylladb/scylla-operator/.github/actions/release-notes
+      with:
+        githubRepository: ${{ github.repository }}
+        githubRef: ${{ env.current_tag }}
+        githubToken: ${{ secrets.GITHUB_TOKEN }}
+        goVersion: ${{ env.go_version }}
+        genReleaseNotesVersionRef: master

--- a/pkg/cmd/releasenotes/generate.go
+++ b/pkg/cmd/releasenotes/generate.go
@@ -49,6 +49,7 @@ func NewGenGitReleaseNotesCommand(ctx context.Context, streams genericclioptions
 	cmd.Flags().StringVar(&o.ReleaseName, "release-name", o.ReleaseName, "Name of the release.")
 	cmd.Flags().StringVar(&o.PreviousReleaseName, "previous-release-name", o.PreviousReleaseName, "Name of the previous release.")
 	cmd.Flags().StringVar(&o.RepositoryPath, "repository-path", o.RepositoryPath, "Path to the git repository.")
+	cmd.Flags().StringVar(&o.Repository, "repository", o.Repository, `Name of repository in "owner/name" format.`)
 	cmd.Flags().StringVar(&o.StartRef, "start-ref", o.StartRef, "First commit reference, pull requests merged after this ref (including this ref) will be part of the release notes.")
 	cmd.Flags().StringVar(&o.EndRef, "end-ref", o.EndRef, "Last commit reference, pull requests merged before (including this ref) this ref will be part of the release notes.")
 	cmd.Flags().StringVar(&o.GithubToken, "github-token", o.GithubToken, "GitHub token used to authenticate requests.")

--- a/pkg/cmd/releasenotes/github.go
+++ b/pkg/cmd/releasenotes/github.go
@@ -72,12 +72,8 @@ func dateToken(start, end time.Time) string {
 	return fmt.Sprintf("merged:%s..%s", startString, endString)
 }
 
-func repoToken(owner, name string) string {
-	return fmt.Sprintf("repo:%s/%s", owner, name)
-}
-
-func listPullRequests(ctx context.Context, ghClient *githubql.Client, owner, repoName string, start, end time.Time) ([]PullRequest, error) {
-	params := []string{"is:pr", "is:merged", repoToken(owner, repoName), dateToken(start, end)}
+func listPullRequests(ctx context.Context, ghClient *githubql.Client, repository string, start, end time.Time) ([]PullRequest, error) {
+	params := []string{"is:pr", "is:merged", fmt.Sprintf("repo:%s", repository), dateToken(start, end)}
 
 	var cursor *githubql.String
 	var sq searchQuery

--- a/pkg/cmd/releasenotes/options.go
+++ b/pkg/cmd/releasenotes/options.go
@@ -16,9 +16,8 @@ import (
 type GenerateOptions struct {
 	genericclioptions.IOStreams
 
-	OrganizationName string
-	RepositoryName   string
-	RepositoryPath   string
+	Repository     string
+	RepositoryPath string
 
 	GithubToken string
 
@@ -32,10 +31,9 @@ type GenerateOptions struct {
 
 func NewGitGenerateOptions(streams genericclioptions.IOStreams) *GenerateOptions {
 	return &GenerateOptions{
-		IOStreams:        streams,
-		OrganizationName: "scylladb",
-		RepositoryName:   "scylla-operator",
-		RepositoryPath:   ".",
+		IOStreams:      streams,
+		Repository:     "scylladb/scylla-operator",
+		RepositoryPath: ".",
 	}
 }
 
@@ -64,6 +62,14 @@ func (o *GenerateOptions) Validate() error {
 
 	if len(o.GithubToken) == 0 {
 		errs = append(errs, fmt.Errorf("github-token can't be empty"))
+	}
+
+	if len(o.Repository) == 0 {
+		errs = append(errs, fmt.Errorf("repository can't be empty"))
+	}
+
+	if len(strings.Split(o.Repository, "/")) != 2 {
+		errs = append(errs, fmt.Errorf(`repository must be in "owner/name" format`))
 	}
 
 	return errors.NewAggregate(errs)

--- a/pkg/cmd/releasenotes/releasenotes.go
+++ b/pkg/cmd/releasenotes/releasenotes.go
@@ -44,7 +44,7 @@ func (o *GenerateOptions) Run(ctx context.Context) error {
 	} else {
 		startDate, endDate := commits[0].Committer.When, commits[len(commits)-1].Committer.When
 
-		prs, err = listPullRequests(ctx, o.ghClient, o.OrganizationName, o.RepositoryName, startDate, endDate)
+		prs, err = listPullRequests(ctx, o.ghClient, o.Repository, startDate, endDate)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
With current approach, the code for generating and publishing release notes
would need to be copied and pasted across multiple repositories,
leading to maintenance issues and duplication of effort.
To address this, I have extracted the release notes functionality into
a standalone GitHub Action, which can be easily reused across different projects.
The new composite action takes parameters that allow it to be customized
for each repository's specific needs, while still using the same underlying release note
generation tool.