### PR TITLE
Run node cleanup after scaling the ScyllaCluster 

### DIFF
--- a/pkg/cmd/operator/cleanupjob.go
+++ b/pkg/cmd/operator/cleanupjob.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2023 ScyllaDB.
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
+	"github.com/scylladb/scylla-operator/pkg/signals"
+	"github.com/scylladb/scylla-operator/pkg/version"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+)
+
+type CleanupJobOptions struct {
+	ManagerAuthConfigPath string
+	NodeAddress           string
+
+	scyllaClient *scyllaclient.Client
+}
+
+func NewCleanupJobOptions(streams genericclioptions.IOStreams) *CleanupJobOptions {
+	return &CleanupJobOptions{}
+}
+
+func NewCleanupJobCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewCleanupJobOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "cleanup-job",
+		Short: "Runs a cleanup procedure against a node.",
+		Long:  "Runs a cleanup procedure against a node.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate()
+			if err != nil {
+				return err
+			}
+
+			err = o.Complete()
+			if err != nil {
+				return err
+			}
+
+			err = o.Run(streams, cmd)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	cmd.Flags().StringVarP(&o.ManagerAuthConfigPath, "manager-auth-config-path", "", o.ManagerAuthConfigPath, "Path to a file containing Scylla Manager config containing auth token.")
+	cmd.Flags().StringVarP(&o.NodeAddress, "node-address", "", o.NodeAddress, "Address of a node where cleanup will be performed.")
+
+	return cmd
+}
+
+func (o *CleanupJobOptions) Validate() error {
+	var errs []error
+
+	if len(o.ManagerAuthConfigPath) == 0 {
+		errs = append(errs, fmt.Errorf("manager-auth-config-path cannot be empty"))
+	}
+
+	if len(o.NodeAddress) == 0 {
+		errs = append(errs, fmt.Errorf("node-address cannot be empty"))
+	}
+
+	return apierrors.NewAggregate(errs)
+}
+
+func (o *CleanupJobOptions) Complete() error {
+	var err error
+
+	buf, err := os.ReadFile(o.ManagerAuthConfigPath)
+	if err != nil {
+		return fmt.Errorf("can't read auth token file at %q: %w", o.ManagerAuthConfigPath, err)
+	}
+
+	authToken, err := helpers.ParseTokenFromConfig(buf)
+	if err != nil {
+		return fmt.Errorf("can't parse auth token file at %q: %w", o.ManagerAuthConfigPath, err)
+	}
+
+	if len(authToken) == 0 {
+		return fmt.Errorf("manager agent auth token cannot be empty")
+	}
+
+	o.scyllaClient, err = controllerhelpers.NewScyllaClientFromToken([]string{o.NodeAddress}, authToken)
+	if err != nil {
+		return fmt.Errorf("can't create scylla client: %w", err)
+	}
+
+	return nil
+}
+
+func (o *CleanupJobOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Command) error {
+	klog.InfoS("Starting the node cleanup", "version", version.Get())
+
+	defer func(startTime time.Time) {
+		klog.InfoS("Node cleanup completed", "duration", time.Since(startTime))
+	}(time.Now())
+
+	cliflag.PrintFlags(cmd.Flags())
+
+	stopCh := signals.StopChannel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	keyspaces, err := o.scyllaClient.Keyspaces(ctx)
+	if err != nil {
+		return fmt.Errorf("can't get list of keyspaces: %w", err)
+	}
+
+	klog.InfoS("Discovered keyspaces for cleanup", "keyspaces", keyspaces)
+
+	var errs []error
+	for _, keyspace := range keyspaces {
+		klog.InfoS("Starting a keyspace cleanup", "keyspace", keyspace)
+		startTime := time.Now()
+
+		err = o.scyllaClient.Cleanup(ctx, o.NodeAddress, keyspace)
+		if err != nil {
+			klog.Warningf("Can't cleanup keyspace %q: %s", keyspace, err)
+			errs = append(errs, fmt.Errorf("can't cleanup keyspace %q: %w", keyspace, err))
+			continue
+		}
+
+		klog.InfoS("Finished keyspace cleanup", "keyspace", keyspace, "duration", time.Since(startTime))
+	}
+
+	err = apierrors.NewAggregate(errs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -20,6 +20,7 @@ func NewOperatorCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(NewSidecarCmd(streams))
 	cmd.AddCommand(NewManagerControllerCmd(streams))
 	cmd.AddCommand(NewNodeSetupCmd(streams))
+	cmd.AddCommand(NewCleanupJobCmd(streams))
 
 	// TODO: wrap help func for the root command and every subcommand to add a line about automatic env vars and the prefix.
 

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -258,6 +258,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		kubeInformers.Apps().V1().StatefulSets(),
 		kubeInformers.Policy().V1().PodDisruptionBudgets(),
 		kubeInformers.Networking().V1().Ingresses(),
+		kubeInformers.Batch().V1().Jobs(),
 		scyllaInformers.Scylla().V1().ScyllaClusters(),
 		o.OperatorImage,
 		o.CQLSIngressPort,

--- a/pkg/controller/nodeconfigpod/sync_configmaps.go
+++ b/pkg/controller/nodeconfigpod/sync_configmaps.go
@@ -24,6 +24,10 @@ func (ncpc *Controller) makeConfigMap(ctx context.Context, pod *corev1.Pod) (*co
 		return nil, nil
 	}
 
+	if !controllerhelpers.IsScyllaPod(pod) {
+		return nil, nil
+	}
+
 	node, err := ncpc.nodeLister.Get(pod.Spec.NodeName)
 	if err != nil {
 		return nil, fmt.Errorf("can't get node: %w", err)

--- a/pkg/controller/scyllacluster/conditions.go
+++ b/pkg/controller/scyllacluster/conditions.go
@@ -18,4 +18,6 @@ const (
 	pdbControllerDegradedCondition               = "PDBControllerDegraded"
 	ingressControllerProgressingCondition        = "IngressControllerProgressing"
 	ingressControllerDegradedCondition           = "IngressControllerDegraded"
+	jobControllerProgressingCondition            = "JobControllerProgressing"
+	jobControllerDegradedCondition               = "JobControllerDegraded"
 )

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -9,6 +9,7 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/features"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -18,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
 )
 
 func TestMemberService(t *testing.T) {
@@ -42,8 +42,8 @@ func TestMemberService(t *testing.T) {
 			Kind:               "ScyllaCluster",
 			Name:               "basic",
 			UID:                "the-uid",
-			Controller:         pointer.Bool(true),
-			BlockOwnerDeletion: pointer.Bool(true),
+			Controller:         pointer.Ptr(true),
+			BlockOwnerDeletion: pointer.Ptr(true),
 		},
 	}
 	basicRackName := "rack"
@@ -433,13 +433,13 @@ func TestStatefulSetForRack(t *testing.T) {
 						Kind:               "ScyllaCluster",
 						Name:               "basic",
 						UID:                "the-uid",
-						Controller:         pointer.Bool(true),
-						BlockOwnerDeletion: pointer.Bool(true),
+						Controller:         pointer.Ptr(true),
+						BlockOwnerDeletion: pointer.Ptr(true),
 					},
 				},
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: pointer.Int32(0),
+				Replicas: pointer.Ptr(int32(0)),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: newBasicStatefulSetLabels(),
 				},
