### PR TITLE
[v1.11] Fix example file in 'Setting up nodes for ScyllaDB' of 'Deploying Scylla on EKS' documentation page

### DIFF
--- a/docs/source/eks.md
+++ b/docs/source/eks.md
@@ -97,7 +97,7 @@ ScyllaDB, except when in developer mode, requires storage with XFS filesystem. T
 
 Deploy `NodeConfig` to let it take care of the above operations:
 ```
-kubectl apply --server-side -f examples/gke/nodeconfig-alpha.yaml
+kubectl apply --server-side -f examples/eks/nodeconfig-alpha.yaml
 ```
 
 #### Deploying Local Volume Provisioner


### PR DESCRIPTION
Pre-release backport of https://github.com/scylladb/scylla-operator/pull/1496.

/kind documentation
/priority important-longterm