### PR TITLE
[WIP] Forward ClusterIP traffic to inter-node communication port before CQL is ready

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -27,7 +27,6 @@ rules:
   - ""
   resources:
   - nodes
-  - endpoints
   verbs:
   - get
   - list
@@ -283,6 +282,30 @@ rules:
   - patch
   - update
   - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 
 ---
 apiVersion: v1

--- a/deploy/operator/00_clusterrole_def.yaml
+++ b/deploy/operator/00_clusterrole_def.yaml
@@ -17,7 +17,6 @@ rules:
   - ""
   resources:
   - nodes
-  - endpoints
   verbs:
   - get
   - list
@@ -273,3 +272,27 @@ rules:
   - patch
   - update
   - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/helm/scylla-operator/templates/clusterrole_def.yaml
+++ b/helm/scylla-operator/templates/clusterrole_def.yaml
@@ -17,7 +17,6 @@ rules:
   - ""
   resources:
   - nodes
-  - endpoints
   verbs:
   - get
   - list
@@ -273,3 +272,27 @@ rules:
   - patch
   - update
   - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -267,6 +267,8 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		kubeInformers.Policy().V1().PodDisruptionBudgets(),
 		kubeInformers.Networking().V1().Ingresses(),
 		kubeInformers.Batch().V1().Jobs(),
+		kubeInformers.Discovery().V1().EndpointSlices(),
+		kubeInformers.Core().V1().Endpoints(),
 		scyllaInformers.Scylla().V1().ScyllaClusters(),
 		o.OperatorImage,
 		o.CQLSIngressPort,

--- a/pkg/controller/scyllacluster/conditions.go
+++ b/pkg/controller/scyllacluster/conditions.go
@@ -22,4 +22,8 @@ const (
 	jobControllerDegradedCondition               = "JobControllerDegraded"
 	configControllerProgressingCondition         = "ConfigControllerProgressing"
 	configControllerDegradedCondition            = "ConfigControllerDegraded"
+	endpointSliceControllerProgressingCondition  = "EndpointSliceControllerProgressing"
+	endpointSliceControllerDegradedCondition     = "EndpointSliceControllerDegraded"
+	endpointsControllerProgressingCondition      = "EndpointsControllerProgressing"
+	endpointsControllerDegradedCondition         = "EndpointsControllerDegraded"
 )

--- a/pkg/controller/scyllacluster/controller.go
+++ b/pkg/controller/scyllacluster/controller.go
@@ -17,6 +17,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -29,6 +30,7 @@ import (
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	batchv1informers "k8s.io/client-go/informers/batch/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
+	discoveryv1informers "k8s.io/client-go/informers/discovery/v1"
 	networkingv1informers "k8s.io/client-go/informers/networking/v1"
 	policyv1informers "k8s.io/client-go/informers/policy/v1"
 	rbacv1informers "k8s.io/client-go/informers/rbac/v1"
@@ -37,6 +39,7 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	batchv1listers "k8s.io/client-go/listers/batch/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	discoveryv1listers "k8s.io/client-go/listers/discovery/v1"
 	networkingv1listers "k8s.io/client-go/listers/networking/v1"
 	policyv1listers "k8s.io/client-go/listers/policy/v1"
 	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
@@ -76,6 +79,8 @@ type Controller struct {
 	ingressLister        networkingv1listers.IngressLister
 	scyllaLister         scyllav1listers.ScyllaClusterLister
 	jobLister            batchv1listers.JobLister
+	endpointSliceLister  discoveryv1listers.EndpointSliceLister
+	endpointsLister      corev1listers.EndpointsLister
 
 	cachesToSync []cache.InformerSynced
 
@@ -100,6 +105,8 @@ func NewController(
 	pdbInformer policyv1informers.PodDisruptionBudgetInformer,
 	ingressInformer networkingv1informers.IngressInformer,
 	jobInformer batchv1informers.JobInformer,
+	endpointSliceInformer discoveryv1informers.EndpointSliceInformer,
+	endpointsInformer corev1informers.EndpointsInformer,
 	scyllaClusterInformer scyllav1informers.ScyllaClusterInformer,
 	operatorImage string,
 	cqlsIngressPort int,
@@ -127,6 +134,8 @@ func NewController(
 		ingressLister:        ingressInformer.Lister(),
 		scyllaLister:         scyllaClusterInformer.Lister(),
 		jobLister:            jobInformer.Lister(),
+		endpointSliceLister:  endpointSliceInformer.Lister(),
+		endpointsLister:      endpointsInformer.Lister(),
 
 		cachesToSync: []cache.InformerSynced{
 			podInformer.Informer().HasSynced,
@@ -140,6 +149,8 @@ func NewController(
 			ingressInformer.Informer().HasSynced,
 			scyllaClusterInformer.Informer().HasSynced,
 			jobInformer.Informer().HasSynced,
+			endpointSliceInformer.Informer().HasSynced,
+			endpointsInformer.Informer().HasSynced,
 		},
 
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "scyllacluster-controller"}),
@@ -233,6 +244,18 @@ func NewController(
 		AddFunc:    scc.addJob,
 		UpdateFunc: scc.updateJob,
 		DeleteFunc: scc.deleteJob,
+	})
+
+	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    scc.addEndpointSlice,
+		UpdateFunc: scc.updateEndpointSlice,
+		DeleteFunc: scc.deleteEndpointSlice,
+	})
+
+	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    scc.addEndpoints,
+		UpdateFunc: scc.updateEndpoints,
+		DeleteFunc: scc.deleteEndpoints,
 	})
 
 	return scc, nil
