### PR TITLE
Clarify supported platform in our docs

### DIFF
--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -67,3 +67,29 @@ Support matrix table shows the version requirements for a particular **scylla-op
 | Scylla Manager    | `>=3.2.6`  | `>=3.2.6`  | `>=3.2`    | `>=2.6`    |
 | Scylla Monitoring | `(CRD)`    | `(CRD)`    | `(CRD)`    | `>=4.0`    |
 :::
+
+### Supported Kubernetes platforms
+
+We officially test and recommend to use the following platforms:
+
+:::{table}
+| Platform         | OS Image     |
+|:-----------------|:-------------|
+| GKE              | Ubuntu       |
+| EKS              | Amazon Linux |
+:::
+
+While our APIs generally work on any Kubernetes conformant cluster,
+performance tuning and other pieces that need to interact with the host OS, kubelet, CRI, kernel, etc. might hit some incompatibilities.
+
+
+:::{warning}
+The following platforms are known **not to work correctly** at this time.
+
+:::{table}
+| Platform         | OS Image     | Details |
+|:-----------------|:-------------| :------ |
+| GKE              | Container OS |         |
+| EKS              | Bottlerocket | Suspected kernel/cgroups issue that breaks available memory detection for ScyllaDB |
+:::
+:::


### PR DESCRIPTION
**Description of your changes:**
This will add clarification on the Kubernetes platforms we support and test. This is somewhat present on https://www.scylladb.com/product/scylladb-operator-kubernetes/ but not very well updated or detailed.

![Screenshot from 2024-04-03 17-16-40](https://github.com/scylladb/scylla-operator/assets/11869554/169f6b67-4708-45e2-9056-81ba391d9a29)

