### PR TITLE
Add resourceapply helpers for PersistentVolumeClaims

### DIFF
--- a/pkg/resourceapply/core.go
+++ b/pkg/resourceapply/core.go
@@ -243,3 +243,35 @@ func ApplyPod(
 		options,
 	)
 }
+
+func ApplyPersistentVolumeClaimWithControl(
+	ctx context.Context,
+	control ApplyControlInterface[*corev1.PersistentVolumeClaim],
+	recorder record.EventRecorder,
+	required *corev1.PersistentVolumeClaim,
+	options ApplyOptions,
+) (*corev1.PersistentVolumeClaim, bool, error) {
+	return ApplyGeneric[*corev1.PersistentVolumeClaim](ctx, control, recorder, required, options)
+}
+
+func ApplyPersistentVolumeClaim(
+	ctx context.Context,
+	client corev1client.PersistentVolumeClaimsGetter,
+	lister corev1listers.PersistentVolumeClaimLister,
+	recorder record.EventRecorder,
+	required *corev1.PersistentVolumeClaim,
+	options ApplyOptions,
+) (*corev1.PersistentVolumeClaim, bool, error) {
+	return ApplyPersistentVolumeClaimWithControl(
+		ctx,
+		ApplyControlFuncs[*corev1.PersistentVolumeClaim]{
+			GetCachedFunc: lister.PersistentVolumeClaims(required.Namespace).Get,
+			CreateFunc:    client.PersistentVolumeClaims(required.Namespace).Create,
+			UpdateFunc:    client.PersistentVolumeClaims(required.Namespace).Update,
+			DeleteFunc:    client.PersistentVolumeClaims(required.Namespace).Delete,
+		},
+		recorder,
+		required,
+		options,
+	)
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR adds resourceapply helpers for PersistentVolumeClaims. Required for https://github.com/scylladb/scylla-operator-ci-tools/pull/12.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-soon