@@ -620,6 +643,52 @@ func (scc *Controller) updateJob(old, cur interface{}) {
 }
 
 func (scc *Controller) deleteJob(obj interface{}) {
+	scc.handlers.HandleDelete(
+		obj,
+		scc.handlers.EnqueueOwner,
+	)
+}
+
+func (scc *Controller) addEndpointSlice(obj interface{}) {
+	scc.handlers.HandleAdd(
+		obj.(*discoveryv1.EndpointSlice),
+		scc.handlers.EnqueueOwner,
+	)
+}
+
+func (scc *Controller) updateEndpointSlice(old, cur interface{}) {
+	scc.handlers.HandleUpdate(
+		old.(*discoveryv1.EndpointSlice),
+		cur.(*discoveryv1.EndpointSlice),
+		scc.handlers.EnqueueOwner,
+		scc.deleteEndpointSlice,
+	)
+}
+
+func (scc *Controller) deleteEndpointSlice(obj interface{}) {
+	scc.handlers.HandleDelete(
+		obj,
+		scc.handlers.EnqueueOwner,
+	)
+}
+
+func (scc *Controller) addEndpoints(obj interface{}) {
+	scc.handlers.HandleAdd(
+		obj.(*corev1.Endpoints),
+		scc.handlers.EnqueueOwner,
+	)
+}
+
+func (scc *Controller) updateEndpoints(old, cur interface{}) {
+	scc.handlers.HandleUpdate(
+		old.(*corev1.Endpoints),
+		cur.(*corev1.Endpoints),
+		scc.handlers.EnqueueOwner,
+		scc.deleteEndpoints,
+	)
+}
+
+func (scc *Controller) deleteEndpoints(obj interface{}) {
 	scc.handlers.HandleDelete(
 		obj,
 		scc.handlers.EnqueueOwner,

--- a/pkg/controller/scyllacluster/sync_endpoints.go
+++ b/pkg/controller/scyllacluster/sync_endpoints.go
@@ -1,0 +1,74 @@
+package scyllacluster
+
+import (
+	"context"
+	"fmt"
+
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/resourceapply"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Endpoints are reconciled additionally to EndpointSlices because Prometheus Operator which we rely on in ScyllaDBMonitoring
+// doesn't support EndpointSlices yet.
+func (scc *Controller) syncEndpoints(
+	ctx context.Context,
+	sc *scyllav1.ScyllaCluster,
+	endpoints map[string]*corev1.Endpoints,
+	services map[string]*corev1.Service,
+) ([]metav1.Condition, error) {
+	var progressingConditions []metav1.Condition
+
+	// EndpointSlices supersedes Endpoints, so to make sure reconciling logic is the same,
+	// convert from one to the other.
+	requiredEndpointSlices, err := MakeEndpointSlices(sc, services, scc.podLister)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't make endpointslices: %w", err)
+	}
+
+	requiredEndpoints, err := controllerhelpers.ConvertEndpointSlicesToEndpoints(requiredEndpointSlices)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't convert endpointslices to endpoints: %w", err)
+	}
+
+	err = controllerhelpers.Prune(
+		ctx,
+		requiredEndpoints,
+		endpoints,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: scc.kubeClient.CoreV1().Endpoints(sc.Namespace).Delete,
+		},
+		scc.eventRecorder)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't prune endpoints: %w", err)
+	}
+
+	for _, rs := range requiredEndpoints {
+		updated, changed, err := resourceapply.ApplyEndpoints(ctx, scc.kubeClient.CoreV1(), scc.endpointsLister, scc.eventRecorder, rs, resourceapply.ApplyOptions{})
+		if changed {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, endpointsControllerProgressingCondition, rs, "apply", sc.Generation)
+		}
+		if err != nil {
+			return progressingConditions, fmt.Errorf("can't apply endpoints: %w", err)
+		}
+
+		_, _, hasUnreadySubset := slices.Find(updated.Subsets, func(sn corev1.EndpointSubset) bool {
+			return len(sn.NotReadyAddresses) != 0
+		})
+		if len(updated.Subsets) == 0 || hasUnreadySubset {
+			progressingConditions = append(progressingConditions, metav1.Condition{
+				Type:               endpointsControllerProgressingCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             "EndpointsNotReady",
+				Message:            fmt.Sprintf("Endpoints %q is not yet ready", naming.ObjRef(updated)),
+				ObservedGeneration: sc.Generation,
+			})
+		}
+	}
+
+	return progressingConditions, nil
+}

