### PR TITLE
Deprecate interval in manager task schedule spec

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1155,7 +1155,7 @@ spec:
                           type: string
                         type: array
                       interval:
-                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        description: 'interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.'
                         type: string
                       keyspace:
                         description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
@@ -3127,7 +3127,7 @@ spec:
                         description: intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
                         type: string
                       interval:
-                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        description: 'interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.'
                         type: string
                       keyspace:
                         description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
@@ -3201,7 +3201,7 @@ spec:
                         description: id is the identification number of the backup task.
                         type: string
                       interval:
-                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        description: 'interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.'
                         type: string
                       keyspace:
                         description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
@@ -3388,7 +3388,7 @@ spec:
                         description: intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
                         type: string
                       interval:
-                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        description: 'interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.'
                         type: string
                       keyspace:
                         description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.

--- a/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -298,7 +298,7 @@ object
      - dc is a list of datacenter glob patterns, e.g. 'dc1,!otherdc*' used to specify the DCs to include or exclude from backup.
    * - interval
      - string
-     - interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+     - interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.
    * - keyspace
      - array (string)
      - keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
@@ -4684,7 +4684,7 @@ object
      - intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
    * - interval
      - string
-     - interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+     - interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.
    * - keyspace
      - array (string)
      - keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
@@ -4797,7 +4797,7 @@ object
      - id is the identification number of the backup task.
    * - interval
      - string
-     - interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+     - interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.
    * - keyspace
      - array (string)
      - keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
@@ -4929,7 +4929,7 @@ object
      - intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
    * - interval
      - string
-     - interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+     - interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.
    * - keyspace
      - array (string)
      - keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -213,7 +213,7 @@
                 "type": "array"
               },
               "interval": {
-                "description": "interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.",
+                "description": "interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.",
                 "type": "string"
               },
               "keyspace": {
@@ -570,7 +570,7 @@
                 "type": "string"
               },
               "interval": {
-                "description": "interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.",
+                "description": "interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.",
                 "type": "string"
               },
               "keyspace": {

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -102,7 +102,7 @@
             "type": "array"
           },
           "interval": {
-            "description": "interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.",
+            "description": "interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.",
             "type": "string"
           },
           "keyspace": {
@@ -459,7 +459,7 @@
             "type": "string"
           },
           "interval": {
-            "description": "interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.",
+            "description": "interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.",
             "type": "string"
           },
           "keyspace": {

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -127,7 +127,7 @@ spec:
                           type: string
                         type: array
                       interval:
-                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        description: 'interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.'
                         type: string
                       keyspace:
                         description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
@@ -2099,7 +2099,7 @@ spec:
                         description: intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
                         type: string
                       interval:
-                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        description: 'interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.'
                         type: string
                       keyspace:
                         description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
@@ -2173,7 +2173,7 @@ spec:
                         description: id is the identification number of the backup task.
                         type: string
                       interval:
-                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        description: 'interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.'
                         type: string
                       keyspace:
                         description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
@@ -2360,7 +2360,7 @@ spec:
                         description: intensity indicates how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
                         type: string
                       interval:
-                        description: interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+                        description: 'interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s. Deprecated: please use cron instead.'
                         type: string
                       keyspace:
                         description: keyspace is a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -322,6 +322,7 @@ type SchedulerTaskSpec struct {
 	StartDate *string `json:"startDate,omitempty"`
 
 	// interval represents a task schedule interval e.g. 3d2h10m, valid units are d, h, m, s.
+	// Deprecated: please use cron instead.
 	// +optional
 	Interval *string `json:"interval,omitempty"`
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR deprecates the interval field in manager task schedule spec in favour of cron.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/1796

/kind feature
/priority important-longterm
/hold for https://github.com/scylladb/scylla-operator/pull/1851