### PR TITLE
Enable pending replace e2e test awaiting for 2023.1.0 release

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -186,9 +186,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 			scyllaVersion:         "5.2.6",
 			validateScyllaConfig:  validateReplaceViaHostID,
 		}),
-		// TODO: Enable test when ScyllaDB Enterprise 2023.1 is released
-		//       Ref: https://github.com/scylladb/scylla-operator/issues/1325
-		g.PEntry(describeEntry, &entry{
+		g.Entry(describeEntry, &entry{
 			procedure:             "HostID",
 			scyllaImageRepository: scyllaEnterpriseImageRepository,
 			scyllaVersion:         "2023.1.0",


### PR DESCRIPTION
ScyllaDB Enterprise 2023.1.0 was released.

Fixes #1325