### PR TITLE
Loosen validation for LoadBalancerClass in NodeServiceTemplate

### DIFF
--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -190,7 +190,7 @@ func ValidateNodeService(nodeService *scyllav1.NodeServiceTemplate, fldPath *fie
 	}
 
 	if nodeService.LoadBalancerClass != nil && len(*nodeService.LoadBalancerClass) != 0 {
-		for _, msg := range apimachineryvalidation.NameIsDNSSubdomain(*nodeService.LoadBalancerClass, false) {
+		for _, msg := range apimachineryutilvalidation.IsQualifiedName(*nodeService.LoadBalancerClass) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("loadBalancerClass"), *nodeService.LoadBalancerClass, msg))
 		}
 	}

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -147,9 +147,25 @@ func TestValidateScyllaCluster(t *testing.T) {
 				return cluster
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.exposeOptions.nodeService.loadBalancerClass", BadValue: "-hello", Detail: `a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.exposeOptions.nodeService.loadBalancerClass", BadValue: "-hello", Detail: `name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`},
 			},
-			expectedErrorString: `spec.exposeOptions.nodeService.loadBalancerClass: Invalid value: "-hello": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
+			expectedErrorString: `spec.exposeOptions.nodeService.loadBalancerClass: Invalid value: "-hello": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`,
+		},
+		{
+			name: "EKS NLB LoadBalancerClass is valid",
+			cluster: func() *v1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.ExposeOptions = &v1.ExposeOptions{
+					NodeService: &v1.NodeServiceTemplate{
+						Type:              v1.NodeServiceTypeLoadBalancer,
+						LoadBalancerClass: pointer.Ptr("service.k8s.aws/nlb"),
+					},
+				}
+
+				return cluster
+			}(),
+			expectedErrorList:   field.ErrorList{},
+			expectedErrorString: "",
 		},
 		{
 			name: "unsupported type of client broadcast address",


### PR DESCRIPTION
NameIsDNSSubdomain was too strict to validate this field, preventing from setting load balancer classes available in cloud environments.

