### PR TITLE
Raise default ScyllaCluster storage capacity for e2es

### DIFF
--- a/test/e2e/fixture/scylla/basic.scyllacluster.yaml
+++ b/test/e2e/fixture/scylla/basic.scyllacluster.yaml
@@ -12,7 +12,7 @@ spec:
     - name: us-east-1a
       members: 1
       storage:
-        capacity: 300Mi
+        capacity: 500Mi
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
**Description of your changes:**
Raising default ScyllaCluster capacity from 300Mi to 500Mi

**Which issue is resolved by this Pull Request:**
My upgrage tests were hitting storage space issues
```
WARN  2023-08-21 10:10:08,075 [shard 1] commitlog - Exception in segment reservation: storage_io_error (Storage I/O error: 28: No space left on device)
WARN  2023-08-21 10:10:08,095 [shard 0] commitlog - Exception in segment reservation: storage_io_error (Storage I/O error: 28: No space left on device)
```
