### PR TITLE
Replace nowSafety buffer with zero-value datetime in manager task scheduling

### DIFF
--- a/pkg/controller/manager/types_old.go
+++ b/pkg/controller/manager/types_old.go
@@ -19,10 +19,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/util/duration"
 )
 
-const (
-	nowSafety = 30 * time.Second
-)
-
 type RepairTask v1.RepairTaskStatus
 
 func (r RepairTask) ToManager() (*managerclient.Task, error) {
@@ -192,7 +188,7 @@ func parseStartDate(value string) (strfmt.DateTime, error) {
 	now := timeutc.Now()
 
 	if value == "now" {
-		return strfmt.DateTime(now.Add(nowSafety)), nil
+		return strfmt.DateTime{}, nil
 	}
 
 	if strings.HasPrefix(value, "now") {


### PR DESCRIPTION
**Description of your changes:**
Currently, when translating manager tasks, the operator adds a "safety buffer" to a current time for special "now" syntax. This PR doesn't fix the entire "now+duration" syntax issue, but is limited to this specific case.

**Which issue is resolved by this Pull Request:**
Resolves #1705

/cc
/kind bug