### PR TITLE
updating chart readme + adding optional XFS storage class definition

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -25,10 +25,11 @@ You can then run `helm search repo scylla-operator` to see the charts.
 
 ```console
 # Install Scylla Operator
-$ helm install [NAME] scylla-operator/scylla-operator --create-namespace --namespace scylla-operator
+$ helm install [NAME] scylla-operator/scylla-operator --create-namespace --namespace scylla-operator     
 
 # Install Scylla Manager
 $ helm install [NAME] scylla-operator/scylla-manager --create-namespace --namespace scylla-manager
+    # scylla-manager imports scylla chart so you dont need to install `scylla` seperatley if you install it
 
 # Install Scylla 
 $ helm install [NAME] scylla-operator/scylla --create-namespace --namespace scylla

--- a/helm/scylla-operator/templates/xfs_storage_class.yaml
+++ b/helm/scylla-operator/templates/xfs_storage_class.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.storageClass.create }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: xfs-class-{{.Release.Name}}
+{{- if .Values.storageClass.create }}
+provisioner: {{ .Values.storageClass.provisioner }}
+{{- end }}
+parameters:
+  type: {{.Values.storageClass.type}}
+  csi.storage.k8s.io/fstype: xfs
+{{- if .Values.storageClass.volumeBindingMode }}
+volumeBindingMode: {{.Values.storageClass.volumeBindingMode}}
+{{- end}}
+{{- if .Values.storageClass.allowVolumeExpansion }}
+allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
+{{- end}}
+{{- end }}

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -23,6 +23,13 @@ nodeSelector: { }
 # Tolerations for Scylla Operator pods
 tolerations: [ ]
 
+storageClass:
+  create: true
+  type: standard
+  provisioner: ''
+  volumeBindingMode: 'WaitForFirstConsumer'
+  allowVolumeExpansion: true
+
 # Affinity for Scylla Operator pods
 affinity:
   podAntiAffinity:

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -24,7 +24,7 @@ nodeSelector: { }
 tolerations: [ ]
 
 storageClass:
-  create: true
+  create: false
   type: standard
   provisioner: ''
   volumeBindingMode: 'WaitForFirstConsumer'


### PR DESCRIPTION
- operator helm charet: now can create an xfs storage class that can be used by the scylla cluster
- updating helm README.md

K8S now supports XFS file system StorageClass and it can be created by the operator chart if enabled

// values.yaml
```
storageClass:
  create: true
  type: standard
  provisioner: ''
  volumeBindingMode: 'WaitForFirstConsumer'
  allowVolumeExpansion: true
```

k8s 1.24 also supports volume expansion that allows increasing disk size of existing PVC dynamically. The storage class the operator creates enables this flag by default.
