### PR TITLE
[v1.11] Explicitly disable CQL over TLS in Scylla Manager cluster integration

### DIFF
--- a/pkg/controller/manager/sync_action.go
+++ b/pkg/controller/manager/sync_action.go
@@ -44,6 +44,9 @@ func runSync(ctx context.Context, cluster *v1.ScyllaCluster, authToken string, s
 							ID:   c.ID,
 							Name: naming.ManagerClusterName(cluster),
 							Host: naming.CrossNamespaceServiceNameForCluster(cluster),
+							// TODO: enable CQL over TLS when https://github.com/scylladb/scylla-operator/issues/1766 is completed
+							ForceNonSslSessionPort: true,
+							ForceTLSDisabled:       true,
 						},
 					})
 					requeue = true
@@ -61,6 +64,9 @@ func runSync(ctx context.Context, cluster *v1.ScyllaCluster, authToken string, s
 				Host:      naming.CrossNamespaceServiceNameForCluster(cluster),
 				Name:      naming.ManagerClusterName(cluster),
 				AuthToken: authToken,
+				// TODO: enable CQL over TLS when https://github.com/scylladb/scylla-operator/issues/1766 is completed
+				ForceNonSslSessionPort: true,
+				ForceTLSDisabled:       true,
 			},
 		})
 		requeue = true


### PR DESCRIPTION
**Description of your changes:** Backport of https://github.com/scylladb/scylla-operator/pull/1798.

**Which issue is resolved by this Pull Request**:
Resolves https://github.com/scylladb/scylla-operator/issues/1675

/kind bug
/priority important-soon
