### PR TITLE
Make example ScyllaCluster in EKS docs consistently use scylladb-local-xfs storage class

### DIFF
--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -53,7 +53,7 @@ spec:
     - name: b
       members: 1
       storage:
-        storageClassName: local-raid-disks
+        storageClassName: scylladb-local-xfs
         capacity: 1800G
       resources:
         limits:
@@ -80,7 +80,7 @@ spec:
     - name: c
       members: 1
       storage:
-        storageClassName: local-raid-disks
+        storageClassName: scylladb-local-xfs
         capacity: 1800G
       resources:
         limits:


### PR DESCRIPTION
**Description of your changes:**
The [ScyllaCluster manifest used in EKS examples](https://github.com/scylladb/scylla-operator/blob/master/examples/eks/cluster.yaml) uses inconsitent StorageClasses among the racks:

- [scylladb-local-xfs](https://github.com/scylladb/scylla-operator/blob/084f0446740bb3f652ead32dc4ac3bbb943ac0f4/examples/eks/cluster.yaml#L29)
- leftover [local-raid-disks](https://github.com/scylladb/scylla-operator/blob/084f0446740bb3f652ead32dc4ac3bbb943ac0f4/examples/eks/cluster.yaml#L56C42-L56C42)

Since the doc (and the tldr script) only deploy k8s-local-volume-provisioner, this causes the ScyllaCluster created by following the guide to fail to deploy.

This PR makes the manifest use scylladb-local-xfs storage class consistently.


**Which issue is resolved by this Pull Request:**
Resolves #1468 

/kind documentation
/priority important-longterm
