### PR TITLE
Support scaling changes during ongoing scaling

### DIFF
--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -514,6 +514,7 @@ type RackCondition struct {
 type RackConditionType string
 
 const (
+	// Deprecated: in favor of RackConditionTypeMemberDecommissioning.
 	RackConditionTypeMemberLeaving         RackConditionType = "MemberLeaving"
 	RackConditionTypeUpgrading             RackConditionType = "RackUpgrading"
 	RackConditionTypeMemberReplacing       RackConditionType = "MemberReplacing"

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -81,6 +81,10 @@ func MemberService(sc *scyllav1.ScyllaCluster, rackName, name string, oldService
 		if hasReplaceLabel {
 			svcLabels[naming.ReplaceLabel] = replaceAddr
 		}
+
+		if decommissionLabel, ok := oldService.Labels[naming.DecommissionedLabel]; ok {
+			svcLabels[naming.DecommissionedLabel] = decommissionLabel
+		}
 	}
 
 	// Only new service should get the replace address, old service keeps "" until deleted.

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -380,7 +380,8 @@ func TestMemberService(t *testing.T) {
 						"internal.scylla-operator.scylladb.com/current-token-ring-hash": "abc",
 					},
 				},
-			}, jobs: nil,
+			},
+			jobs: nil,
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   basicSVCName,
@@ -430,6 +431,29 @@ func TestMemberService(t *testing.T) {
 					Selector:                 basicSVCSelector,
 					PublishNotReadyAddresses: true,
 					Ports:                    basicPorts,
+				},
+			},
+		},
+		{
+			name:          "existing service with decommission label carries it over into required object",
+			scyllaCluster: basicSC,
+			rackName:      basicRackName,
+			svcName:       basicSVCName,
+			oldService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						naming.DecommissionedLabel: naming.LabelValueFalse,
+					},
+				},
+			},
+			expectedService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: basicSVCName,
+					Labels: func() map[string]string {
+						labels := basicSVCLabels()
+						labels[naming.DecommissionedLabel] = naming.LabelValueFalse
+						return labels
+					}(),
 				},
 			},
 		},

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -43,6 +43,9 @@ const (
 
 	// CleanupJobTokenRingHashAnnotation reflects which version of token ring cleanup Job is cleaning.
 	CleanupJobTokenRingHashAnnotation = "internal.scylla-operator.scylladb.com/cleanup-token-ring-hash"
+
+	// NodeInitialized means given node was started.
+	NodeInitialized = "internal.scylla-operator.scylladb.com/node-initialized"
 )
 
 type ScyllaServiceType string

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -4,25 +4,265 @@ package scyllacluster
 
 import (
 	"context"
+	"sync/atomic"
+	"time"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/controller/scyllacluster"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
 	defer g.GinkgoRecover()
 
 	f := framework.NewFramework("scyllacluster")
+
+	g.It("should react on scaling up in the middle of scaling down", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc.Spec.Datacenter.Racks[0].Members = 3
+
+		framework.By("Creating a ScyllaCluster with 3 nodes")
+		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
+		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx1Cancel()
+		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		scyllaClient, _, err := utils.GetScyllaClient(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer scyllaClient.Close()
+
+		firstNodeIP, err := utils.NodeIndexToIP(ctx, f.KubeClient().CoreV1(), sc, sc.Spec.Datacenter.Racks[0], 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Scaling the ScyllaCluster to 1 node")
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+			ctx,
+			sc.Name,
+			types.JSONPatchType,
+			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 1}]`),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(1))
+
+		framework.By("Waiting for the ScyllaCluster to start decommissioning 3rd node (RV=%s)", sc.ResourceVersion)
+
+		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx2Cancel()
+
+		o.Eventually(func(g o.Gomega, ctx context.Context) {
+			nss, err := scyllaClient.Status(ctx, firstNodeIP)
+			g.Expect(err).NotTo(o.HaveOccurred())
+
+			thirdNodeID, err := utils.NodeIndexToHostID(ctx, f.KubeClient().CoreV1(), sc, sc.Spec.Datacenter.Racks[0], 2)
+			g.Expect(err).NotTo(o.HaveOccurred())
+			g.Expect(thirdNodeID).NotTo(o.BeEmpty())
+
+			for _, ns := range nss {
+				if ns.HostID == thirdNodeID {
+					klog.Infof("Node %q status %s%s", thirdNodeID, ns.Status, ns.State)
+
+					g.Expect(ns.Status).To(o.Equal(scyllaclient.NodeStatusUp))
+					g.Expect(ns.State).To(o.Equal(scyllaclient.NodeStateLeaving))
+				}
+			}
+		}).WithContext(waitCtx2).WithPolling(time.Second).Should(o.Succeed())
+
+		var secondNodeWasLeaving atomic.Bool
+		observerCtx, observerCancel := context.WithCancel(ctx)
+		defer observerCancel()
+		go func() {
+			defer g.GinkgoRecover()
+
+			wait.Until(func() {
+				statuses, err := scyllaClient.Status(ctx, firstNodeIP)
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				nodeHostID, err := utils.NodeIndexToHostID(ctx, f.KubeClient().CoreV1(), sc, sc.Spec.Datacenter.Racks[0], 1)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(nodeHostID).NotTo(o.BeEmpty())
+
+				for _, s := range statuses {
+					if s.HostID == nodeHostID {
+						if s.State == scyllaclient.NodeStateLeaving {
+							secondNodeWasLeaving.CompareAndSwap(false, true)
+						}
+						return
+					}
+				}
+			}, time.Second, observerCtx.Done())
+		}()
+
+		framework.By("Scaling up the ScyllaCluster to 4 replicas")
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+			ctx,
+			sc.Name,
+			types.JSONPatchType,
+			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 4}]`),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(4))
+
+		waitCtx3, waitCtx3Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx3Cancel()
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
+		sc, err = utils.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		o.Expect(secondNodeWasLeaving.Load()).To(o.BeFalse())
+	})
+
+	g.It("should react on scaling down in the middle of scaling up", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		framework.By("Limiting number of Pods to 5")
+		_, err := f.KubeAdminClient().CoreV1().ResourceQuotas(f.Namespace()).Create(
+			ctx,
+			&corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "limit",
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: corev1.ResourceList{
+						corev1.ResourcePods: resource.MustParse("5"),
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc.Spec.Datacenter.Racks[0].Members = 1
+
+		framework.By("Creating a ScyllaCluster with 1 member")
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
+		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx1Cancel()
+		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		framework.By("Scaling the ScyllaCluster to 10 replicas")
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+			ctx,
+			sc.Name,
+			types.JSONPatchType,
+			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 10}]`),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(10))
+
+		framework.By("Waiting for the ScyllaCluster to start progressing with 3rd node(RV=%s)", sc.ResourceVersion)
+
+		scyllaClient, _, err := utils.GetScyllaClient(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer scyllaClient.Close()
+
+		firstNodeIP, err := utils.NodeIndexToIP(ctx, f.KubeClient().CoreV1(), sc, sc.Spec.Datacenter.Racks[0], 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, func() *scyllav1.ScyllaCluster {
+			// Make a copy of sc with 3 members to properly calculate timeout - ContextForRollout takes number of replicas into account
+			scCopy := sc.DeepCopy()
+			scCopy.Spec.Datacenter.Racks[0].Members = 3
+			return scCopy
+		}())
+		defer waitCtx2Cancel()
+		o.Eventually(func(g o.Gomega, ctx context.Context) {
+			nss, err := scyllaClient.Status(ctx, firstNodeIP)
+			g.Expect(err).NotTo(o.HaveOccurred())
+
+			thirdNodeID, err := utils.NodeIndexToHostID(ctx, f.KubeClient().CoreV1(), sc, sc.Spec.Datacenter.Racks[0], 2)
+			g.Expect(err).NotTo(o.HaveOccurred())
+			g.Expect(thirdNodeID).NotTo(o.BeEmpty())
+
+			for _, ns := range nss {
+				if ns.HostID == thirdNodeID {
+					klog.Infof("Node %q status %s%s", thirdNodeID, ns.Status, ns.State)
+
+					g.Expect(ns.Status).To(o.Equal(scyllaclient.NodeStatusUp))
+					g.Expect(ns.State).To(o.Equal(scyllaclient.NodeStateJoining))
+				}
+			}
+		}).WithContext(waitCtx2).WithPolling(time.Second).Should(o.Succeed())
+
+		framework.By("Scaling down the ScyllaCluster to 2 replicas")
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+			ctx,
+			sc.Name,
+			types.JSONPatchType,
+			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 2}]`),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(2))
+
+		framework.By("Awaiting UP/LEAVING status from 3rd node")
+
+		waitCtx3, waitCtx3Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx3Cancel()
+
+		o.Eventually(func(g o.Gomega, ctx context.Context) {
+			nss, err := scyllaClient.Status(ctx, firstNodeIP)
+			g.Expect(err).NotTo(o.HaveOccurred())
+
+			thirdNodeID, err := utils.NodeIndexToHostID(ctx, f.KubeClient().CoreV1(), sc, sc.Spec.Datacenter.Racks[0], 2)
+			g.Expect(err).NotTo(o.HaveOccurred())
+			g.Expect(thirdNodeID).NotTo(o.BeEmpty())
+
+			for _, ns := range nss {
+				if ns.HostID == thirdNodeID {
+					klog.Infof("Node %q status %s%s", thirdNodeID, ns.Status, ns.State)
+
+					g.Expect(ns.Status).To(o.Equal(scyllaclient.NodeStatusUp))
+					g.Expect(ns.State).To(o.Equal(scyllaclient.NodeStateLeaving))
+				}
+			}
+		}).WithContext(waitCtx3).WithPolling(time.Second).Should(o.Succeed())
+
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
+		sc, err = utils.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+	})
 
 	g.It("should support scaling", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)


### PR DESCRIPTION
Decommissioning label reconcilation was moved from StatefulSet controller into Service controller.
StatefulSet controller can now react dynamically to scaling events occuring while scaling operations are still ongoing.

Fixes #1188
