### PR TITLE
Split ScyllaDB API status probes into a dedicated container

### DIFF
--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"fmt"
 
+	"github.com/scylladb/scylla-operator/pkg/cmd/operator/probeserver"
 	versioncmd "github.com/scylladb/scylla-operator/pkg/cmd/version"
 	"github.com/scylladb/scylla-operator/pkg/cmdutil"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
@@ -41,6 +42,7 @@ func NewOperatorCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(NewCleanupJobCmd(streams))
 	cmd.AddCommand(NewGatherCmd(streams))
 	cmd.AddCommand(NewMustGatherCmd(streams))
+	cmd.AddCommand(probeserver.NewServeProbesCmd(streams))
 
 	// TODO: wrap help func for the root command and every subcommand to add a line about automatic env vars and the prefix.
 

--- a/pkg/cmd/operator/probeserver/cmd.go
+++ b/pkg/cmd/operator/probeserver/cmd.go
@@ -1,0 +1,18 @@
+package probeserver
+
+import (
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/spf13/cobra"
+)
+
+func NewServeProbesCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "serve-probes",
+		Short:  "Internal command used by Scylla Operator to interface Kubernetes probes and ScyllaDB internal status.",
+		Hidden: true,
+	}
+
+	cmd.AddCommand(NewScyllaDBAPIStatusCmd(streams))
+
+	return cmd
+}

--- a/pkg/cmd/operator/probeserver/scylladbapistatus.go
+++ b/pkg/cmd/operator/probeserver/scylladbapistatus.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
 	"github.com/scylladb/scylla-operator/pkg/naming"
-	"github.com/scylladb/scylla-operator/pkg/sidecar"
+	"github.com/scylladb/scylla-operator/pkg/probeserver/scylladbapistatus"
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
@@ -157,7 +157,7 @@ func (o *ScyllaDBAPIStatusOptions) Execute(ctx context.Context, originalStreams 
 	)
 	singleServiceInformer := singleServiceKubeInformers.Core().V1().Services()
 
-	prober := sidecar.NewProber(
+	prober := scylladbapistatus.NewProber(
 		o.Namespace,
 		o.ServiceName,
 		singleServiceInformer.Lister(),

--- a/pkg/cmd/operator/probeserver/scylladbapistatus.go
+++ b/pkg/cmd/operator/probeserver/scylladbapistatus.go
@@ -1,0 +1,179 @@
+package probeserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/sidecar"
+	"github.com/scylladb/scylla-operator/pkg/signals"
+	"github.com/scylladb/scylla-operator/pkg/version"
+	"github.com/spf13/cobra"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+)
+
+type ScyllaDBAPIStatusOptions struct {
+	ServeProbesOptions
+
+	genericclioptions.ClientConfig
+	genericclioptions.InClusterReflection
+	ServiceName string
+
+	mux        *http.ServeMux
+	kubeClient kubernetes.Interface
+}
+
+func NewScyllaDBAPIStatusOptions(streams genericclioptions.IOStreams) *ScyllaDBAPIStatusOptions {
+	mux := http.NewServeMux()
+
+	return &ScyllaDBAPIStatusOptions{
+		ServeProbesOptions: *NewServeProbesOptions(streams, naming.ScyllaDBAPIStatusProbePort, mux),
+		ClientConfig:       genericclioptions.NewClientConfig("scylla-operator-scylladb-api-status-probe"),
+		mux:                mux,
+	}
+}
+
+func (o *ScyllaDBAPIStatusOptions) AddFlags(cmd *cobra.Command) {
+	o.ServeProbesOptions.AddFlags(cmd)
+	o.ClientConfig.AddFlags(cmd)
+	o.InClusterReflection.AddFlags(cmd)
+
+	cmd.Flags().StringVarP(&o.ServiceName, "service-name", "", o.ServiceName, "Name of the service corresponding to the managed node.")
+}
+
+func NewScyllaDBAPIStatusCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewScyllaDBAPIStatusOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "scylladb-api-status",
+		Short: "Serves probes based on ScyllaDB API status.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate(args)
+			if err != nil {
+				return err
+			}
+
+			err = o.Complete(args)
+			if err != nil {
+				return err
+			}
+
+			err = o.Run(streams, cmd)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}
+
+func (o *ScyllaDBAPIStatusOptions) Validate(args []string) error {
+	var errs []error
+
+	errs = append(errs, o.ServeProbesOptions.Validate(args))
+	errs = append(errs, o.ClientConfig.Validate())
+	errs = append(errs, o.InClusterReflection.Validate())
+
+	if len(o.ServiceName) == 0 {
+		errs = append(errs, fmt.Errorf("service-name can't be empty"))
+	} else {
+		serviceNameValidationErrs := apimachineryvalidation.NameIsDNS1035Label(o.ServiceName, false)
+		if len(serviceNameValidationErrs) != 0 {
+			errs = append(errs, fmt.Errorf("invalid service name %q: %v", o.ServiceName, serviceNameValidationErrs))
+		}
+	}
+
+	return apierrors.NewAggregate(errs)
+}
+
+func (o *ScyllaDBAPIStatusOptions) Complete(args []string) error {
+	err := o.ServeProbesOptions.Complete(args)
+	if err != nil {
+		return err
+	}
+
+	err = o.ClientConfig.Complete()
+	if err != nil {
+		return err
+	}
+
+	err = o.InClusterReflection.Complete()
+	if err != nil {
+		return err
+	}
+
+	o.kubeClient, err = kubernetes.NewForConfig(o.ProtoConfig)
+	if err != nil {
+		return fmt.Errorf("can't build kubernetes clientset: %w", err)
+	}
+
+	return nil
+}
+
+func (o *ScyllaDBAPIStatusOptions) Run(originalStreams genericclioptions.IOStreams, cmd *cobra.Command) (returnErr error) {
+	klog.Infof("%s version %s", cmd.Name(), version.Get())
+	cliflag.PrintFlags(cmd.Flags())
+
+	stopCh := signals.StopChannel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	return o.Execute(ctx, originalStreams, cmd)
+}
+
+func (o *ScyllaDBAPIStatusOptions) Execute(ctx context.Context, originalStreams genericclioptions.IOStreams, cmd *cobra.Command) (returnErr error) {
+	singleServiceKubeInformers := informers.NewSharedInformerFactoryWithOptions(
+		o.kubeClient,
+		12*time.Hour,
+		informers.WithNamespace(o.Namespace),
+		informers.WithTweakListOptions(
+			func(options *metav1.ListOptions) {
+				options.FieldSelector = fields.OneTermEqualSelector("metadata.name", o.ServiceName).String()
+			},
+		),
+	)
+	singleServiceInformer := singleServiceKubeInformers.Core().V1().Services()
+
+	prober := sidecar.NewProber(
+		o.Namespace,
+		o.ServiceName,
+		singleServiceInformer.Lister(),
+	)
+
+	o.mux.HandleFunc(naming.LivenessProbePath, prober.Healthz)
+	o.mux.HandleFunc(naming.ReadinessProbePath, prober.Readyz)
+
+	// Start informers.
+	singleServiceKubeInformers.Start(ctx.Done())
+	defer singleServiceKubeInformers.Shutdown()
+
+	ok := cache.WaitForNamedCacheSync("Prober", ctx.Done(), singleServiceInformer.Informer().HasSynced)
+	if !ok {
+		return fmt.Errorf("error waiting for service informer cache to sync")
+	}
+
+	return o.ServeProbesOptions.Execute(ctx, originalStreams, cmd)
+}

