### PR TITLE
Skip CSI driver creation for empty SO_CSI_DRIVER_PATH in deploy release script

### DIFF
--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -78,8 +78,15 @@ else
  kubectl_create -f="${SO_NODECONFIG_PATH}"
 fi
 
-kubectl_create -n=local-csi-driver -f="${source_url}/${revision}/examples/common/local-volume-provisioner/local-csi-driver/"{00_namespace.yaml,00_scylladb-local-xfs.storageclass.yaml,10_csidriver.yaml,10_driver.serviceaccount.yaml,10_provisioner_clusterrole.yaml,20_provisioner_clusterrolebinding.yaml,50_daemonset.yaml}
-kubectl -n=local-csi-driver rollout status --timeout=5m daemonset.apps/local-csi-driver
+if [[ -z "${SO_CSI_DRIVER_PATH+x}" ]]; then
+  kubectl_create -n=local-csi-driver -f="${source_url}/${revision}/examples/common/local-volume-provisioner/local-csi-driver/"{00_namespace.yaml,00_scylladb-local-xfs.storageclass.yaml,10_csidriver.yaml,10_driver.serviceaccount.yaml,10_provisioner_clusterrole.yaml,20_provisioner_clusterrolebinding.yaml,50_daemonset.yaml}
+  kubectl -n=local-csi-driver rollout status --timeout=5m daemonset.apps/local-csi-driver
+elif [[ -n "${SO_CSI_DRIVER_PATH}" ]]; then
+  kubectl_create -n=local-csi-driver -f="${SO_CSI_DRIVER_PATH}"
+  kubectl -n=local-csi-driver rollout status --timeout=5m daemonset.apps/local-csi-driver
+else
+  echo "Skipping CSI driver creation"
+fi
 
 mkdir "${ARTIFACTS}/manager"
 cat > "${ARTIFACTS}/manager/kustomization.yaml" << EOF


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Currently ci-deploy-release script times out waiting for local-csi-driver to roll out, despite `SO_CSI_DRIVER_PATH` being empty.

https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/ci-scylla-operator-latest-e2e-gke-arm64-serial/1805169160804634624#1:test-build-log.txt%3A306

~From my understanding the intention was to always run the given revision of local-csi-driver example manifests, since, contrary to the regular deploy script, the release deploy script doesn't account for `SO_CSI_DRIVER_PATH` whatsoever.~

~Hence this PR skips local-csi-driver creation together with NodeConfig creation when empty `SO_NODECONFIG_PATH` is provided. We can always make it more granular if we need to deploy local-csi-driver without configuring a NodeConfig, but for now that seems good enough.~

Edit: local-csi-driver path can now be overridden by setting SO_CSI_DRIVER_PATH. In case the env var is empty, local-csi-driver deployment is skipped.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/1987

/kind bug
/priority important-soon
/cc tnozicka