### PR TITLE
Use real salted_hash in alternator e2e

### DIFF
--- a/test/e2e/fixture/scylla/registry.go
+++ b/test/e2e/fixture/scylla/registry.go
@@ -8,6 +8,7 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/assets"
 	"github.com/scylladb/scylla-operator/test/e2e/scheme"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -19,6 +20,10 @@ var (
 	//go:embed "scyllacluster.yaml.tmpl"
 	ScyllaClusterTemplateString string
 	ScyllaClusterTemplate       = ParseObjectTemplateOrDie[*scyllav1.ScyllaCluster]("scyllacluster", ScyllaClusterTemplateString)
+
+	//go:embed "scylladb-config.yaml.tmpl"
+	ScyllaDBConfigTemplateString string
+	ScyllaDBConfigTemplate       = ParseObjectTemplateOrDie[*corev1.ConfigMap]("scylladb-config", ScyllaDBConfigTemplateString)
 
 	//go:embed "nodeconfig.yaml"
 	NodeConfig NodeConfigBytes

--- a/test/e2e/fixture/scylla/scylladb-config.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladb-config.yaml.tmpl
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scylladb-config
+data:
+  scylla.yaml: |
+    {{- .config | nindent 4 }}


### PR DESCRIPTION
**Description of your changes:**
`salted_hash` is supposed to come from ScyllaDB, unfortunatelly it wasn't populating it for the default user without explicitly enabling AuthN+AuthZ which lead to a confusion on who should populate the value.

This PR sets up CQL AuthN+AuthZ for alternator e2e which is how our users would do it. With that, it only needs to read the token (`salted_hash`).

**Which issue is resolved by this Pull Request:**
Resolves #1808
