### PR TITLE
Drain the node before Pod is terminated

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2947,6 +2947,10 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
+                minTerminationGracePeriodSeconds:
+                  description: minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+                  format: int32
+                  type: integer
                 network:
                   description: network holds the networking config.
                   properties:

--- a/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -117,6 +117,9 @@ object
    * - :ref:`imagePullSecrets<api-scylla.scylladb.com-scyllaclusters-v1-.spec.imagePullSecrets[]>`
      - array (object)
      - imagePullSecrets is an optional list of references to secrets in the same namespace used for pulling Scylla and Agent images.
+   * - minTerminationGracePeriodSeconds
+     - integer
+     - minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
    * - :ref:`network<api-scylla.scylladb.com-scyllaclusters-v1-.spec.network>`
      - object
      - network holds the networking config.

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -405,6 +405,11 @@
           },
           "type": "array"
         },
+        "minTerminationGracePeriodSeconds": {
+          "description": "minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",
+          "format": "int32",
+          "type": "integer"
+        },
         "network": {
           "description": "network holds the networking config.",
           "properties": {

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -294,6 +294,11 @@
       },
       "type": "array"
     },
+    "minTerminationGracePeriodSeconds": {
+      "description": "minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",
+      "format": "int32",
+      "type": "integer"
+    },
     "network": {
       "description": "network holds the networking config.",
       "properties": {

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -1943,6 +1943,10 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
+                minTerminationGracePeriodSeconds:
+                  description: minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+                  format: int32
+                  type: integer
                 network:
                   description: network holds the networking config.
                   properties:

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -109,6 +109,15 @@ type ScyllaClusterSpec struct {
 
 	// externalSeeds specifies the external seeds to propagate to ScyllaDB binary on startup as "seeds" parameter of seed-provider.
 	ExternalSeeds []string `json:"externalSeeds,omitempty"`
+
+	// minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is
+	// terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore
+	// and stop forwarding new requests.
+	// This applies only when node is terminated gracefully.
+	// If not provided, Operator will determine this value.
+	// EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+	// +optional
+	MinTerminationGracePeriodSeconds int32 `json:"minTerminationGracePeriodSeconds,omitempty"`
 }
 
 type PodIPSourceType string

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -110,6 +110,10 @@ func ValidateScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *field.
 		allErrs = append(allErrs, ValidateExposeOptions(spec.ExposeOptions, fldPath.Child("exposeOptions"))...)
 	}
 
+	if spec.MinTerminationGracePeriodSeconds < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("minTerminationGracePeriodSeconds"), spec.MinTerminationGracePeriodSeconds, "must be non-negative integer"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -294,6 +294,19 @@ func TestValidateScyllaCluster(t *testing.T) {
 			},
 			expectedErrorString: `[spec.exposeOptions.broadcastOptions.clients.type: Invalid value: "ServiceLoadBalancerIngress": can't broadcast address unavailable within the selected node service type, allowed types for chosen broadcast address type are: [LoadBalancer], spec.exposeOptions.broadcastOptions.nodes.type: Invalid value: "ServiceLoadBalancerIngress": can't broadcast address unavailable within the selected node service type, allowed types for chosen broadcast address type are: [LoadBalancer]]`,
 		},
+		{
+			name: "negative minTerminationGracePeriodSeconds",
+			cluster: func() *v1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.MinTerminationGracePeriodSeconds = -42
+
+				return cluster
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.minTerminationGracePeriodSeconds", BadValue: int32(-42), Detail: "must be non-negative integer"},
+			},
+			expectedErrorString: `spec.minTerminationGracePeriodSeconds: Invalid value: -42: must be non-negative integer`,
+		},
 	}
 
 	for i := range tests {

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/features"
@@ -242,6 +243,21 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 	storageCapacity, err := resource.ParseQuantity(r.Storage.Capacity)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse %q: %v", r.Storage.Capacity, err)
+	}
+
+	// Assume kube-proxy notices readiness change and reconcile Endpoints within this period
+	kubeProxyEndpointsSyncPeriod := 5 * time.Second
+
+	readinessFailureThreshold := int32(1)
+	readinessPeriodSeconds := int32(10)
+	minTerminationGracePeriod := time.Duration(readinessFailureThreshold*readinessPeriodSeconds)*time.Second + kubeProxyEndpointsSyncPeriod
+
+	if c.Spec.ExposeOptions != nil && c.Spec.ExposeOptions.NodeService != nil && c.Spec.ExposeOptions.NodeService.Type == scyllav1.NodeServiceTypeLoadBalancer {
+		// Any "upstream" Load Balancer should notice Endpoint readiness change within this period.
+		minTerminationGracePeriod = 60 * time.Second
+	}
+	if c.Spec.MinTerminationGracePeriodSeconds != 0 {
+		minTerminationGracePeriod = time.Duration(c.Spec.MinTerminationGracePeriodSeconds) * time.Second
 	}
 
 	sts := &appsv1.StatefulSet{
@@ -542,8 +558,8 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 								// to 30s to survive cluster overload.
 								// Relevant issue: https://github.com/scylladb/scylla-operator/issues/844
 								TimeoutSeconds:   int32(30),
-								FailureThreshold: int32(1),
-								PeriodSeconds:    int32(10),
+								FailureThreshold: readinessFailureThreshold,
+								PeriodSeconds:    readinessPeriodSeconds,
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Port: intstr.FromInt(naming.ProbePort),
@@ -552,14 +568,20 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 								},
 							},
 							// Before a Scylla Pod is stopped, execute nodetool drain to
-							// flush the memtable to disk and stop listening for connections.
-							// This is necessary to ensure we don't lose any data and we don't
-							// need to replay the commitlog in the next startup.
+							// flush the memtable to disk, finish existing requests and stop listening for connections.
+							// Sleep is required to give chance to Load Balancers to acknowledge Pod going down with their
+							// probes.
 							Lifecycle: &corev1.Lifecycle{
 								PreStop: &corev1.LifecycleHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{
-											"/bin/sh", "-c", "PID=$(pgrep -x scylla);supervisorctl stop scylla; while kill -0 $PID; do sleep 1; done;",
+											"/usr/bin/bash",
+											"-euExo",
+											"pipefail",
+											"-O",
+											"inherit_errexit",
+											"-c",
+											fmt.Sprintf("nodetool drain &; sleep %.0f &; wait", minTerminationGracePeriod.Seconds()),
 										},
 									},
 								},

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -909,7 +909,13 @@ func TestStatefulSetForRack(t *testing.T) {
 									PreStop: &corev1.LifecycleHandler{
 										Exec: &corev1.ExecAction{
 											Command: []string{
-												"/bin/sh", "-c", "PID=$(pgrep -x scylla);supervisorctl stop scylla; while kill -0 $PID; do sleep 1; done;",
+												"/usr/bin/bash",
+												"-euExo",
+												"pipefail",
+												"-O",
+												"inherit_errexit",
+												"-c",
+												"nodetool drain &; sleep 15 &; wait",
 											},
 										},
 									},


### PR DESCRIPTION
Draining node before SIGTERM gracefully shuts down and allows for finishing inflight requests, and prevents new ones.

/cc tnozicka

Part of bigger PR https://github.com/scylladb/scylla-operator/pull/1614