### PR TITLE
Collect only ServiceMonitors managed by given ScyllaDBMonitoring

### DIFF
--- a/assets/monitoring/prometheus/v1/prometheus.yaml
+++ b/assets/monitoring/prometheus/v1/prometheus.yaml
@@ -29,7 +29,8 @@ spec:
     httpConfig:
       http2: true
   serviceMonitorSelector:
-    matchLabels: {}
+    matchLabels:
+      scylla-operator.scylladb.com/scylladbmonitoring-name: "{{ .scyllaDBMonitoringName }}"
   affinity:
     {{- .affinity | toYAML | nindent 4 }}
   tolerations:

--- a/pkg/controller/scylladbmonitoring/sync_prometheus_test.go
+++ b/pkg/controller/scylladbmonitoring/sync_prometheus_test.go
@@ -274,7 +274,8 @@ spec:
     httpConfig:
       http2: true
   serviceMonitorSelector:
-    matchLabels: {}
+    matchLabels:
+      scylla-operator.scylladb.com/scylladbmonitoring-name: "sm-name"
   affinity:
     {}
   tolerations:
@@ -350,7 +351,8 @@ spec:
     httpConfig:
       http2: true
   serviceMonitorSelector:
-    matchLabels: {}
+    matchLabels:
+      scylla-operator.scylladb.com/scylladbmonitoring-name: "sm-name"
   affinity:
     {}
   tolerations:


### PR DESCRIPTION
Prometheus object had empty serviceMonitorSelector which matched every ServiceMonitor within the same namespace.
This sets serviceMonitorSelector to match only ServiceMonitor's that are managed by the same ScyllaDBMonitoring.

Fixes #1716 

/cc tnozicka