### PR TITLE
[v1.11] Don't use docs CI from master

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -29,7 +29,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        ref: 'master'
         persist-credentials: false
         fetch-depth: 0
 


### PR DESCRIPTION
**Description of your changes:**
This should use it's own CI code, not master.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/actions/runs/6575445787/job/17862594992#step:3:1
```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/scylla-operator/scylla-operator/.github/actions/docs/setup'. Did you forget to run actions/checkout before running your local action?
```
