### PR TITLE
Expose scylladb as service

### DIFF
--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -79,14 +79,14 @@ Now that the operator is running, we can create an instance of a Scylla cluster 
 Some of that resource's values are configurable, so feel free to browse `cluster.yaml` and tweak the settings to your liking.
 Full details for all the configuration options can be found in the [Scylla Cluster CRD documentation](api-reference/groups/scylla.scylladb.com/scyllaclusters.rst).
 
-When you are ready to create a Scylla cluster, simply run:
+To create a Scylla cluster, follow these steps:
 
-If you want to **expose scylladb cluster as service**, that is If you want to connect to scylla db cluster with host and port name, run the below command
+**To Expose the ScyllaDB Cluster as a Service**: If you need to connect to the ScyllaDB cluster using a host and port, run the following command
 ```console
 kubectl create -f examples/generic/cluster_expose.yaml
 ```
 
-else run below command
+**Without Exposing the Cluster**: If you do not need to expose the ScyllaDB cluster, run this command instead:
 ```console
 kubectl create -f examples/generic/cluster.yaml
 ```
@@ -235,10 +235,11 @@ If you are running the Alternator you can access the API on the port you specifi
 
 ## Accessing the Database using host and port
 
-If you have used 'expose scylladb cluster as service' step earlier,
-You will be seeing a service named 'simple-cluster-client' running, get its publicip and port will be 9042
+If you followed the step to expose the ScyllaDB cluster as a service, you will see a service named simple-cluster-client running. To connect to the database:
+Retrieve the public IP address of the simple-cluster-client service.
+Use the following command to connect to the ScyllaDB cluster, with the port set to 9042:
 ```console
-cqlsh publicip port
+cqlsh <publicip> <9042>
 ```
 
 ## Configure Scylla

--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -81,6 +81,12 @@ Full details for all the configuration options can be found in the [Scylla Clust
 
 When you are ready to create a Scylla cluster, simply run:
 
+If you want to **expose scylladb cluster as service**, that is If you want to connect to scylla db cluster with host and port name, run the below command
+```console
+kubectl create -f examples/generic/cluster_expose.yaml
+```
+
+else run below command
 ```console
 kubectl create -f examples/generic/cluster.yaml
 ```
@@ -226,6 +232,14 @@ session = cluster.connect()
 ```
 
 If you are running the Alternator you can access the API on the port you specified using plain http.
+
+## Accessing the Database using host and port
+
+If you have used 'expose scylladb cluster as service' step earlier,
+You will be seeing a service named 'simple-cluster-client' running, get its publicip and port will be 9042
+```console
+cqlsh publicip port
+```
 
 ## Configure Scylla
 

--- a/examples/generic/cluster_expose.yaml
+++ b/examples/generic/cluster_expose.yaml
@@ -1,0 +1,61 @@
+# Namespace where the Scylla Cluster will be created
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scylla
+
+---
+
+# Simple Scylla Cluster
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: simple-cluster
+  namespace: scylla
+spec:
+  agentVersion: 3.2.8
+  version: 5.4.3
+  developerMode: true
+  datacenter:
+    name: us-east-1
+    racks:
+      - name: us-east-1a
+        scyllaConfig: "scylla-config"
+        scyllaAgentConfig: "scylla-agent-config"
+        members: 3
+        storage:
+          capacity: 5Gi
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+          limits:
+            cpu: 1
+            memory: 1Gi
+        volumes:
+          - name: coredumpfs
+            hostPath:
+              path: /tmp/coredumps
+        volumeMounts:
+          - mountPath: /tmp/coredumps
+            name: coredumpfs
+
+---
+
+# ScyllaDB Service to expose the cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: scylla-service
+  namespace: scylla
+spec:
+  type: LoadBalancer  # Use LoadBalancer if you need to expose the service externally
+  ports:
+    - port: 9042
+      name: cql
+      targetPort: 9042
+  selector:
+    app.kubernetes.io/instance: simple-cluster
+    app.kubernetes.io/name: scylla


### PR DESCRIPTION
Have added new sample yaml to expose the scylla db cluster as a service, So that people can connect to it via host and port.
Updated the docs to add instruction for it and how to connect to scylla db with host and port
