### PR TITLE
Change minTerminationGracePeriodSeconds to *int32

### DIFF
--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -131,7 +131,7 @@ type ScyllaClusterSpec struct {
 	// If not provided, Operator will determine this value.
 	// EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
 	// +optional
-	MinTerminationGracePeriodSeconds int32 `json:"minTerminationGracePeriodSeconds,omitempty"`
+	MinTerminationGracePeriodSeconds *int32 `json:"minTerminationGracePeriodSeconds,omitempty"`
 }
 
 type PodIPSourceType string

--- a/pkg/api/scylla/v1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1/zz_generated.deepcopy.go
@@ -691,6 +691,11 @@ func (in *ScyllaClusterSpec) DeepCopyInto(out *ScyllaClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MinTerminationGracePeriodSeconds != nil {
+		in, out := &in.MinTerminationGracePeriodSeconds, &out.MinTerminationGracePeriodSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -110,8 +110,8 @@ func ValidateScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *field.
 		allErrs = append(allErrs, ValidateExposeOptions(spec.ExposeOptions, fldPath.Child("exposeOptions"))...)
 	}
 
-	if spec.MinTerminationGracePeriodSeconds < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("minTerminationGracePeriodSeconds"), spec.MinTerminationGracePeriodSeconds, "must be non-negative integer"))
+	if spec.MinTerminationGracePeriodSeconds != nil && *spec.MinTerminationGracePeriodSeconds < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("minTerminationGracePeriodSeconds"), *spec.MinTerminationGracePeriodSeconds, "must be non-negative integer"))
 	}
 
 	return allErrs

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -298,7 +298,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 			name: "negative minTerminationGracePeriodSeconds",
 			cluster: func() *v1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
-				cluster.Spec.MinTerminationGracePeriodSeconds = -42
+				cluster.Spec.MinTerminationGracePeriodSeconds = pointer.Ptr(int32(-42))
 
 				return cluster
 			}(),

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -338,8 +338,8 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 		// Any "upstream" Load Balancer should notice Endpoint readiness change within this period.
 		minTerminationGracePeriod = 60 * time.Second
 	}
-	if c.Spec.MinTerminationGracePeriodSeconds != 0 {
-		minTerminationGracePeriod = time.Duration(c.Spec.MinTerminationGracePeriodSeconds) * time.Second
+	if c.Spec.MinTerminationGracePeriodSeconds != nil {
+		minTerminationGracePeriod = time.Duration(*c.Spec.MinTerminationGracePeriodSeconds) * time.Second
 	}
 
 	sts := &appsv1.StatefulSet{


### PR DESCRIPTION
By mistake we didn't support 0 as a value which is has a proper meaining. It wasn't distinguishable from unset value. To fix it, type of this field was changed to pointer.

Fix of #1707 