### PR TITLE
Use gocql client's default timeouts in tests

### DIFF
--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -180,8 +180,6 @@ func (di *DataInserter) GetExpected() []*TestData {
 
 func (di *DataInserter) createSession(hosts []string) error {
 	clusterConfig := gocql.NewCluster(hosts...)
-	clusterConfig.Timeout = 3 * time.Second
-	clusterConfig.ConnectTimeout = 3 * time.Second
 	// Set a small reconnect interval to avoid flakes, if not reconnected in time.
 	clusterConfig.ReconnectInterval = 500 * time.Millisecond
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Our E2E suite has gotten noticeably more flaky since we introduced a suite using PDs instead of the NVMes we've been using so far. All of the observed flakes are coming from the gocql client we're using for data consistency verification, see e.g. https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/1614/pull-scylla-operator-master-e2e-gke-parallel-clusterip/1767126234778570752#1:test-build-log.txt%3A761. This PR addresses that by removing the explicitly set timeouts and falling back to the client's default, which is set to accommodate the longest default server-side timeout.

**Which issue is resolved by this Pull Request:**
Resolves #


/kind machinery
/priority important-soon