### PR TITLE
Evaluate ScyllaDB 6.0.0-rc2 in CI

### DIFF
--- a/pkg/scyllafeatures/scyllafeatures.go
+++ b/pkg/scyllafeatures/scyllafeatures.go
@@ -18,6 +18,7 @@ type ScyllaFeature string
 const (
 	ReplacingNodeUsingHostID                          ScyllaFeature = "ReplacingNodeUsingHostID"
 	ExposingScyllaClusterViaServiceOtherThanClusterIP ScyllaFeature = "ExposingScyllaClusterViaServiceOtherThanClusterIP"
+	ConsistentTopologyUpdates                         ScyllaFeature = "ConsistentTopologyUpdates"
 )
 
 type scyllaDBVersionMinimalConstraint struct {
@@ -34,6 +35,10 @@ var featureMinimalVersionConstraints = map[ScyllaFeature]scyllaDBVersionMinimalC
 	ExposingScyllaClusterViaServiceOtherThanClusterIP: {
 		openSource: semver.MustParse("5.2.0"),
 		enterprise: semver.MustParse("2023.1.0"),
+	},
+	ConsistentTopologyUpdates: {
+		openSource: semver.MustParse("6.0.0"),
+		enterprise: semver.MustParse("9999.9.9"),
 	},
 }
 

--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
    bar: foo
 spec:
   agentVersion: 3.2.8
-  version: 5.4.3
+  version: 6.0.0-rc2
   developerMode: true
   exposeOptions:
     nodeService:

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	updateFromScyllaVersion  = "5.4.0"
-	updateToScyllaVersion    = "5.4.3"
-	upgradeFromScyllaVersion = "5.2.15"
-	upgradeToScyllaVersion   = "5.4.3"
+	updateFromScyllaVersion  = "5.4.5"
+	updateToScyllaVersion    = "5.4.6"
+	upgradeFromScyllaVersion = "5.4.6"
+	upgradeToScyllaVersion   = "6.0.0-rc2"
 
 	testTimeout = 45 * time.Minute
 )

--- a/test/e2e/set/scyllacluster/scyllacluster_alternator.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_alternator.go
@@ -128,7 +128,7 @@ authorizer: CassandraAuthorizer
 		}
 
 		q := cqlSession.Query(
-			`SELECT salted_hash FROM system_auth.roles WHERE role = ?`,
+			`SELECT salted_hash FROM system.roles WHERE role = ?`,
 			awsCredentials.AccessKeyID,
 		).WithContext(ctx)
 		err = q.Scan(&awsCredentials.SecretAccessKey)

