### PR TITLE
Bump ScyllaDB version used in replace via HostID e2e to latest 5.2.6

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -183,7 +183,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		g.Entry(describeEntry, &entry{
 			procedure:             "HostID",
 			scyllaImageRepository: scyllaOSImageRepository,
-			scyllaVersion:         "5.2.0",
+			scyllaVersion:         "5.2.6",
 			validateScyllaConfig:  validateReplaceViaHostID,
 		}),
 		// TODO: Enable test when ScyllaDB Enterprise 2023.1 is released


### PR DESCRIPTION
5.2.0 had a bug where a new node having the same IP as a node it replaced was considered as down after the replacement.
Ref: https://github.com/scylladb/scylladb/pull/13677

Fix is available from 5.2.1 onwards.

Fixes #1336