### PR TITLE
Use correct key in error message when getting agent token

### DIFF
--- a/pkg/helpers/agent.go
+++ b/pkg/helpers/agent.go
@@ -27,7 +27,7 @@ func ParseTokenFromConfig(data []byte) (string, error) {
 func GetAgentAuthTokenFromAgentConfigSecret(secret *corev1.Secret) (string, error) {
 	configData, ok := secret.Data[naming.ScyllaAgentConfigFileName]
 	if !ok {
-		return "", fmt.Errorf("secret %q is missing %q data", naming.ObjRef(secret), naming.ScyllaAgentAuthTokenFileName)
+		return "", fmt.Errorf("secret %q is missing %q data", naming.ObjRef(secret), naming.ScyllaAgentConfigFileName)
 	}
 
 	return ParseTokenFromConfig(configData)


### PR DESCRIPTION
**Description of your changes:**
This PR fixes error message when getting agent token from config file, to refer to the same key it's asserting.

**Which issue is resolved by this Pull Request:**
Resolves #1519
