### PR TITLE
Remove haproxy tunning that breaks GKE

### DIFF
--- a/examples/third-party/haproxy-ingress/10_haproxy-ingress.cm.yaml
+++ b/examples/third-party/haproxy-ingress/10_haproxy-ingress.cm.yaml
@@ -25,8 +25,6 @@ data:
     tune.idletimer 0
     tune.ssl.cachesize 200000
     tune.ssl.lifetime 300000
-    tune.pipesize 10485760
-    maxpipes 400000
   backend-config-snippet: |
     option splice-auto
     option splice-request


### PR DESCRIPTION
**Description of your changes:**
Most of the haproxy option were just initial attempts. The ones removed here were breaking deployment on GKE, so for now we'll go back to the defaults.