### PR TITLE
Check for presence of ARTIFACTS env var in e2e script

### DIFF
--- a/hack/.ci/run-e2e-gke.sh
+++ b/hack/.ci/run-e2e-gke.sh
@@ -16,6 +16,11 @@ if [ -z ${SO_IMAGE+x} ]; then
   exit 2
 fi
 
+if [ -z ${ARTIFACTS+x} ]; then
+  echo "ARTIFACTS can't be empty" > /dev/stderr
+  exit 2
+fi
+
 SO_DISABLE_NODECONFIG=${SO_DISABLE_NODECONFIG:-false}
 
 field_manager=run-e2e-script


### PR DESCRIPTION
**Description of your changes:** This PR adds a check for presence of ARTIFACTS environment variable presence in e2e script. At the moment the unset variable causes the e2e pod to hang indefinitely waiting for finilization of a subprocess which exists prematurely.

/kind machinery
/priority important-longterm