### PR TITLE
Make E2E suite expose ScyllaClusters on PodIPs by default

### DIFF
--- a/hack/.ci/run-e2e-gke.sh
+++ b/hack/.ci/run-e2e-gke.sh
@@ -16,6 +16,21 @@ if [ -z ${SO_IMAGE+x} ]; then
   exit 2
 fi
 
+if [ -z ${SO_SCYLLACLUSTER_NODE_SERVICE_TYPE+x} ]; then
+  echo "SO_SCYLLACLUSTER_NODE_SERVICE_TYPE can't be empty" > /dev/stderr
+  exit 2
+fi
+
+if [ -z ${SO_SCYLLACLUSTER_NODES_BROADCAST_ADDRESS_TYPE+x} ]; then
+  echo "SO_SCYLLACLUSTER_NODES_BROADCAST_ADDRESS_TYPE can't be empty" > /dev/stderr
+  exit 2
+fi
+
+if [ -z ${SO_SCYLLACLUSTER_CLIENTS_BROADCAST_ADDRESS_TYPE+x} ]; then
+  echo "SO_SCYLLACLUSTER_CLIENTS_BROADCAST_ADDRESS_TYPE can't be empty" > /dev/stderr
+  exit 2
+fi
+
 if [ -z ${ARTIFACTS+x} ]; then
   echo "ARTIFACTS can't be empty" > /dev/stderr
   exit 2
@@ -156,7 +171,7 @@ ingress_controller_address="$( kubectl -n haproxy-ingress get svc haproxy-ingres
 
 kubectl create -n e2e pdb my-pdb --selector='app=e2e' --min-available=1 --dry-run=client -o yaml | kubectl_create -f -
 
-kubectl -n e2e run --restart=Never --image="${SO_IMAGE}" --labels='app=e2e' --command=true e2e -- bash -euExo pipefail -O inherit_errexit -c "function wait-for-artifacts { touch /tmp/done && until [[ -f '/tmp/exit' ]]; do sleep 1; done } && trap wait-for-artifacts EXIT && mkdir /tmp/artifacts && scylla-operator-tests run '${SO_SUITE}' --loglevel=2 --color=false --artifacts-dir=/tmp/artifacts --feature-gates='${SCYLLA_OPERATOR_FEATURE_GATES}' --ingress-controller-address='${ingress_controller_address}' --ingress-controller-ingress-class-name='${ingress_class_name}' --ingress-controller-custom-annotations='${ingress_custom_annotations}'"
+kubectl -n e2e run --restart=Never --image="${SO_IMAGE}" --labels='app=e2e' --command=true e2e -- bash -euExo pipefail -O inherit_errexit -c "function wait-for-artifacts { touch /tmp/done && until [[ -f '/tmp/exit' ]]; do sleep 1; done } && trap wait-for-artifacts EXIT && mkdir /tmp/artifacts && scylla-operator-tests run '${SO_SUITE}' --loglevel=2 --color=false --artifacts-dir=/tmp/artifacts --feature-gates='${SCYLLA_OPERATOR_FEATURE_GATES}' --ingress-controller-address='${ingress_controller_address}' --ingress-controller-ingress-class-name='${ingress_class_name}' --ingress-controller-custom-annotations='${ingress_custom_annotations}' --scyllacluster-node-service-type='${SO_SCYLLACLUSTER_NODE_SERVICE_TYPE}' --scyllacluster-nodes-broadcast-address-type='${SO_SCYLLACLUSTER_NODES_BROADCAST_ADDRESS_TYPE}' --scyllacluster-clients-broadcast-address-type='${SO_SCYLLACLUSTER_CLIENTS_BROADCAST_ADDRESS_TYPE}'"
 kubectl -n e2e wait --for=condition=Ready pod/e2e
 
 # Setup artifacts transfer when finished and unblock the e2e pod when done.

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
@@ -15,11 +17,29 @@ type IngressControllerOptions struct {
 	CustomAnnotations map[string]string
 }
 
+type ScyllaClusterOptions struct {
+	NodeServiceType             string
+	NodesBroadcastAddressType   string
+	ClientsBroadcastAddressType string
+}
+
+var supportedNodeServiceTypes = []scyllav1.NodeServiceType{
+	scyllav1.NodeServiceTypeHeadless,
+	scyllav1.NodeServiceTypeClusterIP,
+}
+
+var supportedBroadcastAddressTypes = []scyllav1.BroadcastAddressType{
+	scyllav1.BroadcastAddressTypePodIP,
+	scyllav1.BroadcastAddressTypeServiceClusterIP,
+}
+
 type TestFrameworkOptions struct {
 	ArtifactsDir                 string
 	DeleteTestingNSPolicyUntyped string
 	DeleteTestingNSPolicy        framework.DeleteTestingNSPolicyType
 	IngressController            *IngressControllerOptions
+	ScyllaClusterOptionsUntyped  *ScyllaClusterOptions
+	scyllaClusterOptions         *framework.ScyllaClusterOptions
 }
 
 func NewTestFrameworkOptions() TestFrameworkOptions {
@@ -27,6 +47,11 @@ func NewTestFrameworkOptions() TestFrameworkOptions {
 		ArtifactsDir:                 "",
 		DeleteTestingNSPolicyUntyped: string(framework.DeleteTestingNSPolicyAlways),
 		IngressController:            &IngressControllerOptions{},
+		ScyllaClusterOptionsUntyped: &ScyllaClusterOptions{
+			NodeServiceType:             string(scyllav1.NodeServiceTypeHeadless),
+			NodesBroadcastAddressType:   string(scyllav1.BroadcastAddressTypePodIP),
+			ClientsBroadcastAddressType: string(scyllav1.BroadcastAddressTypePodIP),
+		},
 	}
 }
 
