### PR TITLE
Extend Handlers' EnqueueAll with enqueing func parameter

### DIFF
--- a/pkg/controllerhelpers/handlers.go
+++ b/pkg/controllerhelpers/handlers.go
@@ -90,14 +90,20 @@ func (h *Handlers[T]) Enqueue(depth int, untypedObj kubeinterfaces.ObjectInterfa
 func (h *Handlers[T]) EnqueueAll(depth int, untypedObj kubeinterfaces.ObjectInterface, op HandlerOperationType) {
 	klog.V(4).InfoSDepth(depth, "Enqueuing all controller objects", getObjectLogContext(untypedObj, nil)...)
 
-	controllerObjs, err := h.getterLister.List(untypedObj.GetNamespace(), labels.Everything())
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't list all controller objects for %T: %w", untypedObj, err))
-		return
-	}
+	h.EnqueueAllFunc(h.Enqueue)(depth+1, untypedObj, op)
+}
 
-	for _, controllerObj := range controllerObjs {
-		h.Enqueue(depth+1, controllerObj, op)
+func (h *Handlers[T]) EnqueueAllFunc(enqueueFunc EnqueueFuncType) EnqueueFuncType {
+	return func(depth int, untypedObj kubeinterfaces.ObjectInterface, op HandlerOperationType) {
+		controllerObjs, err := h.getterLister.List(untypedObj.GetNamespace(), labels.Everything())
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("couldn't list all controller objects for %T: %w", untypedObj, err))
+			return
+		}
+
+		for _, controllerObj := range controllerObjs {
+			enqueueFunc(depth+1, controllerObj, op)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Conditionally enqueueing a subset of controlled objects seems to be a repeating use case in our codebase. This PR extends the EnqueueAll handler method parameters with an enqueueing function, making it possible to use function composition for such use cases.

Xref: https://github.com/scylladb/scylla-operator-enterprise/pull/25#discussion_r1638032987

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-longterm

/cc zimnx
/assign zimnx