### PR TITLE
Extract container image name as a parameter in gen-release-notes 

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -16,6 +16,9 @@ inputs:
   genReleaseNotesVersionRef:
     description: "Version ref of gen-release-notes"
     required: true
+  containerImageName:
+    description: "Full name of the container image"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -91,6 +94,7 @@ runs:
       --previous-release-name="${previous_release_name}" \
       --github-token="${{ inputs.githubToken }}" \
       --repository="${{ inputs.githubRepository }}" \
+      --container-image-name="${{ inputs.containerImageName }}" \
       --loglevel=2 > ~/release_notes.md
       
       data="$( jq -n \

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -55,3 +55,4 @@ jobs:
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         goVersion: ${{ env.go_version }}
         genReleaseNotesVersionRef: master
+        containerImageName: docker.io/scylladb/scylla-operator

--- a/pkg/cmd/releasenotes/generate.go
+++ b/pkg/cmd/releasenotes/generate.go
@@ -49,6 +49,7 @@ func NewGenGitReleaseNotesCommand(ctx context.Context, streams genericclioptions
 	cmd.Flags().StringVar(&o.ReleaseName, "release-name", o.ReleaseName, "Name of the release.")
 	cmd.Flags().StringVar(&o.PreviousReleaseName, "previous-release-name", o.PreviousReleaseName, "Name of the previous release.")
 	cmd.Flags().StringVar(&o.RepositoryPath, "repository-path", o.RepositoryPath, "Path to the git repository.")
+	cmd.Flags().StringVar(&o.ContainerImageName, "container-image-name", o.Repository, `Full name of the container image.`)
 	cmd.Flags().StringVar(&o.Repository, "repository", o.Repository, `Name of repository in "owner/name" format.`)
 	cmd.Flags().StringVar(&o.StartRef, "start-ref", o.StartRef, "First commit reference, pull requests merged after this ref (including this ref) will be part of the release notes.")
 	cmd.Flags().StringVar(&o.EndRef, "end-ref", o.EndRef, "Last commit reference, pull requests merged before (including this ref) this ref will be part of the release notes.")

--- a/pkg/cmd/releasenotes/options.go
+++ b/pkg/cmd/releasenotes/options.go
@@ -26,14 +26,17 @@ type GenerateOptions struct {
 	StartRef            string
 	EndRef              string
 
+	ContainerImageName string
+
 	ghClient *githubql.Client
 }
 
 func NewGitGenerateOptions(streams genericclioptions.IOStreams) *GenerateOptions {
 	return &GenerateOptions{
-		IOStreams:      streams,
-		Repository:     "scylladb/scylla-operator",
-		RepositoryPath: ".",
+		IOStreams:          streams,
+		Repository:         "scylladb/scylla-operator",
+		ContainerImageName: "docker.io/scylladb/scylla-operator",
+		RepositoryPath:     ".",
 	}
 }
 
@@ -62,6 +65,10 @@ func (o *GenerateOptions) Validate() error {
 
 	if len(o.GithubToken) == 0 {
 		errs = append(errs, fmt.Errorf("github-token can't be empty"))
+	}
+
+	if len(o.ContainerImageName) == 0 {
+		errs = append(errs, fmt.Errorf("container-image-name can't be empty"))
 	}
 
 	if len(o.Repository) == 0 {

--- a/pkg/cmd/releasenotes/releasenotes.go
+++ b/pkg/cmd/releasenotes/releasenotes.go
@@ -69,7 +69,7 @@ func (o *GenerateOptions) Run(ctx context.Context) error {
 		return errors.NewAggregate(errs)
 	}
 
-	if err := renderReleaseNotes(o.Out, o.ReleaseName, o.PreviousReleaseName, filteredPRs); err != nil {
+	if err := renderReleaseNotes(o.Out, o.ContainerImageName, o.ReleaseName, o.PreviousReleaseName, filteredPRs); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/releasenotes/render.go
+++ b/pkg/cmd/releasenotes/render.go
@@ -17,7 +17,7 @@ const releaseNotesTemplate = `
 # Release notes for {{ .Release }}
 ## Container images
 
-` + "```\ndocker.io/scylladb/scylla-operator:{{ .Release }}\n```" + `
+` + "```\n{{ .ContainerImageName }}:{{ .Release }}\n```" + `
 
 ## Changes By Kind (since {{ .PreviousRelease }})
 
@@ -102,12 +102,13 @@ func categorizePullRequests(prs []*PullRequest) []section {
 }
 
 type releaseNoteData struct {
-	Sections        []section
-	Release         string
-	PreviousRelease string
+	Sections           []section
+	Release            string
+	PreviousRelease    string
+	ContainerImageName string
 }
 
-func renderReleaseNotes(out io.Writer, release, previousRelease string, pullRequests []*PullRequest) error {
+func renderReleaseNotes(out io.Writer, containerImageName, release, previousRelease string, pullRequests []*PullRequest) error {
 	// Render in the order of merge date.
 	sort.Slice(pullRequests, func(i, j int) bool {
 		return pullRequests[i].MergedAt.Before(pullRequests[j].MergedAt.Time)
@@ -116,9 +117,10 @@ func renderReleaseNotes(out io.Writer, release, previousRelease string, pullRequ
 	sections := categorizePullRequests(pullRequests)
 
 	data := releaseNoteData{
-		Release:         release,
-		PreviousRelease: previousRelease,
-		Sections:        sections,
+		Release:            release,
+		PreviousRelease:    previousRelease,
+		Sections:           sections,
+		ContainerImageName: containerImageName,
 	}
 
 	t := template.New("release-notes").Funcs(map[string]interface{}{


### PR DESCRIPTION
Current version had a hardcoded 'docker.io/scylladb/scylla-operator'.
This causes invalid image reference in release notes of different repositories
using this tool.