--- a/test/e2e/set/scyllacluster/scyllacluster_updates.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_updates.go
@@ -124,30 +124,22 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 		for _, rp := range []resourcePair{
 			{
-				cpu:    resource.MustParse("4"),
-				memory: resource.MustParse("400Mi"),
+				cpu: resource.MustParse("5"),
 			},
 			{
-				cpu:    resource.MustParse("-3"),
-				memory: resource.MustParse("-300Mi"),
+				cpu: resource.MustParse("2"),
 			},
 		} {
 			framework.By("Adding %q cpu, %q memory to pod resources", rp.cpu, rp.memory)
 			oldResources := *sc.Spec.Datacenter.Racks[0].Resources.DeepCopy()
 			newResources := *oldResources.DeepCopy()
-			o.Expect(oldResources.Requests).To(o.HaveKey(corev1.ResourceCPU))
-			o.Expect(oldResources.Requests).To(o.HaveKey(corev1.ResourceMemory))
-			o.Expect(oldResources.Limits).To(o.HaveKey(corev1.ResourceCPU))
-			o.Expect(oldResources.Limits).To(o.HaveKey(corev1.ResourceMemory))
+			o.Expect(newResources.Requests).To(o.HaveKey(corev1.ResourceCPU))
+			o.Expect(newResources.Requests).To(o.HaveKey(corev1.ResourceMemory))
+			o.Expect(newResources.Limits).To(o.HaveKey(corev1.ResourceCPU))
+			o.Expect(newResources.Limits).To(o.HaveKey(corev1.ResourceMemory))
 
-			newResources.Requests[corev1.ResourceCPU] = *addQuantity(newResources.Requests[corev1.ResourceCPU], rp.cpu)
-			newResources.Requests[corev1.ResourceMemory] = *addQuantity(newResources.Requests[corev1.ResourceMemory], rp.memory)
-			o.Expect(newResources.Requests).NotTo(o.BeEquivalentTo(oldResources.Requests))
-
-			newResources.Limits[corev1.ResourceCPU] = *addQuantity(newResources.Limits[corev1.ResourceCPU], rp.cpu)
-			newResources.Limits[corev1.ResourceMemory] = *addQuantity(newResources.Limits[corev1.ResourceMemory], rp.memory)
+			newResources.Limits[corev1.ResourceCPU] = rp.cpu
 			o.Expect(newResources.Limits).NotTo(o.BeEquivalentTo(oldResources.Limits))
-
 			o.Expect(newResources).NotTo(o.BeEquivalentTo(oldResources))
 
 			newResourcesJSON, err := json.Marshal(newResources)

--- a/test/e2e/set/scyllacluster/scyllacluster_updates.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_updates.go
@@ -124,12 +124,12 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 		for _, rp := range []resourcePair{
 			{
-				cpu:    resource.MustParse("1m"),
-				memory: resource.MustParse("1Mi"),
+				cpu:    resource.MustParse("4"),
+				memory: resource.MustParse("400Mi"),
 			},
 			{
-				cpu:    resource.MustParse("-2m"),
-				memory: resource.MustParse("-2Mi"),
+				cpu:    resource.MustParse("-3"),
+				memory: resource.MustParse("-300Mi"),
 			},
 		} {
 			framework.By("Adding %q cpu, %q memory to pod resources", rp.cpu, rp.memory)

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -266,8 +266,8 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 
 		targetSC := f.GetDefaultScyllaCluster()
 		targetSC.Spec.Datacenter.Racks[0].Members = sourceSC.Spec.Datacenter.Racks[0].Members
-		// Restoring schema with ScyllaDB OS 5.4.X or ScyllaDB Enterprise 2024.1.X and consistent_cluster_management isn’t supported.
-		targetSC.Spec.ScyllaArgs = "--consistent-cluster-management=false"
+		// // Restoring schema with ScyllaDB OS 5.4.X or ScyllaDB Enterprise 2024.1.X and consistent_cluster_management isn’t supported.
+		// targetSC.Spec.ScyllaArgs = "--consistent-cluster-management=false"
 
 		switch objectStorageType {
 		case framework.ObjectStorageTypeGCS:
@@ -382,24 +382,24 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		verifyScyllaCluster(ctx, f.KubeClient(), targetSC)
 		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), targetSC)
 
-		framework.By("Enabling raft in target cluster")
-		_, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-			ctx,
-			targetSC.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op":"replace","path":"/spec/scyllaArgs","value":"--consistent-cluster-management=true"}]`),
-			metav1.PatchOptions{},
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		framework.By("Waiting for the target ScyllaCluster to roll out")
-		waitCtx10, waitCtx10Cancel := utils.ContextForRollout(ctx, targetSC)
-		defer waitCtx10Cancel()
-		targetSC, err = controllerhelpers.WaitForScyllaClusterState(waitCtx10, f.ScyllaClient().ScyllaV1().ScyllaClusters(targetSC.Namespace), targetSC.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		verifyScyllaCluster(ctx, f.KubeClient(), targetSC)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), targetSC)
+		// framework.By("Enabling raft in target cluster")
+		// _, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+		// 	ctx,
+		// 	targetSC.Name,
+		// 	types.JSONPatchType,
+		// 	[]byte(`[{"op":"replace","path":"/spec/scyllaArgs","value":"--consistent-cluster-management=true"}]`),
+		// 	metav1.PatchOptions{},
+		// )
+		// o.Expect(err).NotTo(o.HaveOccurred())
+		//
+		// framework.By("Waiting for the target ScyllaCluster to roll out")
+		// waitCtx10, waitCtx10Cancel := utils.ContextForRollout(ctx, targetSC)
+		// defer waitCtx10Cancel()
+		// targetSC, err = controllerhelpers.WaitForScyllaClusterState(waitCtx10, f.ScyllaClient().ScyllaV1().ScyllaClusters(targetSC.Namespace), targetSC.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		// o.Expect(err).NotTo(o.HaveOccurred())
+		//
+		// verifyScyllaCluster(ctx, f.KubeClient(), targetSC)
+		// waitForFullQuorum(ctx, f.KubeClient().CoreV1(), targetSC)
 
 		framework.By("Creating a tables restore task")
 		stdout, stderr, err = utils.ExecWithOptions(f.AdminClientConfig(), f.KubeAdminClient().CoreV1(), utils.ExecOptions{


### PR DESCRIPTION
This bumps ScyllaDB version used in CI to 6.0.0-rc2 to evaluate whether it doesn't break our tests.

/cc