### PR TITLE
Remove TLS disablement note from restore docs

### DIFF
--- a/docs/source/nodeoperations/restore.md
+++ b/docs/source/nodeoperations/restore.md
@@ -2,19 +2,6 @@
 
 This procedure will describe how to restore from backup taken using [Scylla Manager](../manager.md) to a fresh **empty** cluster of any size.
 
-:::{caution}
-Due to a [bug](https://github.com/scylladb/scylla-manager/issues/3679) in Scylla Manager not supporting ScyllaClusters having both non-TLS and TLS CQL ports open, you have to disable the TLS certificate management
-in Scylla Operator.
-This step will no longer be required, when the bug is fixed.
-
-To disable TLS certificate management in Scylla Operator add `--feature-gates="AutomaticTLSCertificates=false"` flag to Scylla Operator deployment.
-
-```console
-kubectl -n scylla-operator patch deployment/scylla-operator --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--feature-gates=AutomaticTLSCertificates=false"}]'
-```
-
-:::
-
 In the following example, the ScyllaCluster, which was used to take the backup, is called `source`. Backup will be restored into the ScyllaCluster named `target`.
 
 ::::{tab-set}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** https://github.com/scylladb/scylla-operator/issues/1674 was merged, so with Scylla Manager 3.2.6, the users no longer need to disable `AutomaticTLSCertificates` for the restore procedure to work. This PR removes the note asking the users to disable it from the restore procedure doc.

**Which issue is resolved by this Pull Request:**
Resolves #1830

/kind documentation
/priority important-longterm
/hold to be tested manually, preferably together with a 5.4 workaround
