### PR TITLE
Rollback StatefulSet selector

### DIFF
--- a/pkg/controller/scyllacluster/sync_statefulsets.go
+++ b/pkg/controller/scyllacluster/sync_statefulsets.go
@@ -49,9 +49,9 @@ func snapshotTag(prefix string, t time.Time) string {
 
 func (scc *Controller) makeRacks(sc *scyllav1.ScyllaCluster, statefulSets map[string]*appsv1.StatefulSet) ([]*appsv1.StatefulSet, error) {
 	sets := make([]*appsv1.StatefulSet, 0, len(sc.Spec.Datacenter.Racks))
-	for _, rack := range sc.Spec.Datacenter.Racks {
+	for i, rack := range sc.Spec.Datacenter.Racks {
 		oldSts := statefulSets[naming.StatefulSetNameForRack(rack, sc)]
-		sts, err := StatefulSetForRack(rack, sc, oldSts, scc.operatorImage)
+		sts, err := StatefulSetForRack(rack, sc, oldSts, scc.operatorImage, i)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/helpers/collections.go
+++ b/pkg/helpers/collections.go
@@ -18,11 +18,3 @@ func GetMapValues[M ~map[K]V, K comparable, V any](m M) []V {
 	}
 	return res
 }
-
-func ShallowCopyMap[M ~map[K]V, K comparable, V any](m M) M {
-	res := make(M, len(m))
-	for k, v := range m {
-		res[k] = v
-	}
-	return res
-}


### PR DESCRIPTION
Immutable StatefulSet selector was changed as part of #1388. 
This caused issues on upgrades because Operator tried to update immutable selector field.

This rolls back StatefulSet selector to one used in <v1.11.0 versions, but keeps added labels as is.

