### PR TITLE
Fix kubectl logs retry in gke e2e script

### DIFF
--- a/hack/.ci/run-e2e-gke.sh
+++ b/hack/.ci/run-e2e-gke.sh
@@ -189,7 +189,7 @@ e2e_bg_pid=$!
 
 exit_code=""
 while [[ "${exit_code}" == "" ]]; do
-  kubectl -n e2e logs -f pod/e2e
+  kubectl -n e2e logs -f pod/e2e || echo "kubectl logs failed before the pod has finished, retrying..." > /dev/stderr
   exit_code="$( kubectl -n e2e get pods/e2e --output='jsonpath={.status.containerStatuses[0].state.terminated.exitCode}' )"
 done
 kubectl -n e2e delete pod/e2e --wait=false


### PR DESCRIPTION
**Description of your changes:**
While we retry the e2e logs we need to make that call succeed or `-e` will fail the script

**Which issue is resolved by this Pull Request:**
Resolves #1698
