### PR TITLE
Update tooManyFiles alerts to filter for only the scylla data mountpoint

### DIFF
--- a/assets/monitoring/prometheus/v1/alerts.prometheusrule.yaml
+++ b/assets/monitoring/prometheus/v1/alerts.prometheusrule.yaml
@@ -270,24 +270,24 @@ spec:
         description: 'OOM Kill on {{ $labels.instance }}'
         summary: A process was terminated on Instance {{ $labels.instance }}
     - alert: tooManyFiles
-      expr: (node_filesystem_files - node_filesystem_files_free) / on(instance) group_left count(scylla_reactor_cpu_busy_ms) by (instance)>20000
+      expr: (node_filesystem_files{mountpoint="/var/lib/scylla"} - node_filesystem_files_free) / on(instance) group_left count(scylla_reactor_cpu_busy_ms) by (instance)>20000
       for: 10s
       labels:
         severity: "info"
         description: 'Over 20k open files per shard {{ $labels.instance }}'
-        summary: There are over 20K open files per shard on Insace {{ $labels.instance }}
+        summary: There are over 20K open files per shard on Instance {{ $labels.instance }}
     - alert: tooManyFiles
-      expr: (node_filesystem_files - node_filesystem_files_free) / on(instance) group_left count(scylla_reactor_cpu_busy_ms) by (instance)>30000
+      expr: (node_filesystem_files{mountpoint="/var/lib/scylla"} - node_filesystem_files_free) / on(instance) group_left count(scylla_reactor_cpu_busy_ms) by (instance)>30000
       for: 10s
       labels:
         severity: "warn"
         description: 'Over 30k open files per shard {{ $labels.instance }}'
-        summary: There are over 30K open files per shard on Insace {{ $labels.instance }}
+        summary: There are over 30K open files per shard on Instance {{ $labels.instance }}
     - alert: tooManyFiles
-      expr: (node_filesystem_files - node_filesystem_files_free) / on(instance) group_left count(scylla_reactor_cpu_busy_ms) by (instance)>40000
+      expr: (node_filesystem_files{mountpoint="/var/lib/scylla"} - node_filesystem_files_free) / on(instance) group_left count(scylla_reactor_cpu_busy_ms) by (instance)>40000
       for: 10s
       labels:
         severity: "error"
         description: 'Over 40k open files per shard {{ $labels.instance }}'
-        summary: There are over 40K open files per shard on Insace {{ $labels.instance }}
+        summary: There are over 40K open files per shard on Instance {{ $labels.instance }}
 `}}


### PR DESCRIPTION
After implementing scylla operator, we started getting alerts for too many open files on our new clusters. I noticed that all the alerts were for `/etc/hosts` and other files that should not be generating alerts IMO. 
 - Added a filter similar to other alerts in the file to only alert when the mountpoint used for scylla data has too many open files
 - Corrected a typo in Instance

Looking on scylla-monitoring, it looks like similar changes must have been made already:

https://github.com/scylladb/scylla-monitoring/blob/master/prometheus/prom_rules/prometheus.rules.yml#L265