### PR TITLE
Avoid controller-gen issue with path parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ update-crds:
 	$(call generate-crds,)
 .PHONY: update-crds
 
-verify-crds: tmp_dir :=$(shell mktemp -d)
+verify-crds: tmp_dir :=$(shell mktemp -d crd-XXXXXX)
 verify-crds:
 	mkdir '$(tmp_dir)'/{original,generated}
 


### PR DESCRIPTION
**Description of your changes:**
This PR avoids [controller-gen issue](https://github.com/kubernetes-sigs/controller-tools/issues/734) with path parsing by avoiding `.` in the `mktemp` by using custom pattern

**Which issue is resolved by this Pull Request:**
Resolves #1546
