### PR TITLE
Avoid service enpoints size limit in monitoring examples

### DIFF
--- a/docs/source/monitoring.md
+++ b/docs/source/monitoring.md
@@ -13,7 +13,7 @@ spec:
   endpointsSelector:
     matchLabels:
       app.kubernetes.io/name: scylla
-      scylla-operator.scylladb.com/scylla-service-type: identity
+      scylla-operator.scylladb.com/scylla-service-type: member
       scylla/cluster: replace-with-your-scyllacluster-name
   components:
     prometheus:

--- a/examples/monitoring/v1alpha1/scylladbmonitoring.yaml
+++ b/examples/monitoring/v1alpha1/scylladbmonitoring.yaml
@@ -7,7 +7,7 @@ spec:
   endpointsSelector:
     matchLabels:
       app.kubernetes.io/name: scylla
-      scylla-operator.scylladb.com/scylla-service-type: identity
+      scylla-operator.scylladb.com/scylla-service-type: member
       scylla/cluster: replace-with-your-scyllacluster-name
   components:
     prometheus:

--- a/test/e2e/fixture/scylla/scylladbmonitoring.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbmonitoring.yaml.tmpl
@@ -6,7 +6,7 @@ spec:
   endpointsSelector:
     matchLabels:
       app.kubernetes.io/name: scylla
-      scylla-operator.scylladb.com/scylla-service-type: identity
+      scylla-operator.scylladb.com/scylla-service-type: member
       scylla/cluster: "{{ .scyllaClusterName }}"
   components:
     prometheus:


### PR DESCRIPTION
**Description of your changes:**
We should select member services when configuring ScyllaDBMonitoring. For small clusters the identity Endpoints set is identical, but there is a limit to the number of endpoints aggregated there. Prometheus doesn't care about publishing not ready endpoints and does its own health checks

**Which issue is resolved by this Pull Request:**
Future issues with larger clusters.
