### PR TITLE
Explicitly set TLS CQL shard aware port

### DIFF
--- a/assets/scylladb/defaultconfig.yaml
+++ b/assets/scylladb/defaultconfig.yaml
@@ -3,6 +3,7 @@ rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 {{- if .enableTLS }}
 native_transport_port_ssl: 9142
+native_shard_aware_transport_port_ssl: 19142
 client_encryption_options:
   enabled: true
   optional: false

--- a/pkg/sidecar/config/config_test.go
+++ b/pkg/sidecar/config/config_test.go
@@ -354,6 +354,7 @@ cluster_name: "foo"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 native_transport_port_ssl: 9142
+native_shard_aware_transport_port_ssl: 19142
 client_encryption_options:
   enabled: true
   optional: false


### PR DESCRIPTION
When TLS is disabled Scylla uses following ports:
| port  | encryption  | type            |
|-------|-------------|-----------------|
| 9042 | unencrypted | non-shard-aware |
| 19042 | unencrypted | shard-aware     |

When TLS was enabled by default in #1407, Scylla started listening on following ports: 
| port  | encryption  | type            |
|-------|-------------|-----------------|
| 9042  | unencrypted | non-shard-aware |
| 19042 | encrypted   | shard-aware     |
| 9142  | encrypted   | non-shard-aware |

This caused issues on upgrades because previously unencrypted port was suddenly encrypted.

To fix backward compatibility, we should explictly set SSL shard-aware port. 
With this change Scylla use following ports:
| port  | encryption  | type            |
|-------|-------------|-----------------|
| 9042  | unencrypted | non-shard-aware |
| 19042 | unencrypted | shard-aware     |
| 9142  | encrypted   | non-shard-aware |
| 19142 | encrypted   | shard-aware     |

Resolves #1446