@@ -43,6 +68,18 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&o.IngressController.Address, "ingress-controller-address", "", o.IngressController.Address, "Overrides destination address when sending testing data to applications behind ingresses.")
 	cmd.PersistentFlags().StringVarP(&o.IngressController.IngressClassName, "ingress-controller-ingress-class-name", "", o.IngressController.IngressClassName, "Ingress class name under which ingress controller is registered")
 	cmd.PersistentFlags().StringToStringVarP(&o.IngressController.CustomAnnotations, "ingress-controller-custom-annotations", "", o.IngressController.CustomAnnotations, "Custom annotations required by the ingress controller")
+	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.NodeServiceType, "scyllacluster-node-service-type", "", o.ScyllaClusterOptionsUntyped.NodeServiceType, fmt.Sprintf("Kubernetes service type that the ScyllaCluster nodes are exposed with. Allowed values are [%s].", strings.Join(
+		slices.ConvertSlice(supportedNodeServiceTypes, slices.ToString[scyllav1.NodeServiceType]),
+		", ",
+	)))
+	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType, "scyllacluster-nodes-broadcast-address-type", "", o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType, fmt.Sprintf("Type of address that the ScyllaCluster nodes broadcast for communication with other nodes. Allowed values are [%s].", strings.Join(
+		slices.ConvertSlice(supportedBroadcastAddressTypes, slices.ToString[scyllav1.BroadcastAddressType]),
+		", ",
+	)))
+	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType, "scyllacluster-clients-broadcast-address-type", "", o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType, fmt.Sprintf("Type of address that the ScyllaCluster nodes broadcast for communication with clients. Allowed values are [%s].", strings.Join(
+		slices.ConvertSlice(supportedBroadcastAddressTypes, slices.ToString[scyllav1.BroadcastAddressType]),
+		", ",
+	)))
 }
 
 func (o *TestFrameworkOptions) Validate() error {
@@ -56,6 +93,18 @@ func (o *TestFrameworkOptions) Validate() error {
 		errors = append(errors, fmt.Errorf("invalid DeleteTestingNSPolicy: %q", p))
 	}
 
+	if !slices.ContainsItem(supportedNodeServiceTypes, scyllav1.NodeServiceType(o.ScyllaClusterOptionsUntyped.NodeServiceType)) {
+		errors = append(errors, fmt.Errorf("invalid scylla-cluster-node-service-type: %q", o.ScyllaClusterOptionsUntyped.NodeServiceType))
+	}
+
+	if !slices.ContainsItem(supportedBroadcastAddressTypes, scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType)) {
+		errors = append(errors, fmt.Errorf("invalid scylla-cluster-nodes-broadcast-address-type: %q", o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType))
+	}
+
+	if !slices.ContainsItem(supportedBroadcastAddressTypes, scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType)) {
+		errors = append(errors, fmt.Errorf("invalid scylla-cluster-clients-broadcast-address-type: %q", o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType))
+	}
+
 	return apierrors.NewAggregate(errors)
 }
 
@@ -64,6 +113,14 @@ func (o *TestFrameworkOptions) Complete() error {
 
 	// Trim spaces so we can reason later if the dir is set or not
 	o.ArtifactsDir = strings.TrimSpace(o.ArtifactsDir)
+
+	o.scyllaClusterOptions = &framework.ScyllaClusterOptions{
+		ExposeOptions: framework.ExposeOptions{
+			NodeServiceType:             scyllav1.NodeServiceType(o.ScyllaClusterOptionsUntyped.NodeServiceType),
+			NodesBroadcastAddressType:   scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType),
+			ClientsBroadcastAddressType: scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType),
+		},
+	}
 
 	return nil
 }

