### PR TITLE
Add 'externalSeeds' support to ScyllaDB Helm chart

### DIFF
--- a/helm/scylla/templates/scyllacluster.yaml
+++ b/helm/scylla/templates/scyllacluster.yaml
@@ -54,6 +54,10 @@ spec:
   exposeOptions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.externalSeeds }}
+  externalSeeds:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   datacenter:
     name: {{ .Values.datacenter }}
     racks:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR adds support for `externalSeeds` to ScyllaDB Helm chart.

**Which issue is resolved by this Pull Request:**
Resolves #1484 

/kind machinery
/priority important-longterm


