### PR TITLE
Add CI script to deploy published releases

### DIFF
--- a/hack/.ci/run-e2e-gke-release.sh
+++ b/hack/.ci/run-e2e-gke-release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2024 ScyllaDB
+#
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+if [ -z "${ARTIFACTS+x}" ]; then
+  echo "ARTIFACTS can't be empty" > /dev/stderr
+  exit 2
+fi
+
+source "$( dirname "${BASH_SOURCE[0]}" )/../lib/kube.sh"
+source "$( dirname "${BASH_SOURCE[0]}" )/lib/e2e.sh"
+parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
+
+trap gather-artifact-on-exit EXIT
+
+
+SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=${parent_dir}/manifests/cluster/nodeconfig.yaml}"
+export SO_NODECONFIG_PATH
+
+# Make sure there is no default storage class before we create our own so we always use our own provisioner from the release.
+for r in $( kubectl get storageclasses -o name ); do kubectl patch "${r}" -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'; done
+
+SCYLLA_OPERATOR_FEATURE_GATES="${SCYLLA_OPERATOR_FEATURE_GATES:-AllAlpha=true,AllBeta=true}"
+export SCYLLA_OPERATOR_FEATURE_GATES
+
+timeout --foreground -v 10m "${parent_dir}/../ci-deploy-release.sh" "${SO_IMAGE}"
+
+apply-e2e-workarounds
+run-e2e

--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# Copyright (C) 2024 ScyllaDB
+#
+# This script deploys scylla-operator stack.
+# Usage: ${0} <operator_image_ref>
+# (Avoid using rolling tags.)
+
+set -euxEo pipefail
+shopt -s inherit_errexit
+
+source "$( dirname "${BASH_SOURCE[0]}" )/lib/kube.sh"
+
+if [[ -n "${1+x}" ]]; then
+    operator_image_ref="${1}"
+else
+    echo "Missing operator image ref.\nUsage: ${0} <operator_image_ref>" >&2 >/dev/null
+    exit 1
+fi
+
+source_raw="$( skopeo inspect --format='{{ index .Labels "org.opencontainers.image.source" }}' "docker://${operator_image_ref}" )"
+if [[ -z "${source_raw}" ]]; then
+    echo "Image '${operator_image_ref}' is missing source label" >&2 >/dev/null
+    exit 1
+fi
+source_url="${source_raw/"://github.com/"/"://raw.githubusercontent.com/"}"
+
+revision="$( skopeo inspect --format='{{ index .Labels "org.opencontainers.image.revision" }}' "docker://${operator_image_ref}" )"
+if [[ -z "${revision}" ]]; then
+    echo "Image '${operator_image_ref}' is missing revision label" >&2 >/dev/null
+    exit 1
+fi
+
+ARTIFACTS="${ARTIFACTS:-$( mktemp -d )}"
+
+kubectl_create -n=prometheus-operator -f="${source_url}/${revision}/examples/third-party/prometheus-operator.yaml"
+kubectl_create -n=haproxy-ingress -f="${source_url}/${revision}/examples/third-party/haproxy-ingress.yaml"
+
+kubectl_create -f="${source_url}/${revision}/examples/common/cert-manager.yaml"
+# Wait for cert-manager crd and webhooks
+kubectl wait --for condition=established --timeout=60s crd/certificates.cert-manager.io crd/issuers.cert-manager.io
+for d in cert-manager{,-cainjector,-webhook}; do
+    kubectl -n=cert-manager rollout status --timeout=5m "deployment.apps/${d}"
+done
+wait-for-object-creation cert-manager secret/cert-manager-webhook-ca
+
+mkdir "${ARTIFACTS}/operator"
+cat > "${ARTIFACTS}/operator/kustomization.yaml" << EOF
+resources:
+- ${source_url}/${revision}/deploy/operator.yaml
+patches:
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: scylla-operator
+      namespace: scylla-operator
+    spec:
+      template:
+        spec:
+          containers:
+          - name: scylla-operator
+            image: "${operator_image_ref}"
+            env:
+            - name: SCYLLA_OPERATOR_IMAGE
+              value: "${operator_image_ref}"
+EOF
+kubectl kustomize "${ARTIFACTS}/operator" | kubectl_create -n=scylla-operator -f=-
+
+# Manager needs scylla CRD registered and the webhook running
+kubectl wait --for condition=established crd/{scyllaclusters,nodeconfigs}.scylla.scylladb.com
+kubectl -n=scylla-operator rollout status --timeout=5m deployment.apps/scylla-operator
+kubectl -n=scylla-operator rollout status --timeout=5m deployment.apps/webhook-server
+
+if [[ -z "${SO_NODECONFIG_PATH:-}" ]]; then
+ echo "Skipping NodeConfig creation"
+else
+ kubectl_create -f="${SO_NODECONFIG_PATH}"
+fi
+
+kubectl_create -n=local-csi-driver -f="${source_url}/${revision}/examples/common/local-volume-provisioner/local-csi-driver/"{00_namespace.yaml,00_scylladb-local-xfs.storageclass.yaml,10_csidriver.yaml,10_driver.serviceaccount.yaml,10_provisioner_clusterrole.yaml,20_provisioner_clusterrolebinding.yaml,50_daemonset.yaml}
+kubectl -n=local-csi-driver rollout status --timeout=5m daemonset.apps/local-csi-driver
+
+mkdir "${ARTIFACTS}/manager"
+cat > "${ARTIFACTS}/manager/kustomization.yaml" << EOF
+resources:
+- ${source_url}/${revision}/deploy/manager-prod.yaml
+patches:
+- target:
+    group: scylla.scylladb.com
+    version: v1
+    kind: ScyllaCluster
+    name: scylla-manager-cluster
+  patch: |
+    - op: replace
+      path: /spec/datacenter/racks/0/storage/storageClassName
+      value: scylladb-local-xfs
+EOF
+kubectl kustomize "${ARTIFACTS}/manager" | kubectl_create -n=scylla-manager -f=-
+
+wait-for-object-creation scylla-manager statefulset.apps/scylla-manager-cluster-manager-dc-manager-rack
+kubectl -n=scylla-manager rollout status --timeout=5m statefulset.apps/scylla-manager-cluster-manager-dc-manager-rack
+kubectl -n=scylla-manager rollout status --timeout=5m deployment.apps/scylla-manager
+kubectl -n=scylla-manager rollout status --timeout=5m deployment.apps/scylla-manager-controller
+
+kubectl -n=haproxy-ingress rollout status --timeout=5m deployment.apps/haproxy-ingress
+
+kubectl wait --for condition=established crd/{scyllaoperatorconfigs,scylladbmonitorings}.scylla.scylladb.com
+kubectl wait --for condition=established crd/{prometheuses,prometheusrules,servicemonitors}.monitoring.coreos.com


### PR DESCRIPTION
**Description of your changes:**
This script will be used in periodics to test our published images. It essentially codifies what needs to be done to deploy a particular scylla-operator version. Some action could be simplified by restructuring manifest but it's out of the scope of this PR. Eventually, we should fix this and possibly have some smarter templating / publish manifests into releases with the replaced image. So take this PR as a start with what we have now, not where it should end.

**Which issue is resolved by this Pull Request:**
Resolves #1936 

### Requires
- [x] #1901 
- [x] #1922
- [x] https://github.com/scylladb/scylla-operator-release/pull/193
- [x] https://github.com/scylladb/scylla-operator-release/pull/194
