### PR TITLE
Fix workouround for controler-gen interpreting numbers in file paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ update-crds:
 	$(call generate-crds,)
 .PHONY: update-crds
 
-verify-crds: tmp_dir :=$(shell mktemp -d /tmp/crd-XXXXXX)
+verify-crds: tmp_dir :=$(shell mktemp -d /tmp/crd-TMPXXXXXX)
 verify-crds:
 	mkdir '$(tmp_dir)'/{original,generated}
 


### PR DESCRIPTION
**Description of your changes:**
This PR avoids creating temporary directories that could be interpreted as a number by controller-gen. See https://github.com/kubernetes-sigs/controller-tools/issues/734
```
$ go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen -- crd paths='./pkg/api/scylla/v1' output:dir='/tmp/crd-2P4zCT/generated/./pkg/api/scylla/v1'
Error: unable to parse option "output:dir=/tmp/crd-2P4zCT/generated/./pkg/api/scylla/v1": ['P' exponent requires hexadecimal mantissa (at <input>:1:10)] 
```


**Which issue is resolved by this Pull Request:**
Resolves #1546
