### PR TITLE
Revert introspection

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -5136,10 +5136,8 @@ spec:
         image: docker.io/scylladb/scylla-operator:latest
         imagePullPolicy: IfNotPresent
         env:
-        - name: SCYLLA_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
+        - name: SCYLLA_OPERATOR_IMAGE
+          value: docker.io/scylladb/scylla-operator:latest
         args:
         - operator
         - --loglevel=2

--- a/deploy/operator/50_operator.deployment.yaml
+++ b/deploy/operator/50_operator.deployment.yaml
@@ -26,10 +26,8 @@ spec:
         image: docker.io/scylladb/scylla-operator:latest
         imagePullPolicy: IfNotPresent
         env:
-        - name: SCYLLA_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
+        - name: SCYLLA_OPERATOR_IMAGE
+          value: docker.io/scylladb/scylla-operator:latest
         args:
         - operator
         - --loglevel=2

--- a/helm/scylla-operator/templates/operator.deployment.yaml
+++ b/helm/scylla-operator/templates/operator.deployment.yaml
@@ -34,10 +34,8 @@ spec:
         image: {{ .Values.image.repository }}/scylla-operator:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-        - name: SCYLLA_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
+        - name: SCYLLA_OPERATOR_IMAGE
+          value: {{ .Values.image.repository }}/scylla-operator:{{ .Values.image.tag | default .Chart.AppVersion }}
         args:
         - operator
         - --loglevel={{ .Values.logLevel }}

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -15,7 +15,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controller/scyllacluster"
 	"github.com/scylladb/scylla-operator/pkg/controller/scylladbmonitoring"
 	"github.com/scylladb/scylla-operator/pkg/controller/scyllaoperatorconfig"
-	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/crypto"
 	monitoringversionedclient "github.com/scylladb/scylla-operator/pkg/externalclient/monitoring/clientset/versioned"
 	monitoringinformers "github.com/scylladb/scylla-operator/pkg/externalclient/monitoring/informers/externalversions"
