### PR TITLE
Disable Secret redaction in E2E dumps

### DIFF
--- a/hack/.ci/run-e2e-gke.sh
+++ b/hack/.ci/run-e2e-gke.sh
@@ -36,7 +36,7 @@ function kubectl_create {
 }
 
 function gather-artifacts {
-  kubectl -n e2e run --restart=Never --image="${SO_IMAGE}" --labels='app=must-gather' --command=true must-gather -- bash -euExo pipefail -O inherit_errexit -c "function wait-for-artifacts { touch /tmp/done && until [[ -f '/tmp/exit' ]]; do sleep 1; done } && trap wait-for-artifacts EXIT && mkdir /tmp/artifacts && scylla-operator must-gather --all-resources --loglevel=2 --dest-dir=/tmp/artifacts"
+  kubectl -n e2e run --restart=Never --image="${SO_IMAGE}" --labels='app=must-gather' --command=true must-gather -- bash -euExo pipefail -O inherit_errexit -c "function wait-for-artifacts { touch /tmp/done && until [[ -f '/tmp/exit' ]]; do sleep 1; done } && trap wait-for-artifacts EXIT && mkdir /tmp/artifacts && scylla-operator must-gather --all-resources --loglevel=2 --dest-dir=/tmp/artifacts --disable-secret-redaction"
   kubectl -n e2e wait --for=condition=Ready pod/must-gather
 
   # Setup artifacts transfer when finished and unblock the must-gather pod when done.

--- a/pkg/cmd/operator/gather.go
+++ b/pkg/cmd/operator/gather.go
@@ -156,6 +156,7 @@ func (o *GatherOptions) run(ctx context.Context) error {
 		o.CollectRelatedResources,
 		o.KeepGoing,
 		o.LogsLimitBytes,
+		o.DisableSecretRedaction,
 	)
 
 	startTime := time.Now()

--- a/pkg/cmd/operator/gatherbase.go
+++ b/pkg/cmd/operator/gatherbase.go
@@ -32,10 +32,11 @@ type GatherBaseOptions struct {
 	dynamicClient   dynamic.Interface
 	discoveryClient discovery.DiscoveryInterface
 
-	DestDir              string
-	CollectManagedFields bool
-	LogsLimitBytes       int64
-	KeepGoing            bool
+	DestDir                string
+	CollectManagedFields   bool
+	LogsLimitBytes         int64
+	KeepGoing              bool
+	DisableSecretRedaction bool
 }
 
 func NewGatherBaseOptions(gathererName string, keepGoing bool) *GatherBaseOptions {
@@ -62,6 +63,7 @@ func (o *GatherBaseOptions) AddFlags(flagset *pflag.FlagSet) {
 	flagset.Int64VarP(&o.LogsLimitBytes, "log-limit-bytes", "", o.LogsLimitBytes, "Maximum number of bytes collected for each log file, 0 means unlimited.")
 	flagset.BoolVarP(&o.CollectManagedFields, "managed-fields", "", o.CollectManagedFields, "Controls whether metadata.managedFields should be collected in the resource dumps.")
 	flagset.BoolVarP(&o.KeepGoing, "keep-going", "", o.KeepGoing, "Controls whether the collection should proceed to other resources over collection errors, accumulating errors.")
+	flagset.BoolVarP(&o.DisableSecretRedaction, "disable-secret-redaction", "", o.DisableSecretRedaction, "Disables Secret data redaction. WARNING: Setting this causes that private data will be part of the dump.")
 }
 
 func (o *GatherBaseOptions) Validate() error {

--- a/pkg/cmd/operator/mustgather.go
+++ b/pkg/cmd/operator/mustgather.go
@@ -234,6 +234,7 @@ func (o *MustGatherOptions) run(ctx context.Context) error {
 		true,
 		o.KeepGoing,
 		o.LogsLimitBytes,
+		o.DisableSecretRedaction,
 	)
 
 	var resourceSpecs []resourceSpec

--- a/test/e2e/framework/dump.go
+++ b/test/e2e/framework/dump.go
@@ -27,7 +27,7 @@ func DumpNamespace(ctx context.Context, discoveryClient discovery.DiscoveryInter
 		true,
 		true,
 		0,
-		false,
+		true,
 	)
 	err := collector.CollectResource(
 		ctx,

--- a/test/e2e/framework/dump.go
+++ b/test/e2e/framework/dump.go
@@ -27,6 +27,7 @@ func DumpNamespace(ctx context.Context, discoveryClient discovery.DiscoveryInter
 		true,
 		true,
 		0,
+		false,
 	)
 	err := collector.CollectResource(
 		ctx,


### PR DESCRIPTION
E2E dump contains temporary data which is not sensitive.
Redaction prevents from inspecting Operator output which
prevents from debugging CI flakes.

Prerequisites:

- [ ] https://github.com/scylladb/scylla-operator/pull/1629

/hold for #1629