### PR TITLE
Fix hosts comparison after replacement in orphaned PV e2e test

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -344,7 +344,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 		oldHosts := hosts
 		hosts = getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(hosts).To(o.HaveLen(len(oldHosts)))
-		o.Expect(hosts).NotTo(o.ConsistOf(oldHosts))
+		o.Expect(hosts).To(o.ConsistOf(oldHosts))
 		err = di.SetClientEndpoints(hosts)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		verifyCQLData(ctx, di)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Currently, the `ScyllaCluster Orphaned PV controller [It] should replace a node with orphaned PV` fails consistently on master. Bisecting the commit tree showed that the error was introduced in https://github.com/scylladb/scylla-operator/pull/1370. This is because we have recently moved to a new replacement procedure for Scylla versions >= 5.2.6. Therefore, it is no longer correct to expect the pre-replacement addresses to differ from the post-replacement ones. This PR changes the assertion.

This PR does not add coverage of both procedures, since they are covered in the relevant replacement e2e test.

**Which issue is resolved by this Pull Request:**
Resolves #1390 
