### PR TITLE
Unify docs index pages and make sure they are always in sync with the menu

### DIFF
--- a/docs/source/multidc/index.rst
+++ b/docs/source/multidc/index.rst
@@ -5,21 +5,14 @@ Deploying multi-datacenter ScyllaDB clusters in Kubernetes
 Prepare a platform for a multi datacenter ScyllaDB cluster deployment:
 
 .. toctree::
-   :hidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    eks
    gke
 
-* :doc:`Build multiple Amazon EKS clusters with Inter-Kubernetes networking <eks>`
-* :doc:`Build multiple GKE clusters with Inter-Kubernetes networking <gke>`
-
 Deploy a multi-datacenter ScyllaDB cluster in Kubernetes:
 
 .. toctree::
-   :hidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    multidc
-
-* :doc:`Deploy a multi-datacenter ScyllaDB cluster in multiple interconnected Kubernetes clusters <multidc>`

--- a/docs/source/nodeoperations/index.rst
+++ b/docs/source/nodeoperations/index.rst
@@ -3,20 +3,10 @@ Node operations using Scylla Operator
 ======================================
 
 .. toctree::
-   :hidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    scylla-upgrade
    replace-node
    automatic-cleanup
    maintenance-mode
    restore
-
-
-Choose a topic:
-
-* :doc:`Scylla version upgrade <scylla-upgrade>`
-* :doc:`Replace Scylla node <replace-node>`
-* :doc:`Automatic cleanup and replacement when k8s node is lost <automatic-cleanup>`
-* :doc:`Maintenance mode <maintenance-mode>`
-* :doc:`Restore from backup <restore>`


### PR DESCRIPTION
**Description of your changes:**
This PR makes sure, that our toctree in the left menu matches the index pages and removes the inconsistencies, like when some links were named differently. This also eliminates the possibility that we miss some links that are present in the menu.

While it's not as pretty as when written manually, the consistency should prevail + I've filed https://github.com/scylladb/sphinx-scylladb-theme/issues/935

/cc @rzetelskik 
(on your request)
