### PR TITLE
Fix release notes generation

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -43,7 +43,7 @@ runs:
       cd ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator
       make build GO_BUILD_PACKAGES=./cmd/gen-release-notes --warn-undefined-variables
       
-      echo "${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator" >> ${GITHUB_PATH}
+      sudo mv ./gen-release-notes /usr/local/bin/gen-release-notes
   
   - uses: actions/checkout@v3
     with:


### PR DESCRIPTION
In case when release notes Action was executed with scylladb/scylla-operator repository gen-release-notes binary was built in the same directory where target repository was checked out. By default checkout action cleans the directory, which removed the binary resulting in missing command.

To overcome this, binary is moved to other PATH directory which won't be cleared out.
