### PR TITLE
Support overriding deploy dir in deploy script

### DIFF
--- a/hack/.ci/run-e2e-gke.sh
+++ b/hack/.ci/run-e2e-gke.sh
@@ -35,7 +35,7 @@ SCYLLA_OPERATOR_FEATURE_GATES="${SCYLLA_OPERATOR_FEATURE_GATES:-AllAlpha=true,Al
 export SCYLLA_OPERATOR_FEATURE_GATES
 
 for i in "${!KUBECONFIGS[@]}"; do
-  KUBECONFIG="${KUBECONFIGS[$i]}" timeout --foreground -v 10m "${parent_dir}/../ci-deploy.sh" "${SO_IMAGE}" &
+  KUBECONFIG="${KUBECONFIGS[$i]}" DEPLOY_DIR="${ARTIFACTS}/deploy/${i}" timeout --foreground -v 10m "${parent_dir}/../ci-deploy.sh" "${SO_IMAGE}" &
   ci_deploy_bg_pids["${i}"]=$!
 done
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Currently, ci-deploy script hardcodes a subpath for its deploy manifests as `"${ARTIFACTS}/deploy"`. To make it possible to align the file structure with other existing workflows (i.e. `<artifacts>/<deploy>/<cluster-idx>`, this PR allows for overriding the deploy target path.

Release testing workflow will need other tweaks so I'll send it in a separate PR.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-soon
/cc tnozicka