--- a/pkg/cmd/operator/probeserver/serveprobes.go
+++ b/pkg/cmd/operator/probeserver/serveprobes.go
@@ -1,0 +1,104 @@
+package probeserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/signals"
+	"github.com/scylladb/scylla-operator/pkg/version"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+)
+
+type ServeProbesOptions struct {
+	Address string
+	Port    uint16
+
+	handler http.Handler
+}
+
+func NewServeProbesOptions(streams genericclioptions.IOStreams, port uint16, handler http.Handler) *ServeProbesOptions {
+	return &ServeProbesOptions{
+		Address: "",
+		Port:    port,
+		handler: handler,
+	}
+}
+func (o *ServeProbesOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Address, "address", "", o.Address, "Listen address for the server.")
+	cmd.Flags().Uint16VarP(&o.Port, "port", "", o.Port, "Port to use for the server.")
+}
+
+func (o *ServeProbesOptions) Validate(args []string) error {
+	var errs []error
+
+	return apierrors.NewAggregate(errs)
+}
+
+func (o *ServeProbesOptions) Complete(args []string) error {
+	return nil
+}
+
+func (o *ServeProbesOptions) Run(originalStreams genericclioptions.IOStreams, cmd *cobra.Command) (returnErr error) {
+	klog.Infof("%s version %s", cmd.Name(), version.Get())
+	cliflag.PrintFlags(cmd.Flags())
+
+	stopCh := signals.StopChannel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	return o.Execute(ctx, originalStreams, cmd)
+}
+
+func (o *ServeProbesOptions) Execute(ctx context.Context, originalStreams genericclioptions.IOStreams, cmd *cobra.Command) error {
+	server := &http.Server{
+		Addr:    net.JoinHostPort(o.Address, strconv.Itoa(int(o.Port))),
+		Handler: o.handler,
+	}
+
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return fmt.Errorf("can't create tcp listener on addess %q: %w", server.Addr, err)
+	}
+
+	resolvedListenAddr := listener.Addr().String()
+	klog.InfoS("Starting probe server", "Address", resolvedListenAddr)
+	defer klog.InfoS("Probe server shut down")
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		<-ctx.Done()
+		klog.Infof("Shutting down probe server.")
+		shutdownCtx, shutdownCtxCancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer shutdownCtxCancel()
+		err := server.Shutdown(shutdownCtx)
+		if err != nil {
+			klog.ErrorS(err, "can't shut down the server")
+		}
+	}()
+
+	err = server.Serve(listener)
+	if !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -676,7 +676,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 								PeriodSeconds:    int32(10),
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Port: intstr.FromInt(naming.ProbePort),
+										Port: intstr.FromInt(naming.ScyllaDBAPIStatusProbePort),
 										Path: naming.LivenessProbePath,
 									},
 								},
