### PR TITLE
Fix and trim release matrix to supported releases

### DIFF
--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -3,13 +3,16 @@
 ## Schedule
 We are aiming to ship a new release approximately every 6 weeks. The following release schedule is only advisory, there are no commitments made to hitting these dates.
 
+:::{table}
 | Release | Code freeze | General availability |
 |:-------:|:-----------:|:--------------------:|
 |  1.12   | 2023-12-18  |      2024-01-08      |
+:::
 
 ## Supported releases
 We support the latest 2 releases of the operator to give everyone time to upgrade.
 
+:::{table}
 | Release | General availability |  Support ends   |
 |:-------:|:--------------------:|:---------------:|
 |  1.11   |      2023-11-09      | Release of 1.13 |
@@ -24,6 +27,7 @@ We support the latest 2 releases of the operator to give everyone time to upgrad
 |   1.2   |      2021-05-06      |   2021-08-10    |
 |   1.1   |      2021-03-22      |   2021-06-17    |
 |   1.0   |      2021-01-21      |   2021-05-06    |
+:::
 
 ### Backport policy
 Usually, only important bug fixes are eligible for being backported.
@@ -34,6 +38,7 @@ We use [GitHub actions](https://github.com/scylladb/scylla-operator/actions/work
 
 ### Automated promotions
 
+:::{table}
 | Git reference      | Type   | Container image                                      |
 | :----------------: | :----: | :--------------------------------------------------: |
 | **master**         | branch | docker.io/scylladb/scylla-operator:**latest**        |
@@ -42,6 +47,7 @@ We use [GitHub actions](https://github.com/scylladb/scylla-operator/actions/work
 | **vX.Y.Z-alpha.N** | tag    | docker.io/scylladb/scylla-operator:**X.Y.Z-alpha.N** |
 | **vX.Y.Z-beta.N**  | tag    | docker.io/scylladb/scylla-operator:**X.Y.Z-beta.N**  |
 | **vX.Y.Z-rc.N**    | tag    | docker.io/scylladb/scylla-operator:**X.Y.Z-rc.N**    |
+:::
 
 ### Generally available
 GA images aren't build from scratch but rather promoted from an existing release candidates. When we decide a release candidate has the acceptable quality and QA sings it off, the release candidate is promoted to become the GA release. This makes sure the image has exactly the same content and SHA as the tested release candidate.
@@ -50,11 +56,13 @@ GA images aren't build from scratch but rather promoted from an existing release
 
 Support matrix table shows the version requirements for a particular **scylla-operator** version. Be sure to match these requirements, otherwise some functionality will not work.
 
-|                   |   v1.12   | |  v1.11    |   v1.10    |    v1.9    |    v1.8    |       v1.7        |         v1.6         |    v1.5     |    v1.4     |    v1.3    |    v1.2    |    v1.1    |    v1.0    |
-|:-----------------:|:-----------|:|----------:|:----------:|:----------:|:----------:|:-----------------:|:--------------------:|:-----------:|:-----------:|:----------:|:----------:|:----------:|:----------:|
-|    Kubernetes     | `>=1.21`   | | `>=1.21`  |  `>=1.21`  |  `>=1.21`  |  `>=1.21`  | `>=1.20 && <1.25` | `>=1.19.10 && <1.25` | `>=1.19.10` | `>=1.19.10` |  `>=1.19`  |  `>=1.19`  |  `>=1.11`  |  `>=1.11`  |
-|      CRI API      | `v1`       | |   `v1`    |    `v1`    |    `v1`    | `v1alpha2` |    `v1alpha2`     |      `v1alpha2`      |             |             |            |            |            |            |
-|     Scylla OS     | `>=5.0`    | | `>=5.0`   |  `>=5.0`   |  `>=5.0`   |  `>=5.0`   |      `>=4.3`      |       `>=4.3`        |   `>=4.3`   |   `>=4.3`   |  `>=4.2`   |  `>=4.2`   |  `>=4.0`   |  `>=4.0`   |
-| Scylla Enterprise | `>=2021.1` | |`>=2021.1` | `>=2021.1` | `>=2021.1` | `>=2021.1` |    `>=2021.1`     |      `>=2021.1`      | `>=2021.1`  | `>=2021.1`  | `>=2020.1` | `>=2020.1` | `>=2020.1` | `>=2020.1` |
-|  Scylla Manager   | `>=3.2.6`  | | `>=3.2`   |  `>=2.6`   |  `>=2.6`   |  `>=2.6`   |      `>=2.2`      |       `>=2.2`        |   `>=2.2`   |   `>=2.2`   |  `>=2.2`   |  `>=2.2`   |  `>=2.2`   |  `>=2.2`   |
-| Scylla Monitoring | `4.4.5`    | | `4.4.5`   |  `>=4.0`   |  `>=4.0`   |  `>=4.0`   |      `>=3.0`      |       `>=3.0`        |   `>=1.0`   |   `>=1.0`   |  `>=1.0`   |  `>=1.0`   |  `>=1.0`   |  `>=1.0`   |
+:::{table}
+| Component         | v1.12      | v1.11      | v1.10      |
+|:-----------------:|:----------:|:----------:|:----------:|
+| Kubernetes        | `>=1.21`   | `>=1.21`   | `>=1.21`   |
+| CRI API           | `v1`       | `v1`       | `v1`       |
+| Scylla OS         | `>=5.0`    | `>=5.0`    | `>=5.0`    |
+| Scylla Enterprise | `>=2021.1` | `>=2021.1` | `>=2021.1` |
+| Scylla Manager    | `>=3.2.6`  | `>=3.2`    | `>=2.6`    |
+| Scylla Monitoring | `(CRD)`    | `(CRD)`    | `>=4.0`    |
+:::


### PR DESCRIPTION
**Description of your changes:**
@rzetelskik has noticed that support matrix rendering is broken.

This PR adds the `:::{table}` directive that maker sure there is a rendering error next time. It also truncates the table to supported release to make it more manageable.

**Which issue is resolved by this Pull Request:**
Resolves #1858
