### PR TITLE
Fix the cluster label selector in e2e helpers

### DIFF
--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -18,6 +18,11 @@ func ClusterLabels(c *scyllav1.ScyllaCluster) map[string]string {
 	return labels
 }
 
+// ClusterSelector returns a labels selector for the given ScyllaCluster.
+func ClusterSelector(c *scyllav1.ScyllaCluster) labels.Selector {
+	return labels.SelectorFromSet(ClusterLabels(c))
+}
+
 // DatacenterLabels returns a map of label keys and values
 // for the given Datacenter.
 func DatacenterLabels(c *scyllav1.ScyllaCluster) map[string]string {

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -512,9 +512,7 @@ func GetNodesServiceIPs(ctx context.Context, client corev1client.CoreV1Interface
 
 func GetNodesPodIPs(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) ([]string, error) {
 	clusterPods, err := client.Pods(sc.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{
-			naming.ClusterNameLabel: sc.Name,
-		}).String(),
+		LabelSelector: naming.ClusterSelector(sc).String(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can't get cluster pods: %w", err)


### PR DESCRIPTION
**Description of your changes:** "ScyllaCluster should setup and maintain up to date TLS certificates" e2e test used an incorrect labels selector which resulted in picking up cleanup Pods in addition to ScyllaDB Pods, and in turn caused the test's flakiness, as described in https://github.com/scylladb/scylla-operator/issues/1414#issuecomment-1735152541. This PR fixes the label selector to only match ScyllaDB Pods of a given cluster.

**Which issue is resolved by this Pull Request:**
Resolves #1414 