--- a/pkg/controller/scyllacluster/sync_endpointslices.go
+++ b/pkg/controller/scyllacluster/sync_endpointslices.go
@@ -1,0 +1,67 @@
+package scyllacluster
+
+import (
+	"context"
+	"fmt"
+
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/resourceapply"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (scc *Controller) syncEndpointSlices(
+	ctx context.Context,
+	sc *scyllav1.ScyllaCluster,
+	endpointSlices map[string]*discoveryv1.EndpointSlice,
+	services map[string]*corev1.Service,
+) ([]metav1.Condition, error) {
+	var progressingConditions []metav1.Condition
+
+	requiredEndpointSlices, err := MakeEndpointSlices(sc, services, scc.podLister)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't make endpointslices: %w", err)
+	}
+
+	err = controllerhelpers.Prune(
+		ctx,
+		requiredEndpointSlices,
+		endpointSlices,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: scc.kubeClient.DiscoveryV1().EndpointSlices(sc.Namespace).Delete,
+		},
+		scc.eventRecorder)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't prune endpointslice(s): %w", err)
+	}
+
+	for _, requiredEndpointSlice := range requiredEndpointSlices {
+		updated, changed, err := resourceapply.ApplyEndpointSlice(ctx, scc.kubeClient.DiscoveryV1(), scc.endpointSliceLister, scc.eventRecorder, requiredEndpointSlice, resourceapply.ApplyOptions{})
+		if changed {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, endpointSliceControllerProgressingCondition, requiredEndpointSlice, "apply", sc.Generation)
+		}
+		if err != nil {
+			return progressingConditions, fmt.Errorf("can't apply endpointslice: %w", err)
+		}
+
+		_, _, hasUnreadyEndpoint := slices.Find(updated.Endpoints, func(ep discoveryv1.Endpoint) bool {
+			return ep.Conditions.Ready == nil || !*ep.Conditions.Ready
+		})
+
+		if len(updated.Endpoints) == 0 || hasUnreadyEndpoint {
+			progressingConditions = append(progressingConditions, metav1.Condition{
+				Type:               endpointSliceControllerProgressingCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             "EndpointSliceNotReady",
+				Message:            fmt.Sprintf("EndpointSlice %q is not yet ready", naming.ObjRef(updated)),
+				ObservedGeneration: sc.Generation,
+			})
+		}
+	}
+
+	return progressingConditions, nil
+}