@@ -689,7 +689,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 								PeriodSeconds:    int32(10),
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Port: intstr.FromInt(naming.ProbePort),
+										Port: intstr.FromInt(naming.ScyllaDBAPIStatusProbePort),
 										Path: naming.LivenessProbePath,
 									},
 								},
@@ -703,7 +703,7 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 								PeriodSeconds:    int32(readinessPeriodSeconds),
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Port: intstr.FromInt(naming.ProbePort),
+										Port: intstr.FromInt(naming.ScyllaDBAPIStatusProbePort),
 										Path: naming.ReadinessProbePath,
 									},
 								},
@@ -725,6 +725,51 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 											fmt.Sprintf("nodetool drain & sleep %d & wait", minTerminationGracePeriodSeconds),
 										},
 									},
+								},
+							},
+						},
+						{
+							// ScyllaDB doesn't provide readiness or liveness probe,
+							// so we use our own probe sidecar to expose such endpoints.
+							Name:            "scylladb-api-status-probe",
+							Image:           sidecarImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command: []string{
+								"/usr/bin/scylla-operator",
+								"serve-probes",
+								"scylladb-api-status",
+								fmt.Sprintf("--port=%d", naming.ScyllaDBAPIStatusProbePort),
+								"--service-name=$(SERVICE_NAME)",
+								"--loglevel=2",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "SERVICE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								TimeoutSeconds:   int32(30),
+								FailureThreshold: int32(1),
+								PeriodSeconds:    int32(5),
+								ProbeHandler: corev1.ProbeHandler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt32(naming.ScyllaDBAPIStatusProbePort),
+									},
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("40Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("40Mi"),
 								},
 							},
 						},

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -991,6 +991,49 @@ func TestStatefulSetForRack(t *testing.T) {
 								},
 							},
 							{
+								Name:            "scylladb-api-status-probe",
+								Image:           "scylladb/scylla-operator:latest",
+								ImagePullPolicy: corev1.PullIfNotPresent,
+								Command: []string{
+									"/usr/bin/scylla-operator",
+									"serve-probes",
+									"scylladb-api-status",
+									"--port=8080",
+									"--service-name=$(SERVICE_NAME)",
+									"--loglevel=2",
+								},
+								Env: []corev1.EnvVar{
+									{
+										Name: "SERVICE_NAME",
+										ValueFrom: &corev1.EnvVarSource{
+											FieldRef: &corev1.ObjectFieldSelector{
+												FieldPath: "metadata.name",
+											},
+										},
+									},
+								},
+								ReadinessProbe: &corev1.Probe{
+									TimeoutSeconds:   int32(30),
+									FailureThreshold: int32(1),
+									PeriodSeconds:    int32(5),
+									ProbeHandler: corev1.ProbeHandler{
+										TCPSocket: &corev1.TCPSocketAction{
+											Port: intstr.FromInt32(naming.ScyllaDBAPIStatusProbePort),
+										},
+									},
+								},
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("40Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("40Mi"),
+									},
+								},
+							},
+							{
 								Name:            "scylla-manager-agent",
 								Image:           ":",
 								ImagePullPolicy: corev1.PullIfNotPresent,

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -122,10 +122,10 @@ const (
 
 	DataDir = "/var/lib/scylla"
 
-	ReadinessProbePath = "/readyz"
-	LivenessProbePath  = "/healthz"
-	ProbePort          = 8080
-	ScyllaAPIPort      = 10000
+	ReadinessProbePath         = "/readyz"
+	LivenessProbePath          = "/healthz"
+	ScyllaDBAPIStatusProbePort = 8080
+	ScyllaAPIPort              = 10000
 
 	OperatorEnvVarPrefix = "SCYLLA_OPERATOR_"
 )

--- a/pkg/probeserver/scylladbapistatus/prober.go
+++ b/pkg/probeserver/scylladbapistatus/prober.go
@@ -1,4 +1,4 @@
-package sidecar
+package scylladbapistatus
 
 import (
 	"context"


### PR DESCRIPTION
**Description of your changes:**
At this point, [ScyllaDB doesn't provide](https://github.com/scylladb/scylladb/issues/8275) standardized `/readyz` and `/healthz` probes, so we serve a wrapper around CQL status (with some tweak) from an operator binary. This is unfortunately running in the same container as ScyllaDB and shares the cpu quota with it and has a negative impact on latency. There are others but this is a first step towards fixing and probes are really the really problematic ones as they serve continuously.

This PR move ScyllaDB probes to run in a separate container so it run in a separate cpu slice and doesn't affect ScyllaDB latency. This is also more architecturally clean and is a step forward to stop coping the operator binary into ScyllaDB container. It also abstracts generic probe patterns and related objects, so we can add other probes in the future, like for the Alternator or other APIs.

This also puts the probe logs at a correct place and no longer mix them with ScyllaDB logs.

**Which issue is resolved by this Pull Request:**
Resolves #620
