### PR TITLE
[v1.11] Add 'externalSeeds' support to ScyllaDB Helm chart

### DIFF
--- a/helm/scylla/templates/scyllacluster.yaml
+++ b/helm/scylla/templates/scyllacluster.yaml
@@ -54,6 +54,10 @@ spec:
   exposeOptions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.externalSeeds }}
+  externalSeeds:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   datacenter:
     name: {{ .Values.datacenter }}
     racks:


### PR DESCRIPTION
Pre-release backport of https://github.com/scylladb/scylla-operator/pull/1487.

/kind machinery
/priority important-longterm