### PR TITLE
Extend StatefulSet selector with rack ordinal label 

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"path"
 	"sort"
-	"strconv"
 	"strings"
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/features"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	appsv1 "k8s.io/api/apps/v1"
@@ -221,13 +219,6 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 	if err != nil {
 		return nil, fmt.Errorf("can't get rack labels: %w", err)
 	}
-	_, rackOrdinal, ok := slices.Find(c.Spec.Datacenter.Racks, func(rack scyllav1.RackSpec) bool {
-		return rack.Name == r.Name
-	})
-	if !ok {
-		return nil, fmt.Errorf("can't find ordinal of rack %q in ScyllaCluster %q", r.Name, naming.ObjRef(c))
-	}
-	rackLabels[naming.RackOrdinalLabel] = strconv.Itoa(rackOrdinal)
 	rackLabels[naming.ScyllaVersionLabel] = c.Spec.Version
 
 	selectorLabels, err := naming.RackLabels(r, c)

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -579,7 +579,7 @@ func TestStatefulSetForRack(t *testing.T) {
 		}
 	}
 
-	newBasicStatefulSetLabels := func() map[string]string {
+	newBasicStatefulSetLabels := func(ordinal int) map[string]string {
 		return map[string]string{
 			"app":                          "scylla",
 			"app.kubernetes.io/managed-by": "scylla-operator",
@@ -587,21 +587,16 @@ func TestStatefulSetForRack(t *testing.T) {
 			"scylla/cluster":               "basic",
 			"scylla/datacenter":            "dc",
 			"scylla/rack":                  "rack",
-			"scylla/rack-ordinal":          "0",
+			"scylla/scylla-version":        "",
+			"scylla/rack-ordinal":          fmt.Sprintf("%d", ordinal),
 		}
-	}
-
-	newBasicStatefulSetLabelsWithVersion := func() map[string]string {
-		m := newBasicStatefulSetLabels()
-		m["scylla/scylla-version"] = ""
-		return m
 	}
 
 	newBasicStatefulSet := func() *appsv1.StatefulSet {
 		return &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "basic-dc-rack",
-				Labels:      newBasicStatefulSetLabelsWithVersion(),
+				Labels:      newBasicStatefulSetLabels(0),
 				Annotations: nil,
 				OwnerReferences: []metav1.OwnerReference{
 					{
@@ -617,11 +612,18 @@ func TestStatefulSetForRack(t *testing.T) {
 			Spec: appsv1.StatefulSetSpec{
 				Replicas: pointer.Ptr(int32(0)),
 				Selector: &metav1.LabelSelector{
-					MatchLabels: newBasicStatefulSetLabels(),
+					MatchLabels: map[string]string{
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "basic",
+						"scylla/datacenter":            "dc",
+						"scylla/rack":                  "rack",
+					},
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: newBasicStatefulSetLabelsWithVersion(),
+						Labels: newBasicStatefulSetLabels(0),
 						Annotations: map[string]string{
 							"prometheus.io/port":   "9180",
 							"prometheus.io/scrape": "true",
@@ -961,8 +963,15 @@ func TestStatefulSetForRack(t *testing.T) {
 				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:   "data",
-							Labels: newBasicStatefulSetLabels(),
+							Name: "data",
+							Labels: map[string]string{
+								"app":                          "scylla",
+								"app.kubernetes.io/managed-by": "scylla-operator",
+								"app.kubernetes.io/name":       "scylla",
+								"scylla/cluster":               "basic",
+								"scylla/datacenter":            "dc",
+								"scylla/rack":                  "rack",
+							},
 						},
 						Spec: corev1.PersistentVolumeClaimSpec{
 							AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -619,6 +619,7 @@ func TestStatefulSetForRack(t *testing.T) {
 						"scylla/cluster":               "basic",
 						"scylla/datacenter":            "dc",
 						"scylla/rack":                  "rack",
+						"scylla/rack-ordinal":          "0",
 					},
 				},
 				Template: corev1.PodTemplateSpec{
@@ -971,6 +972,7 @@ func TestStatefulSetForRack(t *testing.T) {
 								"scylla/cluster":               "basic",
 								"scylla/datacenter":            "dc",
 								"scylla/rack":                  "rack",
+								"scylla/rack-ordinal":          "0",
 							},
 						},
 						Spec: corev1.PersistentVolumeClaimSpec{

--- a/pkg/controller/scyllacluster/sync_statefulsets.go
+++ b/pkg/controller/scyllacluster/sync_statefulsets.go
@@ -403,7 +403,9 @@ func (scc *Controller) createMissingStatefulSets(
 			klog.V(2).InfoS("Creating missing StatefulSet", "StatefulSet", klog.KObj(req))
 			var changed bool
 			var err error
-			sts, changed, err = resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, req, resourceapply.ApplyOptions{})
+			sts, changed, err = resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, req, resourceapply.ApplyOptions{
+				DeletePropagationPolicy: pointer.Ptr(metav1.DeletePropagationOrphan),
+			})
 			if err != nil {
 				errs = append(errs, fmt.Errorf("can't create missing statefulset: %w", err))
 				continue
@@ -725,7 +727,9 @@ func (scc *Controller) syncStatefulSets(
 				required.Spec.Replicas = pointer.Ptr(*existing.Spec.Replicas)
 				required.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Ptr(*existing.Spec.Replicas)
 				// Use apply to also update the spec.template
-				updatedSts, changed, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, required, resourceapply.ApplyOptions{})
+				updatedSts, changed, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, required, resourceapply.ApplyOptions{
+					DeletePropagationPolicy: pointer.Ptr(metav1.DeletePropagationOrphan),
+				})
 				if err != nil {
 					errs = append(errs, fmt.Errorf("can't apply statefulset to set partition: %w", err))
 				}
@@ -918,7 +922,9 @@ func (scc *Controller) syncStatefulSets(
 			}
 		}
 
-		updatedSts, changed, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, required, resourceapply.ApplyOptions{})
+		updatedSts, changed, err := resourceapply.ApplyStatefulSet(ctx, scc.kubeClient.AppsV1(), scc.statefulSetLister, scc.eventRecorder, required, resourceapply.ApplyOptions{
+			DeletePropagationPolicy: pointer.Ptr(metav1.DeletePropagationOrphan),
+		})
 		if err != nil {
 			return progressingConditions, fmt.Errorf("can't apply statefulset update: %w", err)
 		}

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -2,10 +2,8 @@ package naming
 
 import (
 	"fmt"
-	"strconv"
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -39,13 +37,6 @@ func RackLabels(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) (map[string]stri
 	recLabels := ScyllaLabels()
 	rackLabels := DatacenterLabels(c)
 	rackLabels[RackNameLabel] = r.Name
-	_, rackOrdinal, ok := slices.Find(c.Spec.Datacenter.Racks, func(rack scyllav1.RackSpec) bool {
-		return rack.Name == r.Name
-	})
-	if !ok {
-		return nil, fmt.Errorf("can't find ordinal of rack %q in ScyllaCluster %q", r.Name, ObjRef(c))
-	}
-	rackLabels[RackOrdinalLabel] = strconv.Itoa(rackOrdinal)
 
 	return mergeLabels(rackLabels, recLabels), nil
 }

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -2,8 +2,10 @@ package naming
 
 import (
 	"fmt"
+	"strconv"
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -37,6 +39,13 @@ func RackLabels(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) (map[string]stri
 	recLabels := ScyllaLabels()
 	rackLabels := DatacenterLabels(c)
 	rackLabels[RackNameLabel] = r.Name
+	_, rackOrdinal, ok := slices.Find(c.Spec.Datacenter.Racks, func(rack scyllav1.RackSpec) bool {
+		return rack.Name == r.Name
+	})
+	if !ok {
+		return nil, fmt.Errorf("can't find ordinal of rack %q in ScyllaCluster %q", r.Name, ObjRef(c))
+	}
+	rackLabels[RackOrdinalLabel] = strconv.Itoa(rackOrdinal)
 
 	return mergeLabels(rackLabels, recLabels), nil
 }

--- a/pkg/resourceapply/apps.go
+++ b/pkg/resourceapply/apps.go
@@ -17,7 +17,39 @@ func ApplyStatefulSetWithControl(
 	required *appsv1.StatefulSet,
 	options ApplyOptions,
 ) (*appsv1.StatefulSet, bool, error) {
-	return ApplyGeneric[*appsv1.StatefulSet](ctx, control, recorder, required, options)
+	return ApplyGenericWithHandlers[*appsv1.StatefulSet](
+		ctx,
+		control,
+		recorder,
+		required,
+		options,
+		nil,
+		func(required *appsv1.StatefulSet, existing *appsv1.StatefulSet) string {
+			if !equality.Semantic.DeepEqual(existing.Spec.Selector, required.Spec.Selector) {
+				return "spec.selector is immutable"
+			}
+			if !equality.Semantic.DeepEqual(existing.Spec.VolumeClaimTemplates, required.Spec.VolumeClaimTemplates) {
+				return "spec.volumeClaimTemplates is immutable"
+			}
+			if !equality.Semantic.DeepEqual(existing.Spec.ServiceName, required.Spec.ServiceName) {
+				return "spec.serviceName is immutable"
+			}
+			if !equality.Semantic.DeepEqual(existing.Spec.PodManagementPolicy, required.Spec.PodManagementPolicy) {
+				return "spec.podManagementPolicy is immutable"
+			}
+			if !equality.Semantic.DeepEqual(existing.Spec.UpdateStrategy, required.Spec.UpdateStrategy) {
+				return "spec.updateStrategy is immutable"
+			}
+			if !equality.Semantic.DeepEqual(existing.Spec.RevisionHistoryLimit, required.Spec.RevisionHistoryLimit) {
+				return "spec.revisionHistoryLimit is immutable"
+			}
+			if !equality.Semantic.DeepEqual(existing.Spec.Ordinals, required.Spec.Ordinals) {
+				return "spec.ordinals is immutable"
+			}
+
+			return ""
+		},
+	)
 }
 
 func ApplyStatefulSet(

--- a/pkg/resourceapply/apps_test.go
+++ b/pkg/resourceapply/apps_test.go
@@ -493,6 +493,199 @@ func TestApplyStatefulSet(t *testing.T) {
 			expectedErr:     nil,
 			expectedEvents:  []string{"Normal StatefulSetUpdated StatefulSet default/test updated"},
 		},
+		{
+			name: "deletes and creates the StatefulSet when selector differs",
+			existing: []runtime.Object{
+				newSts(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"foo": "bar",
+					},
+				}
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"foo": "bar",
+					},
+				}
+				utilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents: []string{
+				"Normal StatefulSetDeleted StatefulSet default/test deleted",
+				"Normal StatefulSetCreated StatefulSet default/test created",
+			},
+		},
+		{
+			name: "deletes and creates the StatefulSet when volumeClaimTemplate differs",
+			existing: []runtime.Object{
+				newSts(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				}
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				}
+				utilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents: []string{
+				"Normal StatefulSetDeleted StatefulSet default/test deleted",
+				"Normal StatefulSetCreated StatefulSet default/test created",
+			},
+		},
+		{
+			name: "deletes and creates the StatefulSet when serviceName differs",
+			existing: []runtime.Object{
+				newSts(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.ServiceName = "foo"
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.ServiceName = "foo"
+				utilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents: []string{
+				"Normal StatefulSetDeleted StatefulSet default/test deleted",
+				"Normal StatefulSetCreated StatefulSet default/test created",
+			},
+		},
+		{
+			name: "deletes and creates the StatefulSet when podManagementPolicy differs",
+			existing: []runtime.Object{
+				newSts(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+				utilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents: []string{
+				"Normal StatefulSetDeleted StatefulSet default/test deleted",
+				"Normal StatefulSetCreated StatefulSet default/test created",
+			},
+		},
+		{
+			name: "deletes and creates the StatefulSet when updateStrategy differs",
+			existing: []runtime.Object{
+				newSts(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+					Type: appsv1.OnDeleteStatefulSetStrategyType,
+				}
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+					Type: appsv1.OnDeleteStatefulSetStrategyType,
+				}
+				utilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents: []string{
+				"Normal StatefulSetDeleted StatefulSet default/test deleted",
+				"Normal StatefulSetCreated StatefulSet default/test created",
+			},
+		},
+		{
+			name: "deletes and creates the StatefulSet when revisionHistoryLimit differs",
+			existing: []runtime.Object{
+				newSts(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.RevisionHistoryLimit = pointer.Ptr(int32(42))
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.RevisionHistoryLimit = pointer.Ptr(int32(42))
+				utilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents: []string{
+				"Normal StatefulSetDeleted StatefulSet default/test deleted",
+				"Normal StatefulSetCreated StatefulSet default/test created",
+			},
+		},
+		{
+			name: "deletes and creates the StatefulSet when ordinals differs",
+			existing: []runtime.Object{
+				newSts(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.Ordinals = &appsv1.StatefulSetOrdinals{
+					Start: 42,
+				}
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.Ordinals = &appsv1.StatefulSetOrdinals{
+					Start: 42,
+				}
+				utilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents: []string{
+				"Normal StatefulSetDeleted StatefulSet default/test deleted",
+				"Normal StatefulSetCreated StatefulSet default/test created",
+			},
+		},
 	}
 
 	for _, tc := range tt {

--- a/pkg/resourceapply/helpers.go
+++ b/pkg/resourceapply/helpers.go
@@ -235,6 +235,7 @@ func TypeApplyControlInterface[T kubeinterfaces.ObjectInterface](untyped ApplyCo
 type ApplyOptions struct {
 	ForceOwnership            bool
 	AllowMissingControllerRef bool
+	DeletePropagationPolicy   *metav1.DeletionPropagation
 }
 
 func ApplyGenericWithHandlers[T kubeinterfaces.ObjectInterface](
@@ -327,6 +328,9 @@ func ApplyGenericWithHandlers[T kubeinterfaces.ObjectInterface](
 		)
 
 		propagationPolicy := metav1.DeletePropagationBackground
+		if options.DeletePropagationPolicy != nil {
+			propagationPolicy = *options.DeletePropagationPolicy
+		}
 		err := control.Delete(ctx, existing.GetName(), metav1.DeleteOptions{
 			PropagationPolicy: &propagationPolicy,
 		})


### PR DESCRIPTION
StatefulSet Pods label set was extended as part of https://github.com/scylladb/scylla-operator/pull/1388,
we can safely extend selector set to cover it.

Prerequisites:

- [ ] https://github.com/scylladb/scylla-operator/pull/1639