### PR TITLE
Update ScyllaDB to 5.4.0

### DIFF
--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -282,7 +282,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.2.11
+  version: 5.4.0
   agentVersion: 3.1.2
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -282,7 +282,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.2.11
+  version: 5.4.0
   agentVersion: 3.1.2
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.2.11
+  version: 5.4.0
   agentVersion: 3.1.2
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.2.11
+  version: 5.4.0
   agentVersion: 3.1.2
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -143,7 +143,7 @@ To squeeze the most out of your deployment it is sometimes necessary to employ [
 To enable this the CRD allows for specifying a `network` parameter as such:
 
 ```yaml
-version: 4.0.0
+  version: 5.4.0
   agentVersion: 2.0.2
   cpuset: true
   network:
@@ -173,7 +173,7 @@ Change the `cluster.yaml` file from this:
 ```yaml
 spec:
   agentVersion: 2.0.2
-  version: 5.2.11
+  version: 5.4.0
   developerMode: true
   datacenter:
     name: us-east-1
@@ -181,7 +181,7 @@ spec:
 to this:
 ```yaml
 spec:
-  version: 5.2.11
+  version: 5.4.0
   alternator:
     port: 8000
     writeIsolation: only_rmw_uses_lwt

--- a/docs/source/multidc/multidc.md
+++ b/docs/source/multidc/multidc.md
@@ -108,7 +108,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.1.2
-  version: 5.2.11
+  version: 5.4.0
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"
@@ -358,7 +358,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.1.2
-  version: 5.2.11
+  version: 5.4.0
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -70,7 +70,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 2.5.2
-  version: 5.2.11
+  version: 5.4.0
   datacenter:
     name: us-east-1
     racks:

--- a/docs/source/scylla-cluster-crd.md
+++ b/docs/source/scylla-cluster-crd.md
@@ -14,7 +14,7 @@ metadata:
   name: simple-cluster
   namespace: scylla
 spec:
-  version: 5.2.11
+  version: 5.4.0
   repository: scylladb/scylla
   developerMode: true
   cpuset: false

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.1.2
-  version: 5.2.11
+  version: 5.4.0
   cpuset: true
   network:
     hostNetworking: true

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.1.2
-  version: 5.2.11
+  version: 5.4.0
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.1.2
-  version: 5.2.11
+  version: 5.4.0
   cpuset: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -1,6 +1,6 @@
 # Version information
 scyllaImage:
-  tag: 5.2.11
+  tag: 5.4.0
 agentImage:
   tag: 3.1.2
 

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -23,7 +23,7 @@ controllerResources:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 5.2.11
+    tag: 5.4.0
   agentImage:
     tag: 3.1.2
   datacenter: manager-dc

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla
 spec:
   agentVersion: 3.1.0
-  version: 5.2.11
+  version: 5.4.0
   developerMode: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -15,7 +15,7 @@ spec:
     - name: us-east-1a
       members: 1
       storage:
-        capacity: 500Mi
+        capacity: 1Gi
       resources:
         requests:
           cpu: 10m

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -23,7 +23,7 @@ scylla:
   fullnameOverride: scylla-manager-cluster
   scyllaImage:
     repository: docker.io/scylladb/scylla
-    tag: 5.2.11
+    tag: 5.4.0
   agentImage:
     tag: 3.1.2
     repository: docker.io/scylladb/scylla-manager-agent

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -73,7 +73,7 @@ controllerServiceAccount:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 5.2.11
+    tag: 5.4.0
   agentImage:
     tag: 3.1.2
   datacenter: manager-dc

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 scyllaImage:
   repository: scylladb/scylla
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 5.2.11
+  tag: 5.4.0
 # Allows to customize Scylla image
 agentImage:
   repository: scylladb/scylla-manager-agent

--- a/test/e2e/fixture/scylla/basic.scyllacluster.yaml
+++ b/test/e2e/fixture/scylla/basic.scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: basic-
 spec:
   agentVersion: 3.1.0
-  version: 5.2.11
+  version: 5.4.0
   developerMode: true
   datacenter:
     name: us-east-1

--- a/test/e2e/fixture/scylla/basic.scyllacluster.yaml
+++ b/test/e2e/fixture/scylla/basic.scyllacluster.yaml
@@ -12,7 +12,7 @@ spec:
     - name: us-east-1a
       members: 1
       storage:
-        capacity: 500Mi
+        capacity: 1Gi
       resources:
         requests:
           cpu: 10m

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	updateFromScyllaVersion  = "5.2.7"
-	updateToScyllaVersion    = "5.2.11"
-	upgradeFromScyllaVersion = "5.1.18"
-	upgradeToScyllaVersion   = "5.2.11"
+	updateFromScyllaVersion  = "5.4.0-rc2"
+	updateToScyllaVersion    = "5.4.0"
+	upgradeFromScyllaVersion = "5.2.11"
+	upgradeToScyllaVersion   = "5.4.0"
 
 	testTimeout = 45 * time.Minute
 )


### PR DESCRIPTION
**Description of your changes:**
This PR updates our manifests and CI to use `5.4.0`.

Resolves #1607 