### PR TITLE
Improve prerequisites

### DIFF
--- a/docs/source/helm.md
+++ b/docs/source/helm.md
@@ -11,6 +11,7 @@ We will use Minikube K8s cluster, but this could be any K8s cluster supported by
 
 - Kubernetes 1.16+
 - Helm 3+
+- Being in inside of [scylla-operator](https://github.com/scylladb/scylla-operator) directory 
 
 ## TL;DR
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

So i was reading documentation on how to deploy scylla-operator and `kubectl apply -f examples/common/cert-manager.yaml` was not working for me, while its was not being mentioned in _prerequisites_ that i need to be in that directory. I think that will help a lot who find the article on google. 
