### PR TITLE
Make haproxy manifests work on both amd64 and arm64

### DIFF
--- a/examples/third-party/haproxy-ingress.yaml
+++ b/examples/third-party/haproxy-ingress.yaml
@@ -252,7 +252,7 @@ spec:
     spec:
       containers:
       - name: ingress-default-backend
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: docker.io/scylladb/scylla-operator:thirdparty-google_containers-defaultbackend-1.4@sha256:710e7b3ab708ed0fbd3bb4005893bdadf893983441f46c6680ad2ed6f04c261e
         ports:
         - containerPort: 8080
         resources:

--- a/examples/third-party/haproxy-ingress/10_ingress-default-backend.deploy.yaml
+++ b/examples/third-party/haproxy-ingress/10_ingress-default-backend.deploy.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: ingress-default-backend
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: docker.io/scylladb/scylla-operator:thirdparty-google_containers-defaultbackend-1.4@sha256:710e7b3ab708ed0fbd3bb4005893bdadf893983441f46c6680ad2ed6f04c261e
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
**Description of your changes:**
This PR fixes haproxy manifests so they work on both amd64 and arm64. Unfortunately, the source images are nto built for multiarch so we had to aggregate them.
