### PR TITLE
Fix Google GPG key file extension in Kubernetes setup GH action

### DIFF
--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -82,8 +82,8 @@ runs:
       sudo apt-get update
       sudo apt-get install -y --no-install-recommends conntrack socat ebtables
       
-      sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-      echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+      sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.asc https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.asc] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
       sudo apt-get update
       
       # Remove conflicting packages (also removes podman).


### PR DESCRIPTION
`gpg` extension may be interpreted wrong as `gpg` shall be treated as binary file. 
Google key is actually in plain text format. 
Chaning file extensions to the right one fixes an error on apt-get update.