@@ -453,8 +453,8 @@ func TestStatefulSetForRack(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						SecurityContext: &corev1.PodSecurityContext{
-							RunAsUser:  pointer.Int64(0),
-							RunAsGroup: pointer.Int64(0),
+							RunAsUser:  pointer.Ptr(int64(0)),
+							RunAsGroup: pointer.Ptr(int64(0)),
 						},
 						Volumes: func() []corev1.Volume {
 							volumes := []corev1.Volume{
@@ -471,7 +471,7 @@ func TestStatefulSetForRack(t *testing.T) {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "scylla-config",
 											},
-											Optional: pointer.Bool(true),
+											Optional: pointer.Ptr(true),
 										},
 									},
 								},
@@ -480,7 +480,7 @@ func TestStatefulSetForRack(t *testing.T) {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName: "scylla-agent-config-secret",
-											Optional:   pointer.Bool(true),
+											Optional:   pointer.Ptr(true),
 										},
 									},
 								},
@@ -489,7 +489,7 @@ func TestStatefulSetForRack(t *testing.T) {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName: "scylla-client-config-secret",
-											Optional:   pointer.Bool(true),
+											Optional:   pointer.Ptr(true),
 										},
 									},
 								},
@@ -686,8 +686,8 @@ func TestStatefulSetForRack(t *testing.T) {
 									return mounts
 								}(),
 								SecurityContext: &corev1.SecurityContext{
-									RunAsUser:  pointer.Int64(0),
-									RunAsGroup: pointer.Int64(0),
+									RunAsUser:  pointer.Ptr(int64(0)),
+									RunAsGroup: pointer.Ptr(int64(0)),
 									Capabilities: &corev1.Capabilities{
 										Add: []corev1.Capability{"SYS_NICE"},
 									},
@@ -777,7 +777,7 @@ func TestStatefulSetForRack(t *testing.T) {
 						DNSPolicy:                     "ClusterFirstWithHostNet",
 						ServiceAccountName:            "basic-member",
 						Affinity:                      &corev1.Affinity{},
-						TerminationGracePeriodSeconds: pointer.Int64(900),
+						TerminationGracePeriodSeconds: pointer.Ptr(int64(900)),
 					},
 				},
 				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
