### PR TITLE
Collect namespace where NodeConfig Pods are executed

### DIFF
--- a/pkg/cmd/operator/mustgather.go
+++ b/pkg/cmd/operator/mustgather.go
@@ -194,6 +194,14 @@ var mustGatherSpecs = []struct {
 	},
 	{
 		GroupResource: schema.GroupResource{
+			Resource: "namespaces",
+			Group:    "",
+		},
+		Namespace: corev1.NamespaceAll,
+		Name:      "scylla-operator-node-tuning",
+	},
+	{
+		GroupResource: schema.GroupResource{
 			Resource: "customresourcedefinitions",
 			Group:    "apiextensions.k8s.io",
 		},


### PR DESCRIPTION
In case of any errors related to NodeConfig not being able to optimize nodes, we need logs from `scylla-operator-node-config` where NodeConfig Pods are running.
This namespace was missing in must-gather collector.
