### PR TITLE
Add Execute() to OperatorOptions

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -206,6 +206,10 @@ func (o *OperatorOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Co
 		cancel()
 	}()
 
+	return o.Execute(ctx, streams, cmd)
+}
+
+func (o *OperatorOptions) Execute(ctx context.Context, streams genericclioptions.IOStreams, cmd *cobra.Command) error {
 	// Lock names cannot be changed, because it may lead to two leaders during rolling upgrades.
 	const lockName = "scylla-operator-lock"
 


### PR DESCRIPTION
Allows for reusing Operator logic without context signal registration and print of command version which is unwanted when custom command reuses OperatorOptions.