--- a/pkg/cmd/tests/tests_run.go
+++ b/pkg/cmd/tests/tests_run.go
@@ -261,6 +261,7 @@ func (o *RunOptions) run(ctx context.Context, streams genericclioptions.IOStream
 		RestConfig:            o.RestConfig,
 		ArtifactsDir:          o.ArtifactsDir,
 		DeleteTestingNSPolicy: o.DeleteTestingNSPolicy,
+		ScyllaClusterOptions:  o.scyllaClusterOptions,
 	}
 	if o.IngressController != nil {
 		framework.TestContext.IngressController = &framework.IngressController{

--- a/test/e2e/fixture/scylla/registry.go
+++ b/test/e2e/fixture/scylla/registry.go
@@ -16,8 +16,9 @@ func ParseObjectTemplateOrDie[T runtime.Object](name, tmplString string) assets.
 }
 
 var (
-	//go:embed "basic.scyllacluster.yaml"
-	BasicScyllaCluster ScyllaClusterBytes
+	//go:embed "scyllacluster.yaml.tmpl"
+	ScyllaClusterTemplateString string
+	ScyllaClusterTemplate       = ParseObjectTemplateOrDie[*scyllav1.ScyllaCluster]("scyllacluster", ScyllaClusterTemplateString)
 
 	//go:embed "nodeconfig.yaml"
 	NodeConfig NodeConfigBytes
@@ -26,15 +27,6 @@ var (
 	scyllaDBMonitoringTemplateString string
 	ScyllaDBMonitoringTemplate       = ParseObjectTemplateOrDie[*scyllav1alpha1.ScyllaDBMonitoring]("scylladbmonitoring", scyllaDBMonitoringTemplateString)
 )
-
-type ScyllaClusterBytes []byte
-
-func (sc ScyllaClusterBytes) ReadOrFail() *scyllav1.ScyllaCluster {
-	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(sc, nil, nil)
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	return obj.(*scyllav1.ScyllaCluster)
-}
 
 type NodeConfigBytes []byte
 

--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -6,6 +6,14 @@ spec:
   agentVersion: 3.2.5
   version: 5.4.0
   developerMode: true
+  exposeOptions:
+    nodeService:
+      type: {{ .nodeServiceType }}
+    broadcastOptions:
+      nodes:
+        type: {{ .nodesBroadcastAddressType }}
+      clients:
+        type: {{ .clientsBroadcastAddressType }}
   datacenter:
     name: us-east-1
     racks:

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -14,7 +14,9 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllaclientset "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
+	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -141,6 +143,19 @@ func (f *Framework) CommonLabels() map[string]string {
 		"e2e":       "scylla-operator",
 		"framework": f.name,
 	}
+}
+
+func (f *Framework) GetDefaultScyllaCluster() *scyllav1.ScyllaCluster {
+	renderArgs := map[string]any{
+		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
+		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
+		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
+	}
+
+	sc, _, err := scyllafixture.ScyllaClusterTemplate.RenderObject(renderArgs)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return sc
 }
 
 func (f *Framework) setupNamespace(ctx context.Context) {

--- a/test/e2e/framework/meta.go
+++ b/test/e2e/framework/meta.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	SerialLabelName = "Serial"
+	SerialLabelName            = "Serial"
+	RequiresClusterIPLabelName = "RequiresClusterIP"
 )
 
 var (
@@ -15,4 +16,5 @@ var (
 		g.Serial,
 		g.Label(SerialLabelName),
 	}
+	RequiresClusterIP = g.Label(RequiresClusterIPLabelName)
 )

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -3,6 +3,7 @@
 package framework
 
 import (
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -22,9 +23,20 @@ type IngressController struct {
 	CustomAnnotations map[string]string
 }
 
+type ScyllaClusterOptions struct {
+	ExposeOptions ExposeOptions
+}
+
+type ExposeOptions struct {
+	NodeServiceType             scyllav1.NodeServiceType
+	NodesBroadcastAddressType   scyllav1.BroadcastAddressType
+	ClientsBroadcastAddressType scyllav1.BroadcastAddressType
+}
+
 type TestContextType struct {
 	RestConfig            *restclient.Config
 	ArtifactsDir          string
 	DeleteTestingNSPolicy DeleteTestingNSPolicyType
 	IngressController     *IngressController
+	ScyllaClusterOptions  *ScyllaClusterOptions
 }

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -183,7 +183,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		nc, err = f.ScyllaAdminClient().ScyllaV1alpha1().NodeConfigs().Create(ctx, nc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 
 		framework.By("Creating a ScyllaCluster")
 		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})

--- a/test/e2e/set/scyllacluster/scyllacluster_auth.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_auth.go
@@ -12,7 +12,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
-	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	"gopkg.in/yaml.v2"
@@ -30,7 +29,7 @@ var _ = g.Describe("ScyllaCluster authentication", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		sc.Spec.Datacenter.Racks[0].Members = 1
 
 		framework.By("Creating a ScyllaCluster")
@@ -44,7 +43,10 @@ var _ = g.Describe("ScyllaCluster authentication", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
-		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		hosts, hostIDs, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(1))
 		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
@@ -117,7 +119,16 @@ var _ = g.Describe("ScyllaCluster authentication", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
-		o.Expect(hosts).To(o.ConsistOf(getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)))
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		oldHostIDs := hostIDs
+		hosts, hostIDs, err = utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hostIDs).To(o.ConsistOf(oldHostIDs))
+
+		// Reset hosts as the client won't be able to discover a single node after rollout.
+		err = di.SetClientEndpoints(hosts)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		verifyCQLData(ctx, di)
 
 		framework.By("Accepting requests authorized using token from user agent config")
@@ -152,7 +163,16 @@ var _ = g.Describe("ScyllaCluster authentication", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
-		o.Expect(hosts).To(o.ConsistOf(getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)))
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		oldHostIDs = hostIDs
+		hosts, hostIDs, err = utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hostIDs).To(o.ConsistOf(oldHostIDs))
+
+		// Reset hosts as the client won't be able to discover a single node after rollout.
+		err = di.SetClientEndpoints(hosts)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		verifyCQLData(ctx, di)
 
 		framework.By("Accepting requests authorized using token from user agent config")

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
-	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	batchv1 "k8s.io/api/batch/v1"
@@ -30,7 +29,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		sc.Spec.Datacenter.Racks[0].Members = 1
 
 		jobListWatcher := &cache.ListWatch{

--- a/test/e2e/set/scyllacluster/scyllacluster_evictions.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_evictions.go
@@ -7,7 +7,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -23,7 +22,7 @@ var _ = g.Describe("ScyllaCluster evictions", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		sc.Spec.Datacenter.Racks[0].Members = 2
 
 		framework.By("Creating a ScyllaCluster")
@@ -37,7 +36,10 @@ var _ = g.Describe("ScyllaCluster evictions", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
-		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(2))
 		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()

--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -23,7 +23,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/scheme"
 	cqlclientv1alpha1 "github.com/scylladb/scylla-operator/pkg/scylla/api/cqlclient/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
-	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	"github.com/scylladb/scylla-operator/test/e2e/verification"
@@ -52,16 +51,17 @@ var _ = g.Describe("ScyllaCluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 
 		sc.Spec.DNSDomains = []string{fmt.Sprintf("%s.private.nodes.scylladb.com", f.Namespace()), fmt.Sprintf("%s.public.nodes.scylladb.com", f.Namespace())}
 		if framework.TestContext.IngressController != nil {
-			sc.Spec.ExposeOptions = &scyllav1.ExposeOptions{
-				CQL: &scyllav1.CQLExposeOptions{
-					Ingress: &scyllav1.IngressOptions{
-						IngressClassName: framework.TestContext.IngressController.IngressClassName,
-						Annotations:      framework.TestContext.IngressController.CustomAnnotations,
-					},
+			if sc.Spec.ExposeOptions == nil {
+				sc.Spec.ExposeOptions = &scyllav1.ExposeOptions{}
+			}
+			sc.Spec.ExposeOptions.CQL = &scyllav1.CQLExposeOptions{
+				Ingress: &scyllav1.IngressOptions{
+					IngressClassName: framework.TestContext.IngressController.IngressClassName,
+					Annotations:      framework.TestContext.IngressController.CustomAnnotations,
 				},
 			}
 		}
@@ -84,7 +84,10 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 		framework.By("Nodes reloaded the certificate")
 
-		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(int(sc.Spec.Datacenter.Racks[0].Members)))
 
 		connectionBundleDir, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("connection-bundle-%s-", f.Namespace()))
@@ -151,7 +154,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		sc.Spec.Datacenter.Racks[0].Members = 1
 		sc.Spec.ExposeOptions = e.exposeOptions
 
@@ -382,16 +385,17 @@ var _ = g.Describe("ScyllaCluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		sc.Spec.Datacenter.Racks[0].Members = 1
 		sc.Spec.DNSDomains = []string{fmt.Sprintf("%s.private.nodes.scylladb.com", f.Namespace()), fmt.Sprintf("%s.public.nodes.scylladb.com", f.Namespace())}
-		sc.Spec.ExposeOptions = &scyllav1.ExposeOptions{
-			CQL: &scyllav1.CQLExposeOptions{
-				Ingress: &scyllav1.IngressOptions{
-					IngressClassName: "my-cql-ingress-class",
-					Annotations: map[string]string{
-						"my-cql-annotation-key": "my-cql-annotation-value",
-					},
+		if sc.Spec.ExposeOptions == nil {
+			sc.Spec.ExposeOptions = &scyllav1.ExposeOptions{}
+		}
+		sc.Spec.ExposeOptions.CQL = &scyllav1.CQLExposeOptions{
+			Ingress: &scyllav1.IngressOptions{
+				IngressClassName: "my-cql-ingress-class",
+				Annotations: map[string]string{
+					"my-cql-annotation-key": "my-cql-annotation-value",
 				},
 			},
 		}

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -16,7 +16,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
-	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	"github.com/scylladb/scylla-operator/test/e2e/utils/image"
@@ -78,7 +77,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 
 		testStorageClassName := f.Namespace()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		sc.Spec.AutomaticOrphanedNodeCleanup = true
 		sc.Spec.Datacenter.Racks[0].Members = 3
 		sc.Spec.Datacenter.Racks[0].Storage.StorageClassName = pointer.Ptr(testStorageClassName)
@@ -273,7 +272,10 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
-		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		hosts, _, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(3))
 		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
@@ -348,13 +350,11 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
-		oldHosts := hosts
-		hosts = getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
-		o.Expect(hosts).To(o.HaveLen(len(oldHosts)))
-		o.Expect(hosts).To(o.ConsistOf(oldHosts))
-		err = di.SetClientEndpoints(hosts)
+		hosts, err = utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hosts).To(o.HaveLen(3))
 		verifyCQLData(ctx, di)
 
 		// Stop fake provisioner

--- a/test/e2e/set/scyllacluster/scyllacluster_sa.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sa.go
@@ -8,7 +8,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +26,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		sc.Name = names.SimpleNameGenerator.GenerateName(sc.GenerateName)
 		sc.GenerateName = ""
 

--- a/test/e2e/set/scyllacluster/scyllacluster_tls.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_tls.go
@@ -20,7 +20,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/kubecrypto"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
-	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/scheme"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
@@ -47,7 +46,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
 		sc.Spec.Datacenter.Racks[0].Members = 1
 
@@ -68,9 +67,12 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
-		initialHost := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
-		o.Expect(initialHost).To(o.HaveLen(1))
-		di := insertAndVerifyCQLData(ctx, initialHost)
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		initialHosts, initialHostIDs, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(initialHosts).To(o.HaveLen(1))
+		di := insertAndVerifyCQLData(ctx, initialHosts)
 		defer di.Close()
 
 		for _, tc := range []struct {
@@ -122,9 +124,14 @@ var _ = g.Describe("ScyllaCluster", func() {
 				sc, err = utils.WaitForScyllaClusterState(waitCtxL1, f.ScyllaClient().ScyllaV1(), sc.Namespace, sc.Name, utils.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+				verifyScyllaCluster(ctx, f.KubeClient(), sc)
+				waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+				hosts, hostIDs, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(hosts).To(o.HaveLen(tc.replicas))
-				o.Expect(hosts).To(o.ContainElements(initialHost))
+				o.Expect(hostIDs).To(o.HaveLen(tc.replicas))
+				o.Expect(hostIDs).To(o.ContainElements(initialHostIDs))
 
 				framework.By("Verifying TLS API objects")
 
@@ -174,16 +181,12 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 				framework.By("Verifying certificates")
 
-				_, nodeIDs, err := utils.GetHostsAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(nodeIDs).To(o.HaveLen(tc.replicas))
-
 				var sniHosts []string
 				for _, domain := range sc.Spec.DNSDomains {
 					sniHosts = append(sniHosts, fmt.Sprintf("cql.%s", domain))
 
-					for _, nodeID := range nodeIDs {
-						sniHosts = append(sniHosts, fmt.Sprintf("%s.cql.%s", nodeID, domain))
+					for _, hostID := range hostIDs {
+						sniHosts = append(sniHosts, fmt.Sprintf("%s.cql.%s", hostID, domain))
 					}
 				}
 				o.Expect(sniHosts).To(o.HaveLen(len(sc.Spec.DNSDomains) + len(sc.Spec.DNSDomains)*tc.replicas))
@@ -200,7 +203,12 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 				serviceAndPodIPs, err := utils.GetNodesServiceAndPodIPs(ctx, f.KubeClient().CoreV1(), sc)
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(serviceAndPodIPs).To(o.HaveLen(2 * int(utils.GetMemberCount(sc))))
+
+				expectedServiceAndPodIPsNum := 2 * int(utils.GetMemberCount(sc))
+				if sc.Spec.ExposeOptions != nil && sc.Spec.ExposeOptions.NodeService != nil && sc.Spec.ExposeOptions.NodeService.Type == scyllav1.NodeServiceTypeHeadless {
+					expectedServiceAndPodIPsNum = int(utils.GetMemberCount(sc))
+				}
+				o.Expect(serviceAndPodIPs).To(o.HaveLen(expectedServiceAndPodIPsNum))
 
 				hostsIPs, err := helpers.ParseIPs(serviceAndPodIPs)
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -252,7 +260,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
 		sc.Spec.Datacenter.Racks[0].Members = 1
 
@@ -267,9 +275,12 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
-		initialHost := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
-		o.Expect(initialHost).To(o.HaveLen(1))
-		di := insertAndVerifyCQLData(ctx, initialHost)
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		initialHosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(initialHosts).To(o.HaveLen(1))
+		di := insertAndVerifyCQLData(ctx, initialHosts)
 		defer di.Close()
 
 		// This test rotates CAs which makes it dependent on the order.

--- a/test/e2e/set/scyllacluster/scyllacluster_updates.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_updates.go
@@ -9,7 +9,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +37,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		defer cancel()
 
 		framework.By("Creating a ScyllaCluster")
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
 		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(1))
 
@@ -52,7 +51,10 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
-		hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		hosts, hostIDs, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(1))
 		di := insertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
@@ -98,7 +100,18 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
-		o.Expect(hosts).To(o.ConsistOf(getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)))
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+		oldHosts := hosts
+		oldHostIDs := hostIDs
+		hosts, hostIDs, err = utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hosts).To(o.HaveLen(len(oldHosts)))
+		o.Expect(hostIDs).To(o.ConsistOf(oldHostIDs))
+
+		// Reset hosts as the client won't be able to discover a single node after rollout.
+		err = di.SetClientEndpoints(hosts)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		verifyCQLData(ctx, di)
 
 		framework.By("Scaling the ScyllaCluster up to create a new replica")
@@ -124,12 +137,15 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyScyllaCluster(ctx, f.KubeClient(), sc)
+		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
-		oldHosts := hosts
-		hosts = getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
-		o.Expect(oldHosts).To(o.HaveLen(int(oldMembers)))
-		o.Expect(hosts).To(o.HaveLen(int(newMebmers)))
-		o.Expect(hosts).To(o.ContainElements(oldHosts))
+		oldHostIDs = hostIDs
+		_, hostIDs, err = utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(oldHostIDs).To(o.HaveLen(int(oldMembers)))
+		o.Expect(hostIDs).To(o.HaveLen(int(newMebmers)))
+		o.Expect(hostIDs).To(o.ContainElements(oldHostIDs))
 		verifyCQLData(ctx, di)
 	})
 })

--- a/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
@@ -9,7 +9,6 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
-	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +36,7 @@ var _ = g.Describe("ScyllaCluster upgrades", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 			defer cancel()
 
-			sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+			sc := f.GetDefaultScyllaCluster()
 			sc.Spec.Version = e.initialVersion
 
 			o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
@@ -62,8 +61,15 @@ var _ = g.Describe("ScyllaCluster upgrades", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			verifyScyllaCluster(ctx, f.KubeClient(), sc)
-			hosts := getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
-			o.Expect(hosts).To(o.HaveLen(int(e.rackCount * e.rackSize)))
+			waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+			hosts, hostIDs, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			numNodes := int(e.rackCount * e.rackSize)
+			o.Expect(hosts).To(o.HaveLen(numNodes))
+			o.Expect(hostIDs).To(o.HaveLen(numNodes))
+
 			di := insertAndVerifyCQLData(ctx, hosts)
 			defer di.Close()
 
@@ -89,7 +95,19 @@ var _ = g.Describe("ScyllaCluster upgrades", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			verifyScyllaCluster(ctx, f.KubeClient(), sc)
-			o.Expect(hosts).To(o.ConsistOf(getScyllaHostsAndWaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)))
+			waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+
+			oldHosts := hosts
+			oldHostIDs := hostIDs
+			hosts, hostIDs, err = utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(hosts).To(o.HaveLen(len(oldHosts)))
+			o.Expect(hostIDs).To(o.ConsistOf(oldHostIDs))
+			// Reset hosts if there's only one node as the client won't be able to discover it.
+			if numNodes == 1 {
+				err = di.SetClientEndpoints(hosts)
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
 			verifyCQLData(ctx, di)
 		},
 		// Test 1 and 3 member rack to cover e.g. handling PDBs correctly.

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
@@ -34,7 +34,7 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 		defer cancel()
 
-		sc := scyllafixture.BasicScyllaCluster.ReadOrFail()
+		sc := f.GetDefaultScyllaCluster()
 		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
 		sc.Spec.Datacenter.Racks[0].Members = 1
 

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -23,8 +23,10 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	ocrypto "github.com/scylladb/scylla-operator/pkg/crypto"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/mermaidclient"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	appsv1 "k8s.io/api/apps/v1"
@@ -393,7 +395,7 @@ func GetDaemonSetsForNodeConfig(ctx context.Context, client appv1client.AppsV1In
 }
 
 func GetScyllaClient(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) (*scyllaclient.Client, []string, error) {
-	hosts, err := GetHosts(ctx, client, sc)
+	hosts, err := GetBroadcastRPCAddresses(ctx, client, sc)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -436,41 +438,137 @@ func GetScyllaConfigClient(ctx context.Context, client corev1client.CoreV1Interf
 	return configClient, nil
 }
 
-func GetHostsAndUUIDs(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) ([]string, []string, error) {
+func GetBroadcastAddresses(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) ([]string, error) {
 	serviceList, err := client.Services(sc.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: GetMemberServiceSelector(sc.Name).String(),
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	var hosts []string
+	var broadcastAddresses []string
+	for _, svc := range slices.ConvertSlice(serviceList.Items, pointer.Ptr[corev1.Service]) {
+		podName := naming.PodNameFromService(svc)
+		pod, err := client.Pods(sc.Namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("can't get pod %q: %w", naming.ManualRef(sc.Namespace, podName), err)
+		}
+
+		broadcastAddress, err := GetBroadcastAddress(ctx, client, sc, svc, pod)
+		if err != nil {
+			return nil, fmt.Errorf("can't get broadcast address of Service %q: %w", naming.ObjRef(svc), err)
+		}
+
+		broadcastAddresses = append(broadcastAddresses, broadcastAddress)
+	}
+
+	return broadcastAddresses, nil
+}
+
+func GetBroadcastAddress(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster, svc *corev1.Service, pod *corev1.Pod) (string, error) {
+	host, err := controllerhelpers.GetScyllaHost(sc, svc, pod)
+	if err != nil {
+		return "", fmt.Errorf("can't get Scylla host for Service %q: %w", naming.ObjRef(svc), err)
+	}
+
+	configClient, err := GetScyllaConfigClient(ctx, client, sc, host)
+	if err != nil {
+		return "", fmt.Errorf("can't create scylla config client with host %q: %w", host, err)
+	}
+	broadcastAddress, err := configClient.BroadcastAddress(ctx)
+	if err != nil {
+		return "", fmt.Errorf("can't get broadcast_address of host %q: %w", host, err)
+	}
+
+	return broadcastAddress, nil
+}
+
+func GetBroadcastRPCAddresses(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) ([]string, error) {
+	serviceList, err := client.Services(sc.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: GetMemberServiceSelector(sc.Name).String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var broadcastRPCAddresses []string
+	for _, svc := range serviceList.Items {
+		broadcastRPCAddress, err := GetBroadcastRPCAddress(ctx, client, sc, &svc)
+		if err != nil {
+			return nil, fmt.Errorf("can't get broadcast rpc address for service %q: %w", naming.ObjRef(&svc), err)
+		}
+
+		broadcastRPCAddresses = append(broadcastRPCAddresses, broadcastRPCAddress)
+	}
+
+	return broadcastRPCAddresses, err
+}
+
+func GetBroadcastRPCAddressesAndUUIDsByDC(ctx context.Context, dcClientMap map[string]corev1client.CoreV1Interface, scs []*scyllav1.ScyllaCluster) (map[string][]string, map[string][]string, error) {
+	allBroadcastRPCAddresses := map[string][]string{}
+	allUUIDs := map[string][]string{}
+
+	for _, sc := range scs {
+		client, ok := dcClientMap[sc.Spec.Datacenter.Name]
+		if !ok {
+			return nil, nil, fmt.Errorf("client is missing for datacenter %q of ScyllaCluster %q", sc.Spec.Datacenter.Name, naming.ObjRef(sc))
+		}
+
+		broadcastRPCAddresses, uuids, err := GetBroadcastRPCAddressesAndUUIDs(ctx, client, sc)
+		if err != nil {
+			return nil, nil, fmt.Errorf("can't get broadcast rpc address and UUID for ScyllaCluster %q: %w", naming.ObjRef(sc), err)
+		}
+		allBroadcastRPCAddresses[sc.Spec.Datacenter.Name] = broadcastRPCAddresses
+		allUUIDs[sc.Spec.Datacenter.Name] = uuids
+	}
+
+	return allBroadcastRPCAddresses, allUUIDs, nil
+}
+
+func GetBroadcastRPCAddressesAndUUIDs(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) ([]string, []string, error) {
+	scyllaClient, broadcastRPCAddresses, err := GetScyllaClient(ctx, client, sc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't get scylla client for ScyllaCluster %q: %w", naming.ObjRef(sc), err)
+	}
+
 	var uuids []string
-	for _, s := range serviceList.Items {
-		host := s.Spec.ClusterIP
-
-		if host == corev1.ClusterIPNone {
-			pod, err := client.Pods(sc.Namespace).Get(ctx, s.Name, metav1.GetOptions{})
-			if err != nil {
-				return nil, nil, fmt.Errorf("can't get pod %q: %w", naming.ManualRef(sc.Namespace, s.Name), err)
-			}
-			host = pod.Status.PodIP
-		}
-
-		configClient, err := GetScyllaConfigClient(ctx, client, sc, host)
+	for _, broadcastRPCAddress := range broadcastRPCAddresses {
+		uuid, err := scyllaClient.GetLocalHostId(ctx, broadcastRPCAddress, false)
 		if err != nil {
-			return nil, nil, fmt.Errorf("can't create scylla config client with host %q: %w", host, err)
-		}
-		clientBroadcastedAddress, err := configClient.BroadcastRPCAddress(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("can't get broadcast_rpc_address of host %q: %w", host, err)
+			return nil, nil, fmt.Errorf("can't get HostID for node with broadcast rpc address %q: %w", broadcastRPCAddress, err)
 		}
 
-		hosts = append(hosts, clientBroadcastedAddress)
-		uuids = append(uuids, s.Annotations[naming.HostIDAnnotation])
+		uuids = append(uuids, uuid)
 	}
 
-	return hosts, uuids, nil
+	return broadcastRPCAddresses, uuids, nil
+}
+
+func GetBroadcastRPCAddress(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster, svc *corev1.Service) (string, error) {
+	host := svc.Spec.ClusterIP
+
+	if host == corev1.ClusterIPNone {
+		pod, err := client.Pods(sc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("can't get pod %q: %w", naming.ManualRef(sc.Namespace, svc.Name), err)
+		}
+		host = pod.Status.PodIP
+		if len(host) < 1 {
+			return "", fmt.Errorf("empty podIP of pod %q", naming.ManualRef(sc.Namespace, svc.Name))
+		}
+	}
+
+	configClient, err := GetScyllaConfigClient(ctx, client, sc, host)
+	if err != nil {
+		return "", fmt.Errorf("can't create scylla config client with host %q: %w", host, err)
+	}
+
+	broadcastRPCAddress, err := configClient.BroadcastRPCAddress(ctx)
+	if err != nil {
+		return "", fmt.Errorf("can't get broadcast_rpc_address of host %q: %w", host, err)
+	}
+
+	return broadcastRPCAddress, nil
 }
 
 func GetNodesServiceAndPodIPs(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) ([]string, error) {
@@ -530,11 +628,6 @@ func GetNodesPodIPs(ctx context.Context, client corev1client.CoreV1Interface, sc
 	return ipAddresses, nil
 }
 
-func GetHosts(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) ([]string, error) {
-	hosts, _, err := GetHostsAndUUIDs(ctx, client, sc)
-	return hosts, err
-}
-
 // GetManagerClient gets managerClient using IP address. E2E tests shouldn't rely on InCluster DNS.
 func GetManagerClient(ctx context.Context, client corev1client.CoreV1Interface) (*mermaidclient.Client, error) {
 	managerService, err := client.Services(naming.ScyllaManagerNamespace).Get(ctx, naming.ScyllaManagerServiceName, metav1.GetOptions{})
@@ -576,9 +669,9 @@ func GetMemberServiceSelector(scyllaClusterName string) labels.Selector {
 	}.AsSelector()
 }
 
-func GetScyllaHostsByDCAndWaitForFullQuorum(ctx context.Context, dcClientMap map[string]corev1client.CoreV1Interface, scs []*scyllav1.ScyllaCluster) (map[string][]string, error) {
-	allHosts := map[string][]string{}
-	var sortedAllHosts []string
+func WaitForFullMultiDCQuorum(ctx context.Context, dcClientMap map[string]corev1client.CoreV1Interface, scs []*scyllav1.ScyllaCluster) error {
+	allBroadcastAddresses := map[string][]string{}
+	var sortedAllBroadcastAddresses []string
 
 	var errs []error
 	for _, sc := range scs {
@@ -588,19 +681,19 @@ func GetScyllaHostsByDCAndWaitForFullQuorum(ctx context.Context, dcClientMap map
 			continue
 		}
 
-		hosts, err := GetHosts(ctx, client, sc)
+		hosts, err := GetBroadcastAddresses(ctx, client, sc)
 		if err != nil {
-			return nil, fmt.Errorf("can't get hosts for ScyllaCluster %q: %w", sc.Name, err)
+			return fmt.Errorf("can't get broadcast addresses for ScyllaCluster %q: %w", sc.Name, err)
 		}
-		allHosts[sc.Spec.Datacenter.Name] = hosts
-		sortedAllHosts = append(sortedAllHosts, hosts...)
+		allBroadcastAddresses[sc.Spec.Datacenter.Name] = hosts
+		sortedAllBroadcastAddresses = append(sortedAllBroadcastAddresses, hosts...)
 	}
 	err := errors.Join(errs...)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	sort.Strings(sortedAllHosts)
+	sort.Strings(sortedAllBroadcastAddresses)
 
 	for _, sc := range scs {
 		client, ok := dcClientMap[sc.Spec.Datacenter.Name]
@@ -609,7 +702,7 @@ func GetScyllaHostsByDCAndWaitForFullQuorum(ctx context.Context, dcClientMap map
 			continue
 		}
 
-		err = waitForFullQuorum(ctx, client, sc, sortedAllHosts)
+		err = waitForFullQuorum(ctx, client, sc, sortedAllBroadcastAddresses)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -617,12 +710,12 @@ func GetScyllaHostsByDCAndWaitForFullQuorum(ctx context.Context, dcClientMap map
 
 	err = errors.Join(errs...)
 	if err != nil {
-		return nil, fmt.Errorf("can't wait for scylla nodes to reach status consistency: %w", err)
+		return fmt.Errorf("can't wait for scylla nodes to reach status consistency: %w", err)
 	}
 
 	framework.Infof("ScyllaDB nodes have reached status consistency.")
 
-	return allHosts, nil
+	return nil
 }
 
 func waitForFullQuorum(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster, sortedExpectedHosts []string) error {
@@ -721,7 +814,7 @@ func WaitUntilServingCertificateIsLive(ctx context.Context, client corev1client.
 		servingCAPool.AddCert(caCert)
 	}
 
-	hosts, err := GetHosts(ctx, client, sc)
+	hosts, err := GetBroadcastRPCAddresses(ctx, client, sc)
 	if err != nil {
 		return fmt.Errorf("can't get v1.ScyllaCluster %q hosts: %w", naming.ObjRef(sc), err)
 	}


### PR DESCRIPTION
**Description of your changes:** This PR makes expose options configurable in Scylla Operator's test runner, adds support for exposing ScyllaClusters (both broadcast addresses and broadcast rpc addresses) over PodIP in E2E test suite and makes it a default setup.

**Which issue is resolved by this Pull Request:**
Resolves #1416 

/kind feature
/priority important-soon

/hold
for https://github.com/scylladb/scylla-operator/issues/1415, gocql bump is required to pass CI
