### PR TITLE
Always use default minReadySeconds so identity service works

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -340,12 +340,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 		minTerminationGracePeriodSeconds = loadBalancerSyncPeriodSeconds
 		minReadySeconds = loadBalancerSyncPeriodSeconds
 	}
-	if c.Spec.ExposeOptions != nil && c.Spec.ExposeOptions.NodeService != nil && c.Spec.ExposeOptions.NodeService.Type == scyllav1.NodeServiceTypeHeadless {
-		// PodIP exposure doesn't have any load balancer in front of the Pod, there's no need to wait for termination nor availability,
-		// as traffic is rejected and accepted immediately after socket is closed/open.
-		minTerminationGracePeriodSeconds = 0
-		minReadySeconds = 0
-	}
+
 	if c.Spec.MinTerminationGracePeriodSeconds != nil {
 		minTerminationGracePeriodSeconds = int(*c.Spec.MinTerminationGracePeriodSeconds)
 	}


### PR DESCRIPTION
**Description of your changes:**
When using PodIPs, the operator was defaulting `minReadySeconds` to `0` because the node services don't have ClusterIP that would need a delay to propagate to the embedded load balancer but there is still the identity service that's used for initial discovery that needs to be updated. That service is actually even more important with the ephemeral PodIPs for clients, as you might otherwise loose all discovery endpoints, if your client is down during a rolling update.

There is still an option to adjust this on the API level, this changes only the "default" when unspecified.

**Which issue is resolved by this Pull Request:**
Resolves #1745 

/cc @zimnx 
