### PR TITLE
Bump default ScyllaDB utils image to 5.4.2

### DIFF
--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -143,7 +143,7 @@ const (
 	PerftuneJobPrefixName = "perftune"
 
 	// TODO: Make sure this doesn't get out of date.
-	DefaultScyllaUtilsImage = "docker.io/scylladb/scylla:5.0.5"
+	DefaultScyllaUtilsImage = "docker.io/scylladb/scylla:5.4.2"
 )
 
 type NodeConfigJobType string


### PR DESCRIPTION
**Description of your changes:**
Image used for node tuning is part of ScyllaOperatorConfig which default value eventually gets stale.
This bumps it to most recent stable ScyllaDB version.

