### PR TITLE
Enhance handling of non-integer values around replica checks in Operator Helm Chart

### DIFF
--- a/helm/scylla-operator/templates/operator.pdb.yaml
+++ b/helm/scylla-operator/templates/operator.pdb.yaml
@@ -1,4 +1,4 @@
-{{- if gt .Values.replicas 1.0 }}
+{{- if gt (int .Values.replicas) 1 }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/helm/scylla-operator/templates/webhookserver.pdb.yaml
+++ b/helm/scylla-operator/templates/webhookserver.pdb.yaml
@@ -1,4 +1,4 @@
-{{- if gt .Values.webhookServerReplicas 1.0 }}
+{{- if gt (int .Values.webhookServerReplicas) 1 }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
**Description of your changes:**

This PR improves the replica checks in the operator.pdb.yaml and webhookserver.pdb.yaml templates. The conditions have been modified to handle non-integer values, enabling compatibility with commands such as 'helm install --set ...'.

**Which issue is resolved by this Pull Request:**
No GH issue has been opened so far.

PR improves compatibility with [helm CLI](https://helm.sh/docs/helm/helm_install/#:~:text=or%20use%20the%20%27%2D%2Dset%27%20flag%20and%20pass%20configuration%20from%20the%20command%20line) and indirectly with [set {} blocks](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#set) of Terraform's [helm provider](https://registry.terraform.io/providers/hashicorp/helm/latest/docs).

**Here is how to reproduce the problem:**
```bash 
$ helm -n scylla-operator install --set replicas=3 scylla-operator .
Error: INSTALLATION FAILED: template: scylla-operator/templates/operator.pdb.yaml:1:7: executing "scylla-operator/templates/operator.pdb.yaml" at <gt .Values.replicas 1.0>: error calling gt: incompatible types for comparison
$
```

