### PR TITLE
Fix logs in orphaned PV controller

### DIFF
--- a/pkg/controller/orphanedpv/sync.go
+++ b/pkg/controller/orphanedpv/sync.go
@@ -81,7 +81,7 @@ func (opc *Controller) sync(ctx context.Context, key string) error {
 
 	sc, err := opc.scyllaLister.ScyllaClusters(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
-		klog.V(2).InfoS("ScyllaCluster has been deleted", "ScyllaCluster", klog.KObj(sc))
+		klog.V(2).InfoS("ScyllaCluster has been deleted", "ScyllaCluster", klog.KRef(namespace, name))
 		return nil
 	}
 	if err != nil {
@@ -93,7 +93,7 @@ func (opc *Controller) sync(ctx context.Context, key string) error {
 	}
 
 	if !sc.Spec.AutomaticOrphanedNodeCleanup {
-		klog.V(4).InfoS("ScyllaCluster doesn't have AutomaticOrphanedNodeCleanup enabled", "ScyllaCluster", klog.KRef(namespace, name))
+		klog.V(4).InfoS("ScyllaCluster doesn't have AutomaticOrphanedNodeCleanup enabled", "ScyllaCluster", klog.KObj(sc))
 		return nil
 	}
 
@@ -121,7 +121,7 @@ func (opc *Controller) sync(ctx context.Context, key string) error {
 			continue
 		}
 
-		klog.V(2).InfoS("PV is orphaned", "ScyllaCluster", sc, "PV", klog.KObj(pi.PV))
+		klog.V(2).InfoS("PV is orphaned", "ScyllaCluster", klog.KObj(sc), "PV", klog.KObj(pi.PV))
 
 		// Verify that the node doesn't exist with a live call.
 		freshNodes, err := opc.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
@@ -142,7 +142,7 @@ func (opc *Controller) sync(ctx context.Context, key string) error {
 			continue
 		}
 
-		klog.V(2).InfoS("PV is verified as orphaned.", "ScyllaCluster", sc, "PV", klog.KObj(pi.PV))
+		klog.V(2).InfoS("PV is verified as orphaned.", "ScyllaCluster", klog.KObj(sc), "PV", klog.KObj(pi.PV))
 
 		_, err = opc.kubeClient.CoreV1().Services(sc.Namespace).Patch(
 			ctx,
@@ -156,7 +156,7 @@ func (opc *Controller) sync(ctx context.Context, key string) error {
 			continue
 		}
 
-		klog.V(2).InfoS("Marked service for replacement", "ScyllaCluster", sc, "Service", pi.ServiceName)
+		klog.V(2).InfoS("Marked service for replacement", "ScyllaCluster", klog.KObj(sc), "Service", klog.KRef(sc.Namespace, pi.ServiceName))
 	}
 
 	err = utilerrors.NewAggregate(errs)


### PR DESCRIPTION
**Description of your changes:** This PR fixes the logging in orphaned PV controller by:
1. Logging a manual ref for a non-existing ScyllaCluster instead of currently used `KObj`, which prints an empty string given a nil argument.
2. Changing manual refs to `KObj` where possible.
3. Logging `KObj` instead of the entire struct, which currently makes the logs very unreadable and difficult to work with.

The unreadability of the logs can be observed in any of the runs posted in https://github.com/scylladb/scylla-operator/issues/1240.