### PR TITLE
Fix assertion in e2e testing ingress connectivity

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -141,7 +141,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 				di := insertAndVerifyCQLData(ctx, hosts, utils.WithSession(&session))
 				di.Close()
-			}).WithTimeout(30 * time.Second).WithPolling(time.Second)
+			}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(o.Succeed())
 		}
 	})
 


### PR DESCRIPTION
`Eventually` block without `.Should(o.Succeed())` silently passes after first failed execution. This adds this missing assertion fixing the test.
