### PR TITLE
Expose external seeds in ScyllaCluster

### DIFF
--- a/enhancements/proposals/1304-external-seeds/README.md
+++ b/enhancements/proposals/1304-external-seeds/README.md
@@ -132,6 +132,8 @@ In case of a new operator, if the `externalSeeds` are nil, the operator won't ta
 ## Implementation History
 
 - 2023-07-31: Initial enhancement proposal
+- 2023-08-23: Enhancement proposal merged
+- 2023-08-24: Initial enhancement implementation
 
 ## Drawbacks
 

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -2717,6 +2717,11 @@ spec:
                           type: object
                       type: object
                   type: object
+                externalSeeds:
+                  description: externalSeeds specifies the external seeds to propagate to ScyllaDB binary on startup as "seeds" parameter of seed-provider.
+                  items:
+                    type: string
+                  type: array
                 forceRedeploymentReason:
                   description: forceRedeploymentReason can be used to force a rolling update of all racks by providing a unique string.
                   type: string

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -270,6 +270,13 @@
           },
           "type": "object"
         },
+        "externalSeeds": {
+          "description": "externalSeeds specifies the external seeds to propagate to ScyllaDB binary on startup as \"seeds\" parameter of seed-provider.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "forceRedeploymentReason": {
           "description": "forceRedeploymentReason can be used to force a rolling update of all racks by providing a unique string.",
           "type": "string"

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -159,6 +159,13 @@
       },
       "type": "object"
     },
