### PR TITLE
Remove artificial sleep for stale conntrack entries from E2E tests

### DIFF
--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -157,11 +157,6 @@ func IsScyllaClusterRolledOut(sc *scyllav1.ScyllaCluster) (bool, error) {
 
 	framework.Infof("ScyllaCluster %s (RV=%s) is rolled out", klog.KObj(sc), sc.ResourceVersion)
 
-	// Allow CI to remove stale conntrack entries.
-	// https://github.com/scylladb/scylla-operator/issues/975
-	// TODO: remove when GitHub Actions upgrades to kernel version 5.14.
-	time.Sleep(5 * time.Second)
-
 	return true, nil
 }
 


### PR DESCRIPTION
**Description of your changes:**
There's still a leftover artificial sleep in our E2E tests waiting for stale conntrack entries to sync. We have closed https://github.com/scylladb/scylla-operator/issues/975 a long time ago. This PR removes the leftovers.

**Which issue is resolved by this Pull Request:**
Resolves #975 
