### PR TITLE
Split startup logic out of ScyllaDB container

### DIFF
--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -43,6 +43,7 @@ func NewOperatorCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(NewGatherCmd(streams))
 	cmd.AddCommand(NewMustGatherCmd(streams))
 	cmd.AddCommand(probeserver.NewServeProbesCmd(streams))
+	cmd.AddCommand(NewIgnitionCmd(streams))
 
 	// TODO: wrap help func for the root command and every subcommand to add a line about automatic env vars and the prefix.
 

--- a/pkg/cmd/operator/ignition.go
+++ b/pkg/cmd/operator/ignition.go
@@ -1,0 +1,259 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
+	"github.com/scylladb/scylla-operator/pkg/cmd/operator/probeserver"
+	"github.com/scylladb/scylla-operator/pkg/controller/ignition"
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/signals"
+	"github.com/scylladb/scylla-operator/pkg/version"
+	"github.com/spf13/cobra"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+)
+
+type IgnitionOptions struct {
+	genericclioptions.ClientConfig
+	genericclioptions.InClusterReflection
+	probeserver.ServeProbesOptions
+
+	ServiceName                       string
+	NodesBroadcastAddressTypeString   string
+	ClientsBroadcastAddressTypeString string
+
+	kubeClient                  kubernetes.Interface
+	mux                         *http.ServeMux
+	nodesBroadcastAddressType   scyllav1.BroadcastAddressType
+	clientsBroadcastAddressType scyllav1.BroadcastAddressType
+}
+
+func NewIgnitionOptions(streams genericclioptions.IOStreams) *IgnitionOptions {
+	mux := http.NewServeMux()
+
+	return &IgnitionOptions{
+		ServeProbesOptions: *probeserver.NewServeProbesOptions(streams, naming.ScyllaDBIgnitionProbePort, mux),
+		ClientConfig:       genericclioptions.NewClientConfig("scylla-operator-ignition"),
+		mux:                mux,
+	}
+}
+
+func (o *IgnitionOptions) AddFlags(cmd *cobra.Command) {
+	o.ClientConfig.AddFlags(cmd)
+	o.InClusterReflection.AddFlags(cmd)
+	o.ServeProbesOptions.AddFlags(cmd)
+
+	cmd.Flags().StringVarP(&o.ServiceName, "service-name", "", o.ServiceName, "Name of the service corresponding to the managed node.")
+	cmd.Flags().StringVarP(&o.NodesBroadcastAddressTypeString, "nodes-broadcast-address-type", "", o.NodesBroadcastAddressTypeString, "Address type that is broadcasted for communication with other nodes.")
+	cmd.Flags().StringVarP(&o.ClientsBroadcastAddressTypeString, "clients-broadcast-address-type", "", o.ClientsBroadcastAddressTypeString, "Address type that is broadcasted for communication with clients.")
+
+}
+
+func NewIgnitionCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewIgnitionOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "run-ignition",
+		Short: "Bootstraps necessary configurations and waits for tuning to finish.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate(args)
+			if err != nil {
+				return err
+			}
+
+			err = o.Complete(args)
+			if err != nil {
+				return err
+			}
+
+			err = o.Run(streams, cmd)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Hidden:        true,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}
+
+func (o *IgnitionOptions) Validate(args []string) error {
+	var errs []error
+
+	errs = append(errs, o.ClientConfig.Validate())
+	errs = append(errs, o.InClusterReflection.Validate())
+	errs = append(errs, o.ServeProbesOptions.Validate(args))
+
+	if len(o.ServiceName) == 0 {
+		errs = append(errs, fmt.Errorf("service-name can't be empty"))
+	} else {
+		serviceNameValidationErrs := apimachineryvalidation.NameIsDNS1035Label(o.ServiceName, false)
+		if len(serviceNameValidationErrs) != 0 {
+			errs = append(errs, fmt.Errorf("invalid service name %q: %v", o.ServiceName, serviceNameValidationErrs))
+		}
+	}
+
+	if !slices.ContainsItem(validation.SupportedBroadcastAddressTypes, scyllav1.BroadcastAddressType(o.NodesBroadcastAddressTypeString)) {
+		errs = append(errs, fmt.Errorf("unsupported value of nodes-broadcast-address-type %q, supported ones are: %v", o.NodesBroadcastAddressTypeString, validation.SupportedBroadcastAddressTypes))
+	}
+
+	if !slices.ContainsItem(validation.SupportedBroadcastAddressTypes, scyllav1.BroadcastAddressType(o.ClientsBroadcastAddressTypeString)) {
+		errs = append(errs, fmt.Errorf("unsupported value of clients-broadcast-address-type %q, supported ones are: %v", o.ClientsBroadcastAddressTypeString, validation.SupportedBroadcastAddressTypes))
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func (o *IgnitionOptions) Complete(args []string) error {
+	err := o.ClientConfig.Complete()
+	if err != nil {
+		return err
+	}
+
+	err = o.InClusterReflection.Complete()
+	if err != nil {
+		return err
+	}
+
+	err = o.ServeProbesOptions.Complete(args)
+	if err != nil {
+		return err
+	}
+
+	o.kubeClient, err = kubernetes.NewForConfig(o.ProtoConfig)
+	if err != nil {
+		return fmt.Errorf("can't build kubernetes clientset: %w", err)
+	}
+
+	o.nodesBroadcastAddressType = scyllav1.BroadcastAddressType(o.NodesBroadcastAddressTypeString)
+	o.clientsBroadcastAddressType = scyllav1.BroadcastAddressType(o.ClientsBroadcastAddressTypeString)
+
+	return nil
+}
+
+func (o *IgnitionOptions) Run(originalStreams genericclioptions.IOStreams, cmd *cobra.Command) (returnErr error) {
+	klog.Infof("%s version %s", cmd.Name(), version.Get())
+	cliflag.PrintFlags(cmd.Flags())
+
+	stopCh := signals.StopChannel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	return o.Execute(ctx, originalStreams, cmd)
+}
+
+func (o *IgnitionOptions) Execute(cmdCtx context.Context, originalStreams genericclioptions.IOStreams, cmd *cobra.Command) error {
+	identityKubeInformers := informers.NewSharedInformerFactoryWithOptions(
+		o.kubeClient,
+		12*time.Hour,
+		informers.WithNamespace(o.Namespace),
+		informers.WithTweakListOptions(
+			func(options *metav1.ListOptions) {
+				options.FieldSelector = fields.OneTermEqualSelector("metadata.name", o.ServiceName).String()
+			},
+		),
+	)
+	nodeconfigDataCMKubeInformers := informers.NewSharedInformerFactoryWithOptions(
+		o.kubeClient,
+		12*time.Hour,
+		informers.WithNamespace(o.Namespace),
+		informers.WithTweakListOptions(
+			func(options *metav1.ListOptions) {
+				options.LabelSelector = labels.Set{
+					naming.ConfigMapTypeLabel: string(naming.NodeConfigDataConfigMapType),
+				}.String()
+			},
+		),
+	)
+
+	ignitionController, err := ignition.NewController(
+		o.Namespace,
+		o.ServiceName,
+		o.nodesBroadcastAddressType,
+		o.nodesBroadcastAddressType,
+		o.kubeClient,
+		nodeconfigDataCMKubeInformers.Core().V1().ConfigMaps(),
+		identityKubeInformers.Core().V1().Services(),
+		identityKubeInformers.Core().V1().Pods(),
+	)
+	if err != nil {
+		return fmt.Errorf("can't create ignition controller: %w", err)
+	}
+
+	readyzFunc := func(w http.ResponseWriter, r *http.Request) {
+		ignited := ignitionController.IsIgnited()
+		klog.V(3).InfoS("Probe call", "URI", r.RequestURI, "Ignited", ignited)
+		if !ignited {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		return
+	}
+	o.mux.HandleFunc(naming.ReadinessProbePath, readyzFunc)
+
+	var wg sync.WaitGroup
+	defer func() {
+		klog.InfoS("Waiting for background tasks to finish")
+		wg.Wait()
+		klog.InfoS("Background tasks have finished")
+	}()
+
+	ctx, taskCtxCancel := context.WithCancel(cmdCtx)
+	defer taskCtxCancel()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		identityKubeInformers.Start(ctx.Done())
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		nodeconfigDataCMKubeInformers.Start(ctx.Done())
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		err := o.ServeProbesOptions.Execute(ctx, originalStreams, cmd)
+		if err != nil {
+			klog.ErrorS(err, "Error running probe server")
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ignitionController.Run(ctx)
+	}()
+
+	<-cmdCtx.Done()
+
+	return nil
+}

--- a/pkg/cmd/operator/sidecar.go
+++ b/pkg/cmd/operator/sidecar.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"syscall"
@@ -12,30 +11,20 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
 	scyllaversionedclient "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
 	sidecarcontroller "github.com/scylladb/scylla-operator/pkg/controller/sidecar"
-	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
-	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
-	"github.com/scylladb/scylla-operator/pkg/internalapi"
-	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/sidecar/config"
 	"github.com/scylladb/scylla-operator/pkg/sidecar/identity"
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	watchtools "k8s.io/client-go/tools/watch"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 )
@@ -209,140 +198,19 @@ func (o *SidecarOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Com
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
-	// Wait for the service that holds identity for this scylla node.
-	klog.V(2).InfoS("Waiting for Service availability and IP address", "Service", naming.ManualRef(o.Namespace, o.ServiceName))
-	service, err := controllerhelpers.WaitForServiceState(
-		ctx,
-		o.kubeClient.CoreV1().Services(o.Namespace),
-		o.ServiceName,
-		controllerhelpers.WaitForStateOptions{},
-		func(service *corev1.Service) (bool, error) {
-			if o.clientsBroadcastAddressType == scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress ||
-				o.nodesBroadcastAddressType == scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress {
-				if len(service.Status.LoadBalancer.Ingress) == 0 {
-					klog.V(4).InfoS("LoadBalancer Service is awaiting for public endpoint")
-					return false, nil
-				}
-			}
-
-			return true, nil
-		},
-	)
+	service, err := singleServiceInformer.Lister().Services(o.Namespace).Get(o.ServiceName)
 	if err != nil {
-		return fmt.Errorf("can't wait for service %q: %w", naming.ManualRef(o.Namespace, o.ServiceName), err)
+		return fmt.Errorf("can't get service %q: %w", o.ServiceName, err)
 	}
 
-	// Wait for this Pod to have ContainerID set.
-	klog.V(2).InfoS("Waiting for Pod to have IP address assigned and scylla ContainerID set", "Pod", naming.ManualRef(o.Namespace, o.ServiceName))
-	var containerID string
-	pod, err := controllerhelpers.WaitForPodState(
-		ctx,
-		o.kubeClient.CoreV1().Pods(o.Namespace),
-		o.ServiceName,
-		controllerhelpers.WaitForStateOptions{},
-		func(pod *corev1.Pod) (bool, error) {
-			if len(pod.Status.PodIP) == 0 {
-				klog.V(4).InfoS("PodIP is not yet set", "Pod", klog.KObj(pod))
-				return false, nil
-			}
-
-			containerID, err = controllerhelpers.GetScyllaContainerID(pod)
-			if err != nil {
-				klog.Warningf("can't get scylla container id in pod %q: %v", naming.ObjRef(pod), err)
-				return false, nil
-			}
-
-			if len(containerID) == 0 {
-				klog.V(4).InfoS("ContainerID is not yet set", "Pod", klog.KObj(pod))
-				return false, nil
-			}
-
-			return true, nil
-		},
-	)
+	pod, err := o.kubeClient.CoreV1().Pods(o.Namespace).Get(ctx, o.ServiceName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("can't wait for pod's ContainerID: %w", err)
+		return fmt.Errorf("can't get pod %q: %w", o.ServiceName, err)
 	}
 
 	member, err := identity.NewMember(service, pod, o.nodesBroadcastAddressType, o.clientsBroadcastAddressType)
 	if err != nil {
 		return fmt.Errorf("can't create new member from objects: %w", err)
-	}
-
-	labelSelector := labels.Set{
-		naming.OwnerUIDLabel:      string(pod.UID),
-		naming.ConfigMapTypeLabel: string(naming.NodeConfigDataConfigMapType),
-	}.AsSelector()
-	podLW := &cache.ListWatch{
-		ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
-			options.LabelSelector = labelSelector.String()
-			return o.kubeClient.CoreV1().ConfigMaps(pod.Namespace).List(ctx, options)
-		}),
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			options.LabelSelector = labelSelector.String()
-			return o.kubeClient.CoreV1().ConfigMaps(pod.Namespace).Watch(ctx, options)
-		},
-	}
-	klog.V(2).InfoS("Waiting for NodeConfig's data ConfigMap ", "Selector", labelSelector.String())
-	_, err = watchtools.UntilWithSync(
-		ctx,
-		podLW,
-		&corev1.ConfigMap{},
-		nil,
-		func(e watch.Event) (bool, error) {
-			switch t := e.Type; t {
-			case watch.Added, watch.Modified:
-				cm := e.Object.(*corev1.ConfigMap)
-
-				if cm.Data == nil {
-					klog.V(4).InfoS("ConfigMap missing data", "ConfigMap", klog.KObj(cm))
-					return false, nil
-				}
-
-				srcData, found := cm.Data[naming.ScyllaRuntimeConfigKey]
-				if !found {
-					klog.V(4).InfoS("ConfigMap is missing key", "ConfigMap", klog.KObj(cm), "Key", naming.ScyllaRuntimeConfigKey)
-					return false, nil
-				}
-
-				src := &internalapi.SidecarRuntimeConfig{}
-				err = json.Unmarshal([]byte(srcData), src)
-				if err != nil {
-					klog.V(4).ErrorS(err, "Can't unmarshal scylla runtime config", "ConfigMap", klog.KObj(cm), "Key", naming.ScyllaRuntimeConfigKey)
-					return false, nil
-				}
-
-				if src.ContainerID != containerID {
-					klog.V(4).InfoS("Scylla runtime config is not yet updated with our container id",
-						"ConfigMap", klog.KObj(cm),
-						"ConfigContainerID", src.ContainerID,
-						"SidecarContainerID", containerID,
-					)
-					return false, nil
-				}
-
-				if len(src.BlockingNodeConfigs) > 0 {
-					klog.V(4).InfoS("Waiting on NodeConfig(s)",
-						"ConfigMap", klog.KObj(cm),
-						"ContainerID", containerID,
-						"NodeConfig", src.BlockingNodeConfigs,
-					)
-					return false, nil
-				}
-
-				klog.V(4).InfoS("ConfigMap container ready", "ConfigMap", klog.KObj(cm), "ContainerID", containerID)
-				return true, nil
-
-			case watch.Error:
-				return true, apierrors.FromObject(e.Object)
-
-			default:
-				return true, fmt.Errorf("unexpected event type %v", t)
-			}
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("can't wait for optimization: %w", err)
 	}
 
 	klog.V(2).InfoS("Starting scylla")

--- a/pkg/controller/ignition/controller.go
+++ b/pkg/controller/ignition/controller.go
@@ -1,0 +1,217 @@
+package ignition
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/controllertools"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+)
+
+type Controller struct {
+	*controllertools.Observer
+
+	namespace                   string
+	serviceName                 string
+	nodesBroadcastAddressType   scyllav1.BroadcastAddressType
+	clientsBroadcastAddressType scyllav1.BroadcastAddressType
+
+	ignited atomic.Bool
+
+	configMapLister corev1listers.ConfigMapLister
+	serviceLister   corev1listers.ServiceLister
+	podLister       corev1listers.PodLister
+}
+
+func NewController(
+	namespace string,
+	serviceName string,
+	clientsBroadcastAddressType scyllav1.BroadcastAddressType,
+	nodesBroadcastAddressType scyllav1.BroadcastAddressType,
+	kubeClient kubernetes.Interface,
+	configMapInformer corev1informers.ConfigMapInformer,
+	serviceInformer corev1informers.ServiceInformer,
+	podInformer corev1informers.PodInformer,
+) (*Controller, error) {
+	controller := &Controller{
+		namespace:                   namespace,
+		serviceName:                 serviceName,
+		clientsBroadcastAddressType: clientsBroadcastAddressType,
+		nodesBroadcastAddressType:   nodesBroadcastAddressType,
+		ignited:                     atomic.Bool{},
+		configMapLister:             configMapInformer.Lister(),
+		serviceLister:               serviceInformer.Lister(),
+		podLister:                   podInformer.Lister(),
+	}
+
+	observer := controllertools.NewObserver(
+		"scylladb-ignition",
+		kubeClient.CoreV1().Events(corev1.NamespaceAll),
+		controller.Sync,
+	)
+
+	configMapHandler, err := configMapInformer.Informer().AddEventHandler(observer.GetGenericHandlers())
+	if err != nil {
+		return nil, fmt.Errorf("can't add ConfigMap event handler: %w", err)
+	}
+	observer.AddCachesToSync(configMapHandler.HasSynced)
+
+	serviceHandler, err := serviceInformer.Informer().AddEventHandler(observer.GetGenericHandlers())
+	if err != nil {
+		return nil, fmt.Errorf("can't add Service event handler: %w", err)
+	}
+	observer.AddCachesToSync(serviceHandler.HasSynced)
+
+	podHandler, err := podInformer.Informer().AddEventHandler(observer.GetGenericHandlers())
+	if err != nil {
+		return nil, fmt.Errorf("can't add Pod event handler: %w", err)
+	}
+	observer.AddCachesToSync(podHandler.HasSynced)
+
+	controller.Observer = observer
+
+	return controller, nil
+}
+
+func (c *Controller) IsIgnited() bool {
+	return c.ignited.Load()
+}
+
+func (c *Controller) Sync(ctx context.Context) error {
+	startTime := time.Now()
+	klog.V(4).InfoS("Started syncing observer", "Name", c.Observer.Name(), "startTime", startTime)
+	defer func() {
+		klog.V(4).InfoS("Finished syncing observer", "Name", c.Observer.Name(), "duration", time.Since(startTime))
+	}()
+
+	ignited := true
+
+	svc, err := c.serviceLister.Services(c.namespace).Get(c.serviceName)
+	if err != nil {
+		return fmt.Errorf("can't get service %q: %w", c.serviceName, err)
+	}
+
+	// TODO: This isn't bound to the lifecycle of the ScyllaDB Pod and should be evaluated in the controller for the resource.
+	//       https://github.com/scylladb/scylla-operator/issues/604
+	if c.clientsBroadcastAddressType == scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress ||
+		c.nodesBroadcastAddressType == scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress {
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			klog.V(2).InfoS(
+				"Waiting for identity service to have at least one ingress point",
+				"Service", naming.ManualRef(c.namespace, c.serviceName),
+			)
+			ignited = false
+		} else {
+			klog.V(2).InfoS(
+				"Service is available and has an IP address",
+				"Service", naming.ManualRef(svc.Namespace, svc.Name),
+				"UID", svc.UID,
+			)
+		}
+	}
+
+	pod, err := c.podLister.Pods(c.namespace).Get(c.serviceName)
+	if err != nil {
+		return fmt.Errorf("can't get pod %q: %w", c.serviceName, err)
+	}
+
+	if len(pod.Status.PodIP) == 0 {
+		klog.V(2).InfoS("PodIP is not yet set", "Pod", klog.KObj(pod), "UID", pod.UID)
+		ignited = false
+	} else {
+		klog.V(2).InfoS("PodIP is present on the Pod", "Pod", klog.KObj(pod), "UID", pod.UID, "IP", pod.Status.PodIP)
+	}
+
+	containerID, err := controllerhelpers.GetScyllaContainerID(pod)
+	if err != nil {
+		return controllertools.NonRetriable(
+			fmt.Errorf("can't get scylla container id in pod %q: %v", naming.ObjRef(pod), err),
+		)
+	}
+
+	if len(containerID) == 0 {
+		klog.V(2).InfoS("ScyllaDB ContainerID is not yet set", "Pod", klog.KObj(pod), "UID", pod.UID)
+		ignited = false
+	} else {
+		klog.V(2).InfoS("Pod has ScyllaDB ContainerID set", "Pod", klog.KObj(pod), "UID", pod.UID, "ContainerID", containerID)
+	}
+
+	cmLabelSelector := labels.Set{
+		naming.OwnerUIDLabel:      string(pod.UID),
+		naming.ConfigMapTypeLabel: string(naming.NodeConfigDataConfigMapType),
+	}.AsSelector()
+	configMaps, err := c.configMapLister.ConfigMaps(c.namespace).List(cmLabelSelector)
+	if err != nil {
+		return fmt.Errorf("can't list tuning configmap: %w", err)
+	}
+
+	switch l := len(configMaps); l {
+	case 0:
+		klog.V(2).InfoS("Tuning ConfigMap for pod is not yet available", "Pod", klog.KObj(pod), "UID", pod.UID)
+		ignited = false
+
+	case 1:
+		cm := configMaps[0]
+		src := &internalapi.SidecarRuntimeConfig{}
+		src, err = controllerhelpers.GetSidecarRuntimeConfigFromConfigMap(cm)
+		if err != nil {
+			return controllertools.NonRetriable(
+				fmt.Errorf("can't get sidecar runtime config from configmap %q: %w", naming.ObjRef(cm), err),
+			)
+		}
+
+		if containerID == src.ContainerID {
+			if len(src.BlockingNodeConfigs) > 0 {
+				klog.V(2).InfoS("Waiting on NodeConfig(s)",
+					"ConfigMap", klog.KObj(cm),
+					"ContainerID", containerID,
+					"NodeConfig", src.BlockingNodeConfigs,
+				)
+				ignited = false
+			}
+		} else {
+			klog.V(2).InfoS("Scylla runtime config is not yet updated with our ContainerID",
+				"ConfigMap", klog.KObj(cm),
+				"ConfigContainerID", src.ContainerID,
+				"SidecarContainerID", containerID,
+			)
+			ignited = false
+		}
+
+	default:
+		return fmt.Errorf("mutiple tuning configmaps are present for pod %q with UID %q", naming.ObjRef(pod), pod.UID)
+	}
+
+	if ignited {
+		klog.V(2).InfoS("Ignition successful", "SignalFile", naming.ScyllaDBIgnitionDonePath)
+	} else {
+		klog.V(2).InfoS("Waiting for ignition to complete.", "SignalFile", naming.ScyllaDBIgnitionDonePath)
+	}
+
+	klog.V(2).InfoS("Updating ignition", "Ignited", ignited, "SignalFile", naming.ScyllaDBIgnitionDonePath)
+
+	oldIgnited := c.ignited.Load()
+	if ignited != oldIgnited {
+		klog.InfoS("Ignition state has changed", "New", ignited, "Old", oldIgnited)
+	}
+	c.ignited.Store(ignited)
+
+	err = helpers.TouchFile(naming.ScyllaDBIgnitionDonePath)
+	if err != nil {
+		return fmt.Errorf("can't touch signal file %q: %w", naming.ScyllaDBIgnitionDonePath, err)
+	}
+
+	return nil
+}