+    "externalSeeds": {
+      "description": "externalSeeds specifies the external seeds to propagate to ScyllaDB binary on startup as \"seeds\" parameter of seed-provider.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "forceRedeploymentReason": {
       "description": "forceRedeploymentReason can be used to force a rolling update of all racks by providing a unique string.",
       "type": "string"

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -1761,6 +1761,11 @@ spec:
                           type: object
                       type: object
                   type: object
+                externalSeeds:
+                  description: externalSeeds specifies the external seeds to propagate to ScyllaDB binary on startup as "seeds" parameter of seed-provider.
+                  items:
+                    type: string
+                  type: array
                 forceRedeploymentReason:
                   description: forceRedeploymentReason can be used to force a rolling update of all racks by providing a unique string.
                   type: string

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -106,6 +106,9 @@ type ScyllaClusterSpec struct {
 	// EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
 	// +optional
 	ExposeOptions *ExposeOptions `json:"exposeOptions,omitempty"`
+
+	// externalSeeds specifies the external seeds to propagate to ScyllaDB binary on startup as "seeds" parameter of seed-provider.
+	ExternalSeeds []string `json:"externalSeeds,omitempty"`
 }
 
 // ExposeOptions hold options related to exposing ScyllaCluster backends.

--- a/pkg/api/scylla/v1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1/zz_generated.deepcopy.go
@@ -534,6 +534,11 @@ func (in *ScyllaClusterSpec) DeepCopyInto(out *ScyllaClusterSpec) {
 		*out = new(ExposeOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExternalSeeds != nil {
+		in, out := &in.ExternalSeeds, &out.ExternalSeeds
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/cmd/operator/sidecar.go
+++ b/pkg/cmd/operator/sidecar.go
@@ -44,8 +44,9 @@ type SidecarOptions struct {
 	genericclioptions.ClientConfig
 	genericclioptions.InClusterReflection
 
-	ServiceName string
-	CPUCount    int
+	ServiceName   string
+	CPUCount      int
+	ExternalSeeds []string
 
 	kubeClient   kubernetes.Interface
 	scyllaClient scyllaversionedclient.Interface
@@ -97,6 +98,7 @@ func NewSidecarCmd(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.Flags().StringVarP(&o.ServiceName, "service-name", "", o.ServiceName, "Name of the service corresponding to the managed node.")
 	cmd.Flags().IntVarP(&o.CPUCount, "cpu-count", "", o.CPUCount, "Number of cpus to use.")
+	cmd.Flags().StringSliceVar(&o.ExternalSeeds, "external-seeds", o.ExternalSeeds, "The external seeds to propagate to ScyllaDB binary on startup as \"seeds\" parameter of seed-provider.")
 
 	return cmd
 }
@@ -359,7 +361,7 @@ func (o *SidecarOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Com
 
 	klog.V(2).InfoS("Starting scylla")
 
-	cfg := config.NewScyllaConfig(member, o.kubeClient, o.scyllaClient, o.CPUCount)
+	cfg := config.NewScyllaConfig(member, o.kubeClient, o.scyllaClient, o.CPUCount, o.ExternalSeeds)
 	scyllaCmd, err := cfg.Setup(ctx)
 	if err != nil {
 		return fmt.Errorf("can't set up scylla: %w", err)

--- a/pkg/helpers/array.go
+++ b/pkg/helpers/array.go
@@ -72,3 +72,13 @@ func Find[T comparable](slice []T, filterFunc func(T) bool) (T, bool) {
 
 	return *new(T), false
 }
+
+func Flatten[T any](xs [][]T) []T {
+	var res []T
+
+	for _, x := range xs {
+		res = append(res, x...)
+	}
+
+	return res
+}

--- a/pkg/helpers/collections.go
+++ b/pkg/helpers/collections.go
@@ -10,3 +10,11 @@ func MergeMaps[Key comparable, Value any](maps ...map[Key]Value) map[Key]Value {
 	}
 	return res
 }
+
+func GetMapValues[M ~map[K]V, K comparable, V any](m M) []V {
+	res := make([]V, 0, len(m))
+	for _, v := range m {
+		res = append(res, v)
+	}
+	return res
+}

--- a/pkg/scyllaclient/client.go
+++ b/pkg/scyllaclient/client.go
@@ -239,6 +239,18 @@ func (c *Client) StopCleanup(ctx context.Context, host string) error {
 	return nil
 }
 
+func (c *Client) GetSnitchDatacenter(ctx context.Context, host string) (string, error) {
+	resp, err := c.scyllaClient.Operations.SnitchDatacenterGet(&scyllaoperations.SnitchDatacenterGetParams{
+		Context: ctx,
+		Host:    &host,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.GetPayload(), nil
+}
+
 const (
 	snapshotTimeout = 5 * time.Minute
 	drainTimeout    = 5 * time.Minute

--- a/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2023 ScyllaDB
+
+package scyllacluster
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var _ = g.Describe("MultiDC cluster", func() {
+	defer g.GinkgoRecover()
+
+	f1 := framework.NewFramework("scyllacluster")
+	f2 := framework.NewFramework("scyllacluster")
+
+	g.It("should form when external seeds are provided to ScyllaClusters", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		sc1 := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc1.Name = "basic-cluster"
+		sc1.Spec.Datacenter.Name = "us-east-1"
+		sc1.Spec.Datacenter.Racks[0].Name = "us-east-1a"
+		sc1.Spec.Datacenter.Racks[0].Members = 3
+
+		framework.By("Creating first ScyllaCluster")
+		sc1, err := f1.ScyllaClient().ScyllaV1().ScyllaClusters(f1.Namespace()).Create(ctx, sc1, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the first ScyllaCluster to rollout (RV=%s)", sc1.ResourceVersion)
+		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc1)
+		defer waitCtx1Cancel()
+		sc1, err = utils.WaitForScyllaClusterState(waitCtx1, f1.ScyllaClient().ScyllaV1(), sc1.Namespace, sc1.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f1.KubeClient(), sc1)
+		hosts1 := getScyllaHostsAndWaitForFullQuorum(ctx, f1.KubeClient().CoreV1(), sc1)
+		di1 := insertAndVerifyCQLData(ctx, hosts1)
+		defer di1.Close()
+
+		sc2 := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc2.Name = "basic-cluster"
+		sc2.Spec.Datacenter.Name = "us-east-2"
+		sc2.Spec.Datacenter.Racks[0].Name = "us-east-2a"
+		sc2.Spec.Datacenter.Racks[0].Members = 3
+		sc2.Spec.ExternalSeeds = []string{
+			naming.CrossNamespaceServiceNameForCluster(sc1),
+		}
+
+		framework.By("Creating second ScyllaCluster")
+		sc2, err = f2.ScyllaClient().ScyllaV1().ScyllaClusters(f2.Namespace()).Create(ctx, sc2, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the second ScyllaCluster to rollout (RV=%s)", sc2.ResourceVersion)
+		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, sc2)
+		defer waitCtx2Cancel()
+		sc2, err = utils.WaitForScyllaClusterState(waitCtx2, f2.ScyllaClient().ScyllaV1(), sc2.Namespace, sc2.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, f2.KubeClient(), sc2)
+
+		framework.By("Verifying a multi datacenter cluster was formed with the first ScyllaCluster")
+		dcClientMap := make(map[string]corev1client.CoreV1Interface, 2)
+		dcClientMap[sc1.Spec.Datacenter.Name] = f1.KubeClient().CoreV1()
+		dcClientMap[sc2.Spec.Datacenter.Name] = f2.KubeClient().CoreV1()
+		hostsByDC := getScyllaHostsByDCAndWaitForFullQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc1, sc2})
+		o.Expect(hostsByDC[sc1.Spec.Datacenter.Name]).To(o.ConsistOf(hosts1))
+
+		di2 := insertAndVerifyCQLDataByDC(ctx, hostsByDC)
+		defer di2.Close()
+
+		framework.By("Verifying data of datacenter %q", sc1.Spec.Datacenter.Name)
+		verifyCQLData(ctx, di1)
+
+		framework.By("Verifying datacenter allocation of hosts")
+		scyllaClient, _, err := utils.GetScyllaClient(ctx, f2.KubeClient().CoreV1(), sc2)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer scyllaClient.Close()
+
+		for expectedDC, hosts := range hostsByDC {
+			for _, host := range hosts {
+				gotDC, err := scyllaClient.GetSnitchDatacenter(ctx, host)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(gotDC).To(o.Equal(expectedDC))
+			}
+		}
+	})
+})

--- a/test/e2e/set/scyllacluster/verify.go
+++ b/test/e2e/set/scyllacluster/verify.go
@@ -8,6 +8,7 @@ import (
 	o "github.com/onsi/gomega"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/features"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	cqlclientv1alpha1 "github.com/scylladb/scylla-operator/pkg/scylla/api/cqlclient/v1alpha1"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
@@ -260,12 +261,23 @@ func verifyScyllaCluster(ctx context.Context, kubeClient kubernetes.Interface, s
 }
 
 func getScyllaHostsAndWaitForFullQuorum(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) []string {
-	framework.By("Waiting for the ScyllaCluster to reach consistency ALL")
-	hosts, err := utils.GetScyllaHostsAndWaitForFullQuorum(ctx, client, sc)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	o.Expect(hosts).To(o.HaveLen(int(utils.GetMemberCount(sc))))
+	dcClientMap := make(map[string]corev1client.CoreV1Interface, 1)
+	dcClientMap[sc.Spec.Datacenter.Name] = client
+	hosts := getScyllaHostsByDCAndWaitForFullQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc})
+	return helpers.Flatten(helpers.GetMapValues(hosts))
+}
 
-	return hosts
+func getScyllaHostsByDCAndWaitForFullQuorum(ctx context.Context, dcClientMap map[string]corev1client.CoreV1Interface, scs []*scyllav1.ScyllaCluster) map[string][]string {
+	framework.By("Waiting for the ScyllaCluster(s) to reach consistency ALL")
+	dcHosts, err := utils.GetScyllaHostsByDCAndWaitForFullQuorum(ctx, dcClientMap, scs)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	for _, sc := range scs {
+		o.Expect(dcHosts).To(o.HaveKey(sc.Spec.Datacenter.Name))
+		o.Expect(dcHosts[sc.Spec.Datacenter.Name]).To(o.HaveLen(int(utils.GetMemberCount(sc))))
+	}
+
+	return dcHosts
 }
 
 func verifyCQLData(ctx context.Context, di *utils.DataInserter) {
@@ -279,11 +291,24 @@ func verifyCQLData(ctx context.Context, di *utils.DataInserter) {
 }
 
 func insertAndVerifyCQLData(ctx context.Context, hosts []string) *utils.DataInserter {
-	framework.By("Inserting data")
 	di, err := utils.NewDataInserter(hosts)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	err = di.Insert()
+	insertAndVerifyCQLDataUsingDataInserter(ctx, di)
+	return di
+}
+
+func insertAndVerifyCQLDataByDC(ctx context.Context, hosts map[string][]string) *utils.DataInserter {
+	di, err := utils.NewMultiDCDataInserter(hosts)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	insertAndVerifyCQLDataUsingDataInserter(ctx, di)
+	return di
+}
+
+func insertAndVerifyCQLDataUsingDataInserter(ctx context.Context, di *utils.DataInserter) *utils.DataInserter {
+	framework.By("Inserting data")
+	err := di.Insert()
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	verifyCQLData(ctx, di)

--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/gocqlx/v2/table"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
@@ -23,7 +24,7 @@ type DataInserter struct {
 	keyspace          string
 	table             *table.Table
 	data              []*TestData
-	replicationFactor int
+	replicationFactor map[string]int
 }
 
 type TestData struct {
@@ -32,6 +33,11 @@ type TestData struct {
 }
 
 func NewDataInserter(hosts []string) (*DataInserter, error) {
+	// Instead of specifying hosts for the provided datacenter, use 'replication_factor' as a single key to specify a default RF.
+	return NewMultiDCDataInserter(map[string][]string{"replication_factor": hosts})
+}
+
+func NewMultiDCDataInserter(dcHosts map[string][]string) (*DataInserter, error) {
 	keyspace := utilrand.String(8)
 	table := table.New(table.Metadata{
 		Name:    fmt.Sprintf(`"%s"."test"`, keyspace),
@@ -43,14 +49,19 @@ func NewDataInserter(hosts []string) (*DataInserter, error) {
 		data = append(data, &TestData{Id: i, Data: utilrand.String(32)})
 	}
 
+	replicationFactor := make(map[string]int, len(dcHosts))
+	for dc, hosts := range dcHosts {
+		replicationFactor[dc] = len(hosts)
+	}
+
 	di := &DataInserter{
 		keyspace:          keyspace,
 		table:             table,
 		data:              data,
-		replicationFactor: len(hosts),
+		replicationFactor: replicationFactor,
 	}
 
-	err := di.SetClientEndpoints(hosts)
+	err := di.SetClientEndpoints(helpers.Flatten(helpers.GetMapValues(dcHosts)))
 	if err != nil {
 		return nil, fmt.Errorf("can't set client endpoints: %w", err)
 	}
@@ -83,11 +94,17 @@ func (di *DataInserter) SetClientEndpoints(hosts []string) error {
 }
 
 func (di *DataInserter) Insert() error {
-	framework.Infof("Creating keyspace %q with RF %d", di.keyspace, di.replicationFactor)
+	ss := make([]string, 0, len(di.replicationFactor))
+	for dc, rf := range di.replicationFactor {
+		ss = append(ss, fmt.Sprintf("'%s': %d", dc, rf))
+	}
+	replicationFactor := strings.Join(ss, ",")
+
+	framework.Infof("Creating keyspace %q with RF %q", di.keyspace, replicationFactor)
 	err := di.session.ExecStmt(fmt.Sprintf(
-		`CREATE KEYSPACE %q WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': %d}`,
+		`CREATE KEYSPACE %q WITH replication = {'class': 'NetworkTopologyStrategy', %s}`,
 		di.keyspace,
-		di.replicationFactor,
+		replicationFactor,
 	))
 	if err != nil {
 		return fmt.Errorf("can't create keyspace: %w", err)


### PR DESCRIPTION
**Description of your changes:**
Currently, ScyllaDB Operator does not provide any support, neither automated, nor manual, for controlling external seeds propagated to ScyllaDB cluster nodes.
Controlling the provision of external seeds is a prerequisite for supporting both manual and automated setup of multi datacenter ScyllaDB clusters, a feature long requested by many of its users, and as such is a vital step on our roadmap.

This PR adds an option to expose external seeds in ScyllaClusters and extends the operator with necessary changes. It also adjusts our E2E framework and datainserter to support multi datacenter deployments and adds an E2E covering a multidatacenter deployment using external seeds.

The implementation is aligned with the proposal https://github.com/scylladb/scylla-operator/pull/1306.

**Which issue is resolved by this Pull Request:**
Resolves #1318 

**Prerequisites**:
- [x] https://github.com/scylladb/scylla-operator/pull/1306
