### PR TITLE
Bump k8s-local-volume-provisioner to 0.3.2-rc.0 in CI

### DIFF
--- a/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/k8s-local-volume-provisioner:0.3.1-rc.0@sha256:2b21dc3b391f9b60f9e9ed61a7fb55557d0f80bca935aa1d9dc9211e25b47d54
+        image: docker.io/scylladb/k8s-local-volume-provisioner:0.3.2-rc.0@sha256:4ac3e29314bad1291ef9fcf8fdad45c743e0cef9d35d887e073b0f872e92254e
         imagePullPolicy: IfNotPresent
         args:
         - --listen=/csi/csi.sock


### PR DESCRIPTION
To build trust in release candidate let's use it for a while on CI.

