### PR TITLE
Fix a duplicate id in GitHub 'Feature request' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -10,7 +10,7 @@ body:
     required: true
 
 - type: textarea
-  id: expected
+  id: useCase
   attributes:
     label: What is the use case behind this feature?
   validations:


### PR DESCRIPTION
**Description of your changes:** A duplicated id went unnoticed in https://github.com/scylladb/scylla-operator/pull/1549 and the issue template won't render. This PR fixes the id.

/kind machinery
/priority important-soon