### PR TITLE
Collect related objects for ScyllaClusters and ScyllaDBMonitorings in must-gather

### DIFF
--- a/pkg/cmd/operator/mustgather_test.go
+++ b/pkg/cmd/operator/mustgather_test.go
@@ -121,6 +121,16 @@ func TestMustGatherOptions_Run(t *testing.T) {
 						Name: "fedora",
 					},
 				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-namespace",
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-other-namespace",
+					},
+				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "scylla-operator",
@@ -153,6 +163,30 @@ func TestMustGatherOptions_Run(t *testing.T) {
 			expectedDump: &testhelpers.GatherDump{
 				EmptyDirs: nil,
 				Files: []testhelpers.File{
+					{
+						Name: "cluster-scoped/namespaces/my-namespace.yaml",
+						Content: strings.TrimPrefix(`
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: my-namespace
+spec: {}
+status: {}
+`, "\n"),
+					},
+					{
+						Name: "cluster-scoped/namespaces/my-other-namespace.yaml",
+						Content: strings.TrimPrefix(`
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: my-other-namespace
+spec: {}
+status: {}
+`, "\n"),
+					},
 					{
 						Name: "cluster-scoped/namespaces/scylla-operator.yaml",
 						Content: strings.TrimPrefix(`
@@ -262,6 +296,16 @@ metadata:
 						Name: "fedora",
 					},
 				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-namespace",
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-other-namespace",
+					},
+				},
 				&scyllav1.ScyllaCluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "my-namespace",
@@ -285,6 +329,18 @@ metadata:
 			expectedDump: &testhelpers.GatherDump{
 				EmptyDirs: nil,
 				Files: []testhelpers.File{
+					{
+						Name: "cluster-scoped/namespaces/my-namespace.yaml",
+						Content: strings.TrimPrefix(`
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: my-namespace
+spec: {}
+status: {}
+`, "\n"),
+					},
 					{
 						Name: "cluster-scoped/namespaces/scylla-operator.yaml",
 						Content: strings.TrimPrefix(`


### PR DESCRIPTION
**Description of your changes:**
This PR adds support for collecting related resources for ScyllaClusters and ScyllaDBMonitorings. Because not all resources are connected through ownerReferences we dump the same namespace and don't filter the objects. Some examples of where ownerRefs wouldn't works are `Services`, `Endpoints` or other objects that don't have a direct relationship but affect say firewall rules (like NetworkPolicy). In the end, dumping all the objects in the same namespace seems like the best path.

**Which issue is resolved by this Pull Request:**
Resolves #1568
