### PR TITLE
Fix syntax of ScyllaCluster PreStopHook

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -677,7 +677,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 											"-O",
 											"inherit_errexit",
 											"-c",
-											fmt.Sprintf("nodetool drain &; sleep %.0f &; wait", minTerminationGracePeriod.Seconds()),
+											fmt.Sprintf("nodetool drain & sleep %.0f & wait", minTerminationGracePeriod.Seconds()),
 										},
 									},
 								},

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -983,7 +983,7 @@ func TestStatefulSetForRack(t *testing.T) {
 												"-O",
 												"inherit_errexit",
 												"-c",
-												"nodetool drain &; sleep 15 &; wait",
+												"nodetool drain & sleep 15 & wait",
 											},
 										},
 									},


### PR DESCRIPTION
**Description of your changes:**

Asynchronous bash commands doesn't require command separator. Bash complaines about wrong syntax when they are used.

**Which issue is resolved by this Pull Request:**
Resolves #1726 
