### PR TITLE
Revert "Bump ScyllaDB and ScyllaDB Manager versions in Helm chart, examples and e2es "

### DIFF
--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -13,8 +13,8 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 5.2.0
-  agentVersion: 3.1.0
+  version: 5.0.5
+  agentVersion: 3.0.1
   cpuset: true
   network:
     hostNetworking: true

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -15,8 +15,8 @@ metadata:
   name: simple-cluster
   namespace: scylla
 spec:
-  version: 5.2.0
-  agentVersion: 3.1.0
+  version: 5.0.5
+  agentVersion: 3.0.1
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -13,8 +13,8 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 5.2.0
-  agentVersion: 3.1.0
+  version: 5.0.5
+  agentVersion: 3.0.1
   cpuset: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -1,8 +1,8 @@
 # Version information
 scyllaImage:
-  tag: 5.2.0
+  tag: 5.0.5
 agentImage:
-  tag: 3.1.0
+  tag: 3.0.1
 
 # Cluster information
 developerMode: true

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -1,6 +1,6 @@
 # Scylla Manager image
 image:
-  tag: 3.1.0
+  tag: 2.6.3
 
 # Resources allocated to Scylla Manager pods
 resources:
@@ -23,9 +23,9 @@ controllerResources:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 5.2.0
+    tag: 5.0.5
   agentImage:
-    tag: 3.1.0
+    tag: 3.0.1
   datacenter: manager-dc
   racks:
     - name: manager-rack

--- a/test/e2e/fixture/scylla/basic.scyllacluster.yaml
+++ b/test/e2e/fixture/scylla/basic.scyllacluster.yaml
@@ -3,8 +3,8 @@ kind: ScyllaCluster
 metadata:
   generateName: basic-
 spec:
-  version: 5.2.0
-  agentVersion: 3.1.0
+  version: 5.0.5
+  agentVersion: 3.0.1
   developerMode: true
   datacenter:
     name: us-east-1

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	updateFromScyllaVersion  = "5.1.8"
-	updateToScyllaVersion    = "5.1.9"
-	upgradeFromScyllaVersion = "5.1.9"
-	upgradeToScyllaVersion   = "5.2.0"
+	updateFromScyllaVersion  = "5.0.4"
+	updateToScyllaVersion    = "5.0.5"
+	upgradeFromScyllaVersion = "4.6.9"
+	upgradeToScyllaVersion   = "5.0.5"
 
 	testTimeout = 45 * time.Minute
 )


### PR DESCRIPTION
Revert of #1238 due to e2e "ScyllaCluster replace should replace a node" failing on 5.2.0.
