### PR TITLE
Rollback Scylla utils image version to 5.4.0

### DIFF
--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -143,7 +143,8 @@ const (
 	PerftuneJobPrefixName = "perftune"
 
 	// TODO: Make sure this doesn't get out of date.
-	DefaultScyllaUtilsImage = "docker.io/scylladb/scylla:5.4.2"
+	// TODO: Can't be bumped until scylladb/scylladb#17787 is fixed.
+	DefaultScyllaUtilsImage = "docker.io/scylladb/scylla:5.4.0"
 )
 
 type NodeConfigJobType string


### PR DESCRIPTION
Currenly used 5.4.2 image is broken due to missing command (scylladb/scylladb#17787). 5.4.0 is latest version not affected by above bug.

Fixes #1826 