### PR TITLE
Bump default ScyllaDB version used in E2E's to 6.0.1

### DIFF
--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
    bar: foo
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.0.1
   developerMode: true
   exposeOptions:
     nodeService:

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	updateFromScyllaVersion  = "5.4.0"
-	updateToScyllaVersion    = "5.4.3"
-	upgradeFromScyllaVersion = "5.2.15"
-	upgradeToScyllaVersion   = "5.4.3"
+	updateFromScyllaVersion  = "6.0.0"
+	updateToScyllaVersion    = "6.0.1"
+	upgradeFromScyllaVersion = "5.4.7"
+	upgradeToScyllaVersion   = "6.0.1"
 
 	testTimeout = 45 * time.Minute
 

--- a/test/e2e/set/scyllacluster/scyllacluster_alternator.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_alternator.go
@@ -128,7 +128,7 @@ authorizer: CassandraAuthorizer
 		}
 
 		q := cqlSession.Query(
-			`SELECT salted_hash FROM system_auth.roles WHERE role = ?`,
+			`SELECT salted_hash FROM system.roles WHERE role = ?`,
 			awsCredentials.AccessKeyID,
 		).WithContext(ctx)
 		err = q.Scan(&awsCredentials.SecretAccessKey)


### PR DESCRIPTION
Bumps default ScyllaDB version used in E2E's to 6.0.1, and align tests to 6.0 changes.

Scaling E2E was aligned to make sure it doesn't break minimal required quorum on scaling changes.
Existing test scaled below keyspace RF which is no longer possible, as Scylla rejects decommision when there's a keyspace having RF higher than node count.
Test step checking decommission of drained node was moved earlier to fix the same quorum breakage.

Alternator E2E required a table name change from which we are gettingpassword. Table name was renamed in 6.0.

Restore E2E was parametrized to make sure we test the procedure for both default ScyllaDB version and 2024.1 where a workaround explained in the documentation is required.

Fixes #1954