### PR TITLE
Add minReadySeconds and podReadinessGates to ScyllaCluster spec

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2997,6 +2997,10 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
+                minReadySeconds:
+                  description: minReadySeconds is the minimum number of seconds for which a newly created ScyllaDB node should be ready for it to be considered available. When used to control load balanced traffic, this can give the load balancer in front of a node enough time to notice that the node is ready and start forwarding traffic in time. Because it all depends on timing, the order is not guaranteed and, if possible, you should use readinessGates instead. If not provided, Operator will determine this value.
+                  format: int32
+                  type: integer
                 minTerminationGracePeriodSeconds:
                   description: minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
                   format: int32
@@ -3025,6 +3029,18 @@ spec:
                       description: labels is a custom key value map that gets merged with managed object labels.
                       type: object
                   type: object
+                readinessGates:
+                  description: readinessGates specifies custom readiness gates that will be evaluated for every ScyllaDB Pod readiness. It's projected into every ScyllaDB Pod as its readinessGate. Refer to upstream documentation to learn more about readiness gates.
+                  items:
+                    description: PodReadinessGate contains the reference to a pod condition
+                    properties:
+                      conditionType:
+                        description: ConditionType refers to a condition in the pod's condition list with matching type.
+                        type: string
+                    required:
+                      - conditionType
+                    type: object
+                  type: array
                 repairs:
                   description: repairs specify repair tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
                   items:

--- a/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -117,6 +117,9 @@ object
    * - :ref:`imagePullSecrets<api-scylla.scylladb.com-scyllaclusters-v1-.spec.imagePullSecrets[]>`
      - array (object)
      - imagePullSecrets is an optional list of references to secrets in the same namespace used for pulling Scylla and Agent images.
+   * - minReadySeconds
+     - integer
+     - minReadySeconds is the minimum number of seconds for which a newly created ScyllaDB node should be ready for it to be considered available. When used to control load balanced traffic, this can give the load balancer in front of a node enough time to notice that the node is ready and start forwarding traffic in time. Because it all depends on timing, the order is not guaranteed and, if possible, you should use readinessGates instead. If not provided, Operator will determine this value.
    * - minTerminationGracePeriodSeconds
      - integer
      - minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
@@ -126,6 +129,9 @@ object
    * - :ref:`podMetadata<api-scylla.scylladb.com-scyllaclusters-v1-.spec.podMetadata>`
      - object
      - podMetadata controls shared metadata for all pods created based on this spec.
+   * - :ref:`readinessGates<api-scylla.scylladb.com-scyllaclusters-v1-.spec.readinessGates[]>`
+     - array (object)
+     - readinessGates specifies custom readiness gates that will be evaluated for every ScyllaDB Pod readiness. It's projected into every ScyllaDB Pod as its readinessGate. Refer to upstream documentation to learn more about readiness gates.
    * - :ref:`repairs<api-scylla.scylladb.com-scyllaclusters-v1-.spec.repairs[]>`
      - array (object)
      - repairs specify repair tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
