### PR TITLE
Increase e2e parallel jobs timeout

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -206,7 +206,7 @@ jobs:
     name: Test e2e parallel
     runs-on: ubuntu-22.04
     needs: images
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
       with:
@@ -240,7 +240,7 @@ jobs:
     name: Test e2e parallel (with alpha features)
     runs-on: ubuntu-22.04
     needs: images
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
When parallelism of e2e jobs was reduced by half, timeouts weren't changed in hope that they are high enough to accomodate test duration. After couple of CI iterations on master, where bigger test suite timed out without any flakes, it seems they aren't high enough.

Examples of these master runs:
1. https://github.com/scylladb/scylla-operator/actions/runs/5903238096/attempts/1
1. https://github.com/scylladb/scylla-operator/actions/runs/5903882928