### PR TITLE
Fix flaky kubelet boot in CI

### DIFF
--- a/.github/actions/setup-kubernetes/action.yaml
+++ b/.github/actions/setup-kubernetes/action.yaml
@@ -161,6 +161,10 @@ runs:
       hairpinMode: hairpin-veth
       EOF
       
+      # After kubelet installation, kubelet service is started with the default config.
+      # Resetting using kubeadm clears kubelet config and state directories which allows for start from scratch.
+      sudo kubeadm reset --force --cri-socket=unix:///var/run/crio/crio.sock
+      
       sudo kubeadm init --config=/root/kubeadm-config.yaml
       
       mkdir -p "${HOME}/.kube"


### PR DESCRIPTION
Cleaning existing state and default config fixes failure in kubelet startup observed in CI:
```
kubelet[14083]: E0525 05:33:16.57140414083 kubelet.go:1480] "Failed to start ContainerManager" err="start cpu manager error: could not restore state from checkpoint: configured policy \"static\" differs from state checkpoint policy \"none\", please drain this node and delete the CPU manager checkpoint file \"/var/lib/kubelet/cpu_manager_state\" before restarting Kubelet"
```

Fixes #1265