--- a/pkg/controllerhelpers/convert.go
+++ b/pkg/controllerhelpers/convert.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package controllerhelpers
+
+import (
+	"fmt"
+	"maps"
+
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ConvertEndpointSlicesToEndpoints(endpointSlices []*discoveryv1.EndpointSlice) ([]*corev1.Endpoints, error) {
+	serviceToEndpointSlices := map[string][]*discoveryv1.EndpointSlice{}
+	for _, es := range endpointSlices {
+		svcName, ok := es.Labels[discoveryv1.LabelServiceName]
+		if !ok {
+			return nil, fmt.Errorf("EndpointSlice is missing service name in label %q", naming.ObjRef(es))
+		}
+		serviceToEndpointSlices[svcName] = append(serviceToEndpointSlices[svcName], es)
+	}
+
+	var endpoints []*corev1.Endpoints
+	for svcName, ess := range serviceToEndpointSlices {
+		var subsets []corev1.EndpointSubset
+		for _, es := range ess {
+			var addresses []corev1.EndpointAddress
+			var notReadyAddresses []corev1.EndpointAddress
+
+			for _, ep := range es.Endpoints {
+				for _, epa := range ep.Addresses {
+					ea := corev1.EndpointAddress{
+						IP: epa,
+						Hostname: func() string {
+							if ep.Hostname != nil {
+								return *ep.Hostname
+							}
+							return ""
+						}(),
+						NodeName:  ep.NodeName,
+						TargetRef: ep.TargetRef,
+					}
+					if ep.Conditions.Ready != nil && *ep.Conditions.Ready {
+						addresses = append(addresses, ea)
+					} else {
+						notReadyAddresses = append(notReadyAddresses, ea)
+					}
+				}
+			}
+
+			ports := slices.ConvertSlice[corev1.EndpointPort, discoveryv1.EndpointPort](es.Ports, func(port discoveryv1.EndpointPort) corev1.EndpointPort {
+				ep := corev1.EndpointPort{
+					AppProtocol: port.AppProtocol,
+				}
+				if port.Name != nil {
+					ep.Name = *port.Name
+				}
+				if port.Port != nil {
+					ep.Port = *port.Port
+				}
+				if port.Protocol != nil {
+					ep.Protocol = *port.Protocol
+				}
+				return ep
+			})
+
+			if len(addresses) == 0 && len(notReadyAddresses) == 0 {
+				continue
+			}
+
+			subsets = append(subsets, corev1.EndpointSubset{
+				Addresses:         addresses,
+				NotReadyAddresses: notReadyAddresses,
+				Ports:             ports,
+			})
+		}
+
+		// Copy metadata from first EndpointSlice of given Service, they should all be the same.
+		es := ess[0]
+		endpointsLabels := map[string]string{}
+		maps.Copy(endpointsLabels, es.Labels)
+		endpointsLabels[discoveryv1.LabelSkipMirror] = "true"
+
+		endpointsAnnotations := maps.Clone(es.Annotations)
+
+		endpoints = append(endpoints, &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            svcName,
+				Namespace:       es.Namespace,
+				Labels:          endpointsLabels,
+				Annotations:     endpointsAnnotations,
+				OwnerReferences: es.OwnerReferences,
+			},
+			Subsets: subsets,
+		})
+	}
+
+	return endpoints, nil
+}

