### PR TITLE
Fix scylladb example so it deploys on default gke nodes

### DIFF
--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -6,6 +6,9 @@ spec:
   version: 5.2.7
   agentVersion: 3.1.0
   developerMode: true
+  automaticOrphanedNodeCleanup: true
+  sysctls:
+  - "fs.aio-max-nr=30000000"
   datacenter:
     name: us-east-1
     racks:


### PR DESCRIPTION
**Description of your changes:**
2nd node withoutany sysctl adjustments fails on GKE, this will make sure it works a bit more before we have #749

**Which issue is resolved by this Pull Request:**
```
FATAL: Exception during startup, aborting: std::runtime_error (Could not setup Async I/O: Resource temporarily unavailable. The most common cause is not enough request capacity in /proc/sys/fs/aio-max-nr. Try increasing that number or reducing the amount of logical CPUs available for your application)
2023-11-14 11:50:42,850 INFO exited: scylla (exit status 7; not expected)
Traceback (most recent call last):
  File "/opt/scylladb/scripts/libexec/scylla-housekeeping", line 196, in <module>
    args.func(args)
  File "/opt/scylladb/scripts/libexec/scylla-housekeeping", line 122, in check_version
    current_version = sanitize_version(get_api('/storage_service/scylla_release_version'))
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/scylladb/scripts/libexec/scylla-housekeeping", line 80, in get_api
    return get_json_from_url("http://" + api_address + path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/scylladb/scripts/libexec/scylla-housekeeping", line 75, in get_json_from_url
    raise RuntimeError(f'Failed to get "{path}" due to the following error: {retval}')
```
