### PR TITLE
[v1.11] Use the same tag version of gen-release-notes when preparing them

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -54,5 +54,5 @@ jobs:
         githubRef: ${{ env.current_tag }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         goVersion: ${{ env.go_version }}
-        genReleaseNotesVersionRef: master
+        genReleaseNotesVersionRef: ${{ env.current_tag }}
         containerImageName: docker.io/scylladb/scylla-operator


### PR DESCRIPTION
Backport of #1472 