### PR TITLE
Disable unused sshd service in ScyllaDB container

### DIFF
--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -34,6 +35,7 @@ const (
 	scyllaRackDCPropertiesPath          = configDirScylla + "/" + naming.ScyllaRackDCPropertiesName
 	scyllaRackDCPropertiesConfigMapPath = naming.ScyllaConfigDirName + "/" + naming.ScyllaRackDCPropertiesName
 	entrypointPath                      = "/docker-entrypoint.py"
+	supervisordConfDir                  = "/etc/supervisord.conf.d"
 )
 
 var scyllaJMXPaths = []string{"/usr/lib/scylla/jmx/scylla-jmx", "/opt/scylladb/jmx/scylla-jmx"}
@@ -80,6 +82,23 @@ func (s *ScyllaConfig) Setup(ctx context.Context) (*exec.Cmd, error) {
 	cmd, err := s.setupEntrypoint(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("can't setup entrypoint: %w", err)
+	}
+
+	klog.Info("Disabling undesirable supervisord services")
+	// Make sure the directory is present, individual files may be missing between versions.
+	_, err = os.Stat(supervisordConfDir)
+	if err != nil {
+		return nil, fmt.Errorf("can't stat supervisord config directory %q: %w", supervisordConfDir, err)
+	}
+	for _, serviceConfigName := range []string{
+		"sshd-server.conf",
+	} {
+		p := filepath.Join(supervisordConfDir, serviceConfigName)
+		klog.V(2).InfoS("Removing supervisord service", "Path", p)
+		err = os.Remove(p)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("can't remove service config %q: %w", p, err)
+		}
 	}
 
 	return cmd, nil


### PR DESCRIPTION
**Description of your changes:**
This PR disables the unused sshd service that comes from supervisord config in ScyllaDB image [that isn't used by ScyllaDB manager since 2.0](https://github.com/scylladb/scylla-operator/issues/1763#issuecomment-1969388936)

This helps with ScyllaDB latency because cgroup is shared by all the processes in that container and future process split.

**Which issue is resolved by this Pull Request:**
Resolves #1763