@@ -25,10 +24,9 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -51,7 +49,6 @@ type OperatorOptions struct {
 
 	ConcurrentSyncs int
 	OperatorImage   string
-	OperatorPodName string
 	CQLSIngressPort int
 
 	CryptoKeyBufferSizeMin int
@@ -83,25 +80,17 @@ func NewOperatorCmd(streams genericclioptions.IOStreams) *cobra.Command {
 		Short: "Run the scylla operator.",
 		Long:  `Run the scylla operator.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			stopCh := signals.StopChannel()
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			go func() {
-				<-stopCh
-				cancel()
-			}()
-
-			err := o.Validate()
+			err := o.Complete(cmd)
 			if err != nil {
 				return err
 			}
 
-			err = o.Complete(ctx, cmd)
+			err = o.Validate()
 			if err != nil {
 				return err
 			}
 
-			err = o.Run(ctx, streams, cmd)
+			err = o.Run(streams, cmd)
 			if err != nil {
 				return err
 			}
@@ -119,7 +108,6 @@ func NewOperatorCmd(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.Flags().IntVarP(&o.ConcurrentSyncs, "concurrent-syncs", "", o.ConcurrentSyncs, "The number of ScyllaCluster objects that are allowed to sync concurrently.")
 	cmd.Flags().StringVarP(&o.OperatorImage, "image", "", o.OperatorImage, "Image of the operator used.")
-	cmd.Flags().StringVarP(&o.OperatorPodName, "pod-name", "", o.OperatorPodName, "Name of the Pod that this binary is running in. This is meant to be set using Kubernetes Downwards API.")
 	cmd.Flags().IntVarP(&o.CQLSIngressPort, "cqls-ingress-port", "", o.CQLSIngressPort, "Port on which is the ingress controller listening for secure CQL connections.")
 	cmd.Flags().IntVarP(&o.CryptoKeyBufferSizeMin, "crypto-key-buffer-size-min", "", o.CryptoKeyBufferSizeMin, "Minimal number of pre-generated crypto keys that are used for quick certificate issuance. The minimum size is 1.")
 	cmd.Flags().IntVarP(&o.CryptoKeyBufferSizeMax, cryptoKeyBufferSizeMaxFlagKey, "", o.CryptoKeyBufferSizeMax, "Maximum number of pre-generated crypto keys that are used for quick certificate issuance. The minimum size is 1. If not set, it will adjust to be at least the size of crypto-key-buffer-size-min.")
@@ -135,8 +123,12 @@ func (o *OperatorOptions) Validate() error {
 	errs = append(errs, o.InClusterReflection.Validate())
 	errs = append(errs, o.LeaderElection.Validate())
 
-	if len(o.OperatorImage) == 0 && len(o.OperatorPodName) == 0 {
-		errs = append(errs, errors.New("either the image or the pod-name have to be set but both are empty"))
+	if len(o.OperatorImage) == 0 {
+		errs = append(errs, errors.New("operator image can't be empty"))
+	}
+
+	if len(o.OperatorImage) == 0 {
+		errs = append(errs, errors.New("operator image can't be empty"))
 	}
 
 	if o.CryptoKeyBufferSizeMin < 1 {
@@ -160,10 +152,10 @@ func (o *OperatorOptions) Validate() error {
 		errs = append(errs, fmt.Errorf("invalid secure cql ingress port %d: %s", o.CQLSIngressPort, msg))
 	}
 
-	return kutilerrors.NewAggregate(errs)
+	return apierrors.NewAggregate(errs)
 }
 
-func (o *OperatorOptions) Complete(ctx context.Context, cmd *cobra.Command) error {
+func (o *OperatorOptions) Complete(cmd *cobra.Command) error {
 	err := o.ClientConfig.Complete()
 	if err != nil {
 		return err
@@ -199,67 +191,20 @@ func (o *OperatorOptions) Complete(ctx context.Context, cmd *cobra.Command) erro
 		o.CryptoKeyBufferSizeMax = o.CryptoKeyBufferSizeMin
 	}
 
-	if len(o.OperatorImage) == 0 {
-		klog.V(2).InfoS("No explicit operator image specified - starting auto detection from Pod status")
-
-		pod, err := o.kubeClient.CoreV1().Pods(o.Namespace).Get(ctx, o.OperatorPodName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("can't get pod %q to introspect its image: %w", naming.ManualRef(o.Namespace, o.OperatorPodName), err)
-		}
-
-		const soContainerName = "scylla-operator"
-
-		// First, we make sure the container exists in the spec.
-		_, err = naming.FindContainerWithName(pod.Spec.Containers, soContainerName)
-		if err != nil {
-			return fmt.Errorf("can't find container %q", soContainerName)
-		}
-
-		// Now we should wait for the Pod to have its status updated by kubelet.
-		// This should be almost imminent, but we don't want to fail the Pod too soon if the cluster is overloaded.
-		const csWaitTimeout = 5 * time.Minute
-		klog.V(2).InfoS("Waiting for Pod status to be updated", "Timeout", csWaitTimeout)
-		csCtx, csCtxCancel := context.WithTimeout(ctx, csWaitTimeout)
-		defer csCtxCancel()
-		var cs *corev1.ContainerStatus
-		_, err = controllerhelpers.WaitForPodState(
-			csCtx,
-			o.kubeClient.CoreV1().Pods(o.Namespace),
-			o.OperatorPodName,
-			controllerhelpers.WaitForStateOptions{},
-			func(pod *corev1.Pod) (bool, error) {
-				cs = controllerhelpers.FindContainerStatus(pod, soContainerName)
-				if cs == nil {
-					klog.V(4).InfoS(
-						"Container status is not yet present",
-						"Container", soContainerName,
-						"Pod", naming.ObjRef(pod),
-					)
-					return false, nil
-				}
-
-				return true, nil
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("can't wait for pod %q to have container status for container %q: %w", naming.ObjRef(pod), soContainerName, err)
-		}
-
-		if len(cs.ImageID) == 0 {
-			return fmt.Errorf("can't introspect its own image: containerStatus.imageID for container %q in pod %q is empty", soContainerName, naming.ObjRef(pod))
-		}
-
-		o.OperatorImage = cs.ImageID
-
-		klog.V(2).InfoS("Successfully introspected its own image", "OperatorImage", o.OperatorImage)
-	}
-
 	return nil
 }
 
-func (o *OperatorOptions) Run(ctx context.Context, streams genericclioptions.IOStreams, cmd *cobra.Command) error {
+func (o *OperatorOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Command) error {
 	klog.Infof("%s version %s", cmd.Name(), version.Get())
 	cliflag.PrintFlags(cmd.Flags())
+
+	stopCh := signals.StopChannel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-stopCh
+		cancel()
+	}()
 
 	// Lock names cannot be changed, because it may lead to two leaders during rolling upgrades.
 	const lockName = "scylla-operator-lock"

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -246,16 +245,11 @@ func (o *OperatorOptions) Complete(ctx context.Context, cmd *cobra.Command) erro
 			return fmt.Errorf("can't wait for pod %q to have container status for container %q: %w", naming.ObjRef(pod), soContainerName, err)
 		}
 
-		imageID := cs.ImageID
-
-		// containerd can't pull its own reference, so we need to strip the prefix.
-		imageID = strings.TrimPrefix(imageID, "docker-pullable://")
-
-		if len(imageID) == 0 {
+		if len(cs.ImageID) == 0 {
 			return fmt.Errorf("can't introspect its own image: containerStatus.imageID for container %q in pod %q is empty", soContainerName, naming.ObjRef(pod))
 		}
 
-		o.OperatorImage = imageID
+		o.OperatorImage = cs.ImageID
 
 		klog.V(2).InfoS("Successfully introspected its own image", "OperatorImage", o.OperatorImage)
 	}


### PR DESCRIPTION
**Description of your changes:**
crio has change the way they publish image so we have no way ow knowing our own image so it's better to get rid of the introspection and aim for real fix to remove this "identical" image dependency with #604 and #1684

Reverts:
- https://github.com/scylladb/scylla-operator/pull/1425
- https://github.com/scylladb/scylla-operator/pull/1619

**Which issue is resolved by this Pull Request:**
Resolves #1669

/cc @rzetelskik 