### PR TITLE
Align release schedule with team sprints

### DIFF
--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -5,7 +5,7 @@ We are aiming to ship a new release approximately every 6 weeks. The following r
 
 | Release | Code freeze | General availability |
 |:-------:|:-----------:|:--------------------:|
-|  1.11   | 2023-09-29  |      2023-10-06      |
+|  1.11   | 2023-10-02  |      2023-10-16      |
 
 ## Supported releases
 We support the latest 2 releases of the operator to give everyone time to upgrade.


### PR DESCRIPTION
When a GA makes it through the process sooner, we need to keep the schedule aligned with our sprints. This PR aligns the schedules. (Sprint 15 ends on Oct 15, so I postponed the release to the next working day.)