### PR TITLE
Wait for e2e Pod even if logs end prematurely

### DIFF
--- a/hack/.ci/run-e2e-gke.sh
+++ b/hack/.ci/run-e2e-gke.sh
@@ -187,8 +187,11 @@ kubectl -n e2e wait --for=condition=Ready pod/e2e
 ) &
 e2e_bg_pid=$!
 
-kubectl -n e2e logs -f pod/e2e
-exit_code=$( kubectl -n e2e get pods/e2e --output='jsonpath={.status.containerStatuses[0].state.terminated.exitCode}' )
+exit_code=""
+while [[ "${exit_code}" == "" ]]; do
+  kubectl -n e2e logs -f pod/e2e
+  exit_code="$( kubectl -n e2e get pods/e2e --output='jsonpath={.status.containerStatuses[0].state.terminated.exitCode}' )"
+done
 kubectl -n e2e delete pod/e2e --wait=false
 
 wait "${e2e_bg_pid}" || ( echo "Collecting e2e artifacts failed" && exit 2 )


### PR DESCRIPTION
**Description of your changes:**
As seen in #1698 `kubectl logs` can end prematurely, yet our e2e depends on it to detect when it finished. This PR makes sure we retry logs, even if some could be repeated, and always check whether the pod has actually terminated or we retry. If this gets caused by a log rotation isse, we might not even get the duplicated logs, but most importantly, we'll survive.

**Which issue is resolved by this Pull Request:**
Resolves #1698
