### PR TITLE
Bump Scylla-manager version to be 3.2.5

### DIFF
--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -251,7 +251,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.1.2
+        image: docker.io/scylladb/scylla-manager:3.2.5
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager
@@ -283,7 +283,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 5.4.0
-  agentVersion: 3.1.2
+  agentVersion: 3.2.5
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -251,7 +251,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.1.2
+        image: docker.io/scylladb/scylla-manager:3.2.5
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager
@@ -283,7 +283,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 5.4.0
-  agentVersion: 3.1.2
+  agentVersion: 3.2.5
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager/dev/50_manager_deployment.yaml
+++ b/deploy/manager/dev/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.1.2
+        image: docker.io/scylladb/scylla-manager:3.2.5
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 5.4.0
-  agentVersion: 3.1.2
+  agentVersion: 3.2.5
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager/prod/50_manager_deployment.yaml
+++ b/deploy/manager/prod/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.1.2
+        image: docker.io/scylladb/scylla-manager:3.2.5
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 5.4.0
-  agentVersion: 3.1.2
+  agentVersion: 3.2.5
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -144,7 +144,7 @@ To enable this the CRD allows for specifying a `network` parameter as such:
 
 ```yaml
   version: 5.4.0
-  agentVersion: 2.0.2
+  agentVersion: 3.2.5
   cpuset: true
   network:
     hostNetworking: true
@@ -172,7 +172,7 @@ This requires a small change in the cluster definition.
 Change the `cluster.yaml` file from this:
 ```yaml
 spec:
-  agentVersion: 2.0.2
+  agentVersion: 3.2.5
   version: 5.4.0
   developerMode: true
   datacenter:
@@ -185,7 +185,7 @@ spec:
   alternator:
     port: 8000
     writeIsolation: only_rmw_uses_lwt
-  agentVersion: 2.0.2
+  agentVersion: 3.2.5
   developerMode: true
   datacenter:
     name: us-east-1

--- a/docs/source/multidc/multidc.md
+++ b/docs/source/multidc/multidc.md
@@ -107,7 +107,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.1.2
+  agentVersion: 3.2.5
   version: 5.4.0
   cpuset: true
   sysctls:
@@ -357,7 +357,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.1.2
+  agentVersion: 3.2.5
   version: 5.4.0
   cpuset: true
   sysctls:

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -69,7 +69,7 @@ metadata:
   name: guaranteed-cluster
   namespace: scylla
 spec:
-  agentVersion: 2.5.2
+  agentVersion: 3.2.5
   version: 5.4.0
   datacenter:
     name: us-east-1

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -13,7 +13,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.1.2
+  agentVersion: 3.2.5
   version: 5.4.0
   cpuset: true
   network:

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -15,7 +15,7 @@ metadata:
   name: simple-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.1.2
+  agentVersion: 3.2.5
   version: 5.4.0
   developerMode: true
   datacenter:

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -13,7 +13,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.1.2
+  agentVersion: 3.2.5
   version: 5.4.0
   cpuset: true
   automaticOrphanedNodeCleanup: true

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -2,7 +2,7 @@
 scyllaImage:
   tag: 5.4.0
 agentImage:
-  tag: 3.1.2
+  tag: 3.2.5
 
 # Cluster information
 developerMode: true

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -1,6 +1,6 @@
 # Scylla Manager image
 image:
-  tag: 3.1.2
+  tag: 3.2.5
 
 # Resources allocated to Scylla Manager pods
 resources:
@@ -25,7 +25,7 @@ scylla:
   scyllaImage:
     tag: 5.4.0
   agentImage:
-    tag: 3.1.2
+    tag: 3.2.5
   datacenter: manager-dc
   racks:
     - name: manager-rack

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -3,7 +3,7 @@ kind: ScyllaCluster
 metadata:
   name: scylla
 spec:
-  agentVersion: 3.1.0
+  agentVersion: 3.2.5
   version: 5.4.0
   developerMode: true
   automaticOrphanedNodeCleanup: true

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -25,7 +25,7 @@ scylla:
     repository: docker.io/scylladb/scylla
     tag: 5.4.0
   agentImage:
-    tag: 3.1.2
+    tag: 3.2.5
     repository: docker.io/scylladb/scylla-manager-agent
   developerMode: true
   cpuset: true

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 image:
   repository: scylladb
   pullPolicy: IfNotPresent
-  tag: 3.1.2
+  tag: 3.2.5
 
 # Allows to customize Scylla Manager Controller image
 controllerImage:
@@ -75,7 +75,7 @@ scylla:
   scyllaImage:
     tag: 5.4.0
   agentImage:
-    tag: 3.1.2
+    tag: 3.2.5
   datacenter: manager-dc
   racks:
   - name: manager-rack

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -12,7 +12,7 @@ scyllaImage:
 agentImage:
   repository: scylladb/scylla-manager-agent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.1.2
+  tag: 3.2.5
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/test/e2e/fixture/scylla/basic.scyllacluster.yaml
+++ b/test/e2e/fixture/scylla/basic.scyllacluster.yaml
@@ -3,7 +3,7 @@ kind: ScyllaCluster
 metadata:
   generateName: basic-
 spec:
-  agentVersion: 3.1.0
+  agentVersion: 3.2.5
   version: 5.4.0
   developerMode: true
   datacenter:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Bump the scylla-manager for the following reasons:
- The `3.2.5` is the latest available and recommended scylla-manager version
- It is multiarch and supports `ARM` instances as well as `X86`-based.

So, any new user deploying the default manager and it's agent on `ARM` layout won't get failures caused by the instance types incompatibility issues.