### PR TITLE
Propagate kubeconfigs to e2e Pod

### DIFF
--- a/pkg/genericclioptions/genericclioptions.go
+++ b/pkg/genericclioptions/genericclioptions.go
@@ -71,7 +71,7 @@ func NewClientConfigSet(userAgentName string) ClientConfigSet {
 func (ccs *ClientConfigSet) AddFlags(cmd *cobra.Command) {
 	ccs.ClientConfigBase.AddFlags(cmd)
 
-	cmd.PersistentFlags().StringArrayVarP(&ccs.kubeconfigs, "kubeconfig", "", ccs.kubeconfigs, "Path to kubeconfig file(s).")
+	cmd.PersistentFlags().StringSliceVarP(&ccs.kubeconfigs, "kubeconfig", "", ccs.kubeconfigs, "Path to kubeconfig file(s).")
 }
 
 func (ccs *ClientConfigSet) Validate() error {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Kubeconfig propagation to e2e pod got lost among many rebases of https://github.com/scylladb/scylla-operator/pull/1881. This PR adds it as a followup to support running e2e suites in multi-datacenter infrastructure.

**Which issue is resolved by this Pull Request:**
Resolves #

/cc tnozicka
/kind feature
/priority important-soon