### PR TITLE
Explicitly disable CQL over TLS in Scylla Manager cluster integration

### DIFF
--- a/pkg/controller/manager/sync_action.go
+++ b/pkg/controller/manager/sync_action.go
@@ -46,6 +46,9 @@ func runSync(ctx context.Context, cluster *scyllav1.ScyllaCluster, authToken str
 							Name:      naming.ManagerClusterName(cluster),
 							Host:      naming.CrossNamespaceServiceNameForCluster(cluster),
 							AuthToken: authToken,
+							// TODO: enable CQL over TLS when https://github.com/scylladb/scylla-operator/issues/1766 is completed
+							ForceNonSslSessionPort: true,
+							ForceTLSDisabled:       true,
 						},
 					})
 					requeue = true
@@ -63,6 +66,9 @@ func runSync(ctx context.Context, cluster *scyllav1.ScyllaCluster, authToken str
 				Host:      naming.CrossNamespaceServiceNameForCluster(cluster),
 				Name:      naming.ManagerClusterName(cluster),
 				AuthToken: authToken,
+				// TODO: enable CQL over TLS when https://github.com/scylladb/scylla-operator/issues/1766 is completed
+				ForceNonSslSessionPort: true,
+				ForceTLSDisabled:       true,
 			},
 		})
 		requeue = true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR disables CQL over TLS in Scylla Manager cluster integration. See https://github.com/scylladb/scylla-operator/issues/1674.

Requires https://github.com/scylladb/scylla-operator/pull/1797

**Which issue is resolved by this Pull Request:**
Resolves #1674 

/hold for https://github.com/scylladb/scylla-operator/pull/1797
/kind bug
/priority critical-urgent
/cc
