### PR TITLE
Fix invalid commands in Scylla Manager section of GKE mulit-datacenter documentation

### DIFF
--- a/docs/source/multidc/multidc.md
+++ b/docs/source/multidc/multidc.md
@@ -586,12 +586,12 @@ auth_token: 84qtsfvm98qzmps8s65zr2vtpb8rg4sdzcbg4pbmg2pfhxwpg952654gj86tzdljfqns
 
 Save the output, replace the token with your own, and patch the secret in the second datacenter with the below command:
 ```shell
-kubectl --context="${CONTEXT_DC2}"-n=scylla patch secret/scylla-cluster-auth-token --type='json' -p='[{"op": "replace", "path": "/data/auth-token.yaml", "value": "auth_token: 84qtsfvm98qzmps8s65zr2vtpb8rg4sdzcbg4pbmg2pfhxwpg952654gj86tzdljfqnsghndljm58mmhpmwfgpsvjx2kkmnns8bnblmgkbl9n8l9f64rs6tcvttm7kmf"}]'
+kubectl --context="${CONTEXT_DC2}" -n=scylla patch secret/scylla-cluster-auth-token--type='json' -p='[{"op": "add", "path": "/stringData", "value": {"auth-token.yaml": "auth_token: 84qtsfvm98qzmps8s65zr2vtpb8rg4sdzcbg4pbmg2pfhxwpg952654gj86tzdljfqnsghndljm58mmhpmwfgpsvjx2kkmnns8bnblmgkbl9n8l9f64rs6tcvttm7kmf"}}]'
 ```
 
 Execute a rolling restart of the nodes in DC2 to make sure they pick up the new token:
 ```shell
-kubectl --context="${CONTEXT_DC2}" patch scyllacluster/scylla-cluster --type merge -p '{"spec": {"forceRedeploymentReason": "sync scylla-manager-agent token ('$(date)')"}}'
+kubectl --context="${CONTEXT_DC2}" -n=scylla patch scyllacluster/scylla-cluster --type='merge' -p='{"spec": {"forceRedeploymentReason": "sync scylla-manager-agent token ('"$( date )"')"}}'
 ```
 
 


### PR DESCRIPTION
**Description of your changes:**
The commands introduced in https://github.com/scylladb/scylla-operator/pull/1513 are invalid.

```
kubectl --context="${CONTEXT_DC2}"-n=scylla patch secret/scylla-cluster-auth-token --type='json' -p='[{"op": "replace", "path": "/data/auth-token.yaml", "value": "auth_token: 84qtsfvm98qzmps8s65zr2vtpb8rg4sdzcbg4pbmg2pfhxwpg952654gj86tzdljfqnsghndljm58mmhpmwfgpsvjx2kkmnns8bnblmgkbl9n8l9f64rs6tcvttm7kmf"}]'
```
has an invalid context string `"${CONTEXT_DC2}"-n=scylla` and doesn't base64 encode the value.

```
kubectl --context="${CONTEXT_DC2}" patch scyllacluster/scylla-cluster --type merge -p '{"spec": {"forceRedeploymentReason": "sync scylla-manager-agent token ('$(date)')"}}'
```
tries to evaluate a subcommand in single quotes, resulting in a string broken by whitespaces and returns
```
error: there is no need to specify a resource type as a separate argument when passing arguments in resource/name form (e.g. 'kubectl get resource/<resource_name>' instead of 'kubectl get resource resource/<resource_name>'
```
on a run. It also misses a namespace.

**Which issue is resolved by this Pull Request:**
Resolves #1583 

/kind documentation
/priority important-soon
