### PR TITLE
Determine host for Scylla client using ScyllaCluster expose options

### DIFF
--- a/pkg/controllerhelpers/scylla_test.go
+++ b/pkg/controllerhelpers/scylla_test.go
@@ -1,14 +1,20 @@
 package controllerhelpers
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestIsNodeConfigSelectingNode(t *testing.T) {
@@ -309,6 +315,468 @@ func TestFindNodeConfigCondition(t *testing.T) {
 
 			if !reflect.DeepEqual(actual, tc.expected) {
 				t.Errorf("expected and actual conditions differ: %s", cmp.Diff(tc.expected, actual))
+			}
+		})
+	}
+}
+
+func TestGetScyllaHost(t *testing.T) {
+	t.Parallel()
+
+	sc := &scyllav1.ScyllaCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "simple-cluster",
+		},
+		Spec: scyllav1.ScyllaClusterSpec{
+			Datacenter: scyllav1.DatacenterSpec{
+				Name: "us-east1",
+				Racks: []scyllav1.RackSpec{
+					{
+						Name:    "us-east1-b",
+						Members: 1,
+					},
+				},
+			},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "simple-cluster-us-east1-us-east1-b-0",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Type:      corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "simple-cluster-us-east1-us-east1-b-0",
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.1.0.1",
+		},
+	}
+
+	tt := []struct {
+		name          string
+		scyllaCluster *scyllav1.ScyllaCluster
+		svc           *corev1.Service
+		pod           *corev1.Pod
+		expected      string
+		expectedError error
+	}{
+		{
+			name: "service ClusterIP for nil expose options",
+			scyllaCluster: func() *scyllav1.ScyllaCluster {
+				sc := sc.DeepCopy()
+				sc.Spec.ExposeOptions = nil
+				return sc
+			}(),
+			svc:      svc,
+			pod:      pod,
+			expected: "10.0.0.1",
+		},
+		{
+			name: "service ClusterIP for nil broadcast options",
+			scyllaCluster: func() *scyllav1.ScyllaCluster {
+				sc := sc.DeepCopy()
+				sc.Spec.ExposeOptions = &scyllav1.ExposeOptions{}
+				return sc
+			}(),
+			svc:      svc,
+			pod:      pod,
+			expected: "10.0.0.1",
+		},
+	}
+
+	for i := range tt {
+		tc := tt[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := GetScyllaHost(tc.scyllaCluster, tc.svc, tc.pod)
+
+			if !reflect.DeepEqual(err, tc.expectedError) {
+				t.Errorf("expected error %#+v, got %#+v", tc.expectedError, err)
+			}
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("expected host %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetScyllaNodeBroadcastAddress(t *testing.T) {
+	t.Parallel()
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "simple-cluster-us-east1-us-east1-b-0",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Type:      corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "simple-cluster-us-east1-us-east1-b-0",
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.1.0.1",
+		},
+	}
+
+	tt := []struct {
+		name                     string
+		nodeBroadcastAddressType scyllav1.BroadcastAddressType
+		svc                      *corev1.Service
+		pod                      *corev1.Pod
+		expected                 string
+		expectedError            error
+	}{
+
+		{
+			name:                     "service ClusterIP for ClusterIP broadcast address type",
+			nodeBroadcastAddressType: scyllav1.BroadcastAddressTypeServiceClusterIP,
+			pod:                      pod,
+			svc:                      svc,
+			expected:                 "10.0.0.1",
+		},
+		{
+			name:                     "error for ClusterIP broadcast address type and none ClusterIP",
+			nodeBroadcastAddressType: scyllav1.BroadcastAddressTypeServiceClusterIP,
+			pod:                      pod,
+			svc: func() *corev1.Service {
+				svc := svc.DeepCopy()
+
+				svc.Spec.ClusterIP = corev1.ClusterIPNone
+
+				return svc
+			}(),
+			expected:      "",
+			expectedError: fmt.Errorf(`service "simple-cluster-us-east1-us-east1-b-0" does not have a ClusterIP address`),
+		},
+		{
+			name:                     "PodIP broadcast address type",
+			nodeBroadcastAddressType: scyllav1.BroadcastAddressTypePodIP,
+			pod:                      pod,
+			svc:                      svc,
+			expected:                 "10.1.0.1",
+			expectedError:            nil,
+		},
+		{
+			name:                     "error for PodIP broadcast address type and empty PodIP",
+			nodeBroadcastAddressType: scyllav1.BroadcastAddressTypePodIP,
+			pod: func() *corev1.Pod {
+				pod := pod.DeepCopy()
+
+				pod.Status.PodIP = ""
+
+				return pod
+			}(),
+			svc:           svc,
+			expected:      "",
+			expectedError: fmt.Errorf(`pod "simple-cluster-us-east1-us-east1-b-0" does not have a PodIP address`),
+		},
+		{
+			name:                     "error for broadcast address type service load balancer ingress and no service ingress status",
+			nodeBroadcastAddressType: scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress,
+			pod:                      pod,
+			svc: func() *corev1.Service {
+				svc := svc.DeepCopy()
+
+				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+				svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{}
+
+				return svc
+			}(),
+			expected:      "",
+			expectedError: fmt.Errorf(`service "simple-cluster-us-east1-us-east1-b-0" does not have an ingress status`),
+		},
+		{
+			name:                     "ip for broadcast address type service load balancer ingress and non-empty ip in service load balancer status",
+			nodeBroadcastAddressType: scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress,
+			pod:                      pod,
+			svc: func() *corev1.Service {
+				svc := svc.DeepCopy()
+
+				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+				svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+					{
+						IP:       "10.2.0.1",
+						Hostname: "test.scylla.com",
+					},
+				}
+
+				return svc
+			}(),
+			expected:      "10.2.0.1",
+			expectedError: nil,
+		},
+		{
+			name:                     "hostname for broadcast address type service load balancer ingress, empty ip and non-empty hostname in service load balancer status",
+			nodeBroadcastAddressType: scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress,
+			pod:                      pod,
+			svc: func() *corev1.Service {
+				svc := svc.DeepCopy()
+
+				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+				svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+					{
+						IP:       "",
+						Hostname: "test.scylla.com",
+					},
+				}
+
+				return svc
+			}(),
+			expected:      "test.scylla.com",
+			expectedError: nil,
+		},
+		{
+			name:                     "error for broadcast address type service load balancer ingress and no external address in service load balancer status",
+			nodeBroadcastAddressType: scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress,
+			pod:                      pod,
+			svc: func() *corev1.Service {
+				svc := svc.DeepCopy()
+
+				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+				svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+					{
+						IP:       "",
+						Hostname: "",
+					},
+				}
+
+				return svc
+			}(),
+			expected:      "",
+			expectedError: fmt.Errorf(`service "simple-cluster-us-east1-us-east1-b-0" does not have an external address`),
+		},
+		{
+			name:                     "error for unsupported broadcast address type",
+			nodeBroadcastAddressType: scyllav1.BroadcastAddressType("Unsupported"),
+			pod:                      pod,
+			svc:                      svc,
+			expected:                 "",
+			expectedError:            fmt.Errorf(`unsupported broadcast address type: "Unsupported"`),
+		},
+	}
+
+	for i := range tt {
+		tc := tt[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := GetScyllaBroadcastAddress(tc.nodeBroadcastAddressType, tc.svc, tc.pod)
+
+			if !reflect.DeepEqual(err, tc.expectedError) {
+				t.Errorf("expected error %#+v, got %#+v", tc.expectedError, err)
+			}
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("expected host %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetRequiredScyllaHosts(t *testing.T) {
+	t.Parallel()
+
+	sc := &scyllav1.ScyllaCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple-cluster",
+			Namespace: "test",
+		},
+		Spec: scyllav1.ScyllaClusterSpec{
+			Datacenter: scyllav1.DatacenterSpec{
+				Name: "us-east1",
+				Racks: []scyllav1.RackSpec{
+					{
+						Name:    "us-east1-b",
+						Members: 2,
+					},
+				},
+			},
+		},
+		Status: scyllav1.ScyllaClusterStatus{},
+	}
+
+	firstPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple-cluster-us-east1-us-east1-b-0",
+			Namespace: "test",
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.1.0.1",
+		},
+	}
+
+	secondPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple-cluster-us-east1-us-east1-b-1",
+			Namespace: "test",
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.1.0.2",
+		},
+	}
+
+	firstService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple-cluster-us-east1-us-east1-b-0",
+			Namespace: "test",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Type:      corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	secondService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple-cluster-us-east1-us-east1-b-1",
+			Namespace: "test",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.2",
+			Type:      corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	tt := []struct {
+		name          string
+		sc            *scyllav1.ScyllaCluster
+		services      map[string]*corev1.Service
+		existingPods  []*corev1.Pod
+		expected      []string
+		expectedError error
+	}{
+		{
+			name: "missing service",
+			sc:   sc,
+			services: map[string]*corev1.Service{
+				"simple-cluster-us-east1-us-east1-b-0": firstService,
+			},
+			existingPods: []*corev1.Pod{
+				firstPod,
+				secondPod,
+			},
+			expected: nil,
+			expectedError: utilerrors.NewAggregate([]error{
+				fmt.Errorf(`service "test/simple-cluster-us-east1-us-east1-b-1" does not exist`),
+			}),
+		},
+		{
+			name: "missing pod",
+			sc:   sc,
+			services: map[string]*corev1.Service{
+				"simple-cluster-us-east1-us-east1-b-0": firstService,
+				"simple-cluster-us-east1-us-east1-b-1": secondService,
+			},
+			existingPods: []*corev1.Pod{
+				firstPod,
+			},
+			expected: nil,
+			expectedError: utilerrors.NewAggregate([]error{
+				fmt.Errorf(`can't get pod "test/simple-cluster-us-east1-us-east1-b-1": %w`, apierrors.NewNotFound(corev1.Resource("pod"), "simple-cluster-us-east1-us-east1-b-1")),
+			}),
+		},
+		{
+			name: "ClusterIP aggregate",
+			sc:   sc,
+			services: map[string]*corev1.Service{
+				"simple-cluster-us-east1-us-east1-b-0": firstService,
+				"simple-cluster-us-east1-us-east1-b-1": secondService,
+			},
+			existingPods: []*corev1.Pod{
+				firstPod,
+				secondPod,
+			},
+			expected: []string{
+				"10.0.0.1",
+				"10.0.0.2",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "PodIP aggregate",
+			sc: func() *scyllav1.ScyllaCluster {
+				sc := sc.DeepCopy()
+
+				sc.Spec.ExposeOptions = &scyllav1.ExposeOptions{
+					BroadcastOptions: &scyllav1.NodeBroadcastOptions{
+						Nodes: scyllav1.BroadcastOptions{
+							Type: scyllav1.BroadcastAddressTypePodIP,
+						},
+					},
+				}
+
+				return sc
+			}(),
+			services: map[string]*corev1.Service{
+				"simple-cluster-us-east1-us-east1-b-0": firstService,
+				"simple-cluster-us-east1-us-east1-b-1": secondService,
+			},
+			existingPods: []*corev1.Pod{
+				firstPod,
+				secondPod,
+			},
+			expected: []string{
+				"10.1.0.1",
+				"10.1.0.2",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "service missing ClusterIP",
+			sc:   sc,
+			services: map[string]*corev1.Service{
+				"simple-cluster-us-east1-us-east1-b-0": firstService,
+				"simple-cluster-us-east1-us-east1-b-1": func() *corev1.Service {
+					svc := secondService.DeepCopy()
+
+					svc.Spec.ClusterIP = corev1.ClusterIPNone
+
+					return svc
+				}(),
+			},
+			existingPods: []*corev1.Pod{
+				firstPod,
+				secondPod,
+			},
+			expected: nil,
+			expectedError: utilerrors.NewAggregate([]error{
+				fmt.Errorf(`can't get scylla host for service "test/simple-cluster-us-east1-us-east1-b-1": %w`, fmt.Errorf(`service "test/simple-cluster-us-east1-us-east1-b-1" does not have a ClusterIP address`)),
+			}),
+		},
+	}
+
+	for i := range tt {
+		tc := tt[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			podCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, obj := range tc.existingPods {
+				err := podCache.Add(obj)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			podLister := corev1listers.NewPodLister(podCache)
+
+			actual, err := GetRequiredScyllaHosts(tc.sc, tc.services, podLister)
+
+			if !reflect.DeepEqual(err, tc.expectedError) {
+				t.Errorf("expected error %#+v, got %#+v", tc.expectedError, err)
+			}
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("expected host %q, got %q", tc.expected, actual)
 			}
 		})
 	}

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -38,6 +38,11 @@ func ServiceNameFromPod(pod *corev1.Pod) string {
 	return pod.Name
 }
 
+func PodNameFromService(svc *corev1.Service) string {
+	// Pod and its corresponding Service have the same name
+	return svc.Name
+}
+
 func AgentAuthTokenSecretName(clusterName string) string {
 	return fmt.Sprintf("%s-auth-token", clusterName)
 }

--- a/pkg/sidecar/identity/member_test.go
+++ b/pkg/sidecar/identity/member_test.go
@@ -201,13 +201,21 @@ func TestMember_GetSeeds(t *testing.T) {
 			expectSeeds:                []string{secondService.Spec.ClusterIP},
 		},
 		{
-			name:                       "use PodIP from status when node broadcast address type is PodIP",
-			memberPod:                  firstPod,
+			name: "use PodIP from status when node broadcast address type is PodIP",
+			memberPod: func() *corev1.Pod {
+				pod := firstPod.DeepCopy()
+				pod.Status.PodIP = "10.0.0.1"
+				return pod
+			}(),
 			memberService:              firstService,
 			memberClientsBroadcastType: scyllav1.BroadcastAddressTypeServiceClusterIP,
 			memberNodesBroadcastType:   scyllav1.BroadcastAddressTypePodIP,
 			objects: []runtime.Object{
-				firstPod,
+				func() runtime.Object {
+					pod := firstPod.DeepCopy()
+					pod.Status.PodIP = "10.0.0.1"
+					return pod
+				}(),
 				firstService,
 				func() runtime.Object {
 					pod := secondPod.DeepCopy()
@@ -246,17 +254,40 @@ func TestMember_GetSeeds(t *testing.T) {
 			expectSeeds: []string{"1.2.3.4"},
 		},
 		{
-			name:                       "use preferred IP address from first Service ingress status when node broadcast address type is LoadBalancer Ingress",
-			memberPod:                  firstPod,
-			memberService:              firstService,
+			name:      "use preferred IP address from first Service ingress status when node broadcast address type is LoadBalancer Ingress",
+			memberPod: firstPod,
+			memberService: func() *corev1.Service {
+				svc := firstService.DeepCopy()
+				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+				svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{
+							Hostname: "first.service.scylladb.com",
+						},
+					},
+				}
+				return svc
+			}(),
 			memberClientsBroadcastType: scyllav1.BroadcastAddressTypeServiceClusterIP,
 			memberNodesBroadcastType:   scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress,
 			objects: []runtime.Object{
 				firstPod,
-				firstService,
+				func() runtime.Object {
+					svc := firstService.DeepCopy()
+					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								Hostname: "first.service.scylladb.com",
+							},
+						},
+					}
+					return svc
+				}(),
 				secondPod,
 				func() runtime.Object {
 					svc := secondService.DeepCopy()
+					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
 						Ingress: []corev1.LoadBalancerIngress{
 							{
@@ -273,17 +304,40 @@ func TestMember_GetSeeds(t *testing.T) {
 			expectSeeds: []string{"1.2.3.4"},
 		},
 		{
-			name:                       "use hostname from first Service ingress status when node broadcast address type is LoadBalancer Ingress and IP is not available",
-			memberPod:                  firstPod,
-			memberService:              firstService,
+			name:      "use hostname from first Service ingress status when node broadcast address type is LoadBalancer Ingress and IP is not available",
+			memberPod: firstPod,
+			memberService: func() *corev1.Service {
+				svc := firstService.DeepCopy()
+				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+				svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{
+							Hostname: "first.service.scylladb.com",
+						},
+					},
+				}
+				return svc
+			}(),
 			memberClientsBroadcastType: scyllav1.BroadcastAddressTypeServiceClusterIP,
 			memberNodesBroadcastType:   scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress,
 			objects: []runtime.Object{
 				firstPod,
-				firstService,
+				func() runtime.Object {
+					svc := firstService.DeepCopy()
+					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								Hostname: "first.service.scylladb.com",
+							},
+						},
+					}
+					return svc
+				}(),
 				secondPod,
 				func() runtime.Object {
 					svc := secondService.DeepCopy()
+					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
 						Ingress: []corev1.LoadBalancerIngress{
 							{

--- a/pkg/sidecar/probes.go
+++ b/pkg/sidecar/probes.go
@@ -50,15 +50,6 @@ func (p *Prober) isNodeUnderMaintenance() (bool, error) {
 	return hasLabel, nil
 }
 
-func (p *Prober) getNodeAddress() (string, error) {
-	svc, err := p.serviceLister.Services(p.namespace).Get(p.serviceName)
-	if err != nil {
-		return "", err
-	}
-
-	return controllerhelpers.GetScyllaIPFromService(svc)
-}
-
 func (p *Prober) Readyz(w http.ResponseWriter, req *http.Request) {
 	ctx, ctxCancel := context.WithTimeout(req.Context(), p.timeout)
 	defer ctxCancel()


### PR DESCRIPTION
**Description of your changes:** Currently, the functions used to get a host for a Scylla client connection lack support for clusters exposed over PodIPs. Since the functions are used in the StatefulSet controller, it breaks the ScyllaCluster ugprade procedure for clusters exposed over PodIPs. This PR makes the controller use expose options to determine the address to use as a forced host for Scylla client.

**Which issue is resolved by this Pull Request:**
Resolves #1638

/kind bug
/priority critical-urgent