### PR TITLE
Add version command

### DIFF
--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"fmt"
 
+	versioncmd "github.com/scylladb/scylla-operator/pkg/cmd/version"
 	"github.com/scylladb/scylla-operator/pkg/cmdutil"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
 	"github.com/scylladb/scylla-operator/pkg/naming"
@@ -31,6 +32,7 @@ func NewOperatorCommand(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
+	cmd.AddCommand(versioncmd.NewCmd(streams))
 	cmd.AddCommand(NewOperatorCmd(streams))
 	cmd.AddCommand(NewWebhookCmd(streams))
 	cmd.AddCommand(NewSidecarCmd(streams))

--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 
+	versioncmd "github.com/scylladb/scylla-operator/pkg/cmd/version"
 	"github.com/scylladb/scylla-operator/pkg/cmdutil"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
 	ginkgotest "github.com/scylladb/scylla-operator/pkg/test/ginkgo"
@@ -77,6 +78,7 @@ func NewTestsCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	userAgent := "scylla-operator-e2e"
+	cmd.AddCommand(versioncmd.NewCmd(streams))
 	cmd.AddCommand(NewRunCommand(streams, Suites, userAgent))
 
 	// TODO: wrap help func for the root command and every subcommand to add a line about automatic env vars and the prefix.

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2024 ScyllaDB
+
+package version
+
+import (
+	"fmt"
+
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/version"
+	"github.com/spf13/cobra"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+type Options struct {
+}
+
+func NewOptions(streams genericclioptions.IOStreams) *Options {
+	return &Options{}
+}
+
+func NewCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints version.",
+		Long: templates.LongDesc(`
+		version prints the program version.
+		`),
+		Example: templates.Examples(fmt.Sprintf(`
+		# Print the program version
+		version
+		`)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate()
+			if err != nil {
+				return err
+			}
+
+			err = o.Complete()
+			if err != nil {
+				return err
+			}
+
+			err = o.Run(streams, cmd)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		ValidArgs: []string{},
+
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	return cmd
+}
+
+func (o *Options) Validate() error {
+	var errs []error
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func (o *Options) Complete() error {
+	return nil
+}
+
+func (o *Options) Run(originalStreams genericclioptions.IOStreams, cmd *cobra.Command) error {
+	fmt.Printf("%s: %s\n", cmd.Name(), version.Get())
+	return nil
+}


### PR DESCRIPTION
**Description of your changes:**
This PR add `version` command to `scylla-operator` and `scylla-operator-tests` binary so it's easy to figure out where the code was build from.