@@ -802,7 +802,7 @@ func TestStatefulSetForRack(t *testing.T) {
 				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 					Type: appsv1.RollingUpdateStatefulSetStrategyType,
 					RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
-						Partition: pointer.Int32(0),
+						Partition: pointer.Ptr(int32(0)),
 					},
 				},
 			},
@@ -1112,7 +1112,7 @@ func TestMakeIngresses(t *testing.T) {
 				cluster.Spec.ExposeOptions = &scyllav1.ExposeOptions{
 					CQL: &scyllav1.CQLExposeOptions{
 						Ingress: &scyllav1.IngressOptions{
-							Disabled:         pointer.Bool(true),
+							Disabled:         pointer.Ptr(true),
 							IngressClassName: "cql-ingress-class",
 							Annotations: map[string]string{
 								"my-cql-custom-annotation": "my-cql-custom-annotation-value",
@@ -1170,13 +1170,13 @@ func TestMakeIngresses(t *testing.T) {
 								Kind:               "ScyllaCluster",
 								Name:               "basic",
 								UID:                "the-uid",
-								Controller:         pointer.BoolPtr(true),
-								BlockOwnerDeletion: pointer.BoolPtr(true),
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
 							},
 						},
 					},
 					Spec: networkingv1.IngressSpec{
-						IngressClassName: pointer.String("cql-ingress-class"),
+						IngressClassName: pointer.Ptr("cql-ingress-class"),
 						Rules: []networkingv1.IngressRule{
 							{
 								Host: "cql.public.scylladb.com",
@@ -1242,13 +1242,13 @@ func TestMakeIngresses(t *testing.T) {
 								Kind:               "ScyllaCluster",
 								Name:               "basic",
 								UID:                "the-uid",
-								Controller:         pointer.BoolPtr(true),
-								BlockOwnerDeletion: pointer.BoolPtr(true),
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
 							},
 						},
 					},
 					Spec: networkingv1.IngressSpec{
-						IngressClassName: pointer.String("cql-ingress-class"),
+						IngressClassName: pointer.Ptr("cql-ingress-class"),
 						Rules: []networkingv1.IngressRule{
 							{
 								Host: "host-id-1.cql.public.scylladb.com",
@@ -1314,13 +1314,13 @@ func TestMakeIngresses(t *testing.T) {
 								Kind:               "ScyllaCluster",
 								Name:               "basic",
 								UID:                "the-uid",
-								Controller:         pointer.BoolPtr(true),
-								BlockOwnerDeletion: pointer.BoolPtr(true),
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
 							},
 						},
 					},
 					Spec: networkingv1.IngressSpec{
-						IngressClassName: pointer.String("cql-ingress-class"),
+						IngressClassName: pointer.Ptr("cql-ingress-class"),
 						Rules: []networkingv1.IngressRule{
 							{
 								Host: "host-id-2.cql.public.scylladb.com",
@@ -1386,13 +1386,13 @@ func TestMakeIngresses(t *testing.T) {
 								Kind:               "ScyllaCluster",
 								Name:               "basic",
 								UID:                "the-uid",
-								Controller:         pointer.BoolPtr(true),
-								BlockOwnerDeletion: pointer.BoolPtr(true),
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
 							},
 						},
 					},
 					Spec: networkingv1.IngressSpec{
-						IngressClassName: pointer.String("cql-ingress-class"),
+						IngressClassName: pointer.Ptr("cql-ingress-class"),
 						Rules: []networkingv1.IngressRule{
 							{
 								Host: "host-id-3.cql.public.scylladb.com",

--- a/pkg/controller/scyllacluster/sync.go
+++ b/pkg/controller/scyllacluster/sync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/features"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -172,6 +173,21 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 		objectErrs = append(objectErrs, err)
 	}
 
+	jobMap, err := controllerhelpers.GetObjects[CT, *batchv1.Job](
+		ctx,
+		sc,
+		scyllaClusterControllerGVK,
+		scSelector,
+		controllerhelpers.ControlleeManagerGetObjectsFuncs[CT, *batchv1.Job]{
+			GetControllerUncachedFunc: scc.scyllaClient.ScyllaClusters(sc.Namespace).Get,
+			ListObjectsFunc:           scc.jobLister.Jobs(sc.Namespace).List,
+			PatchObjectFunc:           scc.kubeClient.BatchV1().Jobs(sc.Namespace).Patch,
+		},
+	)
+	if err != nil {
+		objectErrs = append(objectErrs, err)
+	}
+
 	objectErr := utilerrors.NewAggregate(objectErrs)
 	if objectErr != nil {
 		return objectErr
@@ -263,7 +279,7 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 		serviceControllerDegradedCondition,
 		sc.Generation,
 		func() ([]metav1.Condition, error) {
-			return scc.syncServices(ctx, sc, status, serviceMap, statefulSetMap)
+			return scc.syncServices(ctx, sc, status, serviceMap, statefulSetMap, jobMap)
 		},
 	)
 	if err != nil {
@@ -294,6 +310,19 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("can't sync ingresses: %w", err))
+	}
+
+	err = controllerhelpers.RunSync(
+		&status.Conditions,
+		jobControllerProgressingCondition,
+		jobControllerDegradedCondition,
+		sc.Generation,
+		func() ([]metav1.Condition, error) {
+			return scc.syncJobs(ctx, sc, serviceMap, jobMap)
+		},
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("can't sync jobs: %w", err))
 	}
 
 	// Aggregate conditions.

--- a/pkg/controller/scyllacluster/sync_jobs.go
+++ b/pkg/controller/scyllacluster/sync_jobs.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2023 ScyllaDB.
+
+package scyllacluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/resourceapply"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (scc *Controller) syncJobs(
+	ctx context.Context,
+	sc *scyllav1.ScyllaCluster,
+	services map[string]*corev1.Service,
+	jobs map[string]*batchv1.Job,
+) ([]metav1.Condition, error) {
+	requiredJobs, progressingConditions := MakeJobs(sc, services, scc.operatorImage)
+	if len(progressingConditions) != 0 {
+		return progressingConditions, nil
+	}
+
+	var progressingMessages []string
+	var errs []error
+
+	err := controllerhelpers.Prune(ctx, requiredJobs, jobs,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: scc.kubeClient.BatchV1().Jobs(sc.Namespace).Delete,
+		},
+		scc.eventRecorder,
+	)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't prune job(s): %w", err)
+	}
+
+	if sc.Status.ObservedGeneration == nil || (sc.Generation != *sc.Status.ObservedGeneration) {
+		progressingMessages = append(progressingMessages, fmt.Sprintf("Waiting for status update of ScyllaCluster %q", naming.ObjRef(sc)))
+	}
+
+	if apimeta.IsStatusConditionTrue(sc.Status.Conditions, statefulSetControllerProgressingCondition) {
+		progressingMessages = append(progressingMessages, fmt.Sprintf("Waiting for StatefulSet controller to finish progressing with ScyllaCluster %q", naming.ObjRef(sc)))
+	}
+
+	if !apimeta.IsStatusConditionTrue(sc.Status.Conditions, scyllav1.AvailableCondition) || !apimeta.IsStatusConditionFalse(sc.Status.Conditions, scyllav1.DegradedCondition) {
+		progressingMessages = append(progressingMessages, fmt.Sprintf("Waiting for ScyllaCluster %q nodes to be ready", naming.ObjRef(sc)))
+	}
+
+	if len(progressingMessages) != 0 {
+		progressingConditions = append(progressingConditions, metav1.Condition{
+			Type:               jobControllerProgressingCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             internalapi.ProgressingReason,
+			Message:            strings.Join(progressingMessages, "\n"),
+			ObservedGeneration: sc.Generation,
+		})
+
+		return progressingConditions, nil
+	}
+
+	for _, job := range requiredJobs {
+		fresh, changed, err := resourceapply.ApplyJob(ctx, scc.kubeClient.BatchV1(), scc.jobLister, scc.eventRecorder, job, resourceapply.ApplyOptions{})
+		if changed {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, jobControllerProgressingCondition, job, "apply", sc.Generation)
+		}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't apply Job: %w", err))
+			continue
+		}
+
+		if fresh.Status.CompletionTime == nil {
+			progressingConditions = append(progressingConditions, metav1.Condition{
+				Type:               jobControllerProgressingCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             "WaitingForJobCompletion",
+				Message:            fmt.Sprintf("Waiting for Job %q to complete.", naming.ObjRef(fresh)),
+				ObservedGeneration: sc.Generation,
+			})
+		}
+	}
+
+	return progressingConditions, nil
+}

--- a/pkg/controllerhelpers/scylla.go
+++ b/pkg/controllerhelpers/scylla.go
@@ -299,6 +299,10 @@ func IsScyllaPod(pod *corev1.Pod) bool {
 		return false
 	}
 
+	if !labels.SelectorFromSet(naming.ScyllaLabels()).Matches(labels.Set(pod.Labels)) {
+		return false
+	}
+
 	_, ok := pod.Labels[naming.ClusterNameLabel]
 	if !ok {
 		return false

--- a/pkg/helpers/agent.go
+++ b/pkg/helpers/agent.go
@@ -14,7 +14,7 @@ type agentAuthTokenSecret struct {
 	AuthToken string `yaml:"auth_token"`
 }
 
-func parseTokenFromConfig(data []byte) (string, error) {
+func ParseTokenFromConfig(data []byte) (string, error) {
 	config := &agentAuthTokenSecret{}
 	err := yaml.Unmarshal(data, config)
 	if err != nil {
@@ -30,7 +30,7 @@ func GetAgentAuthTokenFromAgentConfigSecret(secret *corev1.Secret) (string, erro
 		return "", fmt.Errorf("secret %q is missing %q data", naming.ObjRef(secret), naming.ScyllaAgentAuthTokenFileName)
 	}
 
-	return parseTokenFromConfig(configData)
+	return ParseTokenFromConfig(configData)
 }
 
 func GetAgentAuthTokenFromSecret(secret *corev1.Secret) (string, error) {
@@ -39,7 +39,7 @@ func GetAgentAuthTokenFromSecret(secret *corev1.Secret) (string, error) {
 		return "", fmt.Errorf("secret %q is missing %q data", naming.ObjRef(secret), naming.ScyllaAgentAuthTokenFileName)
 	}
 
-	return parseTokenFromConfig(configData)
+	return ParseTokenFromConfig(configData)
 }
 
 func GetAgentAuthTokenConfig(token string) ([]byte, error) {

--- a/pkg/helpers/array.go
+++ b/pkg/helpers/array.go
@@ -62,3 +62,13 @@ func IdentityFunc[T comparable](item T) func(T) bool {
 func ContainsItem[T comparable](slice []T, item T) bool {
 	return Contains(slice, IdentityFunc(item))
 }
+
+func Find[T comparable](slice []T, filterFunc func(T) bool) (T, bool) {
+	for i := range slice {
+		if filterFunc(slice[i]) {
+			return slice[i], true
+		}
+	}
+
+	return *new(T), false
+}

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -27,10 +27,19 @@ const (
 	LabelValueFalse = "false"
 )
 
-// Annotations used internally by sidecar controller.
+// Annotations used internally.
 const (
 	// HostIDAnnotation reflects the host_id of the scylla node.
 	HostIDAnnotation = "internal.scylla-operator.scylladb.com/host-id"
+
+	// CurrentTokenRingHashAnnotation reflects the current hash of token ring of the scylla node.
+	CurrentTokenRingHashAnnotation = "internal.scylla-operator.scylladb.com/current-token-ring-hash"
+
+	// LastCleanedUpTokenRingHashAnnotation reflects the last cleaned up hash of token ring of the scylla node.
+	LastCleanedUpTokenRingHashAnnotation = "internal.scylla-operator.scylladb.com/last-cleaned-up-token-ring-hash"
+
+	// CleanupJobTokenRingHashAnnotation reflects which version of token ring cleanup Job is cleaning.
+	CleanupJobTokenRingHashAnnotation = "internal.scylla-operator.scylladb.com/cleanup-token-ring-hash"
 )
 
 type ScyllaServiceType string
@@ -64,6 +73,8 @@ const (
 	OwnerUIDLabel                = "scylla-operator.scylladb.com/owner-uid"
 	ScyllaDBMonitoringNameLabel  = "scylla-operator.scylladb.com/scylladbmonitoring-name"
 	ControllerNameLabel          = "scylla-operator.scylladb.com/controller-name"
+	NodeJobLabel                 = "scylla-operator.scylladb.com/node-job"
+	NodeJobTypeLabel             = "scylla-operator.scylladb.com/node-job-type"
 
 	AppName           = "scylla"
 	OperatorAppName   = "scylla-operator"
@@ -85,6 +96,7 @@ const (
 	ScyllaContainerName          = "scylla"
 	SidecarInjectorContainerName = "sidecar-injection"
 	PerftuneContainerName        = "perftune"
+	CleanupContainerName         = "cleanup"
 
 	PVCTemplateName = "data"
 
@@ -147,4 +159,10 @@ type ProtocolDNSLabel string
 
 const (
 	CQLProtocolDNSLabel = "cql"
+)
+
+type NodeJobType string
+
+const (
+	JobTypeCleanup NodeJobType = "Cleanup"
 )

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -203,3 +203,7 @@ func GetCQLProtocolSubDomain(domain string) string {
 func GetCQLHostIDSubDomain(hostID, domain string) string {
 	return fmt.Sprintf("%s.%s", hostID, GetCQLProtocolSubDomain(domain))
 }
+
+func CleanupJobForService(svcName string) string {
+	return fmt.Sprintf("cleanup-%s", svcName)
+}

--- a/pkg/sidecar/identity/member.go
+++ b/pkg/sidecar/identity/member.go
@@ -49,10 +49,11 @@ func NewMemberFromObjects(service *corev1.Service, pod *corev1.Pod) *Member {
 }
 
 func (m *Member) GetSeed(ctx context.Context, coreClient v1.CoreV1Interface) (string, error) {
+	clusterLabels := naming.ScyllaLabels()
+	clusterLabels[naming.ClusterNameLabel] = m.Cluster
+
 	podList, err := coreClient.Pods(m.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labels.Set{
-			naming.ClusterNameLabel: m.Cluster,
-		}).String(),
+		LabelSelector: labels.SelectorFromSet(clusterLabels).String(),
 	})
 	if err != nil {
 		return "", err

--- a/pkg/sidecar/identity/member_test.go
+++ b/pkg/sidecar/identity/member_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,7 +23,10 @@ func TestMember_GetSeeds(t *testing.T) {
 				Name:      name,
 				Namespace: "namespace",
 				Labels: map[string]string{
-					naming.ClusterNameLabel: "my-cluster",
+					"scylla/cluster":               "my-cluster",
+					"app":                          "scylla",
+					"app.kubernetes.io/name":       "scylla",
+					"app.kubernetes.io/managed-by": "scylla-operator",
 				},
 				CreationTimestamp: metav1.NewTime(creationTimestamp),
 			},

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2023 ScyllaDB.
+
+package scyllacluster
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ = g.Describe("ScyllaCluster", func() {
+	defer g.GinkgoRecover()
+
+	f := framework.NewFramework("scyllacluster")
+
+	g.It("nodes are cleaned up after horizontal scaling", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc.Spec.Datacenter.Racks[0].Members = 1
+
+		jobListWatcher := &cache.ListWatch{
+			ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
+				return f.KubeClient().BatchV1().Jobs(f.Namespace()).List(ctx, options)
+			}),
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return f.KubeClient().BatchV1().Jobs(f.Namespace()).Watch(ctx, options)
+			},
+		}
+
+		framework.By("Creating a single node ScyllaCluster")
+
+		jobObserver := utils.ObserveObjects[*batchv1.Job](jobListWatcher)
+		err := jobObserver.Start(ctx)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
+		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx1Cancel()
+		sc, err = utils.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		framework.By("Validating no cleanup jobs were created")
+		jobEvents, err := jobObserver.Stop()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(jobEvents).To(o.BeEmpty())
+
+		framework.By("Scaling the ScyllaCluster to 3 replicas")
+
+		jobObserver = utils.ObserveObjects[*batchv1.Job](jobListWatcher)
+		err = jobObserver.Start(ctx)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+			ctx,
+			sc.Name,
+			types.JSONPatchType,
+			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 3}]`),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(3))
+
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
+		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx2Cancel()
+		sc, err = utils.WaitForScyllaClusterState(waitCtx2, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		framework.By("Validating cleanup jobs were created for all nodes except last one")
+		jobEvents, err = jobObserver.Stop()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(jobEvents).NotTo(o.BeEmpty())
+
+		nodeJobMatcher := func(nodeName string) func(utils.ObserverEvent[*batchv1.Job]) bool {
+			return func(e utils.ObserverEvent[*batchv1.Job]) bool {
+				return e.Obj.Labels[naming.NodeJobLabel] == nodeName
+			}
+		}
+
+		cleanupJobsCreated := helpers.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
+			return e.Action == watch.Added && e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup)
+		})
+
+		o.Expect(cleanupJobsCreated).To(o.HaveLen(2))
+		o.Expect(cleanupJobsCreated).To(o.ConsistOf(
+			o.Satisfy(nodeJobMatcher(naming.MemberServiceName(sc.Spec.Datacenter.Racks[0], sc, 0))),
+			o.Satisfy(nodeJobMatcher(naming.MemberServiceName(sc.Spec.Datacenter.Racks[0], sc, 1))),
+		))
+
+		framework.By("Scaling down the ScyllaCluster to 2 replicas")
+
+		jobObserver = utils.ObserveObjects[*batchv1.Job](jobListWatcher)
+		err = jobObserver.Start(ctx)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+			ctx,
+			sc.Name,
+			types.JSONPatchType,
+			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 2}]`),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(2))
+
+		framework.By("Waiting for the ScyllaCluster to rollout (RV=%s)", sc.ResourceVersion)
+		waitCtx3, waitCtx3Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx3Cancel()
+		sc, err = utils.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+
+		framework.By("Validating cleanup jobs were created for all nodes")
+		jobEvents, err = jobObserver.Stop()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(jobEvents).NotTo(o.BeEmpty())
+
+		cleanupJobsCreated = helpers.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
+			return e.Action == watch.Added && e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup)
+		})
+
+		o.Expect(cleanupJobsCreated).To(o.HaveLen(2))
+		o.Expect(cleanupJobsCreated).To(o.ConsistOf(
+			o.Satisfy(nodeJobMatcher(naming.MemberServiceName(sc.Spec.Datacenter.Racks[0], sc, 0))),
+			o.Satisfy(nodeJobMatcher(naming.MemberServiceName(sc.Spec.Datacenter.Racks[0], sc, 1))),
+		))
+	})
+})

