### PR TITLE
Stop any ongoing cleanup on Job termination and on cleanup startup

### DIFF
--- a/pkg/scyllaclient/client.go
+++ b/pkg/scyllaclient/client.go
@@ -225,6 +225,20 @@ func (c *Client) Cleanup(ctx context.Context, host string, keyspace string) erro
 	return nil
 }
 
+func (c *Client) StopCleanup(ctx context.Context, host string) error {
+	ctx = forceHost(ctx, host)
+
+	_, err := c.scyllaClient.Operations.CompactionManagerStopCompactionPost(&scyllaoperations.CompactionManagerStopCompactionPostParams{
+		Context: ctx,
+		Type:    string(CleanupCompactionType),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 const (
 	snapshotTimeout = 5 * time.Minute
 	drainTimeout    = 5 * time.Minute

--- a/pkg/scyllaclient/model.go
+++ b/pkg/scyllaclient/model.go
@@ -117,6 +117,16 @@ func operationalModeFromString(str string) OperationalMode {
 	return OperationalModeUnknown
 }
 
+type CompactionType string
+
+const (
+	CompactionCompactionType CompactionType = "COMPACTION"
+	CleanupCompactionType    CompactionType = "CLEANUP"
+	ScrubCompactionType      CompactionType = "SCRUB"
+	UpgradeCompactionType    CompactionType = "UPGRADE"
+	ReshapeCompactionType    CompactionType = "RESHAPE"
+)
+
 // NodeStatusInfo represents a nodetool status line.
 type NodeStatusInfo struct {
 	HostID string


### PR DESCRIPTION
**Description of your changes:**

In case when Cleanup Job needs to be recreated by the Operator, the new
Job could complain about that it cannot execute cleanup operation, because there's
already one running.
Also when user would observe that maintenance operations have too big
impact on cluster performance he could decide to stop the cleanup.
Explicit stop is required as Scylla keeps cleaning even when API request
client disconnects.

In case when Cleanup Job was terminated ungracefully, a cleanup might
still be running in Scylla. As we can't keep track of it, a new one
needs to be started from the begining. To overcome an error returned by
Scylla API when cleanup is triggered and there's still one running, we
will stop all ongoing cleanups at the begining.

With this change all ongoing cleanup compactions are stopped when Cleanup Job terminates
due to received stop signal, and on each cleanup startup.

**Which issue is resolved by this Pull Request:**

Resolves #1343 
