### PR TITLE
Unify artifacts dir naming to match Prow default dir

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -15,10 +15,10 @@ if [[ -z ${1+x} ]]; then
     exit 1
 fi
 
-ARTIFACTS_DIR=${ARTIFACTS_DIR:-$( mktemp -d )}
+ARTIFACTS=${ARTIFACTS:-$( mktemp -d )}
 OPERATOR_IMAGE_REF=${1}
 
-deploy_dir=${ARTIFACTS_DIR}/deploy
+deploy_dir=${ARTIFACTS}/deploy
 mkdir -p "${deploy_dir}/"{operator,manager,prometheus-operator,haproxy-ingress}
 
 cp ./deploy/manager/dev/*.yaml "${deploy_dir}/manager"


### PR DESCRIPTION
**Description of your changes:**
This PR unifies artifacts directory name to `ARTIFACTS` to match Prow supplied variable. Other places are already using it.

**Which issue is resolved by this Pull Request:**
https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/1837/pull-scylla-operator-master-e2e-gke-parallel/1791020517587685376#1:test-build-log.txt%3A120
