### PR TITLE
Mark v1.13 as stable version in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,7 @@ UNSTABLE_VERSIONS = ["master"]
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.
-smv_latest_version = 'v1.12'
+smv_latest_version = 'v1.13'
 smv_rename_latest_version = 'stable'
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"


### PR DESCRIPTION
After v1.13.0 is called GA, we should switch `stable` endpoint of documentation to point to v1.13 docs.
