### PR TITLE
Fix headings in 'Deploying Scylla stack using Helm Charts' doc page

### DIFF
--- a/docs/source/helm.md
+++ b/docs/source/helm.md
@@ -240,7 +240,7 @@ To deploy Scylla Manager using customized values file execute the following comm
 helm install scylla-manager scylla/scylla-manager --values examples/helm/values.manager.yaml --create-namespace --namespace scylla-manager
 ```
 
-# Results
+## Results
 
 Scylla need some time to bootstrap all nodes, but after some time you should be ready to roll. It was simple isn't it?
 You can validate if everything was set up correctly by looking at the all resources created in used namespaces.
@@ -311,7 +311,7 @@ statefulset.apps/scylla-us-east-1-us-east-1b   2/2     5m59s
 
 Two running nodes, exactly what we were asking for.
 
-# Monitoring
+## Monitoring
 
 To spin up a Prometheus monitoring refer to [monitoring guide](monitoring.md).
 
@@ -329,7 +329,7 @@ helm upgrade --install scylla --namespace scylla scylla/scylla -f examples/helm/
 
 Helm should notice the difference, install the ServiceMonitor, and then Prometheous will be able to scrape metrics.
 
-# Cleanup
+## Cleanup
 
 To remove these applications you can simply uninstall them using Helm CLI:
 ```shell


### PR DESCRIPTION
**Description of your changes:** https://github.com/scylladb/scylla-operator/pull/1540 went a bit too far and changed some of the headings to H1, resulting in them being rendered as superfluous menu items. This PR reverts these headings back to H2.

**Which issue is resolved by this Pull Request:**
Hotfix for https://github.com/scylladb/scylla-operator/issues/1748, doesn't resolve the main issue though.

/cc @tnozicka
/kind documentation
/priority important-soon
