### PR TITLE
Add a NodeConfig example for generic environments

### DIFF
--- a/examples/generic/nodeconfig-alpha.yaml
+++ b/examples/generic/nodeconfig-alpha.yaml
@@ -1,0 +1,26 @@
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: NodeConfig
+metadata:
+  name: cluster
+spec:
+  localDiskSetup:
+    loopDevices:
+    - name: persistent-volumes
+      imagePath: /mnt/persistent-volumes.img
+      size: 80Gi
+    filesystems:
+    - device: /dev/loops/persistent-volumes
+      type: xfs
+    mounts:
+    - device: /dev/loops/persistent-volumes
+      mountPoint: /mnt/persistent-volumes
+      unsupportedOptions:
+      - prjquota
+  placement:
+    nodeSelector:
+      scylla.scylladb.com/node-type: scylla
+    tolerations:
+    - effect: NoSchedule
+      key: role
+      operator: Equal
+      value: scylla-clusters


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR adds a NodeConfig example dedicated for generic environments. It sets up local storage  on loop devices.

**Which issue is resolved by this Pull Request:**
Resolves #1556 

/kind feature
/priority important-soon
