### PR TITLE
Fix preview target in docs readme

### DIFF
--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -14,7 +14,7 @@ Here is an example how you can start quickly using containers, similarly to how 
 (This assumes you are located at the repository root.)
 
 ```bash
-podman run -it --pull=Always --rm -v="$( pwd )/docs:/go/$( go list -m )/docs:Z" --workdir="/go/$( go list -m )/docs" -p 5500:5500 quay.io/scylladb/scylla-operator-images:poetry-1.5 bash -euExo pipefail -O inherit_errexit -c 'poetry install && make multiversionpreview'
+podman run -it --pull=Always --rm -v="$( pwd )/docs:/go/$( go list -m )/docs:Z" --workdir="/go/$( go list -m )/docs" -p 5500:5500 quay.io/scylladb/scylla-operator-images:poetry-1.5 bash -euExo pipefail -O inherit_errexit -c 'poetry install && make preview'
 ```
 
 Docs will be available at http://localhost:5500/ 


### PR DESCRIPTION
**Description of your changes:**
`multiversionpreview` doesn't actually build the docs on its own so the instructions don't work on a clean repository + it doesn't make sense to checkout the other branches. We should use the `preview` target that builds the docs and live reloads them.