--- a/pkg/controllerhelpers/convert_test.go
+++ b/pkg/controllerhelpers/convert_test.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package controllerhelpers
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_ConvertEndpointSlicesToEndpoints(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name              string
+		endpointSlices    []*discoveryv1.EndpointSlice
+		expectedEndpoints []*corev1.Endpoints
+	}{
+		{
+			name: "single EndpointSlice per Service",
+			endpointSlices: []*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-dc-rack-0-12345678",
+						Namespace: "default",
+						Labels: map[string]string{
+							"foo":                                    "bar",
+							"kubernetes.io/service-name":             "basic-dc-rack-0",
+							"endpointslice.kubernetes.io/managed-by": "scylla-operator.scylladb.com/scylla-operator",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "scylla.scylladb.com/v1",
+								Kind:               "ScyllaCluster",
+								Name:               "basic",
+								UID:                "the-uid",
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
+							},
+						},
+					},
+					AddressType: discoveryv1.AddressTypeIPv4,
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{"1.2.3.4"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready:       pointer.Ptr(true),
+								Serving:     pointer.Ptr(true),
+								Terminating: pointer.Ptr(false),
+							},
+							TargetRef: &corev1.ObjectReference{
+								Kind:      "Pod",
+								Namespace: "default",
+								Name:      "basic-dc-rack-0",
+								UID:       "pod-uid",
+							},
+							NodeName: pointer.Ptr("node-a"),
+						},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						{
+							Name:     pointer.Ptr("port-1"),
+							Protocol: pointer.Ptr(corev1.ProtocolTCP),
+							Port:     pointer.Ptr(int32(777)),
+						},
+					},
+				},
+			},
+			expectedEndpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-dc-rack-0",
+						Namespace: "default",
+						Labels: map[string]string{
+							"foo":                                     "bar",
+							"kubernetes.io/service-name":              "basic-dc-rack-0",
+							"endpointslice.kubernetes.io/managed-by":  "scylla-operator.scylladb.com/scylla-operator",
+							"endpointslice.kubernetes.io/skip-mirror": "true",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "scylla.scylladb.com/v1",
+								Kind:               "ScyllaCluster",
+								Name:               "basic",
+								UID:                "the-uid",
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
+							},
+						},
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+									TargetRef: &corev1.ObjectReference{
+										Kind:      "Pod",
+										Namespace: "default",
+										Name:      "basic-dc-rack-0",
+										UID:       "pod-uid",
+									},
+									NodeName: pointer.Ptr("node-a"),
+								},
+							},
+							NotReadyAddresses: nil,
+							Ports: []corev1.EndpointPort{
+								{
+									Name:     "port-1",
+									Port:     777,
+									Protocol: "TCP",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple EndpointSlices per Service",
+			endpointSlices: []*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-dc-rack-0-abc",
+						Namespace: "default",
+						Labels: map[string]string{
+							"foo":                                    "bar",
+							"kubernetes.io/service-name":             "basic-dc-rack-0",
+							"endpointslice.kubernetes.io/managed-by": "scylla-operator.scylladb.com/scylla-operator",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "scylla.scylladb.com/v1",
+								Kind:               "ScyllaCluster",
+								Name:               "basic",
+								UID:                "the-uid",
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
+							},
+						},
+					},
+					AddressType: discoveryv1.AddressTypeIPv4,
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{"1.2.3.4"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready:       pointer.Ptr(true),
+								Serving:     pointer.Ptr(true),
+								Terminating: pointer.Ptr(false),
+							},
+							TargetRef: &corev1.ObjectReference{
+								Kind:      "Pod",
+								Namespace: "default",
+								Name:      "basic-dc-rack-0",
+								UID:       "pod-uid",
+							},
+							NodeName: pointer.Ptr("node-a"),
+						},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						{
+							Name:     pointer.Ptr("port-1"),
+							Protocol: pointer.Ptr(corev1.ProtocolTCP),
+							Port:     pointer.Ptr(int32(666)),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-dc-rack-0-def",
+						Namespace: "default",
+						Labels: map[string]string{
+							"foo":                                    "bar",
+							"kubernetes.io/service-name":             "basic-dc-rack-0",
+							"endpointslice.kubernetes.io/managed-by": "scylla-operator.scylladb.com/scylla-operator",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "scylla.scylladb.com/v1",
+								Kind:               "ScyllaCluster",
+								Name:               "basic",
+								UID:                "the-uid",
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
+							},
+						},
+					},
+					AddressType: discoveryv1.AddressTypeIPv4,
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{"1.2.3.4"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready:       pointer.Ptr(false),
+								Serving:     pointer.Ptr(false),
+								Terminating: pointer.Ptr(false),
+							},
+							TargetRef: &corev1.ObjectReference{
+								Kind:      "Pod",
+								Namespace: "default",
+								Name:      "basic-dc-rack-0",
+								UID:       "pod-uid",
+							},
+							NodeName: pointer.Ptr("node-a"),
+						},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						{
+							Name:     pointer.Ptr("port-2"),
+							Protocol: pointer.Ptr(corev1.ProtocolTCP),
+							Port:     pointer.Ptr(int32(777)),
+						},
+					},
+				},
+			},
+			expectedEndpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-dc-rack-0",
+						Namespace: "default",
+						Labels: map[string]string{
+							"foo":                                     "bar",
+							"kubernetes.io/service-name":              "basic-dc-rack-0",
+							"endpointslice.kubernetes.io/managed-by":  "scylla-operator.scylladb.com/scylla-operator",
+							"endpointslice.kubernetes.io/skip-mirror": "true",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "scylla.scylladb.com/v1",
+								Kind:               "ScyllaCluster",
+								Name:               "basic",
+								UID:                "the-uid",
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
+							},
+						},
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+									TargetRef: &corev1.ObjectReference{
+										Kind:      "Pod",
+										Namespace: "default",
+										Name:      "basic-dc-rack-0",
+										UID:       "pod-uid",
+									},
+									NodeName: pointer.Ptr("node-a"),
+								},
+							},
+							NotReadyAddresses: nil,
+							Ports: []corev1.EndpointPort{
+								{
+									Name:     "port-1",
+									Port:     666,
+									Protocol: "TCP",
+								},
+							},
+						},
+						{
+							Addresses: nil,
+							NotReadyAddresses: []corev1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+									TargetRef: &corev1.ObjectReference{
+										Kind:      "Pod",
+										Namespace: "default",
+										Name:      "basic-dc-rack-0",
+										UID:       "pod-uid",
+									},
+									NodeName: pointer.Ptr("node-a"),
+								},
+							},
+							Ports: []corev1.EndpointPort{
+								{
+									Name:     "port-2",
+									Port:     777,
+									Protocol: "TCP",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			endpoints, err := ConvertEndpointSlicesToEndpoints(tc.endpointSlices)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !apiequality.Semantic.DeepEqual(endpoints, tc.expectedEndpoints) {
+				t.Errorf("expected and actual Endpoints differ: %s", cmp.Diff(tc.expectedEndpoints, endpoints))
+			}
+		})
+	}
+}

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -80,10 +80,11 @@ const (
 	NodeJobLabel                 = "scylla-operator.scylladb.com/node-job"
 	NodeJobTypeLabel             = "scylla-operator.scylladb.com/node-job-type"
 
-	AppName           = "scylla"
-	OperatorAppName   = "scylla-operator"
-	ManagerAppName    = "scylla-manager"
-	NodeConfigAppName = "scylla-node-config"
+	AppName                   = "scylla"
+	OperatorAppName           = "scylla-operator"
+	ManagerAppName            = "scylla-manager"
+	NodeConfigAppName         = "scylla-node-config"
+	OperatorAppNameWithDomain = "scylla-operator.scylladb.com"
 
 	PrometheusScrapeAnnotation = "prometheus.io/scrape"
 	PrometheusPortAnnotation   = "prometheus.io/port"
@@ -98,10 +99,11 @@ const (
 
 // Configuration Values
 const (
-	ScyllaContainerName          = "scylla"
-	SidecarInjectorContainerName = "sidecar-injection"
-	PerftuneContainerName        = "perftune"
-	CleanupContainerName         = "cleanup"
+	ScyllaContainerName                = "scylla"
+	SidecarInjectorContainerName       = "sidecar-injection"
+	PerftuneContainerName              = "perftune"
+	CleanupContainerName               = "cleanup"
+	InterNodeTrafficProbeContainerName = "inter-node-traffic-probe"
 
 	PVCTemplateName = "data"
 
@@ -126,6 +128,7 @@ const (
 	LivenessProbePath          = "/healthz"
 	ScyllaDBAPIStatusProbePort = 8080
 	ScyllaAPIPort              = 10000
+	StoragePort                = 7000
 
 	OperatorEnvVarPrefix = "SCYLLA_OPERATOR_"
 )

--- a/pkg/util/hash/hash.go
+++ b/pkg/util/hash/hash.go
@@ -6,10 +6,19 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/json"
+	"hash"
+	"hash/fnv"
 )
 
+func HashObjectsShort(objs ...interface{}) (string, error) {
+	return hashObjects(fnv.New32a(), objs...)
+}
+
 func HashObjects(objs ...interface{}) (string, error) {
-	hasher := sha512.New()
+	return hashObjects(sha512.New(), objs...)
+}
+
+func hashObjects(hasher hash.Hash, objs ...interface{}) (string, error) {
 	encoder := json.NewEncoder(hasher)
 	for _, obj := range objs {
 		if err := encoder.Encode(obj); err != nil {

--- a/pkg/util/hash/hash_test.go
+++ b/pkg/util/hash/hash_test.go
@@ -48,3 +48,47 @@ func TestHashObjects(t *testing.T) {
 		})
 	}
 }
+
+func TestHashObjectsShort(t *testing.T) {
+	tt := []struct {
+		name          string
+		sets          [][]interface{}
+		expectedHash  string
+		expectedError error
+	}{
+		{
+			name: "object's map order doesn't matter",
+			sets: [][]interface{}{
+				{
+					map[string]string{
+						"key_1": "val_1",
+						"key_2": "val_2",
+					},
+				},
+				{
+					map[string]string{
+						"key_2": "val_2",
+						"key_1": "val_1",
+					},
+				},
+			},
+			expectedHash:  "SK1zSQ==",
+			expectedError: nil,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, objs := range tc.sets {
+				got, err := HashObjectsShort(objs...)
+
+				if !reflect.DeepEqual(err, tc.expectedError) {
+					t.Errorf("expected error %v, got %v", tc.expectedError, err)
+				}
+
+				if got != tc.expectedHash {
+					t.Errorf("expected hash %q, got %q", tc.expectedHash, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Kubernetes reconciles Endpoints and EndpointSlices for Services having
selector by taking entire Pod readiness into account. Because we need to
allow inter-node communication before CQL traffic we used
PublishNonReadyEndpoints on Services to overcome this.
But at the same time, we would like stop accepting new connections when
Pod is tearing down. These two requirements contradicts with each other.

To satisfy both requirements, Operator will reconcile Endpoints and
EndpointSlice resources in per-container way. If Pod container specifies
port and has its own Readiness probe, Endpoint/EndpointSlice
will become ready for this port when given container is ready. If these
two conditions aren't met, given port becomes ready when entire Pod is
ready.
Controller logic will consider Pod being deleted (non-nil
deletionTimestamp) as fully non-ready so that all endpoints for all ports
and containers will removed.

Additional container added to Scylla Pod controls readiness of ports
used for inter-node communication.

With above logic, nodes observing other node going down, won't be 
able to reconnect until restarted node opens a port for inter-node 
communication because traffic will be rejected immediately when node 
starts terminating. This fixes an issue of traffic disruption during rolling 
restarts happening on ScyllaClusters using ClusterIP for inter-node 
communication which was caused by nodes being stuck on reconnection 
attempts.

Prerequisites:
- [x] https://github.com/scylladb/scylla-operator/pull/1624
- [x] https://github.com/scylladb/scylla-operator/pull/1738

Fixes #1077 