### PR TITLE
Fix systemd unit test

### DIFF
--- a/pkg/systemd/daemon_test.go
+++ b/pkg/systemd/daemon_test.go
@@ -30,7 +30,7 @@ func TestSystemdControl_ErrNotExist(t *testing.T) {
 
 	// FIXME: We should either use fake systemd, or somehow enable it.
 	//        Ref: https://github.com/scylladb/scylla-operator/issues/1379
-	_, err = sc.conn.GetServicePropertyContext(ctx, "systemd1", "ActiveState")
+	_, err = sc.conn.GetAllPropertiesContext(ctx, "systemd1.service")
 	if err != nil {
 		var godbusErr godbus.Error
 		if errors.As(err, &godbusErr) && godbusErr.Name == "org.freedesktop.DBus.Error.ServiceUnknown" {


### PR DESCRIPTION
Test started failing due to bug in #1369. This time it passes on systemd-enabled systems, and within container where it's not available.
