### PR TITLE
Fix grafana permissions for kubectl cp and run it as non root

### DIFF
--- a/assets/monitoring/grafana/v1alpha1/deployment.yaml
+++ b/assets/monitoring/grafana/v1alpha1/deployment.yaml
@@ -15,10 +15,6 @@ spec:
       labels:
         scylla-operator.scylladb.com/deployment-name: "{{ .scyllaDBMonitoringName }}-grafana"
     spec:
-      securityContext:
-        fsGroup: 472
-        supplementalGroups:
-        - 0
       affinity:
         {{- .affinity | toYAML | nindent 8 }}
       tolerations:
@@ -97,6 +93,15 @@ spec:
           mountPath: /var/run/configmaps/prometheus-serving-ca
         - name: grafana-storage
           mountPath: /var/lib/grafana
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 472
+          runAsGroup: 472
+          capabilities:
+            drop:
+            - ALL
       volumes:
       - name: grafana-configs
         configMap:
@@ -122,3 +127,10 @@ spec:
       - name: grafana-storage
         emptyDir:
           sizeLimit: 100Mi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 472
+        runAsGroup: 472
+        fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
`kubectl cp` was hitting permission denied, this PR fixes it + Grafana permissions are scaled down.