### PR TITLE
Remove redundant check in ci deploy script

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -45,7 +45,6 @@ kubectl_create -f "${deploy_dir}"/cert-manager.yaml
 # Wait for cert-manager
 kubectl wait --for condition=established --timeout=60s crd/certificates.cert-manager.io crd/issuers.cert-manager.io
 for d in cert-manager{,-cainjector,-webhook}; do
-    wait-for-object-creation cert-manager deployment.apps/"${d}"
     kubectl -n cert-manager rollout status --timeout=5m deployment.apps/"${d}"
 done
 wait-for-object-creation cert-manager secret/cert-manager-webhook-ca


### PR DESCRIPTION
**Description of your changes:**
When the object is created all the requests through any apiserver should be able to read it immediately. `kubectl` shouldn't hit watch cache.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/pull/1837#discussion_r1616104566

/cc @rzetelskik 