### PR TITLE
Fix update action loop break in manager controller

### DIFF
--- a/pkg/controller/manager/sync_action.go
+++ b/pkg/controller/manager/sync_action.go
@@ -493,8 +493,8 @@ func (a *updateTaskAction) Execute(ctx context.Context, client *managerclient.Cl
 				if err != nil {
 					status.Repairs[i].Error = messageOf(err)
 				}
+				break
 			}
-			break
 		}
 	}
 	if a.task.Type == "backup" {
@@ -504,8 +504,8 @@ func (a *updateTaskAction) Execute(ctx context.Context, client *managerclient.Cl
 				if err != nil {
 					status.Backups[i].Error = messageOf(err)
 				}
+				break
 			}
-			break
 		}
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Current implementation of Scylla Manager controller has a bug in the logic updating status of updated tasks. It will only update status of the task if it matches the first item in the slice.

**Which issue is resolved by this Pull Request:**
Resolves #1820 

/priority important-soon
/kind bug
