### PR TITLE
Use generic pointer.Ptr in entire project

### DIFF
--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
 )
 
 func TestValidateScyllaCluster(t *testing.T) {
@@ -226,7 +226,7 @@ func TestValidateScyllaClusterUpdate(t *testing.T) {
 		},
 		{
 			name: "empty rack with stale status",
-			old:  withStatus(unit.NewSingleRackCluster(0), v1.ScyllaClusterStatus{Racks: map[string]v1.RackStatus{"test-rack": {Stale: pointer.Bool(true), Members: 0}}}),
+			old:  withStatus(unit.NewSingleRackCluster(0), v1.ScyllaClusterStatus{Racks: map[string]v1.RackStatus{"test-rack": {Stale: pointer.Ptr(true), Members: 0}}}),
 			new:  racksDeleted(unit.NewSingleRackCluster(0)),
 			expectedErrorList: field.ErrorList{
 				&field.Error{Type: field.ErrorTypeInternal, Field: "spec.datacenter.racks[0]", Detail: `rack "test-rack" can't be removed because its status, that's used to determine members count, is not yet up to date with the generation of this resource; please retry later`},
@@ -235,7 +235,7 @@ func TestValidateScyllaClusterUpdate(t *testing.T) {
 		},
 		{
 			name: "empty rack with not reconciled generation",
-			old:  withStatus(withGeneration(unit.NewSingleRackCluster(0), 123), v1.ScyllaClusterStatus{ObservedGeneration: pointer.Int64(321), Racks: map[string]v1.RackStatus{"test-rack": {Members: 0}}}),
+			old:  withStatus(withGeneration(unit.NewSingleRackCluster(0), 123), v1.ScyllaClusterStatus{ObservedGeneration: pointer.Ptr(int64(321)), Racks: map[string]v1.RackStatus{"test-rack": {Members: 0}}}),
 			new:  racksDeleted(unit.NewSingleRackCluster(0)),
 			expectedErrorList: field.ErrorList{
 				&field.Error{Type: field.ErrorTypeInternal, Field: "spec.datacenter.racks[0]", Detail: `rack "test-rack" can't be removed because its status, that's used to determine members count, is not yet up to date with the generation of this resource; please retry later`},

--- a/pkg/controller/manager/sync_test.go
+++ b/pkg/controller/manager/sync_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/mermaidclient"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestManagerSynchronization(t *testing.T) {
@@ -69,7 +69,7 @@ func TestManagerSynchronization(t *testing.T) {
 			Name: "Cluster registered in manager but auth token is different, update and requeue",
 			Spec: v1.ScyllaClusterSpec{},
 			Status: v1.ScyllaClusterStatus{
-				ManagerID: pointer.StringPtr(clusterID),
+				ManagerID: pointer.Ptr(clusterID),
 			},
 			State: state{
 				Clusters: []*mermaidclient.Cluster{{
@@ -86,7 +86,7 @@ func TestManagerSynchronization(t *testing.T) {
 			Name: "Name collision, delete old one, add new and requeue",
 			Spec: v1.ScyllaClusterSpec{},
 			Status: v1.ScyllaClusterStatus{
-				ManagerID: pointer.StringPtr(clusterID),
+				ManagerID: pointer.Ptr(clusterID),
 			},
 			State: state{
 				Clusters: []*mermaidclient.Cluster{{
@@ -120,7 +120,7 @@ func TestManagerSynchronization(t *testing.T) {
 				},
 			},
 			Status: v1.ScyllaClusterStatus{
-				ManagerID: pointer.StringPtr(clusterID),
+				ManagerID: pointer.Ptr(clusterID),
 			},
 			State: state{
 				Clusters: []*mermaidclient.Cluster{{
@@ -153,7 +153,7 @@ func TestManagerSynchronization(t *testing.T) {
 				},
 			},
 			Status: v1.ScyllaClusterStatus{
-				ManagerID: pointer.StringPtr(clusterID),
+				ManagerID: pointer.Ptr(clusterID),
 			},
 			State: state{
 				Clusters: []*mermaidclient.Cluster{{
@@ -181,7 +181,7 @@ func TestManagerSynchronization(t *testing.T) {
 				},
 			},
 			Status: v1.ScyllaClusterStatus{
-				ManagerID: pointer.StringPtr(clusterID),
+				ManagerID: pointer.Ptr(clusterID),
 				Repairs: []v1.RepairTaskStatus{
 					{
 						ID: "repair-id",
@@ -237,7 +237,7 @@ func TestManagerSynchronization(t *testing.T) {
 				},
 			},
 			Status: v1.ScyllaClusterStatus{
-				ManagerID: pointer.StringPtr(clusterID),
+				ManagerID: pointer.Ptr(clusterID),
 				Repairs: []v1.RepairTaskStatus{
 					{
 						ID: "repair-id",
@@ -281,7 +281,7 @@ func TestManagerSynchronization(t *testing.T) {
 			Name: "Delete tasks from Manager unknown to spec",
 			Spec: v1.ScyllaClusterSpec{},
 			Status: v1.ScyllaClusterStatus{
-				ManagerID: pointer.StringPtr(clusterID),
+				ManagerID: pointer.Ptr(clusterID),
 			},
 			State: state{
 				Clusters: []*mermaidclient.Cluster{{

--- a/pkg/controller/manager/types_old.go
+++ b/pkg/controller/manager/types_old.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/mermaidclient"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/util/duration"
-	"k8s.io/utils/pointer"
 )
 
 type RepairTask v1.RepairTaskStatus
@@ -76,7 +76,7 @@ func (r *RepairTask) FromManager(t *mermaidclient.ExtendedTask) error {
 	r.Name = t.Name
 	r.Interval = t.Schedule.Interval
 	r.StartDate = t.Schedule.StartDate.String()
-	r.NumRetries = pointer.Int64Ptr(t.Schedule.NumRetries)
+	r.NumRetries = pointer.Ptr(t.Schedule.NumRetries)
 
 	props := t.Properties.(map[string]interface{})
 	if err := mapstructure.Decode(props, r); err != nil {
@@ -143,7 +143,7 @@ func (b *BackupTask) FromManager(t *mermaidclient.ExtendedTask) error {
 	b.Name = t.Name
 	b.Interval = t.Schedule.Interval
 	b.StartDate = t.Schedule.StartDate.String()
-	b.NumRetries = pointer.Int64Ptr(t.Schedule.NumRetries)
+	b.NumRetries = pointer.Ptr(t.Schedule.NumRetries)
 
 	props := t.Properties.(map[string]interface{})
 	if err := mapstructure.Decode(props, b); err != nil {

--- a/pkg/controller/nodeconfigpod/resource_test.go
+++ b/pkg/controller/nodeconfigpod/resource_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestMakeConfigMap(t *testing.T) {
@@ -39,8 +39,8 @@ func TestMakeConfigMap(t *testing.T) {
 							Kind:               "Pod",
 							Name:               "bar",
 							UID:                "42",
-							BlockOwnerDeletion: pointer.BoolPtr(true),
-							Controller:         pointer.Bool(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
+							Controller:         pointer.Ptr(true),
 						},
 					},
 					Labels: map[string]string{

--- a/pkg/controller/nodetune/resource.go
+++ b/pkg/controller/nodetune/resource.go
@@ -8,12 +8,12 @@ import (
 	"path"
 
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 )
 
 // TODO: set anti affinities so config jobs don't run on the same node at the same time
@@ -47,7 +47,7 @@ func makePerftuneJobForNode(controllerRef *metav1.OwnerReference, namespace, nod
 		},
 		Spec: batchv1.JobSpec{
 			// TODO: handle failed jobs and retry.
-			BackoffLimit: pointer.Int32Ptr(math.MaxInt32),
+			BackoffLimit: pointer.Ptr(int32(math.MaxInt32)),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
@@ -73,7 +73,7 @@ func makePerftuneJobForNode(controllerRef *metav1.OwnerReference, namespace, nod
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.BoolPtr(true),
+								Privileged: pointer.Ptr(true),
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								makeVolumeMount("host-sys-class", "/sys/class", false),
@@ -157,7 +157,7 @@ func makePerftuneJobForContainers(controllerRef *metav1.OwnerReference, namespac
 		},
 		Spec: batchv1.JobSpec{
 			// TODO: handle failed jobs and retry.
-			BackoffLimit: pointer.Int32Ptr(math.MaxInt32),
+			BackoffLimit: pointer.Ptr(int32(math.MaxInt32)),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
@@ -183,7 +183,7 @@ func makePerftuneJobForContainers(controllerRef *metav1.OwnerReference, namespac
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.BoolPtr(true),
+								Privileged: pointer.Ptr(true),
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								makeVolumeMount("hostfs", "/host", false),

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -412,7 +412,7 @@ func TestMemberService(t *testing.T) {
 						},
 					},
 					Status: batchv1.JobStatus{
-						CompletionTime: pointer.Time(metav1.Now()),
+						CompletionTime: pointer.Ptr(metav1.Now()),
 					},
 				},
 			},

--- a/pkg/controller/scyllacluster/status.go
+++ b/pkg/controller/scyllacluster/status.go
@@ -7,12 +7,12 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 )
 
 func (scc *Controller) updateStatus(ctx context.Context, currentSC *scyllav1.ScyllaCluster, status *scyllav1.ScyllaClusterStatus) error {
@@ -73,8 +73,8 @@ func (scc *Controller) calculateRackStatus(sc *scyllav1.ScyllaCluster, rackName 
 
 	status.Members = *sts.Spec.Replicas
 	status.ReadyMembers = sts.Status.ReadyReplicas
-	status.UpdatedMembers = pointer.Int32Ptr(sts.Status.UpdatedReplicas)
-	status.Stale = pointer.BoolPtr(sts.Status.ObservedGeneration < sts.Generation)
+	status.UpdatedMembers = pointer.Ptr(sts.Status.UpdatedReplicas)
+	status.Stale = pointer.Ptr(sts.Status.ObservedGeneration < sts.Generation)
 
 	// Update Rack Version
 	if status.Members == 0 {
@@ -123,7 +123,7 @@ func (scc *Controller) calculateRackStatus(sc *scyllav1.ScyllaCluster, rackName 
 // If a particular object can be missing, it should be reflected in the value itself, like "Unknown" or "".
 func (scc *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, statefulSetMap map[string]*appsv1.StatefulSet, serviceMap map[string]*corev1.Service) *scyllav1.ScyllaClusterStatus {
 	status := sc.Status.DeepCopy()
-	status.ObservedGeneration = pointer.Int64Ptr(sc.Generation)
+	status.ObservedGeneration = pointer.Ptr(sc.Generation)
 
 	// Clear the previous rack status.
 	status.Racks = map[string]scyllav1.RackStatus{}

--- a/pkg/controller/scyllacluster/sync_certs_test.go
+++ b/pkg/controller/scyllacluster/sync_certs_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func Test_makeScyllaConnectionConfig(t *testing.T) {
@@ -69,8 +69,8 @@ func Test_makeScyllaConnectionConfig(t *testing.T) {
 							APIVersion:         "scylla.scylladb.com/v1",
 							Kind:               "ScyllaCluster",
 							Name:               "bar",
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 				},
@@ -151,8 +151,8 @@ parameters:
 							APIVersion:         "scylla.scylladb.com/v1",
 							Kind:               "ScyllaCluster",
 							Name:               "bar",
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 				},

--- a/pkg/controller/scyllacluster/sync_statefulsets.go
+++ b/pkg/controller/scyllacluster/sync_statefulsets.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 	"github.com/scylladb/scylla-operator/pkg/util/parallel"
@@ -28,7 +29,6 @@ import (
 	setsutil "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 )
 
 type UpgradePhase string
@@ -701,8 +701,8 @@ func (scc *Controller) syncStatefulSets(
 				// It also forces our informers to be up-to-date.
 				required.ResourceVersion = existing.ResourceVersion
 				// Avoid scaling.
-				required.Spec.Replicas = pointer.Int32Ptr(*existing.Spec.Replicas)
-				required.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(*existing.Spec.Replicas)
+				required.Spec.Replicas = pointer.Ptr(*existing.Spec.Replicas)
+				required.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Ptr(*existing.Spec.Replicas)
 				// Use apply to also update the spec.template
 				updatedSts, changed, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, required, resourceapply.ApplyOptions{})
 				if err != nil {
@@ -808,7 +808,7 @@ func (scc *Controller) syncStatefulSets(
 
 					}
 
-					freshSts.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(nextPartition)
+					freshSts.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Ptr(nextPartition)
 					_, err = scc.kubeClient.AppsV1().StatefulSets(freshSts.Namespace).Update(ctx, freshSts, metav1.UpdateOptions{})
 					if err != nil {
 						return err

--- a/pkg/controller/scylladbmonitoring/status.go
+++ b/pkg/controller/scylladbmonitoring/status.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 )
 
 // calculateStatus calculates the ScyllaDBMonitoring status.
@@ -15,7 +15,7 @@ import (
 // If a particular object can be missing, it should be reflected in the value itself, like "Unknown" or "".
 func (smc *Controller) calculateStatus(sm *scyllav1alpha1.ScyllaDBMonitoring) *scyllav1alpha1.ScyllaDBMonitoringStatus {
 	status := sm.Status.DeepCopy()
-	status.ObservedGeneration = pointer.Int64(sm.Generation)
+	status.ObservedGeneration = pointer.Ptr(sm.Generation)
 
 	return status
 }

--- a/pkg/controller/scylladbmonitoring/sync_grafana.go
+++ b/pkg/controller/scylladbmonitoring/sync_grafana.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	okubecrypto "github.com/scylladb/scylla-operator/pkg/kubecrypto"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/resource"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	"github.com/scylladb/scylla-operator/pkg/resourcemerge"
@@ -24,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
 )
 
 const (
@@ -477,8 +477,8 @@ func (smc *Controller) syncGrafana(
 				Kind:               scylladbMonitoringControllerGVK.Kind,
 				Name:               sm.Name,
 				UID:                sm.UID,
-				Controller:         pointer.Bool(true),
-				BlockOwnerDeletion: pointer.Bool(true),
+				Controller:         pointer.Ptr(true),
+				BlockOwnerDeletion: pointer.Ptr(true),
 			},
 		})
 

--- a/pkg/controller/scylladbmonitoring/sync_prometheus.go
+++ b/pkg/controller/scylladbmonitoring/sync_prometheus.go
@@ -14,6 +14,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	okubecrypto "github.com/scylladb/scylla-operator/pkg/kubecrypto"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/resource"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	"github.com/scylladb/scylla-operator/pkg/resourcemerge"
@@ -23,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/utils/pointer"
 )
 
 func getPrometheusLabels(sm *scyllav1alpha1.ScyllaDBMonitoring) labels.Set {
@@ -499,8 +499,8 @@ func (smc *Controller) syncPrometheus(
 				Kind:               scylladbMonitoringControllerGVK.Kind,
 				Name:               sm.Name,
 				UID:                sm.UID,
-				Controller:         pointer.Bool(true),
-				BlockOwnerDeletion: pointer.Bool(true),
+				Controller:         pointer.Ptr(true),
+				BlockOwnerDeletion: pointer.Ptr(true),
 			},
 		})
 

--- a/pkg/controller/scylladbmonitoring/sync_prometheus_test.go
+++ b/pkg/controller/scylladbmonitoring/sync_prometheus_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func Test_makeScyllaDBServiceMonitor(t *testing.T) {
@@ -304,7 +304,7 @@ spec:
 								VolumeClaimTemplate: corev1.PersistentVolumeClaimTemplate{
 									ObjectMeta: metav1.ObjectMeta{},
 									Spec: corev1.PersistentVolumeClaimSpec{
-										StorageClassName: pointer.String("pv-class"),
+										StorageClassName: pointer.Ptr("pv-class"),
 										Resources: corev1.ResourceRequirements{
 											Requests: map[corev1.ResourceName]resource.Quantity{
 												corev1.ResourceStorage: resource.MustParse("5Gi"),

--- a/pkg/controllerhelpers/apps_test.go
+++ b/pkg/controllerhelpers/apps_test.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestIsStatefulSetRolledOut(t *testing.T) {
@@ -24,7 +24,7 @@ func TestIsStatefulSetRolledOut(t *testing.T) {
 					Generation: 42,
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointer.Int32Ptr(3),
+					Replicas: pointer.Ptr(int32(3)),
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.OnDeleteStatefulSetStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
@@ -43,7 +43,7 @@ func TestIsStatefulSetRolledOut(t *testing.T) {
 					Generation: 42,
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointer.Int32Ptr(3),
+					Replicas: pointer.Ptr(int32(3)),
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
@@ -71,7 +71,7 @@ func TestIsStatefulSetRolledOut(t *testing.T) {
 					Generation: 42,
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointer.Int32Ptr(3),
+					Replicas: pointer.Ptr(int32(3)),
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
@@ -99,11 +99,11 @@ func TestIsStatefulSetRolledOut(t *testing.T) {
 					Generation: 42,
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointer.Int32Ptr(3),
+					Replicas: pointer.Ptr(int32(3)),
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
-							Partition: pointer.Int32Ptr(1),
+							Partition: pointer.Ptr(int32(1)),
 						},
 					},
 				},
@@ -127,7 +127,7 @@ func TestIsStatefulSetRolledOut(t *testing.T) {
 					Generation: 42,
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointer.Int32Ptr(3),
+					Replicas: pointer.Ptr(int32(3)),
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
@@ -155,11 +155,11 @@ func TestIsStatefulSetRolledOut(t *testing.T) {
 					Generation: 42,
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointer.Int32Ptr(3),
+					Replicas: pointer.Ptr(int32(3)),
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
-							Partition: pointer.Int32Ptr(1),
+							Partition: pointer.Ptr(int32(1)),
 						},
 					},
 				},

--- a/pkg/controllerhelpers/mergepatch_test.go
+++ b/pkg/controllerhelpers/mergepatch_test.go
@@ -3,11 +3,11 @@ package controllerhelpers
 import (
 	"testing"
 
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
 )
 
 func TestGenerateMergePatch(t *testing.T) {
@@ -25,13 +25,13 @@ func TestGenerateMergePatch(t *testing.T) {
 					Name:      "bar",
 				},
 				Spec: corev1.PodSpec{
-					ActiveDeadlineSeconds: pointer.Int64Ptr(30),
+					ActiveDeadlineSeconds: pointer.Ptr(int64(30)),
 					NodeName:              "node",
 				},
 			},
 			modifyFn: func(obj runtime.Object) {
 				pod := obj.(*corev1.Pod)
-				pod.Spec.ActiveDeadlineSeconds = pointer.Int64Ptr(10)
+				pod.Spec.ActiveDeadlineSeconds = pointer.Ptr(int64(10))
 			},
 			expected: []byte(`{"spec":{"activeDeadlineSeconds":10}}`),
 		},

--- a/pkg/kubecrypto/certs_test.go
+++ b/pkg/kubecrypto/certs_test.go
@@ -15,11 +15,11 @@ import (
 	ocrypto "github.com/scylladb/scylla-operator/pkg/crypto"
 	"github.com/scylladb/scylla-operator/pkg/crypto/testfiles"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
 )
 
 type testSecretData struct {
@@ -187,8 +187,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					Annotations: map[string]string{
@@ -244,8 +244,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					Annotations: map[string]string{
@@ -309,8 +309,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					UID: "uid-that-should-never-make-it-to-the-desired-object",
@@ -334,8 +334,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					Annotations: map[string]string{
@@ -402,8 +402,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					UID: "uid-that-should-never-make-it-to-the-desired-object",
@@ -427,8 +427,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					Annotations: map[string]string{
@@ -486,8 +486,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					UID: "uid-that-should-never-make-it-to-the-desired-object",
@@ -511,8 +511,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					Annotations: map[string]string{
@@ -578,8 +578,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					UID: "uid-that-should-never-make-it-to-the-desired-object",
@@ -603,8 +603,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					Annotations: map[string]string{
@@ -671,8 +671,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					UID: "uid-that-should-never-make-it-to-the-desired-object",
@@ -696,8 +696,8 @@ func Test_makeCertificate(t *testing.T) {
 							Kind:               "ScyllaCluster",
 							Name:               "sc",
 							UID:                "42",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					},
 					Annotations: map[string]string{

--- a/pkg/pointer/pointer.go
+++ b/pkg/pointer/pointer.go
@@ -1,19 +1,5 @@
 package pointer
 
-import (
-	"crypto/x509"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-func KeyUsage(u x509.KeyUsage) *x509.KeyUsage {
-	return &u
-}
-
-func Time(t metav1.Time) *metav1.Time {
-	return &t
-}
-
 func Ptr[T any](v T) *T {
 	return &v
 }

--- a/pkg/resourceapply/apps_test.go
+++ b/pkg/resourceapply/apps_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -20,7 +21,6 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 )
 
 func TestApplyStatefulSet(t *testing.T) {
@@ -35,17 +35,17 @@ func TestApplyStatefulSet(t *testing.T) {
 				Labels:          map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						Controller:         pointer.BoolPtr(true),
+						Controller:         pointer.Ptr(true),
 						UID:                "abcdefgh",
 						APIVersion:         "scylla.scylladb.com/v1",
 						Kind:               "ScyllaCluster",
 						Name:               "basic",
-						BlockOwnerDeletion: pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.Ptr(true),
 					},
 				},
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: pointer.Int32Ptr(3),
+				Replicas: pointer.Ptr(int32(3)),
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{},
 					Spec: corev1.PodSpec{
@@ -140,12 +140,12 @@ func TestApplyStatefulSet(t *testing.T) {
 			},
 			required: func() *appsv1.StatefulSet {
 				sts := newSts()
-				sts.Spec.Replicas = pointer.Int32Ptr(*sts.Spec.Replicas + 1)
+				sts.Spec.Replicas = pointer.Ptr(*sts.Spec.Replicas + 1)
 				return sts
 			}(),
 			expectedSts: func() *appsv1.StatefulSet {
 				sts := newSts()
-				sts.Spec.Replicas = pointer.Int32Ptr(*sts.Spec.Replicas + 1)
+				sts.Spec.Replicas = pointer.Ptr(*sts.Spec.Replicas + 1)
 				utilruntime.Must(SetHashAnnotation(sts))
 				return sts
 			}(),
@@ -606,12 +606,12 @@ func TestApplyDaemonSet(t *testing.T) {
 				Labels:          map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						Controller:         pointer.BoolPtr(true),
+						Controller:         pointer.Ptr(true),
 						UID:                "abcdefgh",
 						APIVersion:         "scylla.scylladb.com/v1",
 						Kind:               "ScyllaCluster",
 						Name:               "basic",
-						BlockOwnerDeletion: pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.Ptr(true),
 					},
 				},
 			},

--- a/pkg/resourceapply/core_test.go
+++ b/pkg/resourceapply/core_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,7 +20,6 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 )
 
 func TestApplyService(t *testing.T) {
@@ -32,12 +32,12 @@ func TestApplyService(t *testing.T) {
 				Labels:    map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						Controller:         pointer.BoolPtr(true),
+						Controller:         pointer.Ptr(true),
 						UID:                "abcdefgh",
 						APIVersion:         "scylla.scylladb.com/v1",
 						Kind:               "ScyllaCluster",
 						Name:               "basic",
-						BlockOwnerDeletion: pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.Ptr(true),
 					},
 				},
 			},
@@ -576,12 +576,12 @@ func TestApplySecret(t *testing.T) {
 				Labels:    map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						Controller:         pointer.BoolPtr(true),
+						Controller:         pointer.Ptr(true),
 						UID:                "abcdefgh",
 						APIVersion:         "scylla.scylladb.com/v1",
 						Kind:               "ScyllaCluster",
 						Name:               "basic",
-						BlockOwnerDeletion: pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.Ptr(true),
 					},
 				},
 			},
@@ -1119,12 +1119,12 @@ func TestApplyServiceAccount(t *testing.T) {
 		sa := newSA()
 		sa.OwnerReferences = []metav1.OwnerReference{
 			{
-				Controller:         pointer.BoolPtr(true),
+				Controller:         pointer.Ptr(true),
 				UID:                "abcdefgh",
 				APIVersion:         "scylla.scylladb.com/v1",
 				Kind:               "ScyllaCluster",
 				Name:               "basic",
-				BlockOwnerDeletion: pointer.BoolPtr(true),
+				BlockOwnerDeletion: pointer.Ptr(true),
 			},
 		}
 		return sa
@@ -1216,12 +1216,12 @@ func TestApplyServiceAccount(t *testing.T) {
 			allowMissingControllerRef: true,
 			required: func() *corev1.ServiceAccount {
 				sa := newSA()
-				sa.AutomountServiceAccountToken = pointer.BoolPtr(true)
+				sa.AutomountServiceAccountToken = pointer.Ptr(true)
 				return sa
 			}(),
 			expectedSA: func() *corev1.ServiceAccount {
 				sa := newSA()
-				sa.AutomountServiceAccountToken = pointer.BoolPtr(true)
+				sa.AutomountServiceAccountToken = pointer.Ptr(true)
 				utilruntime.Must(SetHashAnnotation(sa))
 				return sa
 			}(),
@@ -1256,7 +1256,7 @@ func TestApplyServiceAccount(t *testing.T) {
 				func() *corev1.ServiceAccount {
 					sa := newSAWithHash()
 					// Simulate admission by changing a value after the hash is computed.
-					sa.AutomountServiceAccountToken = pointer.BoolPtr(true)
+					sa.AutomountServiceAccountToken = pointer.Ptr(true)
 					return sa
 				}(),
 			},
@@ -1265,7 +1265,7 @@ func TestApplyServiceAccount(t *testing.T) {
 			expectedSA: func() *corev1.ServiceAccount {
 				sa := newSAWithHash()
 				// Simulate admission by changing a value after the hash is computed.
-				sa.AutomountServiceAccountToken = pointer.BoolPtr(true)
+				sa.AutomountServiceAccountToken = pointer.Ptr(true)
 				return sa
 			}(),
 			expectedChanged: false,
@@ -1286,13 +1286,13 @@ func TestApplyServiceAccount(t *testing.T) {
 			required: func() *corev1.ServiceAccount {
 				sa := newSA()
 				sa.ResourceVersion = ""
-				sa.AutomountServiceAccountToken = pointer.BoolPtr(true)
+				sa.AutomountServiceAccountToken = pointer.Ptr(true)
 				return sa
 			}(),
 			expectedSA: func() *corev1.ServiceAccount {
 				sa := newSA()
 				sa.ResourceVersion = "21"
-				sa.AutomountServiceAccountToken = pointer.BoolPtr(true)
+				sa.AutomountServiceAccountToken = pointer.Ptr(true)
 				utilruntime.Must(SetHashAnnotation(sa))
 				return sa
 			}(),
@@ -1309,7 +1309,7 @@ func TestApplyServiceAccount(t *testing.T) {
 			allowMissingControllerRef: true,
 			required: func() *corev1.ServiceAccount {
 				sa := newSA()
-				sa.AutomountServiceAccountToken = pointer.BoolPtr(true)
+				sa.AutomountServiceAccountToken = pointer.Ptr(true)
 				return sa
 			}(),
 			expectedSA:      nil,
@@ -1660,12 +1660,12 @@ func TestApplyConfigMap(t *testing.T) {
 				Labels:    map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						Controller:         pointer.BoolPtr(true),
+						Controller:         pointer.Ptr(true),
 						UID:                "abcdefgh",
 						APIVersion:         "scylla.scylladb.com/v1",
 						Kind:               "ScyllaCluster",
 						Name:               "basic",
-						BlockOwnerDeletion: pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.Ptr(true),
 					},
 				},
 			},
@@ -2340,12 +2340,12 @@ func TestApplyNamespace(t *testing.T) {
 					ns := newNS()
 					ns.OwnerReferences = []metav1.OwnerReference{
 						{
-							Controller:         pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
 							UID:                "abcdefgh",
 							APIVersion:         "scylla.scylladb.com/v1",
 							Kind:               "ScyllaCluster",
 							Name:               "basic",
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					}
 					utilruntime.Must(SetHashAnnotation(ns))

--- a/pkg/resourceapply/helpers.go
+++ b/pkg/resourceapply/helpers.go
@@ -26,7 +26,7 @@ func verifyDesiredObject(obj metav1.Object) error {
 		return fmt.Errorf("desired objects are not allowed to have UID set")
 	}
 
-	if !pointer.Time(obj.GetCreationTimestamp()).IsZero() {
+	if !pointer.Ptr(obj.GetCreationTimestamp()).IsZero() {
 		return fmt.Errorf("desired objects are not allowed to have creationTimestamp set")
 	}
 

--- a/pkg/resourceapply/networking_test.go
+++ b/pkg/resourceapply/networking_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,7 +20,6 @@ import (
 	networkingv1listers "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 )
 
 func TestApplyIngress(t *testing.T) {
@@ -32,12 +32,12 @@ func TestApplyIngress(t *testing.T) {
 				Labels:    map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						Controller:         pointer.BoolPtr(true),
+						Controller:         pointer.Ptr(true),
 						UID:                "abcdefgh",
 						APIVersion:         "scylla.scylladb.com/v1",
 						Kind:               "ScyllaCluster",
 						Name:               "basic",
-						BlockOwnerDeletion: pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.Ptr(true),
 					},
 				},
 			},

--- a/pkg/resourceapply/policy_test.go
+++ b/pkg/resourceapply/policy_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,7 +20,6 @@ import (
 	policyv1listers "k8s.io/client-go/listers/policy/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 )
 
 func TestApplyPodDisruptionBudget(t *testing.T) {
@@ -32,12 +32,12 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 				Labels:    map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						Controller:         pointer.BoolPtr(true),
+						Controller:         pointer.Ptr(true),
 						UID:                "abcdefgh",
 						APIVersion:         "scylla.scylladb.com/v1",
 						Kind:               "ScyllaCluster",
 						Name:               "basic",
-						BlockOwnerDeletion: pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.Ptr(true),
 					},
 				},
 			},

--- a/pkg/resourceapply/rbac_test.go
+++ b/pkg/resourceapply/rbac_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -20,7 +21,6 @@ import (
 	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 )
 
 func TestApplyClusterRole(t *testing.T) {
@@ -264,12 +264,12 @@ func TestApplyClusterRole(t *testing.T) {
 				func() *rbacv1.ClusterRole {
 					cr := newCr()
 					cr.OwnerReferences = []metav1.OwnerReference{{
-						Controller:         pointer.BoolPtr(true),
+						Controller:         pointer.Ptr(true),
 						UID:                "abcdefgh",
 						APIVersion:         "scylla.scylladb.com/v1",
 						Kind:               "ScyllaCluster",
 						Name:               "basic",
-						BlockOwnerDeletion: pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.Ptr(true),
 					}}
 					utilruntime.Must(SetHashAnnotation(cr))
 					return cr
@@ -759,12 +759,12 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 					crb := newCrb()
 					crb.OwnerReferences = []metav1.OwnerReference{
 						{
-							Controller:         pointer.BoolPtr(true),
+							Controller:         pointer.Ptr(true),
 							UID:                "abcdefgh",
 							APIVersion:         "scylla.scylladb.com/v1",
 							Kind:               "ScyllaCluster",
 							Name:               "basic",
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					}
 					utilruntime.Must(SetHashAnnotation(crb))
@@ -1025,12 +1025,12 @@ func TestApplyRoleBinding(t *testing.T) {
 		rb := newRB()
 		rb.OwnerReferences = []metav1.OwnerReference{
 			{
-				Controller:         pointer.BoolPtr(true),
+				Controller:         pointer.Ptr(true),
 				UID:                "abcdefgh",
 				APIVersion:         "scylla.scylladb.com/v1",
 				Kind:               "ScyllaCluster",
 				Name:               "basic",
-				BlockOwnerDeletion: pointer.BoolPtr(true),
+				BlockOwnerDeletion: pointer.Ptr(true),
 			},
 		}
 		return rb

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -18,6 +18,7 @@ import (
 	scyllaversionedclient "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
 	"github.com/scylladb/scylla-operator/pkg/features"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/semver"
 	"github.com/scylladb/scylla-operator/pkg/sidecar/identity"
 	"github.com/scylladb/scylla-operator/pkg/util/cpuset"
@@ -25,7 +26,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 )
 
@@ -197,7 +197,7 @@ func convertScyllaArguments(scyllaArguments string) map[string]string {
 func appendScyllaArguments(ctx context.Context, s *ScyllaConfig, scyllaArgs string, scyllaFinalArgs map[string]*string) {
 	for argName, argValue := range convertScyllaArguments(scyllaArgs) {
 		if existing := scyllaFinalArgs[argName]; existing == nil {
-			scyllaFinalArgs[argName] = pointer.StringPtr(strings.TrimSpace(argValue))
+			scyllaFinalArgs[argName] = pointer.Ptr(strings.TrimSpace(argValue))
 		} else {
 			klog.Infof("ScyllaArgs: argument '%s' is ignored, it is already in the list", argName)
 		}
@@ -233,16 +233,16 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		"listen-address":        &listenAddress,
 		"broadcast-address":     &m.StaticIP,
 		"broadcast-rpc-address": &m.StaticIP,
-		"seeds":                 pointer.String(strings.Join(seeds, ",")),
+		"seeds":                 pointer.Ptr(strings.Join(seeds, ",")),
 		"developer-mode":        &devMode,
 		"overprovisioned":       &overprovisioned,
-		"smp":                   pointer.StringPtr(strconv.Itoa(s.cpuCount)),
+		"smp":                   pointer.Ptr(strconv.Itoa(s.cpuCount)),
 		"prometheus-address":    &prometheusAddress,
 	}
 	if cluster.Spec.Alternator.Enabled() {
-		args["alternator-port"] = pointer.StringPtr(strconv.Itoa(int(cluster.Spec.Alternator.Port)))
+		args["alternator-port"] = pointer.Ptr(strconv.Itoa(int(cluster.Spec.Alternator.Port)))
 		if cluster.Spec.Alternator.WriteIsolation != "" {
-			args["alternator-write-isolation"] = pointer.StringPtr(cluster.Spec.Alternator.WriteIsolation)
+			args["alternator-write-isolation"] = pointer.Ptr(cluster.Spec.Alternator.WriteIsolation)
 		}
 	}
 	// If node is being replaced
@@ -250,14 +250,14 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		if len(addr) == 0 {
 			klog.Warningf("Service %q have unexpectedly empty label %q, skipping replace", m.Name, naming.ReplaceLabel)
 		} else {
-			args["replace-address-first-boot"] = pointer.StringPtr(addr)
+			args["replace-address-first-boot"] = pointer.Ptr(addr)
 		}
 	}
 	if hostID, ok := m.ServiceLabels[naming.ReplacingNodeHostIDLabel]; ok {
 		if len(hostID) == 0 {
 			klog.Warningf("Service %q have unexpectedly empty label %q, skipping replace", m.Name, naming.ReplacingNodeHostIDLabel)
 		} else {
-			args["replace-node-first-boot"] = pointer.String(hostID)
+			args["replace-node-first-boot"] = pointer.Ptr(hostID)
 		}
 	}
 
@@ -293,7 +293,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		klog.InfoS("Scylla IO properties are already set, skipping io tuning")
 		ioSetup := "0"
 		args["io-setup"] = &ioSetup
-		args["io-properties-file"] = pointer.StringPtr(scyllaIOPropertiesPath)
+		args["io-properties-file"] = pointer.Ptr(scyllaIOPropertiesPath)
 	}
 
 	var argsList []string

--- a/pkg/test/unit/helpers.go
+++ b/pkg/test/unit/helpers.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 // NewSingleRackCluster returns ScyllaCluster having single racks.
@@ -51,13 +51,13 @@ func NewDetailedSingleRackCluster(name, namespace, repo, version, dc, rack strin
 			},
 		},
 		Status: scyllav1.ScyllaClusterStatus{
-			ObservedGeneration: pointer.Int64(1),
+			ObservedGeneration: pointer.Ptr(int64(1)),
 			Racks: map[string]scyllav1.RackStatus{
 				rack: {
 					Version:      version,
 					Members:      members,
 					ReadyMembers: members,
-					Stale:        pointer.Bool(false),
+					Stale:        pointer.Ptr(false),
 				},
 			},
 		},
@@ -81,7 +81,7 @@ func NewDetailedMultiRackCluster(name, namespace, repo, version, dc string, memb
 			},
 		},
 		Status: scyllav1.ScyllaClusterStatus{
-			ObservedGeneration: pointer.Int64(1),
+			ObservedGeneration: pointer.Ptr(int64(1)),
 			Racks:              map[string]scyllav1.RackStatus{},
 		},
 	}
@@ -99,7 +99,7 @@ func NewDetailedMultiRackCluster(name, namespace, repo, version, dc string, memb
 			Version:      version,
 			Members:      m,
 			ReadyMembers: m,
-			Stale:        pointer.Bool(false),
+			Stale:        pointer.Ptr(false),
 		}
 	}
 

--- a/test/e2e/set/scyllacluster/scyllacluster_tls.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_tls.go
@@ -18,7 +18,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/features"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/kubecrypto"
-	opointer "github.com/scylladb/scylla-operator/pkg/pointer"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/scheme"
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/utils/pointer"
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
@@ -109,7 +108,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 				// TODO: Use generated Apply method when our clients have it.
 				sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(ctx, sc.Name, types.ApplyPatchType, scData, metav1.PatchOptions{
 					FieldManager: f.FieldManager(),
-					Force:        pointer.Bool(true),
+					Force:        pointer.Ptr(true),
 				})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(tc.replicas))
@@ -130,16 +129,16 @@ var _ = g.Describe("ScyllaCluster", func() {
 				clientCASecret, err := f.KubeClient().CoreV1().Secrets(f.Namespace()).Get(ctx, fmt.Sprintf("%s-local-client-ca", sc.Name), metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				clientCACerts, _, _, _ := verification.VerifyAndParseTLSCert(clientCASecret, verification.TLSCertOptions{
-					IsCA:     pointer.Bool(true),
-					KeyUsage: opointer.KeyUsage(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign),
+					IsCA:     pointer.Ptr(true),
+					KeyUsage: pointer.Ptr(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign),
 				})
 				o.Expect(clientCACerts).To(o.HaveLen(1))
 
 				servingCASecret, err := f.KubeClient().CoreV1().Secrets(f.Namespace()).Get(ctx, fmt.Sprintf("%s-local-serving-ca", sc.Name), metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				_, _, _, _ = verification.VerifyAndParseTLSCert(servingCASecret, verification.TLSCertOptions{
-					IsCA:     pointer.Bool(true),
-					KeyUsage: opointer.KeyUsage(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign),
+					IsCA:     pointer.Ptr(true),
+					KeyUsage: pointer.Ptr(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign),
 				})
 
 				servingCABundleConfigMap, err := f.KubeClient().CoreV1().ConfigMaps(f.Namespace()).Get(ctx, fmt.Sprintf("%s-local-serving-ca", sc.Name), metav1.GetOptions{})
@@ -150,15 +149,15 @@ var _ = g.Describe("ScyllaCluster", func() {
 				servingCertSecret, err := f.KubeClient().CoreV1().Secrets(f.Namespace()).Get(ctx, fmt.Sprintf("%s-local-serving-certs", sc.Name), metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				servingCerts, _, _, _ := verification.VerifyAndParseTLSCert(servingCertSecret, verification.TLSCertOptions{
-					IsCA:     pointer.Bool(false),
-					KeyUsage: opointer.KeyUsage(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature),
+					IsCA:     pointer.Ptr(false),
+					KeyUsage: pointer.Ptr(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature),
 				})
 
 				adminClientSecret, err := f.KubeClient().CoreV1().Secrets(f.Namespace()).Get(ctx, fmt.Sprintf("%s-local-user-admin", sc.Name), metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				_, adminClientCertBytes, _, adminClientKeyBytes := verification.VerifyAndParseTLSCert(adminClientSecret, verification.TLSCertOptions{
-					IsCA:     pointer.Bool(false),
-					KeyUsage: opointer.KeyUsage(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature),
+					IsCA:     pointer.Ptr(false),
+					KeyUsage: pointer.Ptr(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature),
 				})
 
 				adminClientConnectionConfigsSecret, err := f.KubeClient().CoreV1().Secrets(f.Namespace()).Get(ctx, fmt.Sprintf("%s-local-cql-connection-configs-admin", sc.Name), metav1.GetOptions{})

--- a/test/e2e/set/scyllacluster/verify.go
+++ b/test/e2e/set/scyllacluster/verify.go
@@ -10,6 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/features"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	cqlclientv1alpha1 "github.com/scylladb/scylla-operator/pkg/scylla/api/cqlclient/v1alpha1"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/scheme"
@@ -22,7 +23,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/utils/pointer"
 )
 
 func verifyPersistentVolumeClaims(ctx context.Context, coreClient corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) {
@@ -78,8 +78,8 @@ func verifyPodDisruptionBudget(sc *scyllav1.ScyllaCluster, pdb *policyv1.PodDisr
 				Kind:               "ScyllaCluster",
 				Name:               sc.Name,
 				UID:                sc.UID,
-				BlockOwnerDeletion: pointer.Bool(true),
-				Controller:         pointer.Bool(true),
+				BlockOwnerDeletion: pointer.Ptr(true),
+				Controller:         pointer.Ptr(true),
 			},
 		}),
 	)

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
@@ -17,13 +17,12 @@ import (
 	o "github.com/onsi/gomega"
 	prometheusappclient "github.com/prometheus/client_golang/api"
 	promeheusappv1api "github.com/prometheus/client_golang/api/prometheus/v1"
-	opointer "github.com/scylladb/scylla-operator/pkg/pointer"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	"github.com/scylladb/scylla-operator/test/e2e/verification"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 var _ = g.Describe("ScyllaDBMonitoring", func() {
@@ -101,8 +100,8 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 		prometheusGrafanaClientSecret, err := f.KubeClient().CoreV1().Secrets(f.Namespace()).Get(ctx, fmt.Sprintf("%s-prometheus-client-grafana", sm.Name), metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		_, prometheusGrafanaClientCertBytes, _, prometheusGrafanaClientKeyBytes := verification.VerifyAndParseTLSCert(prometheusGrafanaClientSecret, verification.TLSCertOptions{
-			IsCA:     pointer.Bool(false),
-			KeyUsage: opointer.KeyUsage(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature),
+			IsCA:     pointer.Ptr(false),
+			KeyUsage: pointer.Ptr(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature),
 		})
 
 		prometheusGrafanaAdminTLSCert, err := tls.X509KeyPair(prometheusGrafanaClientCertBytes, prometheusGrafanaClientKeyBytes)


### PR DESCRIPTION
Thanks to generics we can use pointer.Ptr without specifying required type of return value. All usages of previous typed functions were changed to use the generic one.