--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -526,9 +526,22 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 							// TODO: unprivileged entrypoint
 							Command: func() []string {
 								cmd := []string{
-									path.Join(naming.SharedDirName, "scylla-operator"),
-									"sidecar",
-									fmt.Sprintf("--feature-gates=%s", func() string {
+									"/usr/bin/bash",
+									"-euEo",
+									"pipefail",
+									"-O",
+									"inherit_errexit",
+									"-c",
+									strings.TrimSpace(`
+printf 'INFO %s ignition - Waiting for /mnt/shared/ignition.done\n' "$( date '+%Y-%m-%d %H:%M:%S,%3N' )" > /dev/stderr
+until [[ -f "/mnt/shared/ignition.done" ]]; do
+  sleep 1;
+done
+printf 'INFO %s ignition - Ignited. Starting ScyllaDB...\n' "$( date '+%Y-%m-%d %H:%M:%S,%3N' )" > /dev/stderr
+
+# TODO: This is where we should start ScyllaDB directly after the sidecar split #1942 
+exec /mnt/shared/scylla-operator sidecar \
+--feature-gates=` + func() string {
 										features := utilfeature.DefaultMutableFeatureGate.GetAll()
 										res := make([]string, 0, len(features))
 										for name := range features {
@@ -536,27 +549,29 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 										}
 										sort.Strings(res)
 										return strings.Join(res, ",")
-									}()),
-									fmt.Sprintf("--nodes-broadcast-address-type=%s", func() scyllav1.BroadcastAddressType {
+									}() + ` \
+--nodes-broadcast-address-type=` + func() string {
 										if c.Spec.ExposeOptions != nil && c.Spec.ExposeOptions.BroadcastOptions != nil {
-											return c.Spec.ExposeOptions.BroadcastOptions.Nodes.Type
+											return string(c.Spec.ExposeOptions.BroadcastOptions.Nodes.Type)
 										}
-										return scyllav1.BroadcastAddressTypeServiceClusterIP
-									}()),
-									fmt.Sprintf("--clients-broadcast-address-type=%s", func() scyllav1.BroadcastAddressType {
+										return string(scyllav1.BroadcastAddressTypeServiceClusterIP)
+									}() + ` \
+--clients-broadcast-address-type=` + func() string {
 										if c.Spec.ExposeOptions != nil && c.Spec.ExposeOptions.BroadcastOptions != nil {
-											return c.Spec.ExposeOptions.BroadcastOptions.Clients.Type
+											return string(c.Spec.ExposeOptions.BroadcastOptions.Clients.Type)
 										}
-										return scyllav1.BroadcastAddressTypeServiceClusterIP
-									}()),
-									"--service-name=$(SERVICE_NAME)",
-									"--cpu-count=$(CPU_COUNT)",
-									// TODO: make it configurable
-									"--loglevel=2",
-								}
-
-								if len(c.Spec.ExternalSeeds) > 0 {
-									cmd = append(cmd, fmt.Sprintf("--external-seeds=%s", strings.Join(c.Spec.ExternalSeeds, ",")))
+										return string(scyllav1.BroadcastAddressTypeServiceClusterIP)
+									}() + ` \
+--service-name=$(SERVICE_NAME) \
+--cpu-count=$(CPU_COUNT) \
+--loglevel=2 \
+` + func() string {
+										if len(c.Spec.ExternalSeeds) > 0 {
+											return fmt.Sprintf("--external-seeds=%s", strings.Join(c.Spec.ExternalSeeds, ","))
+										}
+										return ""
+									}(),
+									),
 								}
 
 								return cmd
@@ -705,7 +720,12 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 											"-O",
 											"inherit_errexit",
 											"-c",
-											fmt.Sprintf("nodetool drain & sleep %d & wait", minTerminationGracePeriodSeconds),
+											strings.TrimSpace(`
+trap 'rm /mnt/shared/ignition.done' EXIT
+nodetool drain &
+sleep ` + strconv.Itoa(minTerminationGracePeriodSeconds) + ` &
+wait
+`),
 										},
 									},
 								},
