### PR TITLE
Fix waiting for waitGroup in ScyllaCluster Orphaned PV e2e test

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -99,10 +99,12 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 		// ScyllaCluster is going to request a PVC from that StorageClass, and the test is going to request a clone of the original PVC
 		// from the default StorageClass to get any storage. Then the bound PV is rebounded to the original PVC
 		// but with empty NodeAffinity. This allows the test to trigger the orphaned PV cleanup logic.
-		provisionerCtx, provisionerCancel := context.WithCancel(ctx)
+		var wg sync.WaitGroup
+		defer wg.Wait()
+
+		provisionerCtx, provisionerCancel := context.WithCancel(context.Background())
 		defer provisionerCancel()
 
-		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -252,7 +254,6 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}()
-		defer wg.Wait()
 
 		framework.By("Creating a ScyllaCluster")
 		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Currently, when an error occurs in `ScyllaCluster Orphaned PV controller [It] should replace a node with orphaned PV` E2E test, the test hangs indefinitely, waiting for waitGroup, because of the order of deferred functions. This PR fixes it by reordering the deferred functions.

**Which issue is resolved by this Pull Request:**
Resolves #1390 