@@ -4515,6 +4521,31 @@ Type
 """"
 object
 
+
+.. _api-scylla.scylladb.com-scyllaclusters-v1-.spec.readinessGates[]:
+
+.spec.readinessGates[]
+^^^^^^^^^^^^^^^^^^^^^^
+
+Description
+"""""""""""
+PodReadinessGate contains the reference to a pod condition
+
+Type
+""""
+object
+
+
+.. list-table::
+   :widths: 25 10 150
+   :header-rows: 1
+
+   * - Property
+     - Type
+     - Description
+   * - conditionType
+     - string
+     - ConditionType refers to a condition in the pod's condition list with matching type.
 
 .. _api-scylla.scylladb.com-scyllaclusters-v1-.spec.repairs[]:
 

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -419,6 +419,11 @@
           },
           "type": "array"
         },
+        "minReadySeconds": {
+          "description": "minReadySeconds is the minimum number of seconds for which a newly created ScyllaDB node should be ready for it to be considered available. When used to control load balanced traffic, this can give the load balancer in front of a node enough time to notice that the node is ready and start forwarding traffic in time. Because it all depends on timing, the order is not guaranteed and, if possible, you should use readinessGates instead. If not provided, Operator will determine this value.",
+          "format": "int32",
+          "type": "integer"
+        },
         "minTerminationGracePeriodSeconds": {
           "description": "minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",
           "format": "int32",
@@ -457,6 +462,23 @@
             }
           },
           "type": "object"
+        },
+        "readinessGates": {
+          "description": "readinessGates specifies custom readiness gates that will be evaluated for every ScyllaDB Pod readiness. It's projected into every ScyllaDB Pod as its readinessGate. Refer to upstream documentation to learn more about readiness gates.",
+          "items": {
+            "description": "PodReadinessGate contains the reference to a pod condition",
+            "properties": {
+              "conditionType": {
+                "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "conditionType"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "repairs": {
           "description": "repairs specify repair tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.",

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -308,6 +308,11 @@
       },
       "type": "array"
     },
+    "minReadySeconds": {
+      "description": "minReadySeconds is the minimum number of seconds for which a newly created ScyllaDB node should be ready for it to be considered available. When used to control load balanced traffic, this can give the load balancer in front of a node enough time to notice that the node is ready and start forwarding traffic in time. Because it all depends on timing, the order is not guaranteed and, if possible, you should use readinessGates instead. If not provided, Operator will determine this value.",
+      "format": "int32",
+      "type": "integer"
+    },
     "minTerminationGracePeriodSeconds": {
       "description": "minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",
       "format": "int32",
@@ -346,6 +351,23 @@
         }
       },
       "type": "object"
+    },
+    "readinessGates": {
+      "description": "readinessGates specifies custom readiness gates that will be evaluated for every ScyllaDB Pod readiness. It's projected into every ScyllaDB Pod as its readinessGate. Refer to upstream documentation to learn more about readiness gates.",
+      "items": {
+        "description": "PodReadinessGate contains the reference to a pod condition",
+        "properties": {
+          "conditionType": {
+            "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "conditionType"
+        ],
+        "type": "object"
+      },
+      "type": "array"
     },
     "repairs": {
       "description": "repairs specify repair tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.",

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -1989,6 +1989,10 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
+                minReadySeconds:
+                  description: minReadySeconds is the minimum number of seconds for which a newly created ScyllaDB node should be ready for it to be considered available. When used to control load balanced traffic, this can give the load balancer in front of a node enough time to notice that the node is ready and start forwarding traffic in time. Because it all depends on timing, the order is not guaranteed and, if possible, you should use readinessGates instead. If not provided, Operator will determine this value.
+                  format: int32
+                  type: integer
                 minTerminationGracePeriodSeconds:
                   description: minTerminationGracePeriodSeconds specifies minimum duration in seconds to wait before every drained node is terminated. This gives time to potential load balancer in front of a node to notice that node is not ready anymore and stop forwarding new requests. This applies only when node is terminated gracefully. If not provided, Operator will determine this value. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
                   format: int32
@@ -2017,6 +2021,18 @@ spec:
                       description: labels is a custom key value map that gets merged with managed object labels.
                       type: object
                   type: object
+                readinessGates:
+                  description: readinessGates specifies custom readiness gates that will be evaluated for every ScyllaDB Pod readiness. It's projected into every ScyllaDB Pod as its readinessGate. Refer to upstream documentation to learn more about readiness gates.
+                  items:
+                    description: PodReadinessGate contains the reference to a pod condition
+                    properties:
+                      conditionType:
+                        description: ConditionType refers to a condition in the pod's condition list with matching type.
+                        type: string
+                    required:
+                      - conditionType
+                    type: object
+                  type: array
                 repairs:
                   description: repairs specify repair tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
                   items:

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -132,6 +132,21 @@ type ScyllaClusterSpec struct {
 	// EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
 	// +optional
 	MinTerminationGracePeriodSeconds *int32 `json:"minTerminationGracePeriodSeconds,omitempty"`
+
+	// minReadySeconds is the minimum number of seconds for which a newly created ScyllaDB node should be ready
+	// for it to be considered available.
+	// When used to control load balanced traffic, this can give the load balancer in front of a node enough time to
+	// notice that the node is ready and start forwarding traffic in time. Because it all depends on timing, the order
+	// is not guaranteed and, if possible, you should use readinessGates instead.
+	// If not provided, Operator will determine this value.
+	// +optional
+	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
+
+	// readinessGates specifies custom readiness gates that will be evaluated for every ScyllaDB Pod readiness.
+	// It's projected into every ScyllaDB Pod as its readinessGate. Refer to upstream documentation to learn more
+	// about readiness gates.
+	// +optional
+	ReadinessGates []corev1.PodReadinessGate `json:"readinessGates,omitempty"`
 }
 
 type PodIPSourceType string

--- a/pkg/api/scylla/v1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1/zz_generated.deepcopy.go
@@ -696,6 +696,16 @@ func (in *ScyllaClusterSpec) DeepCopyInto(out *ScyllaClusterSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MinReadySeconds != nil {
+		in, out := &in.MinReadySeconds, &out.MinReadySeconds
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ReadinessGates != nil {
+		in, out := &in.ReadinessGates, &out.ReadinessGates
+		*out = make([]corev1.PodReadinessGate, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -114,6 +114,10 @@ func ValidateScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *field.
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("minTerminationGracePeriodSeconds"), *spec.MinTerminationGracePeriodSeconds, "must be non-negative integer"))
 	}
 
+	if spec.MinReadySeconds != nil && *spec.MinReadySeconds < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("minReadySeconds"), *spec.MinReadySeconds, "must be non-negative integer"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -307,6 +307,19 @@ func TestValidateScyllaCluster(t *testing.T) {
 			},
 			expectedErrorString: `spec.minTerminationGracePeriodSeconds: Invalid value: -42: must be non-negative integer`,
 		},
+		{
+			name: "negative minReadySeconds",
+			cluster: func() *v1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.MinReadySeconds = pointer.Ptr(int32(-42))
+
+				return cluster
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.minReadySeconds", BadValue: int32(-42), Detail: "must be non-negative integer"},
+			},
+			expectedErrorString: `spec.minReadySeconds: Invalid value: -42: must be non-negative integer`,
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
New fields in spec allows for controlling additional readiness
conditions of ScyllaDB Pods. When in front of ScyllaCluster Pods there's
a load balancer (ClusterIP or LoadBalancer Service), it needs to
reconcile internal forwarding rules when ScyllaCluster Pods become
ready. There might be artifical delay between when ScyllaCluster Pod
declares being ready to serve traffic, and when these rules are updated
meaning Pod is available.  Depending whether given load balancer
supports readiness gates, it may add custom condition to Pod Status. If
such load balancer is deployed, users may configure custom
ReadinessGates for which kubelet will wait before it considers ScyllaDB
Pods as ready. If load balancer doesn't support it, users may fall back
to minReadySeconds which will delay ScyllaCluster availability by
configured amount of seconds. As this is vulnerable to race conditions,
users should prefer readiness gates when available. If minReadySeconds
is not provided, Operator will determine this value.
