### PR TITLE
Make 1.11 docs use MyST

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,7 @@ redirects_file = "./redirections.yaml"
 
 # -- Options for markdown extension
 scylladb_markdown_enable = True
-scylladb_markdown_recommonmark_versions = ['v1.8', 'v1.9', 'v1.10', 'v1.11']
+scylladb_markdown_recommonmark_versions = ['v1.8', 'v1.9', 'v1.10']
 
 # -- Options for multiversion extension
 # Whitelist pattern for tags (set to None to ignore all tags)


### PR DESCRIPTION
**Description of your changes:** This PR switches docs for v1.11 from using recommonmark to MyST parser. This allows us to fix the hyperlinks for the yet unreleased branch.

/kind machinery
/priority important-soon

/hold
for #1530, #1534
