### PR TITLE
[WIP] Fix embedded metadata geration for CRDs and deprecate dedicated storage labels and annotations in ScyllaDBMonitoring/v1alpha1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ verify-codegen:
 # $2 - output dir
 # We need to cleanup `---` in the yaml output manually because it shouldn't be there and it breaks opm.
 define run-crd-gen
-	$(CONTROLLER_GEN) crd paths='$(1)' output:dir='$(2)'
+	$(CONTROLLER_GEN) crd paths='$(1)' output:dir='$(2)' crd:generateEmbeddedObjectMeta=true
 	find '$(2)' -mindepth 1 -maxdepth 1 -type f -name '*.yaml' -exec $(YQ) -i eval '.' {} \;
 
 endef

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1993,6 +1993,23 @@ spec:
                                       properties:
                                         metadata:
                                           description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
                                           type: object
                                         spec:
                                           description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
@@ -4320,18 +4337,35 @@ spec:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              description: "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations \n Deprecated: Use volumeClaimTemplate.metadata.annotations."
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              description: "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels \n Deprecated: Use volumeClaimTemplate.metadata.labels on volumeClaimTemplate."
                               type: object
                             volumeClaimTemplate:
                               description: volumeClaimTemplates is a PVC template defining storage to be used by Prometheus.
                               properties:
                                 metadata:
                                   description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    finalizers:
+                                      items:
+                                        type: string
+                                      type: array
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
                                   type: object
                                 spec:
                                   description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -1791,6 +1791,32 @@
                           "properties": {
                             "metadata": {
                               "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "finalizers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
                               "type": "object"
                             },
                             "spec": {

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -1680,6 +1680,32 @@
                       "properties": {
                         "metadata": {
                           "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "finalizers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
                           "type": "object"
                         },
                         "spec": {

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -1037,6 +1037,23 @@ spec:
                                       properties:
                                         metadata:
                                           description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
                                           type: object
                                         spec:
                                           description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbmonitorings.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbmonitorings.yaml
@@ -1177,18 +1177,35 @@ spec:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              description: "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations \n Deprecated: Use volumeClaimTemplate.metadata.annotations."
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              description: "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels \n Deprecated: Use volumeClaimTemplate.metadata.labels on volumeClaimTemplate."
                               type: object
                             volumeClaimTemplate:
                               description: volumeClaimTemplates is a PVC template defining storage to be used by Prometheus.
                               properties:
                                 metadata:
                                   description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    finalizers:
+                                      items:
+                                        type: string
+                                      type: array
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
                                   type: object
                                 spec:
                                   description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.

--- a/pkg/api/scylla/v1alpha1/types_monitoring.go
+++ b/pkg/api/scylla/v1alpha1/types_monitoring.go
@@ -78,6 +78,8 @@ type Storage struct {
 	// and services.
 	// More info: http://kubernetes.io/docs/user-guide/labels
 	// +optional
+	//
+	// Deprecated: Use volumeClaimTemplate.metadata.labels on volumeClaimTemplate.
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Annotations is an unstructured key value map stored with a resource that may be
@@ -85,6 +87,8 @@ type Storage struct {
 	// queryable and should be preserved when modifying objects.
 	// More info: http://kubernetes.io/docs/user-guide/annotations
 	// +optional
+	//
+	// Deprecated: Use volumeClaimTemplate.metadata.annotations.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// volumeClaimTemplates is a PVC template defining storage to be used by Prometheus.

--- a/pkg/externalapi/monitoring/v1/monitoring.coreos.com_alertmanagers.yaml
+++ b/pkg/externalapi/monitoring/v1/monitoring.coreos.com_alertmanagers.yaml
@@ -2849,6 +2849,23 @@ spec:
                           properties:
                             metadata:
                               description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
@@ -3578,6 +3595,23 @@ spec:
                             properties:
                               metadata:
                                 description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  finalizers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               spec:
                                 description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.

--- a/pkg/externalapi/monitoring/v1/monitoring.coreos.com_prometheuses.yaml
+++ b/pkg/externalapi/monitoring/v1/monitoring.coreos.com_prometheuses.yaml
@@ -3995,6 +3995,23 @@ spec:
                           properties:
                             metadata:
                               description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
@@ -5007,6 +5024,23 @@ spec:
                             properties:
                               metadata:
                                 description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  finalizers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               spec:
                                 description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.

--- a/pkg/externalapi/monitoring/v1/monitoring.coreos.com_thanosrulers.yaml
+++ b/pkg/externalapi/monitoring/v1/monitoring.coreos.com_thanosrulers.yaml
@@ -2736,6 +2736,23 @@ spec:
                           properties:
                             metadata:
                               description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
@@ -3450,6 +3467,23 @@ spec:
                             properties:
                               metadata:
                                 description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  finalizers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               spec:
                                 description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.


### PR DESCRIPTION
**Description of your changes:**
Some of our embedded types were missing metadata in the schemes. With that the dedicated labels and annotations can be deprecated.

Fixes #1249 