### PR TITLE
Fix EKS examples

### DIFF
--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -41,6 +41,10 @@ spec:
                   operator: In
                   values:
                     - us-east-1a
+                - key: scylla.scylladb.com/node-type
+                  operator: In
+                  values:
+                  - scylla
         tolerations:
           - key: role
             operator: Equal
@@ -64,6 +68,10 @@ spec:
                 operator: In
                 values:
                 - us-east-1b
+              - key: scylla.scylladb.com/node-type
+                operator: In
+                values:
+                - scylla
         tolerations:
         - key: role
           operator: Equal
@@ -87,6 +95,10 @@ spec:
                 operator: In
                 values:
                 - us-east-1c
+              - key: scylla.scylladb.com/node-type
+                operator: In
+                values:
+                - scylla
         tolerations:
         - key: role
           operator: Equal

--- a/examples/eks/eks-cluster.yaml
+++ b/examples/eks/eks-cluster.yaml
@@ -14,6 +14,8 @@ nodeGroups:
   desiredCapacity: 3
   labels:
     scylla.scylladb.com/node-type: scylla
+  taints:
+    role: "scylla-clusters:NoSchedule"
   ssh:
     allow: true
   kubeletExtraConfig:

--- a/examples/eks/nodeconfig-alpha.yaml
+++ b/examples/eks/nodeconfig-alpha.yaml
@@ -22,3 +22,8 @@ spec:
   placement:
     nodeSelector:
       scylla.scylladb.com/node-type: scylla
+    tolerations:
+    - effect: NoSchedule
+      key: role
+      operator: Equal
+      value: scylla-clusters


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** The existing EKS examples have minor issues:
- The scylla-pool nodes are missing taints, and the ScyllaCluster and NodeConfig nodes are missing corresponding tollerations.
- The deployment script tries to deploy the NodeConfig DaemonSet before the CRs are defined in the cluster. Additionally, there is a missing wait for rollout of deployment.apps/webhook-server, which can result in a failed deployment of NodeConfig.

**Which issue is resolved by this Pull Request:**
Resolves: minor issues with EKS examples