@@ -753,6 +773,67 @@ func StatefulSetForRack(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster, existing
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
 									corev1.ResourceMemory: resource.MustParse("40Mi"),
+								},
+							},
+						},
+						{
+							Name:            "scylladb-ignition",
+							Image:           sidecarImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command: []string{
+								"/usr/bin/scylla-operator",
+								"run-ignition",
+								"--service-name=$(SERVICE_NAME)",
+								fmt.Sprintf("--nodes-broadcast-address-type=%s", func() scyllav1.BroadcastAddressType {
+									if c.Spec.ExposeOptions != nil && c.Spec.ExposeOptions.BroadcastOptions != nil {
+										return c.Spec.ExposeOptions.BroadcastOptions.Nodes.Type
+									}
+									return scyllav1.BroadcastAddressTypeServiceClusterIP
+								}()),
+								fmt.Sprintf("--clients-broadcast-address-type=%s", func() scyllav1.BroadcastAddressType {
+									if c.Spec.ExposeOptions != nil && c.Spec.ExposeOptions.BroadcastOptions != nil {
+										return c.Spec.ExposeOptions.BroadcastOptions.Clients.Type
+									}
+									return scyllav1.BroadcastAddressTypeServiceClusterIP
+								}()),
+								"--loglevel=2",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "SERVICE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								TimeoutSeconds:   int32(30),
+								FailureThreshold: int32(1),
+								PeriodSeconds:    int32(5),
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Port: intstr.FromInt32(naming.ScyllaDBIgnitionProbePort),
+										Path: naming.ReadinessProbePath,
+									},
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("40Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("40Mi"),
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "shared",
+									MountPath: naming.SharedDirName,
+									ReadOnly:  false,
 								},
 							},
 						},