--- a/test/e2e/set/scyllacluster/verify.go
+++ b/test/e2e/set/scyllacluster/verify.go
@@ -185,6 +185,14 @@ func verifyScyllaCluster(ctx context.Context, kubeClient kubernetes.Interface, s
 				condType: "IngressControllerDegraded",
 				status:   metav1.ConditionFalse,
 			},
+			{
+				condType: "JobControllerProgressing",
+				status:   metav1.ConditionFalse,
+			},
+			{
+				condType: "JobControllerDegraded",
+				status:   metav1.ConditionFalse,
+			},
 		}
 
 		if utilfeature.DefaultMutableFeatureGate.Enabled(features.AutomaticTLSCertificates) {

--- a/test/e2e/utils/observer.go
+++ b/test/e2e/utils/observer.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2023 ScyllaDB.
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/scylladb/scylla-operator/pkg/kubeinterfaces"
+	"k8s.io/apimachinery/pkg/util/wait"
+	watchutils "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/watch"
+)
+
+type ObserverEvent[T kubeinterfaces.ObjectInterface] struct {
+	Action watchutils.EventType
+	Obj    T
+}
+
+type ObjectObserver[T kubeinterfaces.ObjectInterface] struct {
+	Events []ObserverEvent[T]
+
+	lw cache.ListerWatcher
+
+	errChan chan error
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+func (o *ObjectObserver[T]) Start(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	o.cancel = cancel
+
+	_, informer, watcher, done := watch.NewIndexerInformerWatcher(o.lw, *new(T))
+
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		return fmt.Errorf("unable to sync caches: %w", ctx.Err())
+	}
+
+	o.wg.Add(1)
+	go func() {
+		defer o.wg.Done()
+		defer func() { <-done }()
+		defer watcher.Stop()
+
+		_, err := watch.UntilWithoutRetry(ctx, watcher, func(e watchutils.Event) (bool, error) {
+			o.Events = append(o.Events, ObserverEvent[T]{
+				Action: e.Type,
+				Obj:    e.Object.DeepCopyObject().(T),
+			})
+			return false, nil
+		})
+
+		if err != nil {
+			if errors.Is(ctx.Err(), context.Canceled) && wait.Interrupted(err) {
+				o.errChan <- nil
+				return
+			}
+			o.errChan <- err
+		}
+
+		o.errChan <- nil
+	}()
+
+	return nil
+}
+
+func (o *ObjectObserver[T]) Stop() ([]ObserverEvent[T], error) {
+	o.cancel()
+
+	o.wg.Wait()
+	err := <-o.errChan
+
+	return o.Events, err
+}
+
+func ObserveObjects[T kubeinterfaces.ObjectInterface](lw cache.ListerWatcher) ObjectObserver[T] {
+	return ObjectObserver[T]{
+		lw:      lw,
+		errChan: make(chan error, 1),
+	}
+}


### PR DESCRIPTION
Running node cleanup after scaling a cluster allows to avoid the
accumulation of unnecessary data on the node disks. When nodes are added
or removed from the cluster, they gain or lose some tokens, which can
result in files stored on the node disks still containing data
associated with lost tokens. Over time, this can lead to a build-up of
unnecessary data and cause disk space issues. By running node cleanup
after scaling, these files can be cleared, freeing up disk space.

Scylla Operator was extended with controllers responsible for executing
a cleanup on nodes after horizontally scaling.

Fixes https://github.com/scylladb/scylla-operator/issues/1317