### PR TITLE
Fix error aggregation in scyllacluster controller job sync

### DIFF
--- a/pkg/controller/scyllacluster/sync_jobs.go
+++ b/pkg/controller/scyllacluster/sync_jobs.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (scc *Controller) syncJobs(
@@ -85,6 +86,10 @@ func (scc *Controller) syncJobs(
 				ObservedGeneration: sc.Generation,
 			})
 		}
+	}
+	err = utilerrors.NewAggregate(errs)
+	if err != nil {
+		return progressingConditions, err
 	}
 
 	return progressingConditions, nil


### PR DESCRIPTION
**Description of your changes:** We don't aggregate and check for errors in ScyllaCluster controller's job sync. This PR fixes it.

/kind bug
/priority important-soon