### PR TITLE
Decrease Scylla API polling interval in sidecar controller

### DIFF
--- a/pkg/controller/sidecar/controller.go
+++ b/pkg/controller/sidecar/controller.go
@@ -30,7 +30,7 @@ const (
 	// maxSyncDuration enforces preemption. Do not raise the value! Controllers shouldn't actively wait,
 	// but rather use the queue.
 	maxSyncDuration          = 30 * time.Second
-	scyllaAPIPollingInterval = 30 * time.Second
+	scyllaAPIPollingInterval = 20 * time.Second
 )
 
 var (


### PR DESCRIPTION
Cleanup Jobs are scheduled when a token ring change is detected. Sidecar polls Scylla API to calculate current token ring hash and when Operator detects a change, it schedules cleanup Jobs. 30s polling interval turned out to be too long to catch token ring changes quick enough to prevent cleanup Jobs being recreated due to hash change.

Resolves #1525 
