### PR TITLE
Limit parallelism in e2e test suites in GH Action postsubmits

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -210,6 +210,7 @@ jobs:
         repositoryPath: ${{ env.git_repo_path }}
         jobSuffix: "parallel"
         suite: "scylla-operator/conformance/parallel"
+        extraArgs: "--parallelism=8"
 
   test-e2e-serial:
     name: Test e2e serial
@@ -245,6 +246,7 @@ jobs:
         jobSuffix: "parallel-alpha"
         suite: "scylla-operator/conformance/parallel"
         featureGates: "AllAlpha=true,AllBeta=true"
+        extraArgs: "--parallelism=8"
 
   test-e2e-serial-alpha:
     name: Test e2e serial (with alpha features)


### PR DESCRIPTION
Default was increased to 42 which is way too high for slow GH Actions workers.
