### PR TITLE
Enable internode compression by default

### DIFF
--- a/assets/scylladb/managedconfig.cm.yaml
+++ b/assets/scylladb/managedconfig.cm.yaml
@@ -10,6 +10,7 @@ data:
     cluster_name: "{{ .ClusterName }}"
     rpc_address: "0.0.0.0"
     endpoint_snitch: "GossipingPropertyFileSnitch"
+    internode_compression: "all"
     {{- if .EnableTLS }}
     native_transport_port_ssl: 9142
     native_shard_aware_transport_port_ssl: 19142

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -2578,6 +2578,7 @@ func Test_MakeManagedScyllaDBConfig(t *testing.T) {
 cluster_name: "foo"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
+internode_compression: "all"
 `, "\n"),
 				},
 			},
@@ -2624,6 +2625,7 @@ endpoint_snitch: "GossipingPropertyFileSnitch"
 cluster_name: "foo"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
+internode_compression: "all"
 native_transport_port_ssl: 9142
 native_shard_aware_transport_port_ssl: 19142
 client_encryption_options:


### PR DESCRIPTION
Scylla documentation points out it should be done for every production deployment.
All ScyllaClusters will have it enabled by default. 
This value is safe to update even for existing clusters, as compression is negotiated between nodes on connection setup.

Fixes #1733 