@@ -916,13 +997,26 @@ func agentContainer(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) corev1.Conta
 		Name:            "scylla-manager-agent",
 		Image:           agentImageForCluster(c),
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Args: []string{
+		// There is no point in starting scylla-manager before ScyllaDB is tuned and ignited. The manager agent fails after 60 attempts and hits backoff unnecessarily.
+		Command: []string{
+			"/usr/bin/bash",
+			"-euEo",
+			"pipefail",
+			"-O",
+			"inherit_errexit",
 			"-c",
-			naming.ScyllaAgentConfigDefaultFile,
-			"-c",
-			path.Join(naming.ScyllaAgentConfigDirName, naming.ScyllaAgentConfigFileName),
-			"-c",
-			path.Join(naming.ScyllaAgentConfigDirName, naming.ScyllaAgentAuthTokenFileName),
+			strings.TrimSpace(`
+printf '{"L":"INFO","T":"%s","M":"Waiting for /mnt/shared/ignition.done"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
+until [[ -f "/mnt/shared/ignition.done" ]]; do
+  sleep 1;
+done
+printf '{"L":"INFO","T":"%s","M":"Ignited. Starting ScyllaDB Manager Agent"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
+
+scylla-manager-agent \
+-c ` + fmt.Sprintf("%q ", naming.ScyllaAgentConfigDefaultFile) + `\
+-c ` + fmt.Sprintf("%q ", path.Join(naming.ScyllaAgentConfigDirName, naming.ScyllaAgentConfigFileName)) + `\
+-c ` + fmt.Sprintf("%q ", path.Join(naming.ScyllaAgentConfigDirName, naming.ScyllaAgentAuthTokenFileName)) + `
+`),
 		},
 		Ports: []corev1.ContainerPort{
 			{
@@ -945,6 +1039,11 @@ func agentContainer(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) corev1.Conta
 				Name:      scyllaAgentAuthTokenVolumeName,
 				MountPath: path.Join(naming.ScyllaAgentConfigDirName, naming.ScyllaAgentAuthTokenFileName),
 				SubPath:   naming.ScyllaAgentAuthTokenFileName,
+				ReadOnly:  true,
+			},
+			{
+				Name:      "shared",
+				MountPath: naming.SharedDirName,
 				ReadOnly:  true,
 			},
 		},

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -763,22 +763,37 @@ func TestStatefulSetForRack(t *testing.T) {
 									},
 								},
 								Command: func() []string {
-									featureGatesFlagString := "--feature-gates=AllAlpha=false,AllBeta=false"
-									if utilfeature.DefaultMutableFeatureGate.Enabled(features.AutomaticTLSCertificates) {
-										featureGatesFlagString += ",AutomaticTLSCertificates=true"
-									} else {
-										featureGatesFlagString += ",AutomaticTLSCertificates=false"
-									}
-
 									return []string{
-										"/mnt/shared/scylla-operator",
-										"sidecar",
-										featureGatesFlagString,
-										"--nodes-broadcast-address-type=ServiceClusterIP",
-										"--clients-broadcast-address-type=ServiceClusterIP",
-										"--service-name=$(SERVICE_NAME)",
-										"--cpu-count=$(CPU_COUNT)",
-										"--loglevel=2",
+										"/usr/bin/bash",
+										"-euEo",
+										"pipefail",
+										"-O",
+										"inherit_errexit",
+										"-c",
+										strings.TrimSpace(`
+printf 'INFO %s ignition - Waiting for /mnt/shared/ignition.done\n' "$( date '+%Y-%m-%d %H:%M:%S,%3N' )" > /dev/stderr
+until [[ -f "/mnt/shared/ignition.done" ]]; do
+  sleep 1;
+done
+printf 'INFO %s ignition - Ignited. Starting ScyllaDB...\n' "$( date '+%Y-%m-%d %H:%M:%S,%3N' )" > /dev/stderr
+
+# TODO: This is where we should start ScyllaDB directly after the sidecar split #1942 
+exec /mnt/shared/scylla-operator sidecar \
+--feature-gates=` + func() string {
+											featureGates := []string{"AllAlpha=false", "AllBeta=false"}
+											if utilfeature.DefaultMutableFeatureGate.Enabled(features.AutomaticTLSCertificates) {
+												featureGates = append(featureGates, "AutomaticTLSCertificates=true")
+											} else {
+												featureGates = append(featureGates, "AutomaticTLSCertificates=false")
+											}
+											return strings.Join(featureGates, ",")
+										}() + ` \
+--nodes-broadcast-address-type=ServiceClusterIP \
+--clients-broadcast-address-type=ServiceClusterIP \
+--service-name=$(SERVICE_NAME) \
+--cpu-count=$(CPU_COUNT) \
+--loglevel=2 \
+`),
 									}
 								}(),
 								Env: []corev1.EnvVar{
@@ -902,7 +917,10 @@ func TestStatefulSetForRack(t *testing.T) {
 												"-O",
 												"inherit_errexit",
 												"-c",
-												"nodetool drain & sleep 15 & wait",
+												`trap 'rm /mnt/shared/ignition.done' EXIT
+nodetool drain &
+sleep 15 &
+wait`,
 											},
 										},
 									},
