### PR TITLE
Bump local volume provisioner to latest stable 0.4.0

### DIFF
--- a/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
+++ b/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/k8s-local-volume-provisioner:0.3.2@sha256:4ac3e29314bad1291ef9fcf8fdad45c743e0cef9d35d887e073b0f872e92254e
+        image: docker.io/scylladb/k8s-local-volume-provisioner:0.4.0@sha256:bf6dc648433cd5037a3787b65d6e8aaf85df1a037db07deb6657d2582ce72a3a
         imagePullPolicy: IfNotPresent
         args:
         - --listen=/csi/csi.sock

--- a/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/k8s-local-volume-provisioner:0.4.0-rc.0@sha256:bf6dc648433cd5037a3787b65d6e8aaf85df1a037db07deb6657d2582ce72a3a
+        image: docker.io/scylladb/k8s-local-volume-provisioner:0.4.0@sha256:bf6dc648433cd5037a3787b65d6e8aaf85df1a037db07deb6657d2582ce72a3a
         imagePullPolicy: IfNotPresent
         args:
         - --listen=/csi/csi.sock


### PR DESCRIPTION
Both CI and examples are using latest stable version of scylladb/k8s-local-volume-provisioner.

