### PR TITLE
Add identity service to ScyllaDB serving certs

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -62,7 +62,7 @@ func IdentityService(c *scyllav1.ScyllaCluster) *corev1.Service {
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        naming.HeadlessServiceNameForCluster(c),
+			Name:        naming.IdentityServiceName(c),
 			Namespace:   c.Namespace,
 			Labels:      svcLabels,
 			Annotations: svcAnnotations,
@@ -355,7 +355,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: pointer.Ptr(r.Members),
 			// Use a common Headless Service for all StatefulSets
-			ServiceName: naming.HeadlessServiceNameForCluster(c),
+			ServiceName: naming.IdentityServiceName(c),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -55,7 +55,7 @@ func ServiceDNSName(service string, c *scyllav1.ScyllaCluster) string {
 	return fmt.Sprintf("%s.%s", service, CrossNamespaceServiceNameForCluster(c))
 }
 
-func HeadlessServiceNameForCluster(c *scyllav1.ScyllaCluster) string {
+func IdentityServiceName(c *scyllav1.ScyllaCluster) string {
 	return fmt.Sprintf("%s-client", c.Name)
 }
 
@@ -64,7 +64,7 @@ func PodDisruptionBudgetName(c *scyllav1.ScyllaCluster) string {
 }
 
 func CrossNamespaceServiceNameForCluster(c *scyllav1.ScyllaCluster) string {
-	return fmt.Sprintf("%s.%s.svc", HeadlessServiceNameForCluster(c), c.Namespace)
+	return fmt.Sprintf("%s.%s.svc", IdentityServiceName(c), c.Namespace)
 }
 
 func ManagerClusterName(c *scyllav1.ScyllaCluster) string {

--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -203,7 +203,15 @@ var _ = g.Describe("ScyllaCluster", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(serviceAndPodIPs).To(o.HaveLen(e.expectedNumberOfIPAddressesInServingCert(int(utils.GetMemberCount(sc)))))
 
-			hostsIPs, err := helpers.ParseIPs(serviceAndPodIPs)
+			indentityServiceIP, err := utils.GetIdentityServiceIP(ctx, f.KubeClient().CoreV1(), sc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(indentityServiceIP).NotTo(o.BeEmpty())
+
+			allIPs := make([]string, 0, len(serviceAndPodIPs)+1)
+			allIPs = append(allIPs, serviceAndPodIPs...)
+			allIPs = append(allIPs, indentityServiceIP)
+
+			hostsIPs, err := helpers.ParseIPs(allIPs)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			var servingDNSNames []string

--- a/test/e2e/set/scyllacluster/scyllacluster_tls.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_tls.go
@@ -211,7 +211,15 @@ var _ = g.Describe("ScyllaCluster", func() {
 				}
 				o.Expect(serviceAndPodIPs).To(o.HaveLen(expectedServiceAndPodIPsNum))
 
-				hostsIPs, err := helpers.ParseIPs(serviceAndPodIPs)
+				indentityServiceIP, err := utils.GetIdentityServiceIP(ctx, f.KubeClient().CoreV1(), sc)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(indentityServiceIP).NotTo(o.BeEmpty())
+
+				allIPs := make([]string, 0, len(serviceAndPodIPs)+1)
+				allIPs = append(allIPs, serviceAndPodIPs...)
+				allIPs = append(allIPs, indentityServiceIP)
+
+				hostsIPs, err := helpers.ParseIPs(allIPs)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				servingDNSNames := make([]string, 0, len(sniHosts)+len(serviceServingDNSNames))

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -512,6 +512,21 @@ func GetNodesPodIPs(ctx context.Context, client corev1client.CoreV1Interface, sc
 	return ipAddresses, nil
 }
 
+func GetIdentityServiceIP(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) (string, error) {
+	svcName := naming.IdentityServiceName(sc)
+	svc, err := client.Services(sc.Namespace).Get(ctx, svcName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("can't get service %q: %w", svcName, err)
+	}
+
+	clusterIP := svc.Spec.ClusterIP
+	if len(clusterIP) == 0 {
+		return "", fmt.Errorf("internal error: member service doesn't have clusterIP assigned")
+	}
+
+	return clusterIP, nil
+}
+
 // GetManagerClient gets managerClient using IP address. E2E tests shouldn't rely on InCluster DNS.
 func GetManagerClient(ctx context.Context, client corev1client.CoreV1Interface) (*managerclient.Client, error) {
 	managerService, err := client.Services(naming.ScyllaManagerNamespace).Get(ctx, naming.ScyllaManagerServiceName, metav1.GetOptions{})


### PR DESCRIPTION
**Description of your changes:**
To use the identity service as an initial contact point we needs its IP and DNS name to be present in ScyllaDB serving certs.

**Which issue is resolved by this Pull Request:**
Resolves #1723
