### PR TITLE
Pass auth token on Scylla Manager cluster update

### DIFF
--- a/pkg/controller/manager/sync_action.go
+++ b/pkg/controller/manager/sync_action.go
@@ -42,9 +42,10 @@ func runSync(ctx context.Context, cluster *scyllav1.ScyllaCluster, authToken str
 				if c.AuthToken != authToken {
 					actions = append(actions, &updateClusterAction{
 						cluster: &managerclient.Cluster{
-							ID:   c.ID,
-							Name: naming.ManagerClusterName(cluster),
-							Host: naming.CrossNamespaceServiceNameForCluster(cluster),
+							ID:        c.ID,
+							Name:      naming.ManagerClusterName(cluster),
+							Host:      naming.CrossNamespaceServiceNameForCluster(cluster),
+							AuthToken: authToken,
 						},
 					})
 					requeue = true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** There is a bug in our Scylla Manager integration where the controller checks for auth token mismatch and issues an update request to Scylla Manager, but it doesn't set said auth token parameter. This PR sets the auth token parameter.

**Which issue is resolved by this Pull Request:**
Resolves #1799

/kind bug
/priority important-longterm
/cc zimnx