### PR TITLE
Fix Operator deployment in GKE and EKS example scripts

### DIFF
--- a/examples/eks/eks.sh
+++ b/examples/eks/eks.sh
@@ -123,7 +123,7 @@ wait-for-object-creation cert-manager deployment.apps/cert-manager-webhook
 kubectl -n cert-manager rollout status --timeout=5m deployment.apps/cert-manager-webhook
 
 echo "Starting the scylla operator..."
-kubectl apply -f ../common/operator.yaml
+kubectl apply -f ../../deploy/operator.yaml
 kubectl wait --for condition=established crd/nodeconfigs.scylla.scylladb.com
 kubectl wait --for condition=established crd/scyllaclusters.scylla.scylladb.com
 wait-for-object-creation scylla-operator deployment.apps/scylla-operator

--- a/examples/gke/gke.sh
+++ b/examples/gke/gke.sh
@@ -186,7 +186,7 @@ wait-for-object-creation cert-manager deployment.apps/cert-manager-webhook
 kubectl -n cert-manager rollout status --timeout=5m deployment.apps/cert-manager-webhook
 
 echo "Starting the scylla operator..."
-kubectl apply -f ../common/operator.yaml
+kubectl apply -f ../../deploy/operator.yaml
 
 kubectl wait --for condition=established crd/nodeconfigs.scylla.scylladb.com
 kubectl wait --for condition=established crd/scyllaclusters.scylla.scylladb.com


### PR DESCRIPTION
**Description of your changes:**
https://github.com/scylladb/scylla-operator/pull/1532 moved the aggregated operator manifest and didn't adjust paths in EKS and GKE example scripts. This PR fixes it.

/kind machinery
/priority important-soon