### PR TITLE
Add linux NodeSelector to generic NodeConfig example

### DIFF
--- a/examples/generic/nodeconfig-alpha.yaml
+++ b/examples/generic/nodeconfig-alpha.yaml
@@ -18,6 +18,7 @@ spec:
       - prjquota
   placement:
     nodeSelector:
+      kubernetes.io/os: linux
       scylla.scylladb.com/node-type: scylla
     tolerations:
     - effect: NoSchedule


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** NodeConfig example for generic environments added in https://github.com/scylladb/scylla-operator/pull/1970 is missing `kubernetes.io/os: linux` node selector. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-longterm
/cc zimnx
/assign zimnx
