### PR TITLE
Fix default ServiceAccount awaiting in E2E framework

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -244,7 +244,7 @@ func (f *Framework) setupNamespace(ctx context.Context) {
 	By("Waiting for default ServiceAccount in namespace %q.", ns.Name)
 	ctxSa, ctxSaCancel := context.WithTimeout(ctx, serviceAccountWaitTimeout)
 	defer ctxSaCancel()
-	_, err = WaitForServiceAccount(ctxSa, f.KubeAdminClient().CoreV1(), ns.Namespace, "default")
+	_, err = WaitForServiceAccount(ctxSa, f.KubeAdminClient().CoreV1(), ns.Name, "default")
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 


### PR DESCRIPTION
Namespace is cluster-wide resource, so it doesn't have 'Namespace' field set. Code awaiting for 'default' ServiceAccount in e2e Namespace should use Name of Namespace.
