### PR TITLE
Add an E2E test suite for multi-datacenter clusters

### DIFF
--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -35,7 +35,11 @@ var Suites = ginkgotest.TestSuites{
 		Description: templates.LongDesc(`
 		Tests that ensure an Scylla Operator is working properly.
 		`),
-		LabelFilter:        fmt.Sprintf("!%s", framework.SerialLabelName),
+		LabelFilter: fmt.Sprintf(
+			"!%s && !%s",
+			framework.SerialLabelName,
+			framework.MultiDatacenterLabelName,
+		),
 		DefaultParallelism: 42,
 	},
 	{
@@ -45,6 +49,14 @@ var Suites = ginkgotest.TestSuites{
 		`),
 		LabelFilter:        fmt.Sprintf("%s", framework.SerialLabelName),
 		DefaultParallelism: 1,
+	},
+	{
+		Name: "scylla-operator/conformance/multi-datacenter-parallel",
+		Description: templates.LongDesc(`
+		Tests that ensure Scylla Operator is working properly in multi-datacenter infrastructure.
+		`),
+		LabelFilter:        fmt.Sprintf("%s", framework.MultiDatacenterLabelName),
+		DefaultParallelism: 42,
 	},
 }
 

--- a/test/e2e/fixture/scylla/registry.go
+++ b/test/e2e/fixture/scylla/registry.go
@@ -21,6 +21,10 @@ var (
 	ScyllaClusterTemplateString string
 	ScyllaClusterTemplate       = ParseObjectTemplateOrDie[*scyllav1.ScyllaCluster]("scyllacluster", ScyllaClusterTemplateString)
 
+	//go:embed "zonal.scyllacluster.yaml.tmpl"
+	ZonalScyllaClusterTemplateString string
+	ZonalScyllaClusterTemplate       = ParseObjectTemplateOrDie[*scyllav1.ScyllaCluster]("zonal-scyllacluster", ZonalScyllaClusterTemplateString)
+
 	//go:embed "scylladb-config.yaml.tmpl"
 	ScyllaDBConfigTemplateString string
 	ScyllaDBConfigTemplate       = ParseObjectTemplateOrDie[*corev1.ConfigMap]("scylladb-config", ScyllaDBConfigTemplateString)

--- a/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
@@ -1,0 +1,38 @@
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  generateName: basic-
+  labels:
+   foo: bar
+  annotations:
+   bar: foo
+spec:
+  agentVersion: 3.2.8
+  version: 5.4.3
+  developerMode: true
+  exposeOptions:
+    nodeService:
+      type: {{ .nodeServiceType }}
+    broadcastOptions:
+      nodes:
+        type: {{ .nodesBroadcastAddressType }}
+      clients:
+        type: {{ .clientsBroadcastAddressType }}
+  datacenter:
+    name: us-east-1
+    racks:
+    {{- range $_, $rackName := .rackNames }}
+    - name: "{{ $rackName }}"
+      members: 1
+      storage:
+        capacity: 1Gi
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          cpu: 1
+          memory: 1Gi
+    {{- end }}
+  sysctls:
+   - fs.aio-max-nr=30000000

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -114,6 +114,20 @@ func (f *Framework) GetDefaultScyllaCluster() *scyllav1.ScyllaCluster {
 	return sc
 }
 
+func (f *Framework) GetDefaultZonalScyllaClusterWithThreeRacks() *scyllav1.ScyllaCluster {
+	renderArgs := map[string]any{
+		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
+		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
+		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
+		"rackNames":                   []string{"a", "b", "c"},
+	}
+
+	sc, _, err := scyllafixture.ZonalScyllaClusterTemplate.RenderObject(renderArgs)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return sc
+}
+
 func (f *Framework) CreateUserNamespace(ctx context.Context) (*corev1.Namespace, Client) {
 	return f.defaultCluster().CreateUserNamespace(ctx)
 }

--- a/test/e2e/framework/meta.go
+++ b/test/e2e/framework/meta.go
@@ -7,7 +7,9 @@ import (
 )
 
 const (
-	SerialLabelName                = "Serial"
+	SerialLabelName          = "Serial"
+	MultiDatacenterLabelName = "MultiDatacenter"
+
 	RequiresClusterIPLabelName     = "RequiresClusterIP"
 	RequiresObjectStorageLabelName = "RequiresObjectStorage"
 )
@@ -17,6 +19,8 @@ var (
 		g.Serial,
 		g.Label(SerialLabelName),
 	}
+	MultiDatacenter = g.Label(MultiDatacenterLabelName)
+
 	RequiresClusterIP     = g.Label(RequiresClusterIPLabelName)
 	RequiresObjectStorage = g.Label(RequiresObjectStorageLabelName)
 )

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -11,4 +11,6 @@ const (
 	upgradeToScyllaVersion   = "5.4.3"
 
 	testTimeout = 45 * time.Minute
+
+	multiDatacenterTestTimeout = 3 * time.Hour
 )

--- a/test/e2e/set/scyllacluster/multi_datacenter_scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/multi_datacenter_scyllacluster_external_seeds.go
@@ -1,0 +1,177 @@
+// Copyright (C) 2024 ScyllaDB
+
+package scyllacluster
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var _ = g.Describe("MultiDC cluster", framework.MultiDatacenter, func() {
+	f := framework.NewFramework("scyllacluster")
+
+	g.It("should form when external seeds are provided to ScyllaClusters", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), multiDatacenterTestTimeout)
+		defer cancel()
+
+		const clusterName = "multi-datacenter-cluster"
+
+		sc0 := f.GetDefaultZonalScyllaClusterWithThreeRacks()
+		sc0.Name = clusterName
+		sc0.Spec.Datacenter.Name = "dc0"
+
+		ns0, ns0Client, ok := f.Cluster(0).DefaultNamespaceIfAny()
+		o.Expect(ok).To(o.BeTrue())
+
+		framework.By("Creating ScyllaCluster #0")
+		sc0, err := ns0Client.ScyllaClient().ScyllaV1().ScyllaClusters(ns0.GetName()).Create(ctx, sc0, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaCluster #0 to rollout (RV=%s)", sc0.ResourceVersion)
+		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc0)
+		defer waitCtx1Cancel()
+		sc0, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, ns0Client.ScyllaClient().ScyllaV1().ScyllaClusters(sc0.Namespace), sc0.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, ns0Client.KubeClient(), sc0)
+		waitForFullQuorum(ctx, ns0Client.KubeClient().CoreV1(), sc0)
+
+		hosts0, hostIDs0, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, ns0Client.KubeClient().CoreV1(), sc0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hosts0).To(o.HaveLen(int(utils.GetMemberCount(sc0))))
+		o.Expect(hostIDs0).To(o.HaveLen(int(utils.GetMemberCount(sc0))))
+
+		di0 := insertAndVerifyCQLData(ctx, hosts0)
+		defer di0.Close()
+
+		seeds0, err := utils.GetBroadcastAddresses(ctx, ns0Client.KubeClient().CoreV1(), sc0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(seeds0).To(o.HaveLen(int(utils.GetMemberCount(sc0))))
+
+		sc1 := f.GetDefaultZonalScyllaClusterWithThreeRacks()
+		sc1.Name = clusterName
+		sc1.Spec.Datacenter.Name = "dc1"
+		sc1.Spec.ExternalSeeds = append(make([]string, 0, len(seeds0)), seeds0...)
+
+		framework.By("Creating namespace in cluster #1")
+		ns1, ns1Client := f.Cluster(1).CreateUserNamespace(ctx)
+
+		framework.By("Creating ScyllaCluster #1")
+		sc1, err = ns1Client.ScyllaClient().ScyllaV1().ScyllaClusters(ns1.GetName()).Create(ctx, sc1, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for ScyllaCluster #1 to rollout (RV=%s)", sc1.ResourceVersion)
+		waitCtx2, waitCtx2Cancel := utils.ContextForMultiDatacenterRollout(ctx, sc1)
+		defer waitCtx2Cancel()
+		sc1, err = controllerhelpers.WaitForScyllaClusterState(waitCtx2, ns1Client.ScyllaClient().ScyllaV1().ScyllaClusters(ns1.GetName()), sc1.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, ns1Client.KubeClient(), sc1)
+
+		framework.By("Verifying a multi-datacenter cluster was formed with ScyllaCluster #0")
+		dcClientMap := make(map[string]corev1client.CoreV1Interface, 2)
+		dcClientMap[sc0.Spec.Datacenter.Name] = ns0Client.KubeClient().CoreV1()
+		dcClientMap[sc1.Spec.Datacenter.Name] = ns1Client.KubeClient().CoreV1()
+
+		waitForFullMultiDCQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1})
+
+		hostsByDC, hostIDsByDC, err := utils.GetBroadcastRPCAddressesAndUUIDsByDC(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hostsByDC).To(o.HaveKey(sc0.Spec.Datacenter.Name))
+		o.Expect(hostsByDC).To(o.HaveKey(sc1.Spec.Datacenter.Name))
+		o.Expect(hostIDsByDC[sc0.Spec.Datacenter.Name]).To(o.ConsistOf(hostIDs0))
+		o.Expect(hostIDsByDC[sc1.Spec.Datacenter.Name]).To(o.HaveLen(int(utils.GetMemberCount(sc1))))
+
+		hostIDs1 := hostIDsByDC[sc1.Spec.Datacenter.Name]
+
+		di1 := insertAndVerifyCQLDataByDC(ctx, hostsByDC)
+		defer di1.Close()
+
+		framework.By("Verifying data of datacenter %q", sc0.Spec.Datacenter.Name)
+		verifyCQLData(ctx, di0)
+
+		framework.By("Verifying datacenter allocation of hosts")
+		scyllaClient, _, err := utils.GetScyllaClient(ctx, ns1Client.KubeClient().CoreV1(), sc1)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer scyllaClient.Close()
+
+		for expectedDC, hosts := range hostsByDC {
+			for _, host := range hosts {
+				gotDC, err := scyllaClient.GetSnitchDatacenter(ctx, host)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(gotDC).To(o.Equal(expectedDC))
+			}
+		}
+
+		seeds1, err := utils.GetBroadcastAddresses(ctx, ns1Client.KubeClient().CoreV1(), sc1)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(seeds1).To(o.HaveLen(int(utils.GetMemberCount(sc1))))
+
+		sc2 := f.GetDefaultZonalScyllaClusterWithThreeRacks()
+		sc2.Name = clusterName
+		sc2.Spec.Datacenter.Name = "dc3"
+		sc2.Spec.ExternalSeeds = append(append(make([]string, 0, len(seeds0)+len(seeds1)), seeds0...), seeds1...)
+
+		framework.By("Creating namespace in cluster #2")
+		ns2, ns2Client := f.Cluster(2).CreateUserNamespace(ctx)
+
+		framework.By("Creating ScyllaCluster #2")
+		sc2, err = ns2Client.ScyllaClient().ScyllaV1().ScyllaClusters(ns2.GetName()).Create(ctx, sc2, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for ScyllaCluster #2 to rollout (RV=%s)", sc2.ResourceVersion)
+		waitCtx3, waitCtx3Cancel := utils.ContextForMultiDatacenterRollout(ctx, sc2)
+		defer waitCtx3Cancel()
+		sc2, err = controllerhelpers.WaitForScyllaClusterState(waitCtx3, ns2Client.ScyllaClient().ScyllaV1().ScyllaClusters(sc2.Namespace), sc2.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaCluster(ctx, ns2Client.KubeClient(), sc2)
+
+		framework.By("Verifying a multi-datacenter cluster was formed with ScyllaClusters #0 and #1")
+		dcClientMap = make(map[string]corev1client.CoreV1Interface, 3)
+		dcClientMap[sc0.Spec.Datacenter.Name] = ns0Client.KubeClient().CoreV1()
+		dcClientMap[sc1.Spec.Datacenter.Name] = ns1Client.KubeClient().CoreV1()
+		dcClientMap[sc2.Spec.Datacenter.Name] = ns2Client.KubeClient().CoreV1()
+
+		waitForFullMultiDCQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1, sc2})
+
+		hostsByDC, hostIDsByDC, err = utils.GetBroadcastRPCAddressesAndUUIDsByDC(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1, sc2})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hostsByDC).To(o.HaveKey(sc0.Spec.Datacenter.Name))
+		o.Expect(hostsByDC).To(o.HaveKey(sc1.Spec.Datacenter.Name))
+		o.Expect(hostsByDC).To(o.HaveKey(sc2.Spec.Datacenter.Name))
+		o.Expect(hostIDsByDC[sc0.Spec.Datacenter.Name]).To(o.ConsistOf(hostIDs0))
+		o.Expect(hostIDsByDC[sc1.Spec.Datacenter.Name]).To(o.ConsistOf(hostIDs1))
+		o.Expect(hostIDsByDC[sc2.Spec.Datacenter.Name]).To(o.HaveLen(int(utils.GetMemberCount(sc2))))
+
+		di2 := insertAndVerifyCQLDataByDC(ctx, hostsByDC)
+		defer di2.Close()
+
+		framework.By("Verifying data of datacenter %q", sc0.Spec.Datacenter.Name)
+		verifyCQLData(ctx, di0)
+
+		framework.By("Verifying data of datacenter %q", sc1.Spec.Datacenter.Name)
+		verifyCQLData(ctx, di1)
+
+		framework.By("Verifying datacenter allocation of hosts")
+		scyllaClient, _, err = utils.GetScyllaClient(ctx, ns2Client.KubeClient().CoreV1(), sc2)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer scyllaClient.Close()
+
+		for expectedDC, hosts := range hostsByDC {
+			for _, host := range hosts {
+				gotDC, err := scyllaClient.GetSnitchDatacenter(ctx, host)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(gotDC).To(o.Equal(expectedDC))
+			}
+		}
+	})
+})

--- a/test/e2e/utils/config.go
+++ b/test/e2e/utils/config.go
@@ -18,6 +18,12 @@ const (
 	// It includes the time to pull the images, copy the necessary files (sidecar), join the cluster and similar.
 	memberRolloutTimeout = 30*time.Second + imagePullTimeout + joinClusterTimeout
 
+	// multiDatacenterJoinClusterBuffer accounts for inter-datacenter latencies affecting RPC calls during repair procedure running on bootstrap.
+	// The value should be enough to cover for up to 15ms of median inter-datacenter latency.
+	// Ref: https://github.com/scylladb/scylladb/issues/19131
+	multiDatacenterJoinClusterBuffer    = 15 * time.Minute
+	multiDatacenterMemberRolloutTimeout = memberRolloutTimeout + multiDatacenterJoinClusterBuffer
+
 	baseManagerSyncTimeout = 3 * time.Minute
 	managerTaskSyncTimeout = 30 * time.Second
 

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -118,6 +118,10 @@ func RolloutTimeoutForScyllaCluster(sc *scyllav1.ScyllaCluster) time.Duration {
 	return SyncTimeout + time.Duration(GetMemberCount(sc))*memberRolloutTimeout + cleanupJobTimeout
 }
 
+func RolloutTimeoutForMultiDatacenterScyllaCluster(sc *scyllav1.ScyllaCluster) time.Duration {
+	return SyncTimeout + time.Duration(GetMemberCount(sc))*multiDatacenterMemberRolloutTimeout + cleanupJobTimeout
+}
+
 func GetMemberCount(sc *scyllav1.ScyllaCluster) int32 {
 	members := int32(0)
 	for _, r := range sc.Spec.Datacenter.Racks {
@@ -129,6 +133,10 @@ func GetMemberCount(sc *scyllav1.ScyllaCluster) int32 {
 
 func ContextForRollout(parent context.Context, sc *scyllav1.ScyllaCluster) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(parent, RolloutTimeoutForScyllaCluster(sc))
+}
+
+func ContextForMultiDatacenterRollout(parent context.Context, sc *scyllav1.ScyllaCluster) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, RolloutTimeoutForMultiDatacenterScyllaCluster(sc))
 }
 
 func SyncTimeoutForScyllaCluster(sc *scyllav1.ScyllaCluster) time.Duration {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR introduces a multi-datacenter E2E test suite with a basic test verifying a multi-datacenter cluster can form across multiple Kubernetes clusters, using external seeds to connect datacenters.

**Which issue is resolved by this Pull Request:**
Resolves  

Requires:
- https://github.com/scylladb/scylla-operator/pull/1951
- https://github.com/scylladb/scylla-operator/pull/1952

/kind feature
/priority important-longterm
/cc