### PR TITLE
Fix a race condition in seed election algorithm

### DIFF
--- a/pkg/cmd/operator/sidecar.go
+++ b/pkg/cmd/operator/sidecar.go
@@ -281,7 +281,10 @@ func (o *SidecarOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Com
 		return fmt.Errorf("can't wait for pod's ContainerID: %w", err)
 	}
 
-	member := identity.NewMemberFromObjects(service, pod)
+	member, err := identity.NewMemberFromObjects(service, pod)
+	if err != nil {
+		return fmt.Errorf("can't create new member from objects: %w", err)
+	}
 
 	labelSelector := labels.Set{
 		naming.OwnerUIDLabel:      string(pod.UID),

--- a/pkg/cmd/tests/tests_run.go
+++ b/pkg/cmd/tests/tests_run.go
@@ -20,7 +20,7 @@ import (
 	gomegaformat "github.com/onsi/gomega/format"
 	"github.com/scylladb/scylla-operator/pkg/cmdutil"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
-	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	ginkgotest "github.com/scylladb/scylla-operator/pkg/test/ginkgo"
 	"github.com/scylladb/scylla-operator/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support"
@@ -358,7 +358,7 @@ func (o *RunOptions) run(ctx context.Context, streams genericclioptions.IOStream
 	commonArgs = append(commonArgs, fmt.Sprintf("--%s=%v", cmdutil.FlagLogLevelKey, o.ParallelLogLevel))
 
 	// Propagate random seed to child processes.
-	if !helpers.Contains(commonArgs, func(arg string) bool {
+	if !slices.Contains(commonArgs, func(arg string) bool {
 		return strings.HasPrefix(arg, fmt.Sprintf("--%s", randomSeedFlagKey))
 	}) {
 		commonArgs = append(commonArgs, fmt.Sprintf("--%s=%v", randomSeedFlagKey, suiteConfig.RandomSeed))

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -195,8 +195,11 @@ func servicePorts(cluster *scyllav1.ScyllaCluster) []corev1.ServicePort {
 // StatefulSetForRack make a StatefulSet for the rack.
 // existingSts may be nil if it doesn't exist yet.
 func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existingSts *appsv1.StatefulSet, sidecarImage string) (*appsv1.StatefulSet, error) {
-	matchLabels := naming.RackLabels(r, c)
-	rackLabels := naming.RackLabels(r, c)
+	rackLabels, err := naming.RackLabels(r, c)
+	if err != nil {
+		return nil, fmt.Errorf("can't get rack labels: %w", err)
+	}
+	matchLabels := helpers.ShallowCopyMap(rackLabels)
 	rackLabels[naming.ScyllaVersionLabel] = c.Spec.Version
 
 	placement := r.Placement

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -486,6 +486,7 @@ func TestStatefulSetForRack(t *testing.T) {
 			"scylla/cluster":               "basic",
 			"scylla/datacenter":            "dc",
 			"scylla/rack":                  "rack",
+			"scylla/rack-ordinal":          "0",
 		}
 	}
 

--- a/pkg/controller/scylladbmonitoring/sync_grafana.go
+++ b/pkg/controller/scylladbmonitoring/sync_grafana.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	ocrypto "github.com/scylladb/scylla-operator/pkg/crypto"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	okubecrypto "github.com/scylladb/scylla-operator/pkg/kubecrypto"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
@@ -303,7 +304,7 @@ func (smc *Controller) syncGrafana(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.ToArray(requiredGrafanaSA),
+		slices.ToSlice(requiredGrafanaSA),
 		serviceAccounts,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.CoreV1().ServiceAccounts(sm.Namespace).Delete,
@@ -343,7 +344,7 @@ func (smc *Controller) syncGrafana(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.ToArray(requiredService),
+		slices.ToSlice(requiredService),
 		services,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.CoreV1().Services(sm.Namespace).Delete,
@@ -354,7 +355,7 @@ func (smc *Controller) syncGrafana(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.ToArray(requiredDeployment),
+		slices.ToSlice(requiredDeployment),
 		deployments,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.AppsV1().Deployments(sm.Namespace).Delete,
@@ -365,7 +366,7 @@ func (smc *Controller) syncGrafana(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.FilterOutNil(helpers.ToArray(requiredIngress)),
+		slices.FilterOutNil(slices.ToSlice(requiredIngress)),
 		ingresses,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.NetworkingV1().Ingresses(sm.Namespace).Delete,

--- a/pkg/controller/scylladbmonitoring/sync_prometheus.go
+++ b/pkg/controller/scylladbmonitoring/sync_prometheus.go
@@ -12,6 +12,7 @@ import (
 	ocrypto "github.com/scylladb/scylla-operator/pkg/crypto"
 	monitoringv1 "github.com/scylladb/scylla-operator/pkg/externalapi/monitoring/v1"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	okubecrypto "github.com/scylladb/scylla-operator/pkg/kubecrypto"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
@@ -300,7 +301,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.ToArray(requiredPrometheusSA),
+		slices.ToSlice(requiredPrometheusSA),
 		serviceAccounts,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.CoreV1().ServiceAccounts(sm.Namespace).Delete,
@@ -311,7 +312,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.ToArray(requiredPrometheusService),
+		slices.ToSlice(requiredPrometheusService),
 		services,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.CoreV1().Services(sm.Namespace).Delete,
@@ -322,7 +323,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.ToArray(requiredPrometheusRoleBinding),
+		slices.ToSlice(requiredPrometheusRoleBinding),
 		roleBindings,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.RbacV1().RoleBindings(sm.Namespace).Delete,
@@ -333,7 +334,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.ToArray(requiredPrometheus),
+		slices.ToSlice(requiredPrometheus),
 		prometheuses,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.monitoringClient.Prometheuses(sm.Namespace).Delete,
@@ -344,7 +345,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.FilterOutNil(helpers.ToArray(requiredIngress)),
+		slices.FilterOutNil(slices.ToSlice(requiredIngress)),
 		ingresses,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.NetworkingV1().Ingresses(sm.Namespace).Delete,
@@ -355,7 +356,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.ToArray(requiredRecodingPrometheusRule, requiredAlertsPrometheusRule),
+		slices.ToSlice(requiredRecodingPrometheusRule, requiredAlertsPrometheusRule),
 		prometheusRules,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.monitoringClient.PrometheusRules(sm.Namespace).Delete,
@@ -366,7 +367,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		helpers.ToArray(requiredScyllaDBServiceMonitor),
+		slices.ToSlice(requiredScyllaDBServiceMonitor),
 		serviceMonitors,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.monitoringClient.ServiceMonitors(sm.Namespace).Delete,

--- a/pkg/helpers/collections.go
+++ b/pkg/helpers/collections.go
@@ -18,3 +18,11 @@ func GetMapValues[M ~map[K]V, K comparable, V any](m M) []V {
 	}
 	return res
 }
+
+func ShallowCopyMap[M ~map[K]V, K comparable, V any](m M) M {
+	res := make(M, len(m))
+	for k, v := range m {
+		res[k] = v
+	}
+	return res
+}

--- a/pkg/helpers/slices/slices.go
+++ b/pkg/helpers/slices/slices.go
@@ -65,14 +65,18 @@ func ContainsItem[T comparable](slice []T, item T) bool {
 	return Contains(slice, IdentityFunc(item))
 }
 
-func Find[T comparable](slice []T, filterFunc func(T) bool) (T, bool) {
+func Find[T any](slice []T, filterFunc func(T) bool) (T, int, bool) {
 	for i := range slice {
 		if filterFunc(slice[i]) {
-			return slice[i], true
+			return slice[i], i, true
 		}
 	}
 
-	return *new(T), false
+	return *new(T), 0, false
+}
+
+func FindItem[T comparable](slice []T, item T) (T, int, bool) {
+	return Find(slice, IdentityFunc(item))
 }
 
 func Flatten[T any](xs [][]T) []T {

--- a/pkg/helpers/slices/slices.go
+++ b/pkg/helpers/slices/slices.go
@@ -1,11 +1,13 @@
-package helpers
+// Copyright (c) 2023 ScyllaDB
 
-func ToArray[T any](objs ...T) []T {
+package slices
+
+func ToSlice[T any](objs ...T) []T {
 	res := make([]T, 0, len(objs))
 	return append(res, objs...)
 }
 
-func ConvertToArray[To, From any](convert func(From) To, objs ...From) []To {
+func ConvertToSlice[To, From any](convert func(From) To, objs ...From) []To {
 	res := make([]To, 0, len(objs))
 
 	for i := range objs {
@@ -16,7 +18,7 @@ func ConvertToArray[To, From any](convert func(From) To, objs ...From) []To {
 }
 
 func ConvertSlice[To, From any](slice []From, convert func(From) To) []To {
-	return ConvertToArray(convert, slice...)
+	return ConvertToSlice(convert, slice...)
 }
 
 func Filter[T any](array []T, filterFunc func(T) bool) []T {

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -64,6 +64,7 @@ const (
 	ClusterNameLabel             = "scylla/cluster"
 	DatacenterNameLabel          = "scylla/datacenter"
 	RackNameLabel                = "scylla/rack"
+	RackOrdinalLabel             = "scylla/rack-ordinal"
 	ScyllaVersionLabel           = "scylla/scylla-version"
 	ScyllaServiceTypeLabel       = "scylla-operator.scylladb.com/scylla-service-type"
 	ScyllaIngressTypeLabel       = "scylla-operator.scylladb.com/scylla-ingress-type"

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -1,7 +1,11 @@
 package naming
 
 import (
+	"fmt"
+	"strconv"
+
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -26,12 +30,19 @@ func DatacenterLabels(c *scyllav1.ScyllaCluster) map[string]string {
 
 // RackLabels returns a map of label keys and values
 // for the given Rack.
-func RackLabels(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) map[string]string {
+func RackLabels(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) (map[string]string, error) {
 	recLabels := ScyllaLabels()
 	rackLabels := DatacenterLabels(c)
 	rackLabels[RackNameLabel] = r.Name
+	_, rackOrdinal, ok := slices.Find(c.Spec.Datacenter.Racks, func(rack scyllav1.RackSpec) bool {
+		return rack.Name == r.Name
+	})
+	if !ok {
+		return nil, fmt.Errorf("can't find ordinal of rack %q in ScyllaCluster %q", r.Name, ObjRef(c))
+	}
+	rackLabels[RackOrdinalLabel] = strconv.Itoa(rackOrdinal)
 
-	return mergeLabels(rackLabels, recLabels)
+	return mergeLabels(rackLabels, recLabels), nil
 }
 
 // StatefulSetPodLabel returns a map of labels to uniquely
@@ -43,12 +54,16 @@ func StatefulSetPodLabel(name string) map[string]string {
 }
 
 // RackSelector returns a LabelSelector for the given rack.
-func RackSelector(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) labels.Selector {
+func RackSelector(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) (labels.Selector, error) {
+	rackLabels, err := RackLabels(r, c)
+	if err != nil {
+		return nil, fmt.Errorf("can't get rack labels: %w", err)
+	}
 
-	rackLabelsSet := labels.Set(RackLabels(r, c))
+	rackLabelsSet := labels.Set(rackLabels)
 	sel := labels.SelectorFromSet(rackLabelsSet)
 
-	return sel
+	return sel, nil
 }
 
 func ScyllaLabels() map[string]string {

--- a/pkg/systemd/unit.go
+++ b/pkg/systemd/unit.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
-	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -156,7 +156,7 @@ func (m *UnitManager) EnsureUnits(ctx context.Context, nc *scyllav1alpha1.NodeCo
 
 	// First save the updated list of managed units first,
 	// so we can clean up in the next run, if we were interrupted.
-	status.ManagedUnits = helpers.ConvertToArray(func(unit *NamedUnit) string {
+	status.ManagedUnits = slices.ConvertToSlice(func(unit *NamedUnit) string {
 		return unit.FileName
 	}, requiredUnits...)
 

--- a/pkg/systemd/unit_test.go
+++ b/pkg/systemd/unit_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -296,10 +296,10 @@ func Test_unitManager_EnsureUnits(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			unexpectedEntries := helpers.Filter(entries, func(entry os.DirEntry) bool {
+			unexpectedEntries := slices.Filter(entries, func(entry os.DirEntry) bool {
 				return !entry.IsDir() &&
 					entry.Name() != m.getStatusName() &&
-					!helpers.Contains(
+					!slices.Contains(
 						tc.expectedUnits,
 						func(v *NamedUnit) bool {
 							return v.FileName == entry.Name()
@@ -308,7 +308,7 @@ func Test_unitManager_EnsureUnits(t *testing.T) {
 			})
 
 			if len(unexpectedEntries) != 0 {
-				unexpectedEntryNames := helpers.ConvertSlice(unexpectedEntries, func(entry os.DirEntry) string {
+				unexpectedEntryNames := slices.ConvertSlice(unexpectedEntries, func(entry os.DirEntry) string {
 					return entry.Name()
 				})
 				t.Errorf("Unexpected files were created: %q", strings.Join(unexpectedEntryNames, ","))

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -8,6 +8,7 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
@@ -101,7 +102,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 			}
 		}
 
-		cleanupJobsCreated := helpers.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
+		cleanupJobsCreated := slices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
 			return e.Action == watch.Added && e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup)
 		})
 
@@ -142,7 +143,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 		o.Expect(jobEvents).NotTo(o.BeEmpty())
 
-		cleanupJobsCreated = helpers.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
+		cleanupJobsCreated = slices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
 			return e.Action == watch.Added && e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup)
 		})
 

--- a/test/e2e/set/scyllacluster/verify.go
+++ b/test/e2e/set/scyllacluster/verify.go
@@ -9,6 +9,7 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/features"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	cqlclientv1alpha1 "github.com/scylladb/scylla-operator/pkg/scylla/api/cqlclient/v1alpha1"
@@ -264,7 +265,7 @@ func getScyllaHostsAndWaitForFullQuorum(ctx context.Context, client corev1client
 	dcClientMap := make(map[string]corev1client.CoreV1Interface, 1)
 	dcClientMap[sc.Spec.Datacenter.Name] = client
 	hosts := getScyllaHostsByDCAndWaitForFullQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc})
-	return helpers.Flatten(helpers.GetMapValues(hosts))
+	return slices.Flatten(helpers.GetMapValues(hosts))
 }
 
 func getScyllaHostsByDCAndWaitForFullQuorum(ctx context.Context, dcClientMap map[string]corev1client.CoreV1Interface, scs []*scyllav1.ScyllaCluster) map[string][]string {

--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/gocqlx/v2/table"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
@@ -61,7 +62,7 @@ func NewMultiDCDataInserter(dcHosts map[string][]string) (*DataInserter, error) 
 		replicationFactor: replicationFactor,
 	}
 
-	err := di.SetClientEndpoints(helpers.Flatten(helpers.GetMapValues(dcHosts)))
+	err := di.SetClientEndpoints(slices.Flatten(helpers.GetMapValues(dcHosts)))
 	if err != nil {
 		return nil, fmt.Errorf("can't set client endpoints: %w", err)
 	}


### PR DESCRIPTION
**Description of your changes:** Currently, the seed election algorithm checks for other existing Pods on startup and only chooses its own identity for seed provisioning if there are no other pods. As described in #1349, this can lead to a race condition where eviction of a Pod with lower ordinal can cause a split-brain cluster to form, as more than one Pod will consider itself the first in the cluster. This PR fixes the issue by verifying the ordinals of the node and the rack it belongs to. To accommodate for these changes, the unit tests also need some tweaks. 

To avoid an import cycle between helpers and naming packages, the array package is moved to a helpers subpackage. Since `array` didn't reflect its contents, it's also renamed to `slices`.

**Which issue is resolved by this Pull Request:**
Resolves #1349 
