### PR TITLE
Generelize GKE NodeConfig so it can be faked on libvirt

### DIFF
--- a/examples/gke/nodeconfig-alpha.yaml
+++ b/examples/gke/nodeconfig-alpha.yaml
@@ -17,7 +17,6 @@ spec:
       type: RAID0
       RAID0:
         devices:
-          modelRegex: nvme_card
           nameRegex: ^/dev/nvme\d+n\d+$
   placement:
     nodeSelector:


### PR DESCRIPTION
**Description of your changes:**
This PR allows to fake NVMe drives on libvirt and still use the same config. I don't think we need to mess with the model by default.
