### PR TITLE
Fix seed propagation in test runner

### DIFF
--- a/pkg/cmd/tests/tests_run.go
+++ b/pkg/cmd/tests/tests_run.go
@@ -20,6 +20,7 @@ import (
 	gomegaformat "github.com/onsi/gomega/format"
 	"github.com/scylladb/scylla-operator/pkg/cmdutil"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	ginkgotest "github.com/scylladb/scylla-operator/pkg/test/ginkgo"
 	"github.com/scylladb/scylla-operator/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support"
@@ -38,6 +39,7 @@ import (
 const (
 	parallelShardFlagKey            = "parallel-shard"
 	parallelServerAddressFlagKey    = "parallel-server-address"
+	randomSeedFlagKey               = "random-seed"
 	ginkgoOutputInterceptorModeNone = "none"
 )
 
@@ -158,7 +160,7 @@ func NewRunCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVarP(&o.LabelFilter, "label-filter", "", o.LabelFilter, "Ginkgo label filter.")
 	cmd.Flags().StringSliceVarP(&o.FocusStrings, "focus", "", o.FocusStrings, "Regex to select a subset of tests to run.")
 	cmd.Flags().StringSliceVarP(&o.SkipStrings, "skip", "", o.SkipStrings, "Regex to select a subset of tests to skip.")
-	cmd.Flags().Int64VarP(&o.RandomSeed, "random-seed", "", o.RandomSeed, "Seed for the test suite.")
+	cmd.Flags().Int64VarP(&o.RandomSeed, randomSeedFlagKey, "", o.RandomSeed, "Seed for the test suite.")
 	cmd.Flags().BoolVarP(&o.DryRun, "dry-run", "", o.DryRun, "Doesn't execute the tests, only prints. Limited to serial execution.")
 	cmd.Flags().BoolVarP(&o.Color, "color", "", o.Color, "Colors the output.")
 	cmd.Flags().StringVarP(&o.OverrideIngressAddress, "override-ingress-address", "", o.OverrideIngressAddress, "This flag will override destination address when sending testing data to applications behind ingresses.")
@@ -411,6 +413,13 @@ func (o *RunOptions) run(ctx context.Context, streams genericclioptions.IOStream
 	}
 	commonArgs = append(commonArgs, fmt.Sprintf("--%s=%v", parallelServerAddressFlagKey, server.Address()))
 	commonArgs = append(commonArgs, fmt.Sprintf("--%s=%v", cmdutil.FlagLogLevelKey, o.ParallelLogLevel))
+
+	// Propagate random seed to child processes.
+	if !helpers.Contains(commonArgs, func(arg string) bool {
+		return strings.HasPrefix(arg, fmt.Sprintf("--%s", randomSeedFlagKey))
+	}) {
+		commonArgs = append(commonArgs, fmt.Sprintf("--%s=%v", randomSeedFlagKey, suiteConfig.RandomSeed))
+	}
 
 	type cmdEntry struct {
 		id  int

--- a/pkg/cmd/tests/tests_run.go
+++ b/pkg/cmd/tests/tests_run.go
@@ -428,9 +428,6 @@ func (o *RunOptions) run(ctx context.Context, streams genericclioptions.IOStream
 	}
 	cmdEntries := make([]*cmdEntry, 0, suiteConfig.ParallelTotal)
 	for i := 1; i <= suiteConfig.ParallelTotal; i++ {
-		suiteConfig := suiteConfig
-		suiteConfig.ParallelProcess = i
-
 		args := make([]string, 0, len(commonArgs)+1)
 		args = append(args, commonArgs...)
 		args = append(args, fmt.Sprintf("--%s=%v", parallelShardFlagKey, i))

--- a/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/client_server.go
+++ b/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/client_server.go
@@ -42,6 +42,8 @@ type Client interface {
 	PostSuiteWillBegin(report types.Report) error
 	PostDidRun(report types.SpecReport) error
 	PostSuiteDidEnd(report types.Report) error
+	PostReportBeforeSuiteCompleted(state types.SpecState) error
+	BlockUntilReportBeforeSuiteCompleted() (types.SpecState, error)
 	PostSynchronizedBeforeSuiteCompleted(state types.SpecState, data []byte) error
 	BlockUntilSynchronizedBeforeSuiteData() (types.SpecState, []byte, error)
 	BlockUntilNonprimaryProcsHaveFinished() error
@@ -49,6 +51,7 @@ type Client interface {
 	FetchNextCounter() (int, error)
 	PostAbort() error
 	ShouldAbort() bool
+	PostEmitProgressReport(report types.ProgressReport) error
 	Write(p []byte) (int, error)
 }
 

--- a/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/http_client.go
+++ b/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/http_client.go
@@ -94,6 +94,23 @@ func (client *httpClient) PostSuiteDidEnd(report types.Report) error {
 	return client.post("/suite-did-end", report)
 }
 
+func (client *httpClient) PostEmitProgressReport(report types.ProgressReport) error {
+	return client.post("/progress-report", report)
+}
+
+func (client *httpClient) PostReportBeforeSuiteCompleted(state types.SpecState) error {
+	return client.post("/report-before-suite-completed", state)
+}
+
+func (client *httpClient) BlockUntilReportBeforeSuiteCompleted() (types.SpecState, error) {
+	var state types.SpecState
+	err := client.poll("/report-before-suite-state", &state)
+	if err == ErrorGone {
+		return types.SpecStateFailed, nil
+	}
+	return state, err
+}
+
 func (client *httpClient) PostSynchronizedBeforeSuiteCompleted(state types.SpecState, data []byte) error {
 	beforeSuiteState := BeforeSuiteState{
 		State: state,

--- a/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/rpc_client.go
+++ b/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/rpc_client.go
@@ -77,6 +77,23 @@ func (client *rpcClient) Write(p []byte) (int, error) {
 	return n, err
 }
 
+func (client *rpcClient) PostEmitProgressReport(report types.ProgressReport) error {
+	return client.client.Call("Server.EmitProgressReport", report, voidReceiver)
+}
+
+func (client *rpcClient) PostReportBeforeSuiteCompleted(state types.SpecState) error {
+	return client.client.Call("Server.ReportBeforeSuiteCompleted", state, voidReceiver)
+}
+
+func (client *rpcClient) BlockUntilReportBeforeSuiteCompleted() (types.SpecState, error) {
+	var state types.SpecState
+	err := client.poll("Server.ReportBeforeSuiteState", &state)
+	if err == ErrorGone {
+		return types.SpecStateFailed, nil
+	}
+	return state, err
+}
+
 func (client *rpcClient) PostSynchronizedBeforeSuiteCompleted(state types.SpecState, data []byte) error {
 	beforeSuiteState := BeforeSuiteState{
 		State: state,

--- a/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/rpc_server.go
+++ b/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/rpc_server.go
@@ -40,7 +40,7 @@ func newRPCServer(parallelTotal int, reporter reporters.Reporter) (*RPCServer, e
 // Start the server.  You don't need to `go s.Start()`, just `s.Start()`
 func (server *RPCServer) Start() {
 	rpcServer := rpc.NewServer()
-	rpcServer.RegisterName("Server", server.handler) //register the handler's methods as the server
+	rpcServer.RegisterName("Server", server.handler) // register the handler's methods as the server
 
 	httpServer := &http.Server{}
 	httpServer.Handler = rpcServer

--- a/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/server_handler.go
+++ b/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support/server_handler.go
@@ -18,16 +18,17 @@ var voidSender Void
 // It handles all the business logic to avoid duplication between the two servers
 
 type ServerHandler struct {
-	done              chan interface{}
-	outputDestination io.Writer
-	reporter          reporters.Reporter
-	alives            []func() bool
-	lock              *sync.Mutex
-	beforeSuiteState  BeforeSuiteState
-	parallelTotal     int
-	counter           int
-	counterLock       *sync.Mutex
-	shouldAbort       bool
+	done                   chan interface{}
+	outputDestination      io.Writer
+	reporter               reporters.Reporter
+	alives                 []func() bool
+	lock                   *sync.Mutex
+	beforeSuiteState       BeforeSuiteState
+	reportBeforeSuiteState types.SpecState
+	parallelTotal          int
+	counter                int
+	counterLock            *sync.Mutex
+	shouldAbort            bool
 
 	numSuiteDidBegins int
 	numSuiteDidEnds   int
@@ -37,11 +38,12 @@ type ServerHandler struct {
 
 func newServerHandler(parallelTotal int, reporter reporters.Reporter) *ServerHandler {
 	return &ServerHandler{
-		reporter:          reporter,
-		lock:              &sync.Mutex{},
-		counterLock:       &sync.Mutex{},
-		alives:            make([]func() bool, parallelTotal),
-		beforeSuiteState:  BeforeSuiteState{Data: nil, State: types.SpecStateInvalid},
+		reporter:         reporter,
+		lock:             &sync.Mutex{},
+		counterLock:      &sync.Mutex{},
+		alives:           make([]func() bool, parallelTotal),
+		beforeSuiteState: BeforeSuiteState{Data: nil, State: types.SpecStateInvalid},
+
 		parallelTotal:     parallelTotal,
 		outputDestination: os.Stdout,
 		done:              make(chan interface{}),
@@ -108,6 +110,13 @@ func (handler *ServerHandler) EmitOutput(output []byte, n *int) error {
 	return err
 }
 
+func (handler *ServerHandler) EmitProgressReport(report types.ProgressReport, _ *Void) error {
+	handler.lock.Lock()
+	defer handler.lock.Unlock()
+	handler.reporter.EmitProgressReport(report)
+	return nil
+}
+
 func (handler *ServerHandler) registerAlive(proc int, alive func() bool) {
 	handler.lock.Lock()
 	defer handler.lock.Unlock()
@@ -131,6 +140,29 @@ func (handler *ServerHandler) haveNonprimaryProcsFinished() bool {
 		}
 	}
 	return true
+}
+
+func (handler *ServerHandler) ReportBeforeSuiteCompleted(reportBeforeSuiteState types.SpecState, _ *Void) error {
+	handler.lock.Lock()
+	defer handler.lock.Unlock()
+	handler.reportBeforeSuiteState = reportBeforeSuiteState
+
+	return nil
+}
+
+func (handler *ServerHandler) ReportBeforeSuiteState(_ Void, reportBeforeSuiteState *types.SpecState) error {
+	proc1IsAlive := handler.procIsAlive(1)
+	handler.lock.Lock()
+	defer handler.lock.Unlock()
+	if handler.reportBeforeSuiteState == types.SpecStateInvalid {
+		if proc1IsAlive {
+			return ErrorEarly
+		} else {
+			return ErrorGone
+		}
+	}
+	*reportBeforeSuiteState = handler.reportBeforeSuiteState
+	return nil
 }
 
 func (handler *ServerHandler) BeforeSuiteCompleted(beforeSuiteState BeforeSuiteState, _ *Void) error {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Unless a `random-seed` flag was provided explicitly to `scylla-operator-tests`, the default RandomSeed was not being propagated to child processes while running tests in parallel. This resulted in the workers generating the seeds themselves and hence a possibility of running with different seeds. Since ginkgo uses seed for ordering the specs (https://github.com/scylladb/scylla-operator/blob/a2cdd29417b536f798dc5b954f5b073c2bad69ec/vendor/github.com/onsi/ginkgo/v2/internal/ordering.go#L65), workers were being assigned overlapping subsets of specs, and in turn some specs were not being ran altogether.
This PR fixes the bug in test runner by always propagating the seed to its child processes. It also removes some unnecessary assignments and updates the internal Ginkgo files copied over from Ginkgo repository.

**Which issue is resolved by this Pull Request:**
Resolves #1245 #1176 