@@ -952,16 +970,79 @@ func TestStatefulSetForRack(t *testing.T) {
 								},
 							},
 							{
+								Name:            "scylladb-ignition",
+								Image:           "scylladb/scylla-operator:latest",
+								ImagePullPolicy: corev1.PullIfNotPresent,
+								Command: []string{
+									"/usr/bin/scylla-operator",
+									"run-ignition",
+									"--service-name=$(SERVICE_NAME)",
+									"--nodes-broadcast-address-type=ServiceClusterIP",
+									"--clients-broadcast-address-type=ServiceClusterIP",
+									"--loglevel=2",
+								},
+								Env: []corev1.EnvVar{
+									{
+										Name: "SERVICE_NAME",
+										ValueFrom: &corev1.EnvVarSource{
+											FieldRef: &corev1.ObjectFieldSelector{
+												FieldPath: "metadata.name",
+											},
+										},
+									},
+								},
+								ReadinessProbe: &corev1.Probe{
+									TimeoutSeconds:   int32(30),
+									FailureThreshold: int32(1),
+									PeriodSeconds:    int32(5),
+									ProbeHandler: corev1.ProbeHandler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Port: intstr.FromInt32(42081),
+											Path: "/readyz",
+										},
+									},
+								},
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("40Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("40Mi"),
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "shared",
+										MountPath: "/mnt/shared",
+										ReadOnly:  false,
+									},
+								},
+							},
+							{
 								Name:            "scylla-manager-agent",
 								Image:           ":",
 								ImagePullPolicy: corev1.PullIfNotPresent,
-								Args: []string{
+								Command: []string{
+									"/usr/bin/bash",
+									"-euEo",
+									"pipefail",
+									"-O",
+									"inherit_errexit",
 									"-c",
-									"/etc/scylla-manager-agent/scylla-manager-agent.yaml",
-									"-c",
-									"/mnt/scylla-agent-config/scylla-manager-agent.yaml",
-									"-c",
-									"/mnt/scylla-agent-config/auth-token.yaml",
+									strings.TrimSpace(`
+printf '{"L":"INFO","T":"%s","M":"Waiting for /mnt/shared/ignition.done"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
+until [[ -f "/mnt/shared/ignition.done" ]]; do
+  sleep 1;
+done
+printf '{"L":"INFO","T":"%s","M":"Ignited. Starting ScyllaDB Manager Agent"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
+
+scylla-manager-agent \
+-c "/etc/scylla-manager-agent/scylla-manager-agent.yaml" \
+-c "/mnt/scylla-agent-config/scylla-manager-agent.yaml" \
+-c "/mnt/scylla-agent-config/auth-token.yaml"
+`),
 								},
 								Ports: []corev1.ContainerPort{
 									{
@@ -984,6 +1065,11 @@ func TestStatefulSetForRack(t *testing.T) {
 										Name:      "scylla-agent-auth-token-volume",
 										MountPath: "/mnt/scylla-agent-config/auth-token.yaml",
 										SubPath:   "auth-token.yaml",
+										ReadOnly:  true,
+									},
+									{
+										Name:      "shared",
+										MountPath: "/mnt/shared",
 										ReadOnly:  true,
 									},
 								},
@@ -1252,7 +1338,7 @@ func TestStatefulSetForRack(t *testing.T) {
 			expectedStatefulSet: func() *appsv1.StatefulSet {
 				sts := newBasicStatefulSet()
 
-				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command = append(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command, "--external-seeds=10.0.1.1,10.0.1.2,10.0.1.3")
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command[len(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command)-1] += "\n--external-seeds=10.0.1.1,10.0.1.2,10.0.1.3"
 
 				return sts
 			}(),

--- a/pkg/controllerhelpers/tuning.go
+++ b/pkg/controllerhelpers/tuning.go
@@ -1,0 +1,29 @@
+package controllerhelpers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func GetSidecarRuntimeConfigFromConfigMap(cm *corev1.ConfigMap) (*internalapi.SidecarRuntimeConfig, error) {
+	if cm.Data == nil {
+		return nil, fmt.Errorf("no data found in configmap %q", naming.ObjRef(cm))
+	}
+
+	srcData, found := cm.Data[naming.ScyllaRuntimeConfigKey]
+	if !found {
+		return nil, fmt.Errorf("no key %q found in configmap %q", naming.ScyllaRuntimeConfigKey, naming.ObjRef(cm))
+	}
+
+	src := &internalapi.SidecarRuntimeConfig{}
+	err := json.Unmarshal([]byte(srcData), src)
+	if err != nil {
+		return nil, fmt.Errorf("can't unmarshal sidecar runtime config in configmap %q: %w", naming.ObjRef(cm), err)
+	}
+
+	return src, nil
+}

--- a/pkg/controllertools/errors.go
+++ b/pkg/controllertools/errors.go
@@ -1,0 +1,17 @@
+package controllertools
+
+import (
+	"errors"
+)
+
+type NonRetriableError struct {
+	error
+}
+
+func NonRetriable(err error) error {
+	return NonRetriableError{err}
+}
+
+func IsNonRetriable(err error) bool {
+	return errors.Is(err, NonRetriableError{})
+}

--- a/pkg/controllertools/observer.go
+++ b/pkg/controllertools/observer.go
@@ -1,0 +1,152 @@
+package controllertools
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/scylladb/scylla-operator/pkg/scheme"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+type ObserverSyncFunc = func(ctx context.Context) error
+
+type Observer struct {
+	name          string
+	queue         workqueue.RateLimitingInterface
+	syncFunc      ObserverSyncFunc
+	eventRecorder record.EventRecorder
+	cachesToSync  []cache.InformerSynced
+}
+
+func NewObserver(name string, eventsClient corev1client.EventInterface, syncFunc ObserverSyncFunc) *Observer {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: eventsClient})
+
+	return &Observer{
+		name: name,
+		queue: workqueue.NewRateLimitingQueueWithConfig(
+			workqueue.DefaultControllerRateLimiter(),
+			workqueue.RateLimitingQueueConfig{
+				Name: name,
+			}),
+		syncFunc:      syncFunc,
+		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: name}),
+	}
+}
+
+func (o *Observer) Name() string {
+	return o.name
+}
+
+func (o *Observer) singletonKey() string {
+	return o.name
+}
+
+func (o *Observer) Enqueue() {
+	o.queue.Add(o.name)
+}
+
+func (o *Observer) AddCachesToSync(caches ...cache.InformerSynced) {
+	o.cachesToSync = append(o.cachesToSync, caches...)
+}
+
+func (o *Observer) AddHandler(obj interface{}) {
+	o.Enqueue()
+}
+
+func (o *Observer) UpdateHandler(old, new interface{}) {
+	o.Enqueue()
+}
+
+func (o *Observer) DeleteHandler(obj interface{}) {
+	o.Enqueue()
+}
+
+func (o *Observer) GetGenericHandlers() cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    o.AddHandler,
+		UpdateFunc: o.UpdateHandler,
+		DeleteFunc: o.DeleteHandler,
+	}
+}
+
+func (o *Observer) processNextItem(ctx context.Context) bool {
+	key, quit := o.queue.Get()
+	if quit {
+		return false
+	}
+	defer o.queue.Done(key)
+
+	if key != o.singletonKey() {
+		klog.ErrorS(fmt.Errorf("wrong key %q", key), "SingletonKey", o.singletonKey())
+	}
+
+	err := o.syncFunc(ctx)
+	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
+	err = utilerrors.Reduce(err)
+	switch {
+	case err == nil:
+		o.queue.Forget(key)
+		return true
+
+	case apierrors.IsConflict(err):
+		klog.V(2).InfoS("Hit conflict, will retry in a bit", "Key", key, "Error", err)
+
+	case apierrors.IsAlreadyExists(err):
+		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
+
+	default:
+		if IsNonRetriable(err) {
+			klog.InfoS("Hit non-retriable error. Dropping the item from the queue.", "Error", err)
+		}
+		utilruntime.HandleError(fmt.Errorf("sync loop has failed: %w", err))
+	}
+
+	o.queue.AddRateLimited(key)
+
+	return true
+}
+
+func (o *Observer) runWorker(ctx context.Context) {
+	for o.processNextItem(ctx) {
+	}
+}
+
+func (o *Observer) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+
+	klog.InfoS("Starting observer", "Name", o.name)
+
+	if !cache.WaitForNamedCacheSync("Observer "+o.name, ctx.Done(), o.cachesToSync...) {
+		klog.ErrorS(fmt.Errorf("timed out waiting for caches to sync"), "Observer", o.name)
+		return
+	}
+
+	var wg sync.WaitGroup
+	defer func() {
+		klog.InfoS("Shutting down observer", "Name", o.name)
+		o.queue.ShutDown()
+		wg.Wait()
+		klog.InfoS("Shut down observer", "Name", o.name)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		wait.UntilWithContext(ctx, o.runWorker, time.Second)
+	}()
+
+	<-ctx.Done()
+}

