### PR TITLE
Add Scheme Builder

### DIFF
--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -25,15 +25,17 @@ var (
 			Strict: true,
 		},
 	)
+	localSchemeBuilder = runtime.SchemeBuilder{
+		kscheme.AddToScheme,
+		scyllav1.Install,
+		scyllav1alpha1.Install,
+		cqlclientv1alpha1.Install,
+		monitoringv1.Install,
+	}
+
+	AddToScheme = localSchemeBuilder.AddToScheme
 )
 
 func init() {
-	utilruntime.Must(kscheme.AddToScheme(Scheme))
-
-	utilruntime.Must(scyllav1.Install(Scheme))
-	utilruntime.Must(scyllav1alpha1.Install(Scheme))
-
-	utilruntime.Must(cqlclientv1alpha1.Install(Scheme))
-
-	utilruntime.Must(monitoringv1.Install(Scheme))
+	utilruntime.Must(AddToScheme(Scheme))
 }


### PR DESCRIPTION
It's useful when other project wants to add all types defined by Scylla Operator to its schema.

