### PR TITLE
Create missing mount points when tuning nodes

### DIFF
--- a/pkg/controller/nodesetup/sync_mounts.go
+++ b/pkg/controller/nodesetup/sync_mounts.go
@@ -32,7 +32,7 @@ func (nsc *Controller) syncMounts(ctx context.Context, nc *scyllav1alpha1.NodeCo
 				Device:      device,
 				MountPoint:  mc.MountPoint,
 				FSType:      mc.FSType,
-				Options:     mc.UnsupportedOptions,
+				Options:     append([]string{"X-mount.mkdir"}, mc.UnsupportedOptions...),
 			}
 
 			mountUnit, err := mount.MakeUnit()
@@ -51,6 +51,9 @@ func (nsc *Controller) syncMounts(ctx context.Context, nc *scyllav1alpha1.NodeCo
 	if err != nil {
 		errs = append(errs, fmt.Errorf("can't ensure units: %w", err))
 	}
+
+	// TODO: Check mount units for failures.
+	//       https://github.com/scylladb/scylla-operator/issues/1334
 
 	err = utilerrors.NewAggregate(errs)
 	if err != nil {


### PR DESCRIPTION
**Description of your changes:**
On GKE the nodetuning was failing because of a missing mount. `X-mount.mkdir` makes sure it's always there.
