### PR TITLE
Migrate leader election to leases only

### DIFF
--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -37,9 +37,8 @@ func Run(ctx context.Context, programName, lockName, lockNamespace string, clien
 	id := hostname + "_" + string(uuid.NewUUID())
 	klog.V(4).Infof("Leader election ID is %q", id)
 
-	// TODO: Migrate to single lock using just coordination API in >=1.9.
 	lock, err := resourcelock.New(
-		resourcelock.ConfigMapsLeasesResourceLock,
+		resourcelock.LeasesResourceLock,
 		lockNamespace,
 		lockName,
 		client.CoreV1(),


### PR DESCRIPTION
**Description of your changes:**
This PR switches leader election from ConfigMap+Leases to Leases only, as we were already on the path with the combined elector and [it has been removed from client-go in 1.28](https://github.com/kubernetes/kubernetes/pull/117558)

This is needed to bump our deps to 1.28.

/cc zimnx