### PR TITLE
Introspect operator image to prevent skew with the sidecar

### DIFF
--- a/deploy/operator/50_operator.deployment.yaml
+++ b/deploy/operator/50_operator.deployment.yaml
@@ -26,8 +26,10 @@ spec:
         image: docker.io/scylladb/scylla-operator:latest
         imagePullPolicy: IfNotPresent
         env:
-        - name: SCYLLA_OPERATOR_IMAGE
-          value: docker.io/scylladb/scylla-operator:latest
+        - name: SCYLLA_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         args:
         - operator
         - --loglevel=2

--- a/examples/common/operator.yaml
+++ b/examples/common/operator.yaml
@@ -4918,8 +4918,10 @@ spec:
         image: docker.io/scylladb/scylla-operator:latest
         imagePullPolicy: IfNotPresent
         env:
-        - name: SCYLLA_OPERATOR_IMAGE
-          value: docker.io/scylladb/scylla-operator:latest
+        - name: SCYLLA_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         args:
         - operator
         - --loglevel=2

--- a/helm/scylla-operator/templates/operator.deployment.yaml
+++ b/helm/scylla-operator/templates/operator.deployment.yaml
@@ -34,8 +34,10 @@ spec:
         image: {{ .Values.image.repository }}/scylla-operator:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-        - name: SCYLLA_OPERATOR_IMAGE
-          value: {{ .Values.image.repository }}/scylla-operator:{{ .Values.image.tag | default .Chart.AppVersion }}
+        - name: SCYLLA_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         args:
         - operator
         - --loglevel={{ .Values.logLevel }}

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -15,21 +15,29 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controller/scyllacluster"
 	"github.com/scylladb/scylla-operator/pkg/controller/scylladbmonitoring"
 	"github.com/scylladb/scylla-operator/pkg/controller/scyllaoperatorconfig"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/crypto"
 	monitoringversionedclient "github.com/scylladb/scylla-operator/pkg/externalclient/monitoring/clientset/versioned"
 	monitoringinformers "github.com/scylladb/scylla-operator/pkg/externalclient/monitoring/informers/externalversions"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/leaderelection"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 )
