### PR TITLE
Use ScyllaDB 5.1.9 and ScyllaDB Manager 3.1.0 as default versions in Helm chart, examples and e2e

### DIFF
--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -13,8 +13,8 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 5.0.5
-  agentVersion: 3.0.1
+  version: 5.1.9
+  agentVersion: 3.1.0
   cpuset: true
   network:
     hostNetworking: true

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -15,8 +15,8 @@ metadata:
   name: simple-cluster
   namespace: scylla
 spec:
-  version: 5.0.5
-  agentVersion: 3.0.1
+  version: 5.1.9
+  agentVersion: 3.1.0
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -13,8 +13,8 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 5.0.5
-  agentVersion: 3.0.1
+  version: 5.1.9
+  agentVersion: 3.1.0
   cpuset: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -1,8 +1,8 @@
 # Version information
 scyllaImage:
-  tag: 5.0.5
+  tag: 5.1.9
 agentImage:
-  tag: 3.0.1
+  tag: 3.1.0
 
 # Cluster information
 developerMode: true

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -1,6 +1,6 @@
 # Scylla Manager image
 image:
-  tag: 2.6.3
+  tag: 3.1.0
 
 # Resources allocated to Scylla Manager pods
 resources:
@@ -23,9 +23,9 @@ controllerResources:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 5.0.5
+    tag: 5.1.9
   agentImage:
-    tag: 3.0.1
+    tag: 3.1.0
   datacenter: manager-dc
   racks:
     - name: manager-rack

--- a/test/e2e/fixture/scylla/basic.scyllacluster.yaml
+++ b/test/e2e/fixture/scylla/basic.scyllacluster.yaml
@@ -3,8 +3,8 @@ kind: ScyllaCluster
 metadata:
   generateName: basic-
 spec:
-  version: 5.0.5
-  agentVersion: 3.0.1
+  version: 5.1.9
+  agentVersion: 3.1.0
   developerMode: true
   datacenter:
     name: us-east-1

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	updateFromScyllaVersion  = "5.0.4"
-	updateToScyllaVersion    = "5.0.5"
-	upgradeFromScyllaVersion = "4.6.9"
-	upgradeToScyllaVersion   = "5.0.5"
+	updateFromScyllaVersion  = "5.1.8"
+	updateToScyllaVersion    = "5.1.9"
+	upgradeFromScyllaVersion = "5.0.12"
+	upgradeToScyllaVersion   = "5.1.9"
 
 	testTimeout = 45 * time.Minute
 )


### PR DESCRIPTION
Examples, e2e and the default version used by ScyllaDB and ScyllaDB Manager Helm charts was changed to 5.1.9 for ScyllaDB and 3.1.0 for ScyllaDB Manager Server and Agent.

