### PR TITLE
 [v1.11] Bump local volume provisioner to 3.2.0

### DIFF
--- a/.github/actions/setup-local-volume-provisioner/manifests/local-csi-driver/50_daemonset.yaml
+++ b/.github/actions/setup-local-volume-provisioner/manifests/local-csi-driver/50_daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/k8s-local-volume-provisioner:0.1.0@sha256:d8c12e96d352077fd4b639c8e4fb050e49e0be11161d78d9339b69f73466f59a
+        image: docker.io/scylladb/k8s-local-volume-provisioner:0.3.2@sha256:4ac3e29314bad1291ef9fcf8fdad45c743e0cef9d35d887e073b0f872e92254e
         imagePullPolicy: Always
         args:
         - --listen=/csi/csi.sock

--- a/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
+++ b/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/k8s-local-volume-provisioner:0.1.0@sha256:d8c12e96d352077fd4b639c8e4fb050e49e0be11161d78d9339b69f73466f59a
+        image: docker.io/scylladb/k8s-local-volume-provisioner:0.3.2@sha256:4ac3e29314bad1291ef9fcf8fdad45c743e0cef9d35d887e073b0f872e92254e
         imagePullPolicy: Always
         args:
         - --listen=/csi/csi.sock

--- a/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/k8s-local-volume-provisioner:0.1
+        image: docker.io/scylladb/k8s-local-volume-provisioner:0.3.2@sha256:4ac3e29314bad1291ef9fcf8fdad45c743e0cef9d35d887e073b0f872e92254e
         imagePullPolicy: IfNotPresent
         args:
         - --listen=/csi/csi.sock


### PR DESCRIPTION
Backport of https://github.com/scylladb/scylla-operator/pull/1927

/hold for https://github.com/scylladb/scylla-operator/pull/1927