### PR TITLE
Update Local Volume Provisioner command to only reference the new file path for the xfs storageclass.

### DIFF
--- a/docs/source/eks.md
+++ b/docs/source/eks.md
@@ -109,7 +109,6 @@ kubectl apply --server-side -f examples/eks/nodeconfig-alpha.yaml
 Afterwards, deploy ScyllaDB's [Local Volume Provisioner](https://github.com/scylladb/k8s-local-volume-provisioner), capable of dynamically provisioning PersistentVolumes for your ScyllaDB clusters on mounted XFS filesystems, earlier created over the configured RAID0 arrays.
 ```
 kubectl -n local-csi-driver apply --server-side -f examples/common/local-volume-provisioner/local-csi-driver/
-kubectl apply --server-side -f examples/common/local-volume-provisioner/storageclass_xfs.yaml
 ```
 
 ### Deploying ScyllaDB


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Updating documentation found here:
https://operator.docs.scylladb.com/stable/eks.html

This example was removed as part of:
https://github.com/scylladb/scylla-operator/pull/1656

This second command can be excluded since the [previous command](https://github.com/scylladb/scylla-operator/pull/1906/files#diff-f31a96e9e0def6479f45a1c4a50e62b932a752c1934d64691b0ea2788613edc2R111) would now pick it up as it was moved to:  `examples/common/local-volume-provisioner/local-csi-driver`

**Which issue is resolved by this Pull Request:**
Resolves #1905 
