### PR TITLE
Bump k8s-local-volume-provisioner to 0.4.0-rc.0 in CI

### DIFF
--- a/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/k8s-local-volume-provisioner:0.3.2@sha256:4ac3e29314bad1291ef9fcf8fdad45c743e0cef9d35d887e073b0f872e92254e
+        image: docker.io/scylladb/k8s-local-volume-provisioner:0.4.0-rc.0@sha256:bf6dc648433cd5037a3787b65d6e8aaf85df1a037db07deb6657d2582ce72a3a
         imagePullPolicy: IfNotPresent
         args:
         - --listen=/csi/csi.sock


### PR DESCRIPTION
To build confidence in release candidate we will use it in CI for a while.

