### PR TITLE
Collect CRDs in must-gather

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	google.golang.org/grpc v1.59.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.28.3
+	k8s.io/apiextensions-apiserver v0.26.2
 	k8s.io/apimachinery v0.28.3
 	k8s.io/apiserver v0.28.3
 	k8s.io/cli-runtime v0.28.3
@@ -165,7 +166,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.26.2 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/pkg/cmd/operator/mustgather.go
+++ b/pkg/cmd/operator/mustgather.go
@@ -194,6 +194,14 @@ var mustGatherSpecs = []struct {
 	},
 	{
 		GroupResource: schema.GroupResource{
+			Resource: "customresourcedefinitions",
+			Group:    "apiextensions.k8s.io",
+		},
+		Namespace: corev1.NamespaceAll,
+		Name:      "",
+	},
+	{
+		GroupResource: schema.GroupResource{
 			Resource: "validatingwebhookconfigurations",
 			Group:    "admissionregistration.k8s.io",
 		},

--- a/pkg/cmd/operator/mustgather_test.go
+++ b/pkg/cmd/operator/mustgather_test.go
@@ -19,6 +19,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,6 +40,12 @@ func TestMustGatherOptions_Run(t *testing.T) {
 				{Name: "namespaces", Namespaced: false, Kind: "Namespace", Verbs: []string{"list"}},
 				{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: []string{"list"}},
 				{Name: "secrets", Namespaced: true, Kind: "Secret", Verbs: []string{"list"}},
+			},
+		},
+		{
+			GroupVersion: apiextensions.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "customresourcedefinitions", Namespaced: false, Kind: "CustomResourceDefinition", Verbs: []string{"list"}},
 			},
 		},
 		{
@@ -72,6 +79,11 @@ func TestMustGatherOptions_Run(t *testing.T) {
 	testScheme := runtime.NewScheme()
 
 	err := kubefakeclient.AddToScheme(testScheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = apiextensions.AddToScheme(testScheme)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**Description of your changes:**
This PR add CRDs collection to must-gather so we can asses whether our CRDs are up to data as users frequently forget to update them because of helm deficiencies. It also helps to see what other extensions are present in the cluster in case of an interference.
