### PR TITLE
Remove explicit copying of replace label between Service instances

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -73,14 +73,10 @@ func MemberService(sc *scyllav1.ScyllaCluster, rackName, name string, oldService
 	svcLabels[naming.RackNameLabel] = rackName
 	svcLabels[naming.ScyllaServiceTypeLabel] = string(naming.ScyllaServiceTypeMember)
 
-	// Copy the old replace label, if present.
 	var replaceAddr string
 	var hasReplaceLabel bool
 	if oldService != nil {
 		replaceAddr, hasReplaceLabel = oldService.Labels[naming.ReplaceLabel]
-		if hasReplaceLabel {
-			svcLabels[naming.ReplaceLabel] = replaceAddr
-		}
 	}
 
 	// Only new service should get the replace address, old service keeps "" until deleted.

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -216,8 +216,10 @@ func TestMemberService(t *testing.T) {
 				},
 			},
 		},
+		// This behaviour is based on the fact the we merge labels on apply.
+		// TODO: to be addressed with https://github.com/scylladb/scylla-operator/issues/1440.
 		{
-			name:          "new service with unsaved IP and existing replace address",
+			name:          "new service with unsaved IP and existing replace label",
 			scyllaCluster: basicSC,
 			rackName:      basicRackName,
 			svcName:       basicSVCName,
@@ -231,43 +233,8 @@ func TestMemberService(t *testing.T) {
 			jobs: nil,
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = "10.0.0.1"
-						return labels
-					}(),
-					OwnerReferences: basicSCOwnerRefs,
-				},
-				Spec: corev1.ServiceSpec{
-					Type:                     corev1.ServiceTypeClusterIP,
-					Selector:                 basicSVCSelector,
-					PublishNotReadyAddresses: true,
-					Ports:                    basicPorts,
-				},
-			},
-		},
-		{
-			name:          "existing initial service",
-			scyllaCluster: basicSC,
-			rackName:      basicRackName,
-			svcName:       basicSVCName,
-			oldService: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						naming.ReplaceLabel: "",
-					},
-				},
-			},
-			jobs: nil,
-			expectedService: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = ""
-						return labels
-					}(),
+					Name:            basicSVCName,
+					Labels:          basicSVCLabels(),
 					OwnerReferences: basicSCOwnerRefs,
 				},
 				Spec: corev1.ServiceSpec{
@@ -301,12 +268,8 @@ func TestMemberService(t *testing.T) {
 			jobs: nil,
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = ""
-						return labels
-					}(),
+					Name:            basicSVCName,
+					Labels:          basicSVCLabels(),
 					OwnerReferences: basicSCOwnerRefs,
 				},
 				Spec: corev1.ServiceSpec{


### PR DESCRIPTION
**Description of your changes:** Currently the replace label is copied explicitly between Service instances. This can result in the replace label being carried over past the end of the replacement procedure in case the replace label is not removed from the original Service on time, which can in turn break the node, as observed in https://github.com/scylladb/scylla-operator/issues/1240. This PR removes the superfluous explicit copy of the replacement label. It's necessary in neither the old nor the new replacement procedure. In the old procedure, the label will be picked up from ScyllaCluster status, while the new procedure doesn't terminate services. This change should fix the issue for the new replacement procedure, as the replacement label will never be carried over to a new Service instance. Unfortunately, this PR doesn't fix the deprecated procedure.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/1240
