### PR TITLE
Set kubelet's CPU manager policy for ScyllaDB node pool only in GKE docs and examples

### DIFF
--- a/docs/source/gke.md
+++ b/docs/source/gke.md
@@ -67,7 +67,6 @@ Then we'll create a GKE cluster with the following:
    --num-nodes "2" \
    --disk-type "pd-ssd" --disk-size "20" \
    --image-type "UBUNTU_CONTAINERD" \
-   --system-config-from-file=systemconfig.yaml \
    --enable-stackdriver-kubernetes \
    --no-enable-autoupgrade \
    --no-enable-autorepair
@@ -103,6 +102,7 @@ Then we'll create a GKE cluster with the following:
    --node-taints role=scylla-clusters:NoSchedule \
    --node-labels scylla.scylladb.com/node-type=scylla \
    --image-type "UBUNTU_CONTAINERD" \
+   --system-config-from-file=systemconfig.yaml \
    --no-enable-autoupgrade \
    --no-enable-autorepair
    ```

--- a/examples/gke/gke.sh
+++ b/examples/gke/gke.sh
@@ -129,7 +129,6 @@ clusters create "${CLUSTER_NAME}" \
 --num-nodes "2" \
 --disk-type "pd-ssd" --disk-size "20" \
 --image-type "UBUNTU_CONTAINERD" \
---system-config-from-file=systemconfig.yaml \
 --enable-stackdriver-kubernetes \
 --no-enable-autoupgrade \
 --no-enable-autorepair
@@ -159,6 +158,7 @@ node-pools create "scylla-pool" \
 --node-taints role=scylla-clusters:NoSchedule \
 --node-labels scylla.scylladb.com/node-type=scylla \
 --image-type "UBUNTU_CONTAINERD" \
+--system-config-from-file=systemconfig.yaml \
 --no-enable-autoupgrade \
 --no-enable-autorepair
 


### PR DESCRIPTION
**Description of your changes:**
Currently the GKE doc for single DC deployments suggests creating a system config file setting kubelet's CPU manager policy to static for the entire cluster.
To align the GKE doc with its EKS counterpart, it should only be done for ScyllaDB node pool.
It also allows us to not duplicate this part of the guide for multi DC GKE setup doc.

This PR  sets `--system-config-from-file=systemconfig.yaml` for ScyllaDB node pool instead of the entire cluster.

**Which issue is resolved by this Pull Request:**
Resolves #1485 

/kind documentation
/priority important-longterm
