### PR TITLE
Bump ScyllaDB to 5.1.15 and ScyllaDB Manager to 3.1.2 in examples, Helm charts and e2e suites

### DIFF
--- a/deploy/manager/dev/50_manager_deployment.yaml
+++ b/deploy/manager/dev/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.0.0
+        image: docker.io/scylladb/scylla-manager:3.1.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -4,8 +4,8 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.0.5
-  agentVersion: 3.0.1
+  version: 5.1.15
+  agentVersion: 3.1.2
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager/prod/50_manager_deployment.yaml
+++ b/deploy/manager/prod/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.0.0
+        image: docker.io/scylladb/scylla-manager:3.1.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -4,8 +4,8 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.0.5
-  agentVersion: 3.0.1
+  version: 5.1.15
+  agentVersion: 3.1.2
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/examples/common/manager.yaml
+++ b/examples/common/manager.yaml
@@ -251,7 +251,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.0.0
+        image: docker.io/scylladb/scylla-manager:3.1.2
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager
@@ -282,8 +282,8 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.0.5
-  agentVersion: 3.0.1
+  version: 5.1.15
+  agentVersion: 3.1.2
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -13,8 +13,8 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 5.1.9
-  agentVersion: 3.1.0
+  version: 5.1.15
+  agentVersion: 3.1.2
   cpuset: true
   network:
     hostNetworking: true

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -15,8 +15,8 @@ metadata:
   name: simple-cluster
   namespace: scylla
 spec:
-  version: 5.1.9
-  agentVersion: 3.1.0
+  version: 5.1.15
+  agentVersion: 3.1.2
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -13,8 +13,8 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  version: 5.1.9
-  agentVersion: 3.1.0
+  version: 5.1.15
+  agentVersion: 3.1.2
   cpuset: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -1,8 +1,8 @@
 # Version information
 scyllaImage:
-  tag: 5.1.9
+  tag: 5.1.15
 agentImage:
-  tag: 3.1.0
+  tag: 3.1.2
 
 # Cluster information
 developerMode: true

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -1,6 +1,6 @@
 # Scylla Manager image
 image:
-  tag: 3.1.0
+  tag: 3.1.2
 
 # Resources allocated to Scylla Manager pods
 resources:
@@ -23,9 +23,9 @@ controllerResources:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 5.1.9
+    tag: 5.1.15
   agentImage:
-    tag: 3.1.0
+    tag: 3.1.2
   datacenter: manager-dc
   racks:
     - name: manager-rack

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -23,9 +23,9 @@ scylla:
   fullnameOverride: scylla-manager-cluster
   scyllaImage:
     repository: docker.io/scylladb/scylla
-    tag: 5.0.5
+    tag: 5.1.15
   agentImage:
-    tag: 3.0.1
+    tag: 3.1.2
     repository: docker.io/scylladb/scylla-manager-agent
   developerMode: true
   cpuset: true

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 image:
   repository: scylladb
   pullPolicy: IfNotPresent
-  tag: 3.0.0
+  tag: 3.1.2
 
 # Allows to customize Scylla Manager Controller image
 controllerImage:
@@ -73,9 +73,9 @@ controllerServiceAccount:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 4.3.0
+    tag: 5.1.15
   agentImage:
-    tag: 3.0.0
+    tag: 3.1.2
   datacenter: manager-dc
   racks:
   - name: manager-rack

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -7,12 +7,12 @@ fullnameOverride: ""
 scyllaImage:
   repository: scylladb/scylla
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 5.0.5
+  tag: 5.1.15
 # Allows to customize Scylla image
 agentImage:
   repository: scylladb/scylla-manager-agent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.0.1
+  tag: 3.1.2
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/test/e2e/fixture/scylla/basic.scyllacluster.yaml
+++ b/test/e2e/fixture/scylla/basic.scyllacluster.yaml
@@ -3,7 +3,7 @@ kind: ScyllaCluster
 metadata:
   generateName: basic-
 spec:
-  version: 5.1.9
+  version: 5.1.15
   agentVersion: 3.1.0
   developerMode: true
   datacenter:

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	updateFromScyllaVersion  = "5.1.8"
-	updateToScyllaVersion    = "5.1.9"
+	updateFromScyllaVersion  = "5.1.14"
+	updateToScyllaVersion    = "5.1.15"
 	upgradeFromScyllaVersion = "5.0.12"
-	upgradeToScyllaVersion   = "5.1.9"
+	upgradeToScyllaVersion   = "5.1.15"
 
 	testTimeout = 45 * time.Minute
 )


### PR DESCRIPTION
**Description of your changes:** In https://github.com/scylladb/scylla-operator/pull/1247, a couple of places were omitted. This PR bumps ScyllaDB version to 5.1.15 and ScyllaDB Manager to 3.1.2 in the missing parts.

**Which issue is resolved by this Pull Request:**
Resolves #1228 