@@ -49,6 +57,7 @@ type OperatorOptions struct {
 
 	ConcurrentSyncs int
 	OperatorImage   string
+	OperatorPodName string
 	CQLSIngressPort int
 
 	CryptoKeyBufferSizeMin int
@@ -80,17 +89,25 @@ func NewOperatorCmd(streams genericclioptions.IOStreams) *cobra.Command {
 		Short: "Run the scylla operator.",
 		Long:  `Run the scylla operator.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Complete(cmd)
+			stopCh := signals.StopChannel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				<-stopCh
+				cancel()
+			}()
+
+			err := o.Validate()
 			if err != nil {
 				return err
 			}
 
-			err = o.Validate()
+			err = o.Complete(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			err = o.Run(streams, cmd)
+			err = o.Run(ctx, streams, cmd)
 			if err != nil {
 				return err
 			}
@@ -108,6 +125,7 @@ func NewOperatorCmd(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.Flags().IntVarP(&o.ConcurrentSyncs, "concurrent-syncs", "", o.ConcurrentSyncs, "The number of ScyllaCluster objects that are allowed to sync concurrently.")
 	cmd.Flags().StringVarP(&o.OperatorImage, "image", "", o.OperatorImage, "Image of the operator used.")
+	cmd.Flags().StringVarP(&o.OperatorPodName, "pod-name", "", o.OperatorPodName, "Name of the Pod that this binary is running in. This is meant to be set using Kubernetes Downwards API.")
 	cmd.Flags().IntVarP(&o.CQLSIngressPort, "cqls-ingress-port", "", o.CQLSIngressPort, "Port on which is the ingress controller listening for secure CQL connections.")
 	cmd.Flags().IntVarP(&o.CryptoKeyBufferSizeMin, "crypto-key-buffer-size-min", "", o.CryptoKeyBufferSizeMin, "Minimal number of pre-generated crypto keys that are used for quick certificate issuance. The minimum size is 1.")
 	cmd.Flags().IntVarP(&o.CryptoKeyBufferSizeMax, cryptoKeyBufferSizeMaxFlagKey, "", o.CryptoKeyBufferSizeMax, "Maximum number of pre-generated crypto keys that are used for quick certificate issuance. The minimum size is 1. If not set, it will adjust to be at least the size of crypto-key-buffer-size-min.")
@@ -123,12 +141,8 @@ func (o *OperatorOptions) Validate() error {
 	errs = append(errs, o.InClusterReflection.Validate())
 	errs = append(errs, o.LeaderElection.Validate())
 
-	if len(o.OperatorImage) == 0 {
-		errs = append(errs, errors.New("operator image can't be empty"))
-	}
-
-	if len(o.OperatorImage) == 0 {
-		errs = append(errs, errors.New("operator image can't be empty"))
+	if len(o.OperatorImage) == 0 && len(o.OperatorPodName) == 0 {
+		errs = append(errs, errors.New("either the image or the pod-name have to be set but both are empty"))
 	}
 
 	if o.CryptoKeyBufferSizeMin < 1 {
@@ -152,10 +166,10 @@ func (o *OperatorOptions) Validate() error {
 		errs = append(errs, fmt.Errorf("invalid secure cql ingress port %d: %s", o.CQLSIngressPort, msg))
 	}
 
-	return apierrors.NewAggregate(errs)
+	return kutilerrors.NewAggregate(errs)
 }
 
-func (o *OperatorOptions) Complete(cmd *cobra.Command) error {
+func (o *OperatorOptions) Complete(ctx context.Context, cmd *cobra.Command) error {
 	err := o.ClientConfig.Complete()
 	if err != nil {
 		return err
@@ -191,20 +205,89 @@ func (o *OperatorOptions) Complete(cmd *cobra.Command) error {
 		o.CryptoKeyBufferSizeMax = o.CryptoKeyBufferSizeMin
 	}
 
+	if len(o.OperatorImage) == 0 {
+		klog.V(2).InfoS("No explicit operator image specified - starting auto detection from Pod status")
+
+		pod, err := o.kubeClient.CoreV1().Pods(o.Namespace).Get(ctx, o.OperatorPodName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("can't get pod %q to introspect its image: %w", naming.ManualRef(o.Namespace, o.OperatorPodName), err)
+		}
+
+		const soContainerName = "scylla-operator"
+
+		// First, we make sure the container exists in the spec.
+		_, err = naming.FindContainerWithName(pod.Spec.Containers, soContainerName)
+		if err != nil {
+			return fmt.Errorf("can't find container %q", soContainerName)
+		}
+
+		// Now we should wait for the Pod to have its status updated by kubelet.
+		// This should be almost imminent, but we don't want to fail the Pod too soon if the cluster is overloaded.
+		const csWaitTimeout = 5 * time.Minute
+		klog.V(2).InfoS("Waiting for Pod status to be updated", "Timeout", csWaitTimeout)
+		csCtx, csCtxCancel := context.WithTimeout(ctx, csWaitTimeout)
+		defer csCtxCancel()
+		podFieldSelector := fields.OneTermEqualSelector("metadata.name", o.OperatorPodName)
+		podLW := &cache.ListWatch{
+			ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
+				options.FieldSelector = podFieldSelector.String()
+				return o.kubeClient.CoreV1().Pods(o.Namespace).List(ctx, options)
+			}),
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.FieldSelector = podFieldSelector.String()
+				return o.kubeClient.CoreV1().Pods(o.Namespace).Watch(ctx, options)
+			},
+		}
+		var cs *corev1.ContainerStatus
+		_, err = watchtools.UntilWithSync(
+			csCtx,
+			podLW,
+			&corev1.Pod{},
+			nil,
+			func(e watch.Event) (bool, error) {
+				switch t := e.Type; t {
+				case watch.Added, watch.Modified:
+					pod = e.Object.(*corev1.Pod)
+
+					cs = controllerhelpers.FindContainerStatus(pod, soContainerName)
+					if cs == nil {
+						klog.V(4).InfoS(
+							"Container status is not yet present",
+							"Container", soContainerName,
+							"Pod", naming.ObjRef(pod),
+						)
+						return false, nil
+					}
+
+					return true, nil
+
+				case watch.Error:
+					return true, apierrors.FromObject(e.Object)
+
+				default:
+					return true, fmt.Errorf("unexpected event type %v", t)
+				}
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("can't wait for pod %q to have container status for container %q: %w", naming.ObjRef(pod), soContainerName, err)
+		}
+
+		if len(cs.ImageID) == 0 {
+			return fmt.Errorf("can't introspect its own image: containerStatus.imageID for container %q in pod %q is empty", soContainerName, naming.ObjRef(pod))
+		}
+
+		o.OperatorImage = cs.ImageID
+
+		klog.V(2).InfoS("Successfully introspected its own image", "OperatorImage", o.OperatorImage)
+	}
+
 	return nil
 }
 
-func (o *OperatorOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Command) error {
+func (o *OperatorOptions) Run(ctx context.Context, streams genericclioptions.IOStreams, cmd *cobra.Command) error {
 	klog.Infof("%s version %s", cmd.Name(), version.Get())
 	cliflag.PrintFlags(cmd.Flags())
-
-	stopCh := signals.StopChannel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		<-stopCh
-		cancel()
-	}()
 
 	// Lock names cannot be changed, because it may lead to two leaders during rolling upgrades.
 	const lockName = "scylla-operator-lock"


### PR DESCRIPTION
**Description of your changes:**
This PR let's the scylla operator image be introspected from pod status when run in the cluster.

**Which issue is resolved by this Pull Request:**
Resolves #1424
