### PR TITLE
Add grafana example for haproxy monitoring

### DIFF
--- a/examples/third-party/haproxy-ingress/20_grafana.cm.yaml
+++ b/examples/third-party/haproxy-ingress/20_grafana.cm.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+data:
+  prometheus.yaml: |-
+    {
+        "apiVersion": 1,
+        "datasources": [
+            {
+               "access":"proxy",
+                "editable": true,
+                "name": "prometheus",
+                "orgId": 1,
+                "type": "prometheus",
+                "url": "http://prometheus.haproxy-ingress.svc:9090",
+                "version": 1
+            }
+        ]
+    }

--- a/examples/third-party/haproxy-ingress/20_grafana.deploy.yaml
+++ b/examples/third-party/haproxy-ingress/20_grafana.deploy.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      name: grafana
+      labels:
+        app: grafana
+    spec:
+      securityContext:
+        fsGroup: 472
+        supplementalGroups:
+          - 0
+      containers:
+      - name: grafana
+        image: grafana/grafana:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http-grafana
+          containerPort: 3000
+          protocol: TCP
+        readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /robots.txt
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+        livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3000
+            timeoutSeconds: 1
+        resources:
+          limits:
+            memory: "1Gi"
+            cpu: "1000m"
+          requests:
+            memory: 500M
+            cpu: "500m"
+        volumeMounts:
+          - mountPath: /var/lib/grafana
+            name: grafana-storage
+          - mountPath: /etc/grafana/provisioning/datasources
+            name: grafana-datasources
+            readOnly: false
+      volumes:
+        - name: grafana-storage
+          persistentVolumeClaim:
+            claimName: grafana-pvc
+        - name: grafana-datasources
+          configMap:
+              defaultMode: 420
+              name: grafana-datasources

--- a/examples/third-party/haproxy-ingress/20_grafana.pvc.yaml
+++ b/examples/third-party/haproxy-ingress/20_grafana.pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/third-party/haproxy-ingress/20_grafana.svc.yaml
+++ b/examples/third-party/haproxy-ingress/20_grafana.svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port:   '3000'
+spec:
+  selector:
+    app: grafana
+  sessionAffinity: None
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: http-grafana
+  type: LoadBalancer


### PR DESCRIPTION
**Description of your changes:**

Adds grafana example for haproxy monitoring.
The default user/password is admin/admin and needs to be changed at first login.

To apply, run `kubectl apply -n haproxy-ingress -f ./examples/third-party/haproxy-ingress/`

For local testing, forward port 3000, `kubectl port-forward service/grafana 3000:3000` and open localhost:3000.

It does not contain a dashboard, but one can be easily imported from, e.g. github.com/rfmoz/grafana-dashboards/blob/master/prometheus/haproxy-full.json or other places.

**Which issue is resolved by this Pull Request:**
Resolves #1236 
