### PR TITLE
Add dedicated ServiceAccount for perftune jobs

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -200,6 +200,7 @@ rules:
   resources:
   - clusterroles
   - clusterrolebindings
+  - roles
   - rolebindings
   verbs:
   - create

--- a/deploy/operator/00_clusterrole_def.yaml
+++ b/deploy/operator/00_clusterrole_def.yaml
@@ -190,6 +190,7 @@ rules:
   resources:
   - clusterroles
   - clusterrolebindings
+  - roles
   - rolebindings
   verbs:
   - create

--- a/helm/scylla-operator/templates/clusterrole_def.yaml
+++ b/helm/scylla-operator/templates/clusterrole_def.yaml
@@ -190,6 +190,7 @@ rules:
   resources:
   - clusterroles
   - clusterrolebindings
+  - roles
   - rolebindings
   verbs:
   - create

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -294,6 +294,8 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		scyllaInformers.Scylla().V1alpha1().ScyllaOperatorConfigs(),
 		kubeInformers.Rbac().V1().ClusterRoles(),
 		kubeInformers.Rbac().V1().ClusterRoleBindings(),
+		kubeInformers.Rbac().V1().Roles(),
+		kubeInformers.Rbac().V1().RoleBindings(),
 		kubeInformers.Apps().V1().DaemonSets(),
 		kubeInformers.Core().V1().Namespaces(),
 		kubeInformers.Core().V1().Nodes(),

--- a/pkg/controller/nodeconfig/resource.go
+++ b/pkg/controller/nodeconfig/resource.go
@@ -38,6 +38,18 @@ func makeNodeConfigServiceAccount() *corev1.ServiceAccount {
 	}
 }
 
+func makePerftuneServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Name:      naming.PerftuneServiceAccountName,
+			Labels: map[string]string{
+				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
+			},
+		},
+	}
+}
+
 func NodeConfigClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
@@ -92,6 +104,19 @@ func NodeConfigClusterRole() *rbacv1.ClusterRole {
 	}
 }
 
+func makePerftuneRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Name:      naming.PerftuneServiceAccountName,
+			Labels: map[string]string{
+				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
+			},
+		},
+		Rules: []rbacv1.PolicyRule{},
+	}
+}
+
 func makeNodeConfigClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -111,6 +136,30 @@ func makeNodeConfigClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 				Kind:      "ServiceAccount",
 				Namespace: naming.ScyllaOperatorNodeTuningNamespace,
 				Name:      naming.NodeConfigAppName,
+			},
+		},
+	}
+}
+
+func makePerftuneRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Name:      naming.PerftuneServiceAccountName,
+			Labels: map[string]string{
+				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     naming.PerftuneServiceAccountName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+				Name:      naming.PerftuneServiceAccountName,
 			},
 		},
 	}

