### PR TITLE
Extend ScyllaCluster rollout timeout in E2E

### DIFF
--- a/test/e2e/utils/config.go
+++ b/test/e2e/utils/config.go
@@ -12,6 +12,7 @@ const (
 	SyncTimeout        = 2 * time.Minute
 	imagePullTimeout   = 4 * time.Minute
 	joinClusterTimeout = 3 * time.Minute
+	cleanupJobTimeout  = 1 * time.Minute
 
 	// memberRolloutTimeout is the maximum amount of time it takes to start a scylla pod and become ready.
 	// It includes the time to pull the images, copy the necessary files (sidecar), join the cluster and similar.

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -116,7 +116,7 @@ func IsNodeConfigDoneWithNodeTuningFunc(nodes []*corev1.Node) func(nc *scyllav1a
 }
 
 func RolloutTimeoutForScyllaCluster(sc *scyllav1.ScyllaCluster) time.Duration {
-	return SyncTimeout + time.Duration(GetMemberCount(sc))*memberRolloutTimeout
+	return SyncTimeout + time.Duration(GetMemberCount(sc))*memberRolloutTimeout + cleanupJobTimeout
 }
 
 func GetMemberCount(sc *scyllav1.ScyllaCluster) int32 {


### PR DESCRIPTION
Rollout timeout didn't take into account time required to schedule and complete cleanup Jobs.

Resolves #1232
