### PR TITLE
Validate whether Scylla container is tuned before Pod is unblocked

### DIFF
--- a/pkg/controller/nodeconfigpod/sync_configmaps.go
+++ b/pkg/controller/nodeconfigpod/sync_configmaps.go
@@ -75,6 +75,10 @@ func (ncpc *Controller) makeConfigMap(ctx context.Context, pod *corev1.Pod) (*co
 				continue
 			}
 
+			if !controllerhelpers.IsPodTunable(pod) {
+				continue
+			}
+
 			if controllerhelpers.IsNodeTunedForContainer(nc, node.Name, containerID) {
 				continue
 			}

--- a/pkg/controller/nodetune/sync_jobs.go
+++ b/pkg/controller/nodetune/sync_jobs.go
@@ -150,7 +150,7 @@ func (ncdc *Controller) makeJobForContainers(ctx context.Context) (*batchv1.Job,
 	for i := range localScyllaPods {
 		scyllaPod := localScyllaPods[i]
 
-		if scyllaPod.Status.QOSClass != corev1.PodQOSGuaranteed {
+		if !controllerhelpers.IsPodTunable(scyllaPod) {
 			klog.V(4).Infof("Pod %q isn't a subject for optimizations", naming.ObjRef(scyllaPod))
 			continue
 		}

--- a/pkg/controller/nodetune/tune.go
+++ b/pkg/controller/nodetune/tune.go
@@ -23,7 +23,7 @@ import (
 func getIRQCPUs(ctx context.Context, kubeletPodResourcesClient kubelet.PodResourcesClient, scyllaPods []*corev1.Pod, hostFullCpuset cpuset.CPUSet) (cpuset.CPUSet, error) {
 	scyllaCPUs := cpuset.CPUSet{}
 	for _, scyllaPod := range scyllaPods {
-		if scyllaPod.Status.QOSClass != corev1.PodQOSGuaranteed {
+		if !controllerhelpers.IsPodTunable(scyllaPod) {
 			continue
 		}
 

--- a/pkg/controllerhelpers/scylla.go
+++ b/pkg/controllerhelpers/scylla.go
@@ -318,7 +318,17 @@ func IsNodeTunedForContainer(nc *scyllav1alpha1.NodeConfig, nodeName string, con
 		return false
 	}
 
-	return true
+	for _, cid := range ns.TunedContainers {
+		if cid == containerID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsPodTunable(pod *corev1.Pod) bool {
+	return pod.Status.QOSClass == corev1.PodQOSGuaranteed
 }
 
 func IsNodeTuned(ncnss []scyllav1alpha1.NodeConfigNodeStatus, nodeName string) bool {

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -96,6 +96,13 @@ func IsNodeConfigDoneWithNodes(nodes []*corev1.Node) func(nc *scyllav1alpha1.Nod
 	}
 }
 
+func IsNodeConfigDoneWithContainerTuningFunc(nodeName, containerID string) func(nc *scyllav1alpha1.NodeConfig) (bool, error) {
+	return func(nc *scyllav1alpha1.NodeConfig) (bool, error) {
+		containerTuned := controllerhelpers.IsNodeTunedForContainer(nc, nodeName, containerID)
+		return containerTuned, nil
+	}
+}
+
 func IsNodeConfigDoneWithNodeTuningFunc(nodes []*corev1.Node) func(nc *scyllav1alpha1.NodeConfig) (bool, error) {
 	return func(nc *scyllav1alpha1.NodeConfig) (bool, error) {
 		for _, node := range nodes {


### PR DESCRIPTION
Scylla Pod was unblocked even when container wasn't yet tuned. E2E validating node optimizations wasn't validating it either giving us a false positive.

Fixes #1856