--- a/pkg/controller/nodeconfig/sync_rolebindings.go
+++ b/pkg/controller/nodeconfig/sync_rolebindings.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2024 ScyllaDB
+
+package nodeconfig
+
+import (
+	"context"
+	"fmt"
+
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/resourceapply"
+	rbacv1 "k8s.io/api/rbac/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func (ncc *Controller) syncRoleBindings(
+	ctx context.Context,
+	nc *scyllav1alpha1.NodeConfig,
+	roleBindings map[string]*rbacv1.RoleBinding,
+) error {
+	requiredRoleBindings := []*rbacv1.RoleBinding{
+		makePerftuneRoleBinding(),
+	}
+
+	// Delete any excessive RoleBindings.
+	// Delete has to be the first action to avoid getting stuck on quota.
+	err := controllerhelpers.Prune(
+		ctx,
+		requiredRoleBindings,
+		roleBindings,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: ncc.kubeClient.RbacV1().RoleBindings(nc.Namespace).Delete,
+		},
+		ncc.eventRecorder)
+	if err != nil {
+		return fmt.Errorf("can't prune RoleBinding(s): %w", err)
+	}
+
+	var errs []error
+	for _, crb := range requiredRoleBindings {
+		_, _, err := resourceapply.ApplyRoleBinding(ctx, ncc.kubeClient.RbacV1(), ncc.roleBindingLister, ncc.eventRecorder, crb, resourceapply.ApplyOptions{
+			AllowMissingControllerRef: true,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't create missing rolebinding: %w", err))
+			continue
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}

--- a/pkg/controller/nodeconfig/sync_roles.go
+++ b/pkg/controller/nodeconfig/sync_roles.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2024 ScyllaDB
+
+package nodeconfig
+
+import (
+	"context"
+	"fmt"
+
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/resourceapply"
+	rbacv1 "k8s.io/api/rbac/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func (ncc *Controller) syncRoles(ctx context.Context, nc *scyllav1alpha1.NodeConfig, roles map[string]*rbacv1.Role) error {
+	requiredRoles := []*rbacv1.Role{
+		makePerftuneRole(),
+	}
+
+	// Delete any excessive Roles.
+	// Delete has to be the first action to avoid getting stuck on quota.
+	err := controllerhelpers.Prune(
+		ctx,
+		requiredRoles,
+		roles,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: ncc.kubeClient.RbacV1().Roles(nc.Namespace).Delete,
+		},
+		ncc.eventRecorder)
+	if err != nil {
+		return fmt.Errorf("can't prune Role(s): %w", err)
+	}
+
+	var errs []error
+	for _, cr := range requiredRoles {
+		_, _, err := resourceapply.ApplyRole(ctx, ncc.kubeClient.RbacV1(), ncc.roleLister, ncc.eventRecorder, cr, resourceapply.ApplyOptions{
+			AllowMissingControllerRef: true,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't create missing Role: %w", err))
+			continue
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}

--- a/pkg/controller/nodeconfig/sync_serviceaccounts.go
+++ b/pkg/controller/nodeconfig/sync_serviceaccounts.go
@@ -15,6 +15,7 @@ import (
 func (ncc *Controller) makeServiceAccounts() []*corev1.ServiceAccount {
 	serviceAccounts := []*corev1.ServiceAccount{
 		makeNodeConfigServiceAccount(),
+		makePerftuneServiceAccount(),
 	}
 
 	return serviceAccounts

--- a/pkg/controller/nodetune/resource.go
+++ b/pkg/controller/nodetune/resource.go
@@ -54,11 +54,12 @@ func makePerftuneJobForNode(controllerRef *metav1.OwnerReference, namespace, nod
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					Tolerations:   podSpec.Tolerations,
-					NodeName:      nodeName,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
-					HostPID:       true,
-					HostNetwork:   true,
+					Tolerations:        podSpec.Tolerations,
+					NodeName:           nodeName,
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
+					HostPID:            true,
+					HostNetwork:        true,
+					ServiceAccountName: naming.PerftuneServiceAccountName,
 					Containers: []corev1.Container{
 						{
 							Name:            naming.PerftuneContainerName,
@@ -164,11 +165,12 @@ func makePerftuneJobForContainers(controllerRef *metav1.OwnerReference, namespac
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					Tolerations:   podSpec.Tolerations,
-					NodeName:      nodeName,
-					RestartPolicy: corev1.RestartPolicyOnFailure,
-					HostPID:       true,
-					HostNetwork:   true,
+					Tolerations:        podSpec.Tolerations,
+					NodeName:           nodeName,
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
+					HostPID:            true,
+					HostNetwork:        true,
+					ServiceAccountName: naming.PerftuneServiceAccountName,
 					Containers: []corev1.Container{
 						{
 							Name:            naming.PerftuneContainerName,

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -140,7 +140,8 @@ const (
 
 	SingletonName = "cluster"
 
-	PerftuneJobPrefixName = "perftune"
+	PerftuneJobPrefixName      = "perftune"
+	PerftuneServiceAccountName = "perftune"
 
 	// TODO: Make sure this doesn't get out of date.
 	// TODO: Can't be bumped until scylladb/scylladb#17787 is fixed.

--- a/pkg/resourceapply/rbac.go
+++ b/pkg/resourceapply/rbac.go
@@ -43,6 +43,38 @@ func ApplyClusterRole(
 	)
 }
 
+func ApplyRoleWithControl(
+	ctx context.Context,
+	control ApplyControlInterface[*rbacv1.Role],
+	recorder record.EventRecorder,
+	required *rbacv1.Role,
+	options ApplyOptions,
+) (*rbacv1.Role, bool, error) {
+	return ApplyGeneric[*rbacv1.Role](ctx, control, recorder, required, options)
+}
+
+func ApplyRole(
+	ctx context.Context,
+	client rbacv1client.RolesGetter,
+	lister rbacv1listers.RoleLister,
+	recorder record.EventRecorder,
+	required *rbacv1.Role,
+	options ApplyOptions,
+) (*rbacv1.Role, bool, error) {
+	return ApplyRoleWithControl(
+		ctx,
+		ApplyControlFuncs[*rbacv1.Role]{
+			GetCachedFunc: lister.Roles(required.Namespace).Get,
+			CreateFunc:    client.Roles(required.Namespace).Create,
+			UpdateFunc:    client.Roles(required.Namespace).Update,
+			DeleteFunc:    client.Roles(required.Namespace).Delete,
+		},
+		recorder,
+		required,
+		options,
+	)
+}
+
 func ApplyRoleBindingWithControl(
 	ctx context.Context,
 	control ApplyControlInterface[*rbacv1.RoleBinding],


### PR DESCRIPTION
**Description of your changes:**
This PR adds a dedicated ServiceAccount to use for perftune jobs which enhances security isolation and allows some platforms (like OpenShift) to grant it extra permissions.

**Which issue is resolved by this Pull Request:**
Resolves #1975

### Requires:
- [x] https://github.com/scylladb/scylla-operator/pull/2000
