### PR TITLE
Bump minimum versions for v1.13 release

### DIFF
--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -62,9 +62,9 @@ Support matrix table shows the version requirements for a particular **scylla-op
 |:-----------------:|:----------:|:----------:|:----------:|:----------:|
 | Kubernetes        | `>=1.21`   | `>=1.21`   | `>=1.21`   | `>=1.21`   |
 | CRI API           | `v1`       | `v1`       | `v1`       | `v1`       |
-| Scylla OS         | `>=5.3`    | `>=5.0`    | `>=5.0`    | `>=5.0`    |
-| Scylla Enterprise | `>=2021.1` | `>=2021.1` | `>=2021.1` | `>=2021.1` |
-| Scylla Manager    | `>=3.2.6`  | `>=3.2.6`  | `>=3.2`    | `>=2.6`    |
+| Scylla OS         | `>=5.4`    | `>=5.0`    | `>=5.0`    | `>=5.0`    |
+| Scylla Enterprise | `>=2023.1` | `>=2021.1` | `>=2021.1` | `>=2021.1` |
+| Scylla Manager    | `>=3.2.8`  | `>=3.2.6`  | `>=3.2`    | `>=2.6`    |
 | Scylla Monitoring | `(CRD)`    | `(CRD)`    | `(CRD)`    | `>=4.0`    |
 :::
 


### PR DESCRIPTION
5.3 specified wasn't released ever.
This bumps minimum ScyllaDB to oldest non-EOL ScyllaDB, and latest Scylla Manager.

