### PR TITLE
Add support for forceRedeploymentReason in Helm chart

### DIFF
--- a/helm/scylla/templates/scyllacluster.yaml
+++ b/helm/scylla/templates/scyllacluster.yaml
@@ -27,6 +27,9 @@ spec:
   {{- if .Values.developerMode }}
   developerMode: {{ .Values.developerMode }}
   {{- end }}
+  {{- if .Values.forceRedeploymentReason }}
+  forceRedeploymentReason: {{ .Values.forceRedeploymentReason }}
+  {{- end }}
   {{- if .Values.cpuset }}
   cpuset: {{ .Values.cpuset }}
   {{- end }}

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -27,6 +27,8 @@ alternator:
   insecureEnableHTTP: true
   writeIsolation: "always"
 
+# If set to a non-empty string, it forces a rolling restart of Scylla. Change it again to trigger a new restart.
+forceRedeploymentReason: ""
 # Whether developer mode should be enabled.
 developerMode: false
 # cpuset determines if the cluster will use cpu-pinning for max performance.


### PR DESCRIPTION
to trigger manual rolling restarts of Scylla

Fixes/implements https://github.com/scylladb/scylla-operator/issues/2007