### PR TITLE
Extract Operator binary path to variable

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -38,6 +38,11 @@ const (
 	cryptoKeyBufferSizeMaxFlagKey = "crypto-key-buffer-size-max"
 )
 
+var (
+	// OperatorBinaryPath specifies path of Operator binary within Operator container image.
+	OperatorBinaryPath = "/usr/bin/scylla-operator"
+)
+
 type OperatorOptions struct {
 	genericclioptions.ClientConfig
 	genericclioptions.InClusterReflection
@@ -261,6 +266,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		kubeInformers.Batch().V1().Jobs(),
 		scyllaInformers.Scylla().V1().ScyllaClusters(),
 		o.OperatorImage,
+		OperatorBinaryPath,
 		o.CQLSIngressPort,
 		rsaKeyGenerator,
 	)
@@ -291,6 +297,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		kubeInformers.Core().V1().Nodes(),
 		kubeInformers.Core().V1().ServiceAccounts(),
 		o.OperatorImage,
+		OperatorBinaryPath,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create nodeconfig controller: %w", err)

--- a/pkg/controller/nodeconfig/controller.go
+++ b/pkg/controller/nodeconfig/controller.go
@@ -70,7 +70,8 @@ type Controller struct {
 	queue    workqueue.RateLimitingInterface
 	handlers *controllerhelpers.Handlers[*scyllav1alpha1.NodeConfig]
 
-	operatorImage string
+	operatorImage      string
+	operatorBinaryPath string
 }
 
 func NewController(
@@ -85,6 +86,7 @@ func NewController(
 	nodeInformer corev1informers.NodeInformer,
 	serviceAccountInformer corev1informers.ServiceAccountInformer,
 	operatorImage string,
+	operatorBinaryPath string,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -118,7 +120,8 @@ func NewController(
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NodeConfig"),
 
-		operatorImage: operatorImage,
+		operatorImage:      operatorImage,
+		operatorBinaryPath: operatorBinaryPath,
 	}
 
 	var err error

--- a/pkg/controller/nodeconfig/resource.go
+++ b/pkg/controller/nodeconfig/resource.go
@@ -116,7 +116,7 @@ func makeNodeConfigClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	}
 }
 
