### PR TITLE
Add server-side printers to our APIs

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -308,7 +308,11 @@ spec:
     singular: nodeconfig
   scope: Cluster
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           properties:
@@ -1019,7 +1023,29 @@ spec:
     singular: scyllacluster
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - jsonPath: .status.readyMembers
+          name: READY
+          type: integer
+        - jsonPath: .status.members
+          name: MEMBERS
+          type: integer
+        - jsonPath: .status.rackCount
+          name: RACKS
+          type: integer
+        - jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: AVAILABLE
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Progressing')].status
+          name: PROGRESSING
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Degraded')].status
+          name: DEGRADED
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           description: ScyllaCluster defines a Scylla cluster.
@@ -3353,7 +3379,20 @@ spec:
     singular: scylladbmonitoring
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: AVAILABLE
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Progressing')].status
+          name: PROGRESSING
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Degraded')].status
+          name: DEGRADED
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: ScyllaDBMonitoring defines a monitoring instance for ScyllaDB clusters.
@@ -4857,7 +4896,11 @@ spec:
     singular: scyllaoperatorconfig
   scope: Cluster
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: ScyllaOperatorConfig describes the Scylla Operator configuration.

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -15,7 +15,29 @@ spec:
     singular: scyllacluster
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - jsonPath: .status.readyMembers
+          name: READY
+          type: integer
+        - jsonPath: .status.members
+          name: MEMBERS
+          type: integer
+        - jsonPath: .status.rackCount
+          name: RACKS
+          type: integer
+        - jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: AVAILABLE
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Progressing')].status
+          name: PROGRESSING
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Degraded')].status
+          name: DEGRADED
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           description: ScyllaCluster defines a Scylla cluster.

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -674,6 +674,13 @@ const (
 // +kubebuilder:storageversion
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:name="READY",type=integer,JSONPath=".status.readyMembers"
+// +kubebuilder:printcolumn:name="MEMBERS",type=integer,JSONPath=".status.members"
+// +kubebuilder:printcolumn:name="RACKS",type=integer,JSONPath=".status.rackCount"
+// +kubebuilder:printcolumn:name="AVAILABLE",type=string,JSONPath=".status.conditions[?(@.type=='Available')].status"
+// +kubebuilder:printcolumn:name="PROGRESSING",type=string,JSONPath=".status.conditions[?(@.type=='Progressing')].status"
+// +kubebuilder:printcolumn:name="DEGRADED",type=string,JSONPath=".status.conditions[?(@.type=='Degraded')].status"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ScyllaCluster defines a Scylla cluster.
 type ScyllaCluster struct {

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_nodeconfigs.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_nodeconfigs.yaml
@@ -15,7 +15,11 @@ spec:
     singular: nodeconfig
   scope: Cluster
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           properties:

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbmonitorings.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbmonitorings.yaml
@@ -15,7 +15,20 @@ spec:
     singular: scylladbmonitoring
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: AVAILABLE
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Progressing')].status
+          name: PROGRESSING
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Degraded')].status
+          name: DEGRADED
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: ScyllaDBMonitoring defines a monitoring instance for ScyllaDB clusters.

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scyllaoperatorconfigs.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scyllaoperatorconfigs.yaml
@@ -15,7 +15,11 @@ spec:
     singular: scyllaoperatorconfig
   scope: Cluster
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: ScyllaOperatorConfig describes the Scylla Operator configuration.

--- a/pkg/api/scylla/v1alpha1/types_monitoring.go
+++ b/pkg/api/scylla/v1alpha1/types_monitoring.go
@@ -200,6 +200,10 @@ type ScyllaDBMonitoringStatus struct {
 // +kubebuilder:storageversion
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:name="AVAILABLE",type=string,JSONPath=".status.conditions[?(@.type=='Available')].status"
+// +kubebuilder:printcolumn:name="PROGRESSING",type=string,JSONPath=".status.conditions[?(@.type=='Progressing')].status"
+// +kubebuilder:printcolumn:name="DEGRADED",type=string,JSONPath=".status.conditions[?(@.type=='Degraded')].status"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ScyllaDBMonitoring defines a monitoring instance for ScyllaDB clusters.
 type ScyllaDBMonitoring struct {

--- a/pkg/api/scylla/v1alpha1/types_nodeconfig.go
+++ b/pkg/api/scylla/v1alpha1/types_nodeconfig.go
@@ -189,6 +189,7 @@ type NodeConfigSpec struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 type NodeConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/api/scylla/v1alpha1/types_operatorconfig.go
+++ b/pkg/api/scylla/v1alpha1/types_operatorconfig.go
@@ -20,6 +20,7 @@ type ScyllaOperatorConfigStatus struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ScyllaOperatorConfig describes the Scylla Operator configuration.
 type ScyllaOperatorConfig struct {


### PR DESCRIPTION
**Description of your changes:**
This PR defines server-side printing for our APIs and extends ScyllaCluster status with aggregated fields needed for server-side printers or generally assessing the status when there are multiple racks.

(This is long overdue, but I got tired of searching all the conditions manually to find the aggregated ones.)

**Which issue is resolved by this Pull Request:**
Resolves #1191

### Before
```
NAME                                     AGE
nodeconfig.scylla.scylladb.com/cluster   21d

NAME                                       AGE
scyllacluster.scylla.scylladb.com/scylla   2d6h

NAME                                             AGE
scylladbmonitoring.scylla.scylladb.com/example   91m

NAME                                               AGE
scyllaoperatorconfig.scylla.scylladb.com/cluster   21d
```

### After
```
NAME                                     AGE
nodeconfig.scylla.scylladb.com/cluster   21d

NAME                                       READY   MEMBERS   RACKS   AVAILABLE   PROGRESSING   DEGRADED   AGE
scyllacluster.scylla.scylladb.com/scylla   5       5         3       True        False         False      3d

NAME                                             AVAILABLE   PROGRESSING   DEGRADED   AGE
scylladbmonitoring.scylla.scylladb.com/example   True        False         False      19h

NAME                                               AGE
scyllaoperatorconfig.scylla.scylladb.com/cluster   21d

```

`scyllaoperatorconfig` doesn't have a status to show
`nodeconfig` needs #1557 first