### PR TITLE
Automatically detect number of cpus from cgroup in Scylla Operator binaries

### DIFF
--- a/cmd/scylla-operator-tests/scylla-operator-tests.go
+++ b/cmd/scylla-operator-tests/scylla-operator-tests.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"runtime"
 	"time"
 
 	cmd "github.com/scylladb/scylla-operator/pkg/cmd/tests"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	_ "go.uber.org/automaxprocs"
 	"k8s.io/klog/v2"
 )
 
@@ -24,10 +24,6 @@ func main() {
 		panic(err)
 	}
 	defer klog.Flush()
-
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
 
 	command := cmd.NewTestsCommand(genericclioptions.IOStreams{
 		In:     os.Stdin,

--- a/cmd/scylla-operator/scylla-operator.go
+++ b/cmd/scylla-operator/scylla-operator.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"runtime"
 	"time"
 
 	cmd "github.com/scylladb/scylla-operator/pkg/cmd/operator"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	_ "go.uber.org/automaxprocs"
 	"k8s.io/klog/v2"
 )
 
@@ -24,10 +24,6 @@ func main() {
 		panic(err)
 	}
 	defer klog.Flush()
-
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
 
 	command := cmd.NewOperatorCommand(genericclioptions.IOStreams{
 		In:     os.Stdin,

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/atomic v1.11.0
+	go.uber.org/automaxprocs v1.5.3
 	go.uber.org/config v1.4.0
 	golang.org/x/oauth2 v0.15.0
 	golang.org/x/sys v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v1.17.0 h1:rl2sfwZMtSthVU752MqfjQozy7blglC+1SOtjMAMh+Q=
 github.com/prometheus/client_golang v1.17.0/go.mod h1:VeL+gMmOAxkS2IqfCq0ZmHSL+LjWfWDUmp1mBz9JgUY=
 github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
@@ -364,6 +366,8 @@ go.starlark.net v0.0.0-20231121155337-90ade8b19d09/go.mod h1:LcLNIzVOMp4oV+uusnp
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
+go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 go.uber.org/config v1.4.0 h1:upnMPpMm6WlbZtXoasNkK4f0FhxwS+W4Iqz5oNznehQ=
 go.uber.org/config v1.4.0/go.mod h1:aCyrMHmUAc/s2h9sv1koP84M9ZF/4K+g2oleyESO/Ig=
 go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=

--- a/vendor/go.uber.org/automaxprocs/.codecov.yml
+++ b/vendor/go.uber.org/automaxprocs/.codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  range: 80..100
+  round: down
+  precision: 2
+
+  status:
+    project:                   # measuring the overall project coverage
+      default:                 # context, you can create multiple ones with custom titles
+        enabled: yes           # must be yes|true to enable this status
+        target: 90%            # specify the target coverage for each commit status
+                               #   option: "auto" (must increase from parent commit or pull request base)
+                               #   option: "X%" a static target percentage to hit
+        if_not_found: success  # if parent is not found report status as success, error, or failure
+        if_ci_failed: error    # if ci fails report status as success, error, or failure

--- a/vendor/go.uber.org/automaxprocs/.gitignore
+++ b/vendor/go.uber.org/automaxprocs/.gitignore
@@ -1,0 +1,33 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+vendor
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+*.pprof
+*.out
+*.log
+coverage.txt
+
+/bin
+cover.out
+cover.html

--- a/vendor/go.uber.org/automaxprocs/CHANGELOG.md
+++ b/vendor/go.uber.org/automaxprocs/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+## v1.5.3 (2023-07-19)
+
+- Fix mountinfo parsing when super options have fields with spaces.
+- Fix division by zero while parsing cgroups.
+
+## v1.5.2 (2023-03-16)
+
+- Support child control cgroups
+- Fix file descriptor leak
+- Update dependencies
+
+## v1.5.1 (2022-04-06)
+
+- Fix cgroups v2 mountpoint detection.
+
+## v1.5.0 (2022-04-05)
+
+- Add support for cgroups v2.
+
+Thanks to @emadolsky for their contribution to this release.
+
+## v1.4.0 (2021-02-01)
+
+- Support colons in cgroup names.
+- Remove linters from runtime dependencies.
+
+## v1.3.0 (2020-01-23)
+
+- Migrate to Go modules.
+
+## v1.2.0 (2018-02-22)
+
+- Fixed quota clamping to always round down rather than up; Rather than
+  guaranteeing constant throttling at saturation, instead assume that the
+  fractional CPU was added as a hedge for factors outside of Go's scheduler.
+
+## v1.1.0 (2017-11-10)
+
+- Log the new value of `GOMAXPROCS` rather than the current value.
+- Make logs more explicit about whether `GOMAXPROCS` was modified or not.
+- Allow customization of the minimum `GOMAXPROCS`, and modify default from 2 to 1.
+
+## v1.0.0 (2017-08-09)
+
+- Initial release.

--- a/vendor/go.uber.org/automaxprocs/CODE_OF_CONDUCT.md
+++ b/vendor/go.uber.org/automaxprocs/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at oss-conduct@uber.com. The project
+team will review and investigate all complaints, and will respond in a way
+that it deems appropriate to the circumstances. The project team is obligated
+to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version].
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/vendor/go.uber.org/automaxprocs/CONTRIBUTING.md
+++ b/vendor/go.uber.org/automaxprocs/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing
+
+We'd love your help improving this package!
+
+If you'd like to add new exported APIs, please [open an issue][open-issue]
+describing your proposal &mdash; discussing API changes ahead of time makes
+pull request review much smoother. In your issue, pull request, and any other
+communications, please remember to treat your fellow contributors with
+respect! We take our [code of conduct](CODE_OF_CONDUCT.md) seriously.
+
+Note that you'll need to sign [Uber's Contributor License Agreement][cla]
+before we can accept any of your contributions. If necessary, a bot will remind
+you to accept the CLA when you open your pull request.
+
+## Setup
+
+[Fork][fork], then clone the repository:
+
+```
+mkdir -p $GOPATH/src/go.uber.org
+cd $GOPATH/src/go.uber.org
+git clone git@github.com:your_github_username/automaxprocs.git
+cd automaxprocs
+git remote add upstream https://github.com/uber-go/automaxprocs.git
+git fetch upstream
+```
+
+Install the test dependencies:
+
+```
+make dependencies
+```
+
+Make sure that the tests and the linters pass:
+
+```
+make test
+make lint
+```
+
+If you're not using the minor version of Go specified in the Makefile's
+`LINTABLE_MINOR_VERSIONS` variable, `make lint` doesn't do anything. This is
+fine, but it means that you'll only discover lint failures after you open your
+pull request.
+
+## Making Changes
+
+Start by creating a new branch for your changes:
+
+```
+cd $GOPATH/src/go.uber.org/automaxprocs
+git checkout master
+git fetch upstream
+git rebase upstream/master
+git checkout -b cool_new_feature
+```
+
+Make your changes, then ensure that `make lint` and `make test` still pass. If
+you're satisfied with your changes, push them to your fork.
+
+```
+git push origin cool_new_feature
+```
+
+Then use the GitHub UI to open a pull request.
+
+At this point, you're waiting on us to review your changes. We *try* to respond
+to issues and pull requests within a few business days, and we may suggest some
+improvements or alternatives. Once your changes are approved, one of the
+project maintainers will merge them.
+
+We're much more likely to approve your changes if you:
+
+* Add tests for new functionality.
+* Write a [good commit message][commit-message].
+* Maintain backward compatibility.
+
+[fork]: https://github.com/uber-go/automaxprocs/fork
+[open-issue]: https://github.com/uber-go/automaxprocs/issues/new
+[cla]: https://cla-assistant.io/uber-go/automaxprocs
+[commit-message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/vendor/go.uber.org/automaxprocs/LICENSE
+++ b/vendor/go.uber.org/automaxprocs/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Uber Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/go.uber.org/automaxprocs/Makefile
+++ b/vendor/go.uber.org/automaxprocs/Makefile
@@ -1,0 +1,46 @@
+export GOBIN ?= $(shell pwd)/bin
+
+GO_FILES := $(shell \
+	find . '(' -path '*/.*' -o -path './vendor' ')' -prune \
+	-o -name '*.go' -print | cut -b3-)
+
+GOLINT = $(GOBIN)/golint
+STATICCHECK = $(GOBIN)/staticcheck
+
+.PHONY: build
+build:
+	go build ./...
+
+.PHONY: install
+install:
+	go mod download
+
+.PHONY: test
+test:
+	go test -race ./...
+
+.PHONY: cover
+cover:
+	go test -coverprofile=cover.out -covermode=atomic -coverpkg=./... ./...
+	go tool cover -html=cover.out -o cover.html
+
+$(GOLINT): tools/go.mod
+	cd tools && go install golang.org/x/lint/golint
+
+$(STATICCHECK): tools/go.mod
+	cd tools && go install honnef.co/go/tools/cmd/staticcheck@2023.1.2
+
+.PHONY: lint
+lint: $(GOLINT) $(STATICCHECK)
+	@rm -rf lint.log
+	@echo "Checking gofmt"
+	@gofmt -d -s $(GO_FILES) 2>&1 | tee lint.log
+	@echo "Checking go vet"
+	@go vet ./... 2>&1 | tee -a lint.log
+	@echo "Checking golint"
+	@$(GOLINT) ./... | tee -a lint.log
+	@echo "Checking staticcheck"
+	@$(STATICCHECK) ./... 2>&1 |  tee -a lint.log
+	@echo "Checking for license headers..."
+	@./.build/check_license.sh | tee -a lint.log
+	@[ ! -s lint.log ]

--- a/vendor/go.uber.org/automaxprocs/README.md
+++ b/vendor/go.uber.org/automaxprocs/README.md
@@ -1,0 +1,71 @@
+# automaxprocs [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+
+Automatically set `GOMAXPROCS` to match Linux container CPU quota.
+
+## Installation
+
+`go get -u go.uber.org/automaxprocs`
+
+## Quick Start
+
+```go
+import _ "go.uber.org/automaxprocs"
+
+func main() {
+  // Your application logic here.
+}
+```
+
+# Performance
+Data measured from Uber's internal load balancer. We ran the load balancer with 200% CPU quota (i.e., 2 cores):
+
+| GOMAXPROCS         |  RPS      | P50 (ms) | P99.9 (ms) |
+| ------------------ | --------- | -------- | ---------- |
+| 1                  | 28,893.18 | 1.46     | 19.70      |
+| 2 (equal to quota) | 44,715.07 | 0.84     | 26.38      |
+| 3                  | 44,212.93 | 0.66     | 30.07      |
+| 4                  | 41,071.15 | 0.57     | 42.94      |
+| 8                  | 33,111.69 | 0.43     | 64.32      |
+| Default (24)       | 22,191.40 | 0.45     | 76.19      |
+
+When `GOMAXPROCS` is increased above the CPU quota, we see P50 decrease slightly, but see significant increases to P99. We also see that the total RPS handled also decreases.
+
+When `GOMAXPROCS` is higher than the CPU quota allocated, we also saw significant throttling:
+
+```
+$ cat /sys/fs/cgroup/cpu,cpuacct/system.slice/[...]/cpu.stat
+nr_periods 42227334
+nr_throttled 131923
+throttled_time 88613212216618
+```
+
+Once `GOMAXPROCS` was reduced to match the CPU quota, we saw no CPU throttling.
+
+## Development Status: Stable
+
+All APIs are finalized, and no breaking changes will be made in the 1.x series
+of releases. Users of semver-aware dependency management systems should pin
+automaxprocs to `^1`.
+
+## Contributing
+
+We encourage and support an active, healthy community of contributors &mdash;
+including you! Details are in the [contribution guide](CONTRIBUTING.md) and
+the [code of conduct](CODE_OF_CONDUCT.md). The automaxprocs maintainers keep
+an eye on issues and pull requests, but you can also report any negative
+conduct to oss-conduct@uber.com. That email list is a private, safe space;
+even the automaxprocs maintainers don't have access, so don't hesitate to hold
+us to a high standard.
+
+<hr>
+
+Released under the [MIT License](LICENSE).
+
+[doc-img]: https://godoc.org/go.uber.org/automaxprocs?status.svg
+[doc]: https://godoc.org/go.uber.org/automaxprocs
+[ci-img]: https://github.com/uber-go/automaxprocs/actions/workflows/go.yml/badge.svg
+[ci]: https://github.com/uber-go/automaxprocs/actions/workflows/go.yml
+[cov-img]: https://codecov.io/gh/uber-go/automaxprocs/branch/master/graph/badge.svg
+[cov]: https://codecov.io/gh/uber-go/automaxprocs
+
+

--- a/vendor/go.uber.org/automaxprocs/automaxprocs.go
+++ b/vendor/go.uber.org/automaxprocs/automaxprocs.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package automaxprocs automatically sets GOMAXPROCS to match the Linux
+// container CPU quota, if any.
+package automaxprocs // import "go.uber.org/automaxprocs"
+
+import (
+	"log"
+
+	"go.uber.org/automaxprocs/maxprocs"
+)
+
+func init() {
+	maxprocs.Set(maxprocs.Logger(log.Printf))
+}

--- a/vendor/go.uber.org/automaxprocs/glide.yaml
+++ b/vendor/go.uber.org/automaxprocs/glide.yaml
@@ -1,0 +1,7 @@
+package: go.uber.org/automaxprocs
+import: []
+testImport:
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - assert

--- a/vendor/go.uber.org/automaxprocs/internal/cgroups/cgroup.go
+++ b/vendor/go.uber.org/automaxprocs/internal/cgroups/cgroup.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build linux
+// +build linux
+
+package cgroups
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// CGroup represents the data structure for a Linux control group.
+type CGroup struct {
+	path string
+}
+
+// NewCGroup returns a new *CGroup from a given path.
+func NewCGroup(path string) *CGroup {
+	return &CGroup{path: path}
+}
+
+// Path returns the path of the CGroup*.
+func (cg *CGroup) Path() string {
+	return cg.path
+}
+
+// ParamPath returns the path of the given cgroup param under itself.
+func (cg *CGroup) ParamPath(param string) string {
+	return filepath.Join(cg.path, param)
+}
+
+// readFirstLine reads the first line from a cgroup param file.
+func (cg *CGroup) readFirstLine(param string) (string, error) {
+	paramFile, err := os.Open(cg.ParamPath(param))
+	if err != nil {
+		return "", err
+	}
+	defer paramFile.Close()
+
+	scanner := bufio.NewScanner(paramFile)
+	if scanner.Scan() {
+		return scanner.Text(), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", io.ErrUnexpectedEOF
+}
+
+// readInt parses the first line from a cgroup param file as int.
+func (cg *CGroup) readInt(param string) (int, error) {
+	text, err := cg.readFirstLine(param)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(text)
+}

--- a/vendor/go.uber.org/automaxprocs/internal/cgroups/cgroups.go
+++ b/vendor/go.uber.org/automaxprocs/internal/cgroups/cgroups.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build linux
+// +build linux
+
+package cgroups
+
+const (
+	// _cgroupFSType is the Linux CGroup file system type used in
+	// `/proc/$PID/mountinfo`.
+	_cgroupFSType = "cgroup"
+	// _cgroupSubsysCPU is the CPU CGroup subsystem.
+	_cgroupSubsysCPU = "cpu"
+	// _cgroupSubsysCPUAcct is the CPU accounting CGroup subsystem.
+	_cgroupSubsysCPUAcct = "cpuacct"
+	// _cgroupSubsysCPUSet is the CPUSet CGroup subsystem.
+	_cgroupSubsysCPUSet = "cpuset"
+	// _cgroupSubsysMemory is the Memory CGroup subsystem.
+	_cgroupSubsysMemory = "memory"
+
+	// _cgroupCPUCFSQuotaUsParam is the file name for the CGroup CFS quota
+	// parameter.
+	_cgroupCPUCFSQuotaUsParam = "cpu.cfs_quota_us"
+	// _cgroupCPUCFSPeriodUsParam is the file name for the CGroup CFS period
+	// parameter.
+	_cgroupCPUCFSPeriodUsParam = "cpu.cfs_period_us"
+)
+
+const (
+	_procPathCGroup    = "/proc/self/cgroup"
+	_procPathMountInfo = "/proc/self/mountinfo"
+)
+
+// CGroups is a map that associates each CGroup with its subsystem name.
+type CGroups map[string]*CGroup
+
+// NewCGroups returns a new *CGroups from given `mountinfo` and `cgroup` files
+// under for some process under `/proc` file system (see also proc(5) for more
+// information).
+func NewCGroups(procPathMountInfo, procPathCGroup string) (CGroups, error) {
+	cgroupSubsystems, err := parseCGroupSubsystems(procPathCGroup)
+	if err != nil {
+		return nil, err
+	}
+
+	cgroups := make(CGroups)
+	newMountPoint := func(mp *MountPoint) error {
+		if mp.FSType != _cgroupFSType {
+			return nil
+		}
+
+		for _, opt := range mp.SuperOptions {
+			subsys, exists := cgroupSubsystems[opt]
+			if !exists {
+				continue
+			}
+
+			cgroupPath, err := mp.Translate(subsys.Name)
+			if err != nil {
+				return err
+			}
+			cgroups[opt] = NewCGroup(cgroupPath)
+		}
+
+		return nil
+	}
+
+	if err := parseMountInfo(procPathMountInfo, newMountPoint); err != nil {
+		return nil, err
+	}
+	return cgroups, nil
+}
+
+// NewCGroupsForCurrentProcess returns a new *CGroups instance for the current
+// process.
+func NewCGroupsForCurrentProcess() (CGroups, error) {
+	return NewCGroups(_procPathMountInfo, _procPathCGroup)
+}
+
+// CPUQuota returns the CPU quota applied with the CPU cgroup controller.
+// It is a result of `cpu.cfs_quota_us / cpu.cfs_period_us`. If the value of
+// `cpu.cfs_quota_us` was not set (-1), the method returns `(-1, nil)`.
+func (cg CGroups) CPUQuota() (float64, bool, error) {
+	cpuCGroup, exists := cg[_cgroupSubsysCPU]
+	if !exists {
+		return -1, false, nil
+	}
+
+	cfsQuotaUs, err := cpuCGroup.readInt(_cgroupCPUCFSQuotaUsParam)
+	if defined := cfsQuotaUs > 0; err != nil || !defined {
+		return -1, defined, err
+	}
+
+	cfsPeriodUs, err := cpuCGroup.readInt(_cgroupCPUCFSPeriodUsParam)
+	if defined := cfsPeriodUs > 0; err != nil || !defined {
+		return -1, defined, err
+	}
+
+	return float64(cfsQuotaUs) / float64(cfsPeriodUs), true, nil
+}

--- a/vendor/go.uber.org/automaxprocs/internal/cgroups/cgroups2.go
+++ b/vendor/go.uber.org/automaxprocs/internal/cgroups/cgroups2.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build linux
+// +build linux
+
+package cgroups
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+)
+
+const (
+	// _cgroupv2CPUMax is the file name for the CGroup-V2 CPU max and period
+	// parameter.
+	_cgroupv2CPUMax = "cpu.max"
+	// _cgroupFSType is the Linux CGroup-V2 file system type used in
+	// `/proc/$PID/mountinfo`.
+	_cgroupv2FSType = "cgroup2"
+
+	_cgroupv2MountPoint = "/sys/fs/cgroup"
+
+	_cgroupV2CPUMaxDefaultPeriod = 100000
+	_cgroupV2CPUMaxQuotaMax      = "max"
+)
+
+const (
+	_cgroupv2CPUMaxQuotaIndex = iota
+	_cgroupv2CPUMaxPeriodIndex
+)
+
+// ErrNotV2 indicates that the system is not using cgroups2.
+var ErrNotV2 = errors.New("not using cgroups2")
+
+// CGroups2 provides access to cgroups data for systems using cgroups2.
+type CGroups2 struct {
+	mountPoint string
+	groupPath  string
+	cpuMaxFile string
+}
+
+// NewCGroups2ForCurrentProcess builds a CGroups2 for the current process.
+//
+// This returns ErrNotV2 if the system is not using cgroups2.
+func NewCGroups2ForCurrentProcess() (*CGroups2, error) {
+	return newCGroups2From(_procPathMountInfo, _procPathCGroup)
+}
+
+func newCGroups2From(mountInfoPath, procPathCGroup string) (*CGroups2, error) {
+	isV2, err := isCGroupV2(mountInfoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isV2 {
+		return nil, ErrNotV2
+	}
+
+	subsystems, err := parseCGroupSubsystems(procPathCGroup)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find v2 subsystem by looking for the `0` id
+	var v2subsys *CGroupSubsys
+	for _, subsys := range subsystems {
+		if subsys.ID == 0 {
+			v2subsys = subsys
+			break
+		}
+	}
+
+	if v2subsys == nil {
+		return nil, ErrNotV2
+	}
+
+	return &CGroups2{
+		mountPoint: _cgroupv2MountPoint,
+		groupPath:  v2subsys.Name,
+		cpuMaxFile: _cgroupv2CPUMax,
+	}, nil
+}
+
+func isCGroupV2(procPathMountInfo string) (bool, error) {
+	var (
+		isV2          bool
+		newMountPoint = func(mp *MountPoint) error {
+			isV2 = isV2 || (mp.FSType == _cgroupv2FSType && mp.MountPoint == _cgroupv2MountPoint)
+			return nil
+		}
+	)
+
+	if err := parseMountInfo(procPathMountInfo, newMountPoint); err != nil {
+		return false, err
+	}
+
+	return isV2, nil
+}
+
+// CPUQuota returns the CPU quota applied with the CPU cgroup2 controller.
+// It is a result of reading cpu quota and period from cpu.max file.
+// It will return `cpu.max / cpu.period`. If cpu.max is set to max, it returns
+// (-1, false, nil)
+func (cg *CGroups2) CPUQuota() (float64, bool, error) {
+	cpuMaxParams, err := os.Open(path.Join(cg.mountPoint, cg.groupPath, cg.cpuMaxFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return -1, false, nil
+		}
+		return -1, false, err
+	}
+	defer cpuMaxParams.Close()
+
+	scanner := bufio.NewScanner(cpuMaxParams)
+	if scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 || len(fields) > 2 {
+			return -1, false, fmt.Errorf("invalid format")
+		}
+
+		if fields[_cgroupv2CPUMaxQuotaIndex] == _cgroupV2CPUMaxQuotaMax {
+			return -1, false, nil
+		}
+
+		max, err := strconv.Atoi(fields[_cgroupv2CPUMaxQuotaIndex])
+		if err != nil {
+			return -1, false, err
+		}
+
+		var period int
+		if len(fields) == 1 {
+			period = _cgroupV2CPUMaxDefaultPeriod
+		} else {
+			period, err = strconv.Atoi(fields[_cgroupv2CPUMaxPeriodIndex])
+			if err != nil {
+				return -1, false, err
+			}
+
+			if period == 0 {
+				return -1, false, errors.New("zero value for period is not allowed")
+			}
+		}
+
+		return float64(max) / float64(period), true, nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return -1, false, err
+	}
+
+	return 0, false, io.ErrUnexpectedEOF
+}

--- a/vendor/go.uber.org/automaxprocs/internal/cgroups/doc.go
+++ b/vendor/go.uber.org/automaxprocs/internal/cgroups/doc.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package cgroups provides utilities to access Linux control group (CGroups)
+// parameters (CPU quota, for example) for a given process.
+package cgroups

--- a/vendor/go.uber.org/automaxprocs/internal/cgroups/errors.go
+++ b/vendor/go.uber.org/automaxprocs/internal/cgroups/errors.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build linux
+// +build linux
+
+package cgroups
+
+import "fmt"
+
+type cgroupSubsysFormatInvalidError struct {
+	line string
+}
+
+type mountPointFormatInvalidError struct {
+	line string
+}
+
+type pathNotExposedFromMountPointError struct {
+	mountPoint string
+	root       string
+	path       string
+}
+
+func (err cgroupSubsysFormatInvalidError) Error() string {
+	return fmt.Sprintf("invalid format for CGroupSubsys: %q", err.line)
+}
+
+func (err mountPointFormatInvalidError) Error() string {
+	return fmt.Sprintf("invalid format for MountPoint: %q", err.line)
+}
+
+func (err pathNotExposedFromMountPointError) Error() string {
+	return fmt.Sprintf("path %q is not a descendant of mount point root %q and cannot be exposed from %q", err.path, err.root, err.mountPoint)
+}

--- a/vendor/go.uber.org/automaxprocs/internal/cgroups/mountpoint.go
+++ b/vendor/go.uber.org/automaxprocs/internal/cgroups/mountpoint.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build linux
+// +build linux
+
+package cgroups
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	_mountInfoSep               = " "
+	_mountInfoOptsSep           = ","
+	_mountInfoOptionalFieldsSep = "-"
+)
+
+const (
+	_miFieldIDMountID = iota
+	_miFieldIDParentID
+	_miFieldIDDeviceID
+	_miFieldIDRoot
+	_miFieldIDMountPoint
+	_miFieldIDOptions
+	_miFieldIDOptionalFields
+
+	_miFieldCountFirstHalf
+)
+
+const (
+	_miFieldOffsetFSType = iota
+	_miFieldOffsetMountSource
+	_miFieldOffsetSuperOptions
+
+	_miFieldCountSecondHalf
+)
+
+const _miFieldCountMin = _miFieldCountFirstHalf + _miFieldCountSecondHalf
+
+// MountPoint is the data structure for the mount points in
+// `/proc/$PID/mountinfo`. See also proc(5) for more information.
+type MountPoint struct {
+	MountID        int
+	ParentID       int
+	DeviceID       string
+	Root           string
+	MountPoint     string
+	Options        []string
+	OptionalFields []string
+	FSType         string
+	MountSource    string
+	SuperOptions   []string
+}
+
+// NewMountPointFromLine parses a line read from `/proc/$PID/mountinfo` and
+// returns a new *MountPoint.
+func NewMountPointFromLine(line string) (*MountPoint, error) {
+	fields := strings.Split(line, _mountInfoSep)
+
+	if len(fields) < _miFieldCountMin {
+		return nil, mountPointFormatInvalidError{line}
+	}
+
+	mountID, err := strconv.Atoi(fields[_miFieldIDMountID])
+	if err != nil {
+		return nil, err
+	}
+
+	parentID, err := strconv.Atoi(fields[_miFieldIDParentID])
+	if err != nil {
+		return nil, err
+	}
+
+	for i, field := range fields[_miFieldIDOptionalFields:] {
+		if field == _mountInfoOptionalFieldsSep {
+			// End of optional fields.
+			fsTypeStart := _miFieldIDOptionalFields + i + 1
+
+			// Now we know where the optional fields end, split the line again with a
+			// limit to avoid issues with spaces in super options as present on WSL.
+			fields = strings.SplitN(line, _mountInfoSep, fsTypeStart+_miFieldCountSecondHalf)
+			if len(fields) != fsTypeStart+_miFieldCountSecondHalf {
+				return nil, mountPointFormatInvalidError{line}
+			}
+
+			miFieldIDFSType := _miFieldOffsetFSType + fsTypeStart
+			miFieldIDMountSource := _miFieldOffsetMountSource + fsTypeStart
+			miFieldIDSuperOptions := _miFieldOffsetSuperOptions + fsTypeStart
+
+			return &MountPoint{
+				MountID:        mountID,
+				ParentID:       parentID,
+				DeviceID:       fields[_miFieldIDDeviceID],
+				Root:           fields[_miFieldIDRoot],
+				MountPoint:     fields[_miFieldIDMountPoint],
+				Options:        strings.Split(fields[_miFieldIDOptions], _mountInfoOptsSep),
+				OptionalFields: fields[_miFieldIDOptionalFields:(fsTypeStart - 1)],
+				FSType:         fields[miFieldIDFSType],
+				MountSource:    fields[miFieldIDMountSource],
+				SuperOptions:   strings.Split(fields[miFieldIDSuperOptions], _mountInfoOptsSep),
+			}, nil
+		}
+	}
+
+	return nil, mountPointFormatInvalidError{line}
+}
+
+// Translate converts an absolute path inside the *MountPoint's file system to
+// the host file system path in the mount namespace the *MountPoint belongs to.
+func (mp *MountPoint) Translate(absPath string) (string, error) {
+	relPath, err := filepath.Rel(mp.Root, absPath)
+
+	if err != nil {
+		return "", err
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, "../") {
+		return "", pathNotExposedFromMountPointError{
+			mountPoint: mp.MountPoint,
+			root:       mp.Root,
+			path:       absPath,
+		}
+	}
+
+	return filepath.Join(mp.MountPoint, relPath), nil
+}
+
+// parseMountInfo parses procPathMountInfo (usually at `/proc/$PID/mountinfo`)
+// and yields parsed *MountPoint into newMountPoint.
+func parseMountInfo(procPathMountInfo string, newMountPoint func(*MountPoint) error) error {
+	mountInfoFile, err := os.Open(procPathMountInfo)
+	if err != nil {
+		return err
+	}
+	defer mountInfoFile.Close()
+
+	scanner := bufio.NewScanner(mountInfoFile)
+
+	for scanner.Scan() {
+		mountPoint, err := NewMountPointFromLine(scanner.Text())
+		if err != nil {
+			return err
+		}
+		if err := newMountPoint(mountPoint); err != nil {
+			return err
+		}
+	}
+
+	return scanner.Err()
+}

--- a/vendor/go.uber.org/automaxprocs/internal/cgroups/subsys.go
+++ b/vendor/go.uber.org/automaxprocs/internal/cgroups/subsys.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build linux
+// +build linux
+
+package cgroups
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	_cgroupSep       = ":"
+	_cgroupSubsysSep = ","
+)
+
+const (
+	_csFieldIDID = iota
+	_csFieldIDSubsystems
+	_csFieldIDName
+	_csFieldCount
+)
+
+// CGroupSubsys represents the data structure for entities in
+// `/proc/$PID/cgroup`. See also proc(5) for more information.
+type CGroupSubsys struct {
+	ID         int
+	Subsystems []string
+	Name       string
+}
+
+// NewCGroupSubsysFromLine returns a new *CGroupSubsys by parsing a string in
+// the format of `/proc/$PID/cgroup`
+func NewCGroupSubsysFromLine(line string) (*CGroupSubsys, error) {
+	fields := strings.SplitN(line, _cgroupSep, _csFieldCount)
+
+	if len(fields) != _csFieldCount {
+		return nil, cgroupSubsysFormatInvalidError{line}
+	}
+
+	id, err := strconv.Atoi(fields[_csFieldIDID])
+	if err != nil {
+		return nil, err
+	}
+
+	cgroup := &CGroupSubsys{
+		ID:         id,
+		Subsystems: strings.Split(fields[_csFieldIDSubsystems], _cgroupSubsysSep),
+		Name:       fields[_csFieldIDName],
+	}
+
+	return cgroup, nil
+}
+
+// parseCGroupSubsystems parses procPathCGroup (usually at `/proc/$PID/cgroup`)
+// and returns a new map[string]*CGroupSubsys.
+func parseCGroupSubsystems(procPathCGroup string) (map[string]*CGroupSubsys, error) {
+	cgroupFile, err := os.Open(procPathCGroup)
+	if err != nil {
+		return nil, err
+	}
+	defer cgroupFile.Close()
+
+	scanner := bufio.NewScanner(cgroupFile)
+	subsystems := make(map[string]*CGroupSubsys)
+
+	for scanner.Scan() {
+		cgroup, err := NewCGroupSubsysFromLine(scanner.Text())
+		if err != nil {
+			return nil, err
+		}
+		for _, subsys := range cgroup.Subsystems {
+			subsystems[subsys] = cgroup
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return subsystems, nil
+}

--- a/vendor/go.uber.org/automaxprocs/internal/runtime/cpu_quota_linux.go
+++ b/vendor/go.uber.org/automaxprocs/internal/runtime/cpu_quota_linux.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build linux
+// +build linux
+
+package runtime
+
+import (
+	"errors"
+	"math"
+
+	cg "go.uber.org/automaxprocs/internal/cgroups"
+)
+
+// CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
+// to a valid GOMAXPROCS value.
+func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
+	cgroups, err := newQueryer()
+	if err != nil {
+		return -1, CPUQuotaUndefined, err
+	}
+
+	quota, defined, err := cgroups.CPUQuota()
+	if !defined || err != nil {
+		return -1, CPUQuotaUndefined, err
+	}
+
+	maxProcs := int(math.Floor(quota))
+	if minValue > 0 && maxProcs < minValue {
+		return minValue, CPUQuotaMinUsed, nil
+	}
+	return maxProcs, CPUQuotaUsed, nil
+}
+
+type queryer interface {
+	CPUQuota() (float64, bool, error)
+}
+
+var (
+	_newCgroups2 = cg.NewCGroups2ForCurrentProcess
+	_newCgroups  = cg.NewCGroupsForCurrentProcess
+)
+
+func newQueryer() (queryer, error) {
+	cgroups, err := _newCgroups2()
+	if err == nil {
+		return cgroups, nil
+	}
+	if errors.Is(err, cg.ErrNotV2) {
+		return _newCgroups()
+	}
+	return nil, err
+}

--- a/vendor/go.uber.org/automaxprocs/internal/runtime/cpu_quota_unsupported.go
+++ b/vendor/go.uber.org/automaxprocs/internal/runtime/cpu_quota_unsupported.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build !linux
+// +build !linux
+
+package runtime
+
+// CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
+// to a valid GOMAXPROCS value. This is Linux-specific and not supported in the
+// current OS.
+func CPUQuotaToGOMAXPROCS(_ int) (int, CPUQuotaStatus, error) {
+	return -1, CPUQuotaUndefined, nil
+}

--- a/vendor/go.uber.org/automaxprocs/internal/runtime/runtime.go
+++ b/vendor/go.uber.org/automaxprocs/internal/runtime/runtime.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package runtime
+
+// CPUQuotaStatus presents the status of how CPU quota is used
+type CPUQuotaStatus int
+
+const (
+	// CPUQuotaUndefined is returned when CPU quota is undefined
+	CPUQuotaUndefined CPUQuotaStatus = iota
+	// CPUQuotaUsed is returned when a valid CPU quota can be used
+	CPUQuotaUsed
+	// CPUQuotaMinUsed is returned when CPU quota is smaller than the min value
+	CPUQuotaMinUsed
+)

--- a/vendor/go.uber.org/automaxprocs/maxprocs/maxprocs.go
+++ b/vendor/go.uber.org/automaxprocs/maxprocs/maxprocs.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package maxprocs lets Go programs easily configure runtime.GOMAXPROCS to
+// match the configured Linux CPU quota. Unlike the top-level automaxprocs
+// package, it lets the caller configure logging and handle errors.
+package maxprocs // import "go.uber.org/automaxprocs/maxprocs"
+
+import (
+	"os"
+	"runtime"
+
+	iruntime "go.uber.org/automaxprocs/internal/runtime"
+)
+
+const _maxProcsKey = "GOMAXPROCS"
+
+func currentMaxProcs() int {
+	return runtime.GOMAXPROCS(0)
+}
+
+type config struct {
+	printf        func(string, ...interface{})
+	procs         func(int) (int, iruntime.CPUQuotaStatus, error)
+	minGOMAXPROCS int
+}
+
+func (c *config) log(fmt string, args ...interface{}) {
+	if c.printf != nil {
+		c.printf(fmt, args...)
+	}
+}
+
+// An Option alters the behavior of Set.
+type Option interface {
+	apply(*config)
+}
+
+// Logger uses the supplied printf implementation for log output. By default,
+// Set doesn't log anything.
+func Logger(printf func(string, ...interface{})) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.printf = printf
+	})
+}
+
+// Min sets the minimum GOMAXPROCS value that will be used.
+// Any value below 1 is ignored.
+func Min(n int) Option {
+	return optionFunc(func(cfg *config) {
+		if n >= 1 {
+			cfg.minGOMAXPROCS = n
+		}
+	})
+}
+
+type optionFunc func(*config)
+
+func (of optionFunc) apply(cfg *config) { of(cfg) }
+
+// Set GOMAXPROCS to match the Linux container CPU quota (if any), returning
+// any error encountered and an undo function.
+//
+// Set is a no-op on non-Linux systems and in Linux environments without a
+// configured CPU quota.
+func Set(opts ...Option) (func(), error) {
+	cfg := &config{
+		procs:         iruntime.CPUQuotaToGOMAXPROCS,
+		minGOMAXPROCS: 1,
+	}
+	for _, o := range opts {
+		o.apply(cfg)
+	}
+
+	undoNoop := func() {
+		cfg.log("maxprocs: No GOMAXPROCS change to reset")
+	}
+
+	// Honor the GOMAXPROCS environment variable if present. Otherwise, amend
+	// `runtime.GOMAXPROCS()` with the current process' CPU quota if the OS is
+	// Linux, and guarantee a minimum value of 1. The minimum guaranteed value
+	// can be overridden using `maxprocs.Min()`.
+	if max, exists := os.LookupEnv(_maxProcsKey); exists {
+		cfg.log("maxprocs: Honoring GOMAXPROCS=%q as set in environment", max)
+		return undoNoop, nil
+	}
+
+	maxProcs, status, err := cfg.procs(cfg.minGOMAXPROCS)
+	if err != nil {
+		return undoNoop, err
+	}
+
+	if status == iruntime.CPUQuotaUndefined {
+		cfg.log("maxprocs: Leaving GOMAXPROCS=%v: CPU quota undefined", currentMaxProcs())
+		return undoNoop, nil
+	}
+
+	prev := currentMaxProcs()
+	undo := func() {
+		cfg.log("maxprocs: Resetting GOMAXPROCS to %v", prev)
+		runtime.GOMAXPROCS(prev)
+	}
+
+	switch status {
+	case iruntime.CPUQuotaMinUsed:
+		cfg.log("maxprocs: Updating GOMAXPROCS=%v: using minimum allowed GOMAXPROCS", maxProcs)
+	case iruntime.CPUQuotaUsed:
+		cfg.log("maxprocs: Updating GOMAXPROCS=%v: determined from CPU quota", maxProcs)
+	}
+
+	runtime.GOMAXPROCS(maxProcs)
+	return undo, nil
+}

--- a/vendor/go.uber.org/automaxprocs/maxprocs/version.go
+++ b/vendor/go.uber.org/automaxprocs/maxprocs/version.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package maxprocs
+
+// Version is the current package version.
+const Version = "1.5.2"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -632,6 +632,12 @@ go.starlark.net/syntax
 # go.uber.org/atomic v1.11.0
 ## explicit; go 1.18
 go.uber.org/atomic
+# go.uber.org/automaxprocs v1.5.3
+## explicit; go 1.18
+go.uber.org/automaxprocs
+go.uber.org/automaxprocs/internal/cgroups
+go.uber.org/automaxprocs/internal/runtime
+go.uber.org/automaxprocs/maxprocs
 # go.uber.org/config v1.4.0
 ## explicit; go 1.13
 go.uber.org/config


### PR DESCRIPTION
**Description of your changes:**

Golang runtime doesn't understand cgroups hence it assumes all cpus are
available for running goroutines.
Since applications on Kubernetes are running under restricted resources
we should detect cgroups settings and align Go runtime to discovered settings.
This should lower resource consumption, and allow us to run on even more limited resources.


