### PR TITLE
Fix must-gather podman command in postsubmit's 'Dump cluster state' job

### DIFF
--- a/.github/actions/run-e2e/action.yaml
+++ b/.github/actions/run-e2e/action.yaml
@@ -141,6 +141,8 @@ runs:
       set -euExo pipefail
       shopt -s inherit_errexit
       
+      mkdir "${ARTIFACTS_DIR}"/must-gather
+
       user="$( id -u )"
       group="$( id -g )"
       sudo timeout -v 10m podman run --user="${user}:${group}" --rm \
@@ -148,7 +150,7 @@ runs:
       -v="${ARTIFACTS_DIR}:${ARTIFACTS_DIR}:rw" \
       -v="${HOME}/.kube/config:/kubeconfig:ro" -e='KUBECONFIG=/kubeconfig' \
       '${{ env.image_repo_ref }}:ci' \
-      run must-gather \
+      must-gather \
       --all-resources \
       --dest-dir="${ARTIFACTS_DIR}/must-gather" \
       --loglevel=2


### PR DESCRIPTION
**Description of your changes:**
Current must-gather podman command is failing on master. This PR fixes the command. It also creates the destination directory beforehand as otherwise the command fails with `Error: destination directory <dest-dir> doesn't exist`

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/1429
