### PR TITLE
Promote automatic client to node TLS certificates to beta

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -16,14 +16,15 @@ const (
 	//
 	// owner: @tnozicka
 	// alpha: v1.8
+	// beta: v1.11
 	AutomaticTLSCertificates featuregate.Feature = "AutomaticTLSCertificates"
 )
 
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
 		AutomaticTLSCertificates: {
-			Default:    false,
-			PreRelease: featuregate.Alpha,
+			Default:    true,
+			PreRelease: featuregate.Beta,
 		},
 	}))
 }


### PR DESCRIPTION
**Description of your changes:**
Automated certificates have been around for long enough as alpha to deserve beta promotion. https://github.com/scylladb/scylla-operator/pull/1359 is also making a use of them.

**Which issue is resolved by this Pull Request:**
Resolves #1402

/cc @zimnx @rzetelskik 