### PR TITLE
Update default ScyllaDB version to 5.4.3

### DIFF
--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -282,7 +282,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.4.0
+  version: 5.4.3
   agentVersion: 3.2.5
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -282,7 +282,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.4.0
+  version: 5.4.3
   agentVersion: 3.2.5
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.4.0
+  version: 5.4.3
   agentVersion: 3.2.5
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.4.0
+  version: 5.4.3
   agentVersion: 3.2.5
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -143,7 +143,7 @@ To squeeze the most out of your deployment it is sometimes necessary to employ [
 To enable this the CRD allows for specifying a `network` parameter as such:
 
 ```yaml
-  version: 5.4.0
+  version: 5.4.3
   agentVersion: 3.2.5
   cpuset: true
   network:
@@ -173,7 +173,7 @@ Change the `cluster.yaml` file from this:
 ```yaml
 spec:
   agentVersion: 3.2.5
-  version: 5.4.0
+  version: 5.4.3
   developerMode: true
   datacenter:
     name: us-east-1
@@ -181,7 +181,7 @@ spec:
 to this:
 ```yaml
 spec:
-  version: 5.4.0
+  version: 5.4.3
   alternator:
     port: 8000
     writeIsolation: only_rmw_uses_lwt

--- a/docs/source/multidc/multidc.md
+++ b/docs/source/multidc/multidc.md
@@ -108,7 +108,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.2.5
-  version: 5.4.0
+  version: 5.4.3
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"
@@ -358,7 +358,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.2.5
-  version: 5.4.0
+  version: 5.4.3
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -70,7 +70,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.2.5
-  version: 5.4.0
+  version: 5.4.3
   datacenter:
     name: us-east-1
     racks:

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.2.5
-  version: 5.4.0
+  version: 5.4.3
   cpuset: true
   network:
     hostNetworking: true

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.2.5
-  version: 5.4.0
+  version: 5.4.3
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.2.5
-  version: 5.4.0
+  version: 5.4.3
   cpuset: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -1,6 +1,6 @@
 # Version information
 scyllaImage:
-  tag: 5.4.0
+  tag: 5.4.3
 agentImage:
   tag: 3.2.5
 

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -23,7 +23,7 @@ controllerResources:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 5.4.0
+    tag: 5.4.3
   agentImage:
     tag: 3.2.5
   datacenter: manager-dc

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla
 spec:
   agentVersion: 3.2.5
-  version: 5.4.0
+  version: 5.4.3
   developerMode: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -23,7 +23,7 @@ scylla:
   fullnameOverride: scylla-manager-cluster
   scyllaImage:
     repository: docker.io/scylladb/scylla
-    tag: 5.4.0
+    tag: 5.4.3
   agentImage:
     tag: 3.2.5
     repository: docker.io/scylladb/scylla-manager-agent

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -73,7 +73,7 @@ controllerServiceAccount:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 5.4.0
+    tag: 5.4.3
   agentImage:
     tag: 3.2.5
   datacenter: manager-dc

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 scyllaImage:
   repository: scylladb/scylla
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 5.4.0
+  tag: 5.4.3
 # Allows to customize Scylla image
 agentImage:
   repository: scylladb/scylla-manager-agent

--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
    bar: foo
 spec:
   agentVersion: 3.2.5
-  version: 5.4.0
+  version: 5.4.3
   developerMode: true
   exposeOptions:
     nodeService:

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	updateFromScyllaVersion  = "5.4.0-rc2"
-	updateToScyllaVersion    = "5.4.0"
-	upgradeFromScyllaVersion = "5.2.11"
-	upgradeToScyllaVersion   = "5.4.0"
+	updateFromScyllaVersion  = "5.4.0"
+	updateToScyllaVersion    = "5.4.3"
+	upgradeFromScyllaVersion = "5.2.15"
+	upgradeToScyllaVersion   = "5.4.3"
 
 	testTimeout = 45 * time.Minute
 )


### PR DESCRIPTION
**Description of your changes:**
Updates default ScyllaDB version in tests and docs to 5.4.3.

In 5.4.1, the sshd service has finally been removed from the ScyllaDB container image, which avoids the need for #1779.

**Which issue is resolved by this Pull Request:**
Resolves #1763