-func makeNodeSetupDaemonSet(nc *scyllav1alpha1.NodeConfig, operatorImage, scyllaImage string) *appsv1.DaemonSet {
+func makeNodeSetupDaemonSet(nc *scyllav1alpha1.NodeConfig, operatorBinaryPath, operatorImage, scyllaImage string) *appsv1.DaemonSet {
 	if nc.Spec.LocalDiskSetup == nil && nc.Spec.DisableOptimizations {
 		return nil
 	}
@@ -223,7 +223,7 @@ fi
 # Mount operator binary
 mkdir -p ./scylla-operator
 touch ./scylla-operator/scylla-operator
-mount --bind /usr/bin/scylla-operator ./scylla-operator/scylla-operator
+mount --bind ` + operatorBinaryPath + ` ./scylla-operator/scylla-operator
 
 # Mount service account
 mkdir -p "./run/secrets/kubernetes.io/serviceaccount"

--- a/pkg/controller/nodeconfig/status.go
+++ b/pkg/controller/nodeconfig/status.go
@@ -22,7 +22,7 @@ func (ncc *Controller) calculateStatus(nc *scyllav1alpha1.NodeConfig, daemonSets
 
 	// TODO: We need to restructure the pattern so status update already know the desired object and we don't
 	// 		 construct it twice.
-	requiredDaemonSet := makeNodeSetupDaemonSet(nc, ncc.operatorImage, scyllaUtilsImage)
+	requiredDaemonSet := makeNodeSetupDaemonSet(nc, ncc.operatorBinaryPath, ncc.operatorImage, scyllaUtilsImage)
 	ds, found := daemonSets[requiredDaemonSet.Name]
 	if !found {
 		klog.V(4).InfoS("Existing DaemonSet not found", "DaemonSet", klog.KObj(ds))

--- a/pkg/controller/nodeconfig/sync_daemonsets.go
+++ b/pkg/controller/nodeconfig/sync_daemonsets.go
@@ -23,7 +23,7 @@ func (ncc *Controller) syncDaemonSet(
 	// FIXME: check that its not empty, emit event
 	// FIXME: add webhook validation for the format
 	requiredDaemonSets := []*appsv1.DaemonSet{
-		makeNodeSetupDaemonSet(nc, ncc.operatorImage, scyllaUtilsImage),
+		makeNodeSetupDaemonSet(nc, ncc.operatorBinaryPath, ncc.operatorImage, scyllaUtilsImage),
 	}
 
 	err := controllerhelpers.Prune(

--- a/pkg/controller/scyllacluster/controller.go
+++ b/pkg/controller/scyllacluster/controller.go
@@ -59,8 +59,9 @@ var (
 )
 
 type Controller struct {
-	operatorImage   string
-	cqlsIngressPort int
+	operatorImage      string
+	operatorBinaryPath string
+	cqlsIngressPort    int
 
 	kubeClient   kubernetes.Interface
 	scyllaClient scyllav1client.ScyllaV1Interface
@@ -102,6 +103,7 @@ func NewController(
 	jobInformer batchv1informers.JobInformer,
 	scyllaClusterInformer scyllav1informers.ScyllaClusterInformer,
 	operatorImage string,
+	operatorBinaryPath string,
 	cqlsIngressPort int,
 	keyGetter crypto.RSAKeyGetter,
 ) (*Controller, error) {
@@ -110,8 +112,9 @@ func NewController(
 	eventBroadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 
 	scc := &Controller{
-		operatorImage:   operatorImage,
-		cqlsIngressPort: cqlsIngressPort,
+		operatorImage:      operatorImage,
+		operatorBinaryPath: operatorBinaryPath,
+		cqlsIngressPort:    cqlsIngressPort,
 
 		kubeClient:   kubeClient,
 		scyllaClient: scyllaClient,

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -255,7 +255,7 @@ func servicePorts(cluster *scyllav1.ScyllaCluster) []corev1.ServicePort {
 
 // StatefulSetForRack make a StatefulSet for the rack.
 // existingSts may be nil if it doesn't exist yet.
-func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existingSts *appsv1.StatefulSet, sidecarImage string, rackOrdinal int, inputsHash string) (*appsv1.StatefulSet, error) {
+func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existingSts *appsv1.StatefulSet, operatorBinaryPath, sidecarImage string, rackOrdinal int, inputsHash string) (*appsv1.StatefulSet, error) {
 	selectorLabels, err := naming.RackSelectorLabels(r, c)
 	if err != nil {
 		return nil, fmt.Errorf("can't get selector labels: %w", err)
@@ -513,7 +513,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 							Command: []string{
 								"/bin/sh",
 								"-c",
-								fmt.Sprintf("cp -a /usr/bin/scylla-operator %s", naming.SharedDirName),
+								fmt.Sprintf("cp -a %s %s", operatorBinaryPath, path.Join(naming.SharedDirName, "scylla-operator")),
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -784,7 +784,7 @@ func TestStatefulSetForRack(t *testing.T) {
 								Command: []string{
 									"/bin/sh",
 									"-c",
-									"cp -a /usr/bin/scylla-operator /mnt/shared",
+									"cp -a /usr/bin/scylla-operator /mnt/shared/scylla-operator",
 								},
 								Resources: corev1.ResourceRequirements{
 									Limits: corev1.ResourceList{
@@ -1478,7 +1478,7 @@ func TestStatefulSetForRack(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := StatefulSetForRack(tc.rack, tc.scyllaCluster, tc.existingStatefulSet, "scylladb/scylla-operator:latest", 0, "")
+			got, err := StatefulSetForRack(tc.rack, tc.scyllaCluster, tc.existingStatefulSet, "/usr/bin/scylla-operator", "scylladb/scylla-operator:latest", 0, "")
 
 			if !reflect.DeepEqual(err, tc.expectedError) {
 				t.Fatalf("expected and actual errors differ: %s",

--- a/pkg/controller/scyllacluster/sync_statefulsets.go
+++ b/pkg/controller/scyllacluster/sync_statefulsets.go
@@ -52,7 +52,7 @@ func (scc *Controller) makeRacks(sc *scyllav1.ScyllaCluster, statefulSets map[st
 	sets := make([]*appsv1.StatefulSet, 0, len(sc.Spec.Datacenter.Racks))
 	for i, rack := range sc.Spec.Datacenter.Racks {
 		oldSts := statefulSets[naming.StatefulSetNameForRack(rack, sc)]
-		sts, err := StatefulSetForRack(rack, sc, oldSts, scc.operatorImage, i, inputsHash)
+		sts, err := StatefulSetForRack(rack, sc, oldSts, scc.operatorBinaryPath, scc.operatorImage, i, inputsHash)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Operator binary path is hardcoded making it impossible to reuse controllers copying operator binary, as binary executing it may be different.
To fix this, binary path is extracted as controller parameter and kept as global variable allowing forks to specify different one, while still allowing for reusing entire operator command.