### PR TITLE
Fix variable defaulting and undefined variables in docs Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,22 +1,32 @@
 # You can set these variables from the command line.
-POETRY        := $(HOME)/.poetry/bin/poetry
-SPHINXBUILD   := $(POETRY) run sphinx-build
-SPHINXOPTS    :=
-PAPER         :=
-BUILDDIR      := _build
-SOURCEDIR     := source
-
-# For Windows users
 ifeq ($(OS),Windows_NT)
-    POETRY = $(APPDATA)\Python\Scripts\poetry
+# For Windows users
+POETRY ?= $(APPDATA)\Python\Scripts\poetry
+else
+POETRY ?= $(HOME)/.poetry/bin/poetry
 endif
 
+SPHINXBUILD ?= $(POETRY) run sphinx-build
+SPHINXOPTS ?=
+PAPER ?=
+BUILDDIR ?= _build
+SOURCEDIR ?= source
+OS ?=
+
+
 # Internal variables.
-PAPEROPT_a4     := -D latex_paper_size=a4
-PAPEROPT_letter := -D latex_paper_size=letter
-ALLSPHINXOPTS   := -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR) -W
+paperopt_a4 := -D latex_paper_size=a4
+paperopt_letter := -D latex_paper_size=letter
+
+ifdef $(PAPER)
+paperopt :=$(paperopt_$(PAPER))
+else
+paperopt :=
+endif
+
+ALLSPHINXOPTS ?= -d $(BUILDDIR)/doctrees $(paperopt) $(SPHINXOPTS) $(SOURCEDIR) -W
 # the i18n builder cannot share the environment and doctrees with the others
-I18NSPHINXOPTS  := $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR)
+I18NSPHINXOPTS ?= $(paperopt) $(SPHINXOPTS) $(SOURCEDIR)
 
 .PHONY: all
 all: dirhtml


### PR DESCRIPTION
**Description of your changes:**

Using unconditional assignment was overwriting env vars, which for poetry resulted in taking  the wrong binary that didn't exist.
`POETRY := $(HOME)/.poetry/bin/poetry`
```
 /tmp/tmp.tuESVb54FZ/.poetry/bin/poetry run sphinx-build -b dirhtml -d _build/doctrees  --keep-going source -W _build/dirhtml
make: /tmp/tmp.tuESVb54FZ/.poetry/bin/poetry: No such file or directory
```
Also there were some undefined variables that needed fixing
```
 + make --warn-undefined-variables dirhtml SPHINXOPTS=--keep-going
Makefile:10: warning: undefined variable 'OS'
Makefile:17: warning: undefined variable 'PAPEROPT_'
Makefile:19: warning: undefined variable 'PAPEROPT_' 
```
~And the spaces after assignments matter in make (taken as literal strings including the leading space).~

~Hopefully, defaulting the paper to a4 works as the default.~