### PR TITLE
Generalise naming of networking's parsing helpers

### DIFF
--- a/pkg/controller/scyllacluster/sync_certs.go
+++ b/pkg/controller/scyllacluster/sync_certs.go
@@ -207,7 +207,7 @@ func (scc *Controller) syncCerts(
 		}
 
 		if svc.Spec.ClusterIP != corev1.ClusterIPNone {
-			parsedIP, err := helpers.ParseClusterIP(svc.Spec.ClusterIP)
+			parsedIP, err := helpers.ParseIP(svc.Spec.ClusterIP)
 			if err != nil {
 				return progressingConditions, fmt.Errorf("can't parse Service %q ClusterIP %q: %w", naming.ObjRef(svc), svc.Spec.ClusterIP, err)
 			}

--- a/pkg/helpers/networking.go
+++ b/pkg/helpers/networking.go
@@ -5,20 +5,20 @@ import (
 	"net"
 )
 
-func ParseClusterIP(s string) (net.IP, error) {
+func ParseIP(s string) (net.IP, error) {
 	parsedIP := net.ParseIP(s)
 	if parsedIP == nil {
-		return nil, fmt.Errorf("can't parse ClusterIP %q", s)
+		return nil, fmt.Errorf("can't parse IP %q", s)
 	}
 
 	return parsedIP, nil
 }
 
-func ParseClusterIPs(ipStrings []string) ([]net.IP, error) {
+func ParseIPs(ipStrings []string) ([]net.IP, error) {
 	var ips []net.IP
 
 	for _, s := range ipStrings {
-		ip, err := ParseClusterIP(s)
+		ip, err := ParseIP(s)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -194,7 +194,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(serviceAndPodIPs).To(o.HaveLen(e.expectedNumberOfIPAddressesInServingCert(int(utils.GetMemberCount(sc)))))
 
-			hostsIPs, err := helpers.ParseClusterIPs(serviceAndPodIPs)
+			hostsIPs, err := helpers.ParseIPs(serviceAndPodIPs)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			var servingDNSNames []string

--- a/test/e2e/set/scyllacluster/scyllacluster_tls.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_tls.go
@@ -202,7 +202,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(serviceAndPodIPs).To(o.HaveLen(2 * int(utils.GetMemberCount(sc))))
 
-				hostsIPs, err := helpers.ParseClusterIPs(serviceAndPodIPs)
+				hostsIPs, err := helpers.ParseIPs(serviceAndPodIPs)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				servingDNSNames := make([]string, 0, len(sniHosts)+len(serviceServingDNSNames))


### PR DESCRIPTION
**Description of your changes:** This PR makes the naming of networking's parsing helpers more generic, as the functions do not only parse ClusterIPs but IPs in general.

Requested in https://github.com/scylladb/scylla-operator/pull/1508#discussion_r1371900973
/cc @tnozicka 

/kind cleanup
/priority important-longterm