### PR TITLE
Fix typo in alternator documentation

### DIFF
--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -195,7 +195,7 @@ You can specify whichever port you want.
 You must provide desired write isolation, supported values are: "always", "forbid_rmw", "only_rmw_uses_lwt".
 Difference between those isolation levels can be found in Scylla Alternator documentation.
 
-Once this is done the regular CQL ports will no longer be available, the cluster is a pure Alienator cluster.
+Once this is done the regular CQL ports will no longer be available, the cluster is a pure Alternator cluster.
 
 ## Accessing the Database
 
@@ -266,7 +266,7 @@ See [Scylla Manager Agent configuration](https://manager.docs.scylladb.com/stabl
 ### Scylla Manager Agent auth token
 
 Operator provisions Agent auth token by copying value from user provided config secret or auto generates it if it's empty.
-To check which value is being used, decode content of `<cluster-name>-auth-token` secret. 
+To check which value is being used, decode content of `<cluster-name>-auth-token` secret.
 To change it simply remove the secret. Operator will create a new one. To pick up the change in the cluster, initiate a rolling restart.
 
 ## Set up monitoring


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Part of the doc mentions adding `altenator` field to the `ScyllaCluster` specification creates an `Alienator` cluster. 
This is a typo, should be `Alternator`.