--- a/pkg/helpers/fs.go
+++ b/pkg/helpers/fs.go
@@ -1,0 +1,31 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func TouchFile(filePath string) error {
+	_, statErr := os.Stat(filePath)
+	if os.IsNotExist(statErr) {
+		file, err := os.Create(filePath)
+		if err != nil {
+			return fmt.Errorf("can't create file %q: %w", filePath, err)
+		}
+		err = file.Close()
+		if err != nil {
+			return fmt.Errorf("can't close file %q", filePath)
+		}
+
+		return nil
+	}
+
+	currentTime := time.Now().Local()
+	err := os.Chtimes(filePath, currentTime, currentTime)
+	if err != nil {
+		return fmt.Errorf("can't change time for file %q to %q", filePath, currentTime)
+	}
+
+	return nil
+}

--- a/pkg/helpers/fs_test.go
+++ b/pkg/helpers/fs_test.go
@@ -1,0 +1,96 @@
+package helpers
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTouchFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	existingFile := filepath.Join(tmpDir, "existing")
+	nonexistingFile := filepath.Join(tmpDir, "nonexisting")
+	nonexistingFileWithoutParent := filepath.Join(tmpDir+"-foo", "nonexisting")
+
+	setupErr := os.WriteFile(existingFile, nil, 0600)
+	if setupErr != nil {
+		t.Fatal(setupErr)
+	}
+
+	tt := []struct {
+		name        string
+		path        string
+		expectedErr error
+	}{
+		{
+			name:        "new file succeeds",
+			path:        nonexistingFile,
+			expectedErr: nil,
+		},
+		{
+			name:        "existing file succeeds",
+			path:        existingFile,
+			expectedErr: nil,
+		},
+		{
+			name: "file without a parent fails",
+			path: nonexistingFileWithoutParent,
+			expectedErr: fmt.Errorf(`can't create file %q: %w`, nonexistingFileWithoutParent, &fs.PathError{
+				Op:   "open",
+				Path: nonexistingFileWithoutParent,
+				Err:  syscall.Errno(0x02),
+			}),
+		},
+	}
+
+	now := time.Now().Local()
+	// Make sure the times are distinguishable.
+	time.Sleep(100 * time.Millisecond)
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var previousModTime time.Time
+			var initialFI os.FileInfo
+			var err error
+			initialFI, err = os.Stat(tc.path)
+			if err == nil {
+				previousModTime = initialFI.ModTime()
+			} else if os.IsNotExist(err) {
+				previousModTime = now
+			} else {
+				t.Fatal(err)
+			}
+
+			err = TouchFile(tc.path)
+			if !reflect.DeepEqual(err, tc.expectedErr) {
+				t.Errorf("expected error %#+v, got %#+v, diff :%s", tc.expectedErr, err, cmp.Diff(tc.expectedErr, err))
+			}
+
+			if tc.expectedErr != nil {
+				return
+			}
+
+			var finalFI os.FileInfo
+			finalFI, err = os.Stat(tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			lastModTime := finalFI.ModTime()
+			if !lastModTime.After(previousModTime) {
+				t.Errorf("file mod time %v is not after the initial file mod time %v", lastModTime, previousModTime)
+			}
+		})
+	}
+}

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -120,11 +120,14 @@ const (
 	ScyllaRackDCPropertiesName   = "cassandra-rackdc.properties"
 	ScyllaIOPropertiesName       = "io_properties.yaml"
 
+	ScyllaDBIgnitionDonePath = SharedDirName + "/ignition.done"
+
 	DataDir = "/var/lib/scylla"
 
 	ReadinessProbePath         = "/readyz"
 	LivenessProbePath          = "/healthz"
 	ScyllaDBAPIStatusProbePort = 8080
+	ScyllaDBIgnitionProbePort  = 42081
 	ScyllaAPIPort              = 10000
 
 	OperatorEnvVarPrefix = "SCYLLA_OPERATOR_"


### PR DESCRIPTION
**Description of your changes:**
Startup logic should run in a separate container. See https://github.com/scylladb/scylla-operator/issues/1940 for more context.

This PR adds the `scylla-operator run-ignition` command, that runs in its own container and signals ScyllaDB container by creating a file that unblocks its start up. Unfortunately, we can't do this with an init container because we need ScyllaDB container running so tuning can be run and its result can unblock the startup.

Contrary to the old logic that was running in the same container where scylla container ID didn't change (it was restarted with it), the new logic has to deal with all the externalities like living through a scylla container restart and its container id changing.

(It also raises log level for checking the tuning ConfigMap so it's clearer what's being waited on.)

**Which issue is resolved by this Pull Request:**
Resolves #1941 

### Requires
- [x] #1926
- [x] #2058 