### PR TITLE
Stop depending on default StorageClass' presence for ScyllaClusters in our manifests, examples, scripts and tests

### DIFF
--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -295,6 +295,7 @@ spec:
         members: 1
         storage:
           capacity: 5Gi
+          storageClassName: scylladb-local-xfs
         resources:
           limits:
             cpu: 200m

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -295,6 +295,7 @@ spec:
       members: 1
       storage:
         capacity: 5Gi
+        storageClassName: scylladb-local-xfs
       resources:
         limits:
           cpu: 1

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -17,6 +17,7 @@ spec:
         members: 1
         storage:
           capacity: 5Gi
+          storageClassName: scylladb-local-xfs
         resources:
           limits:
             cpu: 200m

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -17,6 +17,7 @@ spec:
       members: 1
       storage:
         capacity: 5Gi
+        storageClassName: scylladb-local-xfs
       resources:
         limits:
           cpu: 1

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -12,6 +12,7 @@ racks:
   members: 2
   storage:
     capacity: 5Gi
+    storageClassName: scylladb-local-xfs
   resources:
     limits:
       cpu: 1

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -32,6 +32,7 @@ scylla:
       members: 1
       storage:
         capacity: 5Gi
+        storageClassName: scylladb-local-xfs
       resources:
         limits:
           cpu: 1

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -16,6 +16,7 @@ spec:
       members: 1
       storage:
         capacity: 1Gi
+        storageClassName: scylladb-local-xfs
       resources:
         requests:
           cpu: 10m

--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -94,14 +94,6 @@ function gather-artifacts-on-exit {
   done
 }
 
-function unset-default-storageclass {
-  for f in "${KUBECONFIGS[@]}"; do
-    for r in $( KUBECONFIG="${f}" kubectl get storageclasses -o name ); do
-      KUBECONFIG="${f}" kubectl patch "${r}" -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
-    done
-  done
-}
-
 function apply-e2e-workarounds {
   if [ -z "${SO_IMAGE+x}" ]; then
     echo "SO_IMAGE can't be empty" > /dev/stderr
@@ -191,6 +183,11 @@ function run-e2e {
     exit 2
   fi
 
+  if [ -z "${SO_SCYLLACLUSTER_STORAGECLASS_NAME+x}" ]; then
+    echo "SO_SCYLLACLUSTER_STORAGECLASS_NAME can't be empty" > /dev/stderr
+    exit 2
+  fi
+
   if [ -z "${ARTIFACTS+x}" ]; then
     echo "ARTIFACTS can't be empty" > /dev/stderr
     exit 2
@@ -262,6 +259,7 @@ spec:
     - "--scyllacluster-node-service-type=${SO_SCYLLACLUSTER_NODE_SERVICE_TYPE}"
     - "--scyllacluster-nodes-broadcast-address-type=${SO_SCYLLACLUSTER_NODES_BROADCAST_ADDRESS_TYPE}"
     - "--scyllacluster-clients-broadcast-address-type=${SO_SCYLLACLUSTER_CLIENTS_BROADCAST_ADDRESS_TYPE}"
+    - "--scyllacluster-storageclass-name=${SO_SCYLLACLUSTER_STORAGECLASS_NAME}"
     - "--object-storage-bucket=${SO_BUCKET_NAME}"
     - "--gcs-service-account-key-path=${gcs_sa_in_container_path}"
     image: "${SO_IMAGE}"

--- a/hack/.ci/run-e2e-gke-release.sh
+++ b/hack/.ci/run-e2e-gke-release.sh
@@ -20,8 +20,8 @@ trap gather-artifacts-on-exit EXIT
 SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=${parent_dir}/manifests/cluster/nodeconfig.yaml}"
 export SO_NODECONFIG_PATH
 
-# Make sure there is no default storage class before we create our own so we always use our own provisioner from the release.
-unset-default-storageclass
+SO_SCYLLACLUSTER_STORAGECLASS_NAME="${SO_SCYLLACLUSTER_STORAGECLASS_NAME=scylladb-local-xfs}"
+export SO_SCYLLACLUSTER_STORAGECLASS_NAME
 
 SCYLLA_OPERATOR_FEATURE_GATES="${SCYLLA_OPERATOR_FEATURE_GATES:-AllAlpha=true,AllBeta=true}"
 export SCYLLA_OPERATOR_FEATURE_GATES

--- a/hack/.ci/run-e2e-gke.sh
+++ b/hack/.ci/run-e2e-gke.sh
@@ -21,14 +21,13 @@ SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=./hack/.ci/manifests/cluster/nodeconfig
 export SO_NODECONFIG_PATH
 SO_CSI_DRIVER_PATH="${parent_dir}/manifests/namespaces/local-csi-driver/"
 export SO_CSI_DRIVER_PATH
+SO_SCYLLACLUSTER_STORAGECLASS_NAME="${SO_SCYLLACLUSTER_STORAGECLASS_NAME=scylladb-local-xfs}"
+export SO_SCYLLACLUSTER_STORAGECLASS_NAME
 
 # Backwards compatibility. Remove when release repo stops using SO_DISABLE_NODECONFIG.
 if [[ "${SO_DISABLE_NODECONFIG:-false}" == "true" ]]; then
   SO_NODECONFIG_PATH=""
   SO_CSI_DRIVER_PATH=""
-else
-  # Make sure there is no default storage class before we create our own.
-  unset-default-storageclass
 fi
 
 SCYLLA_OPERATOR_FEATURE_GATES="${SCYLLA_OPERATOR_FEATURE_GATES:-AllAlpha=true,AllBeta=true}"

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -71,6 +71,11 @@ else
   kubectl_create -n=local-csi-driver -f="${SO_CSI_DRIVER_PATH}"
 fi
 
+if [[ -n "${SO_SCYLLACLUSTER_STORAGECLASS_NAME}" ]]; then
+  yq e --inplace '.spec.datacenter.racks[0].storage.storageClassName = env(SO_SCYLLACLUSTER_STORAGECLASS_NAME)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"
+elif [[ -n "${SO_SCYLLACLUSTER_STORAGECLASS_NAME+x}" ]]; then
+  yq e --inplace 'del(.spec.datacenter.racks[0].storage.storageClassName)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"
+fi
 kubectl_create -f "${DEPLOY_DIR}"/manager
 
 kubectl -n=scylla-manager wait --timeout=5m --for='condition=Progressing=False' scyllaclusters.scylla.scylladb.com/scylla-manager-cluster

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -35,6 +35,7 @@ scylla:
     members: 1
     storage:
       capacity: 5Gi
+      storageClassName: scylladb-local-xfs
     resources:
       limits:
         cpu: 1

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -82,6 +82,7 @@ scylla:
     members: 1
     storage:
       capacity: 5Gi
+      storageClassName: scylladb-local-xfs
     resources:
       limits:
         cpu: 1

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -62,6 +62,7 @@ racks:
   members: 3
   # Storage definition
   storage:
+    storageClassName: scylladb-local-xfs
     capacity: 10Gi
   # Scylla container resource definition
   resources:

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -26,6 +26,7 @@ type ScyllaClusterOptions struct {
 	NodeServiceType             string
 	NodesBroadcastAddressType   string
 	ClientsBroadcastAddressType string
+	StorageClassName            string
 }
 
 var supportedNodeServiceTypes = []scyllav1.NodeServiceType{
@@ -63,6 +64,7 @@ func NewTestFrameworkOptions(streams genericclioptions.IOStreams, userAgent stri
 			NodeServiceType:             string(scyllav1.NodeServiceTypeHeadless),
 			NodesBroadcastAddressType:   string(scyllav1.BroadcastAddressTypePodIP),
 			ClientsBroadcastAddressType: string(scyllav1.BroadcastAddressTypePodIP),
+			StorageClassName:            "",
 		},
 		ObjectStorageBucket:      "",
 		GCSServiceAccountKeyPath: "",
@@ -98,6 +100,7 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 		slices.ConvertSlice(supportedBroadcastAddressTypes, slices.ToString[scyllav1.BroadcastAddressType]),
 		", ",
 	)))
+	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.StorageClassName, "scyllacluster-storageclass-name", "", o.ScyllaClusterOptionsUntyped.StorageClassName, fmt.Sprintf("Name of the StorageClass to request for ScyllaCluster storage."))
 	cmd.PersistentFlags().StringVarP(&o.ObjectStorageBucket, "object-storage-bucket", "", o.ObjectStorageBucket, "Name of the object storage bucket.")
 	cmd.PersistentFlags().StringVarP(&o.GCSServiceAccountKeyPath, "gcs-service-account-key-path", "", o.GCSServiceAccountKeyPath, "Path to a file containing a GCS service account key.")
 }
@@ -158,6 +161,7 @@ func (o *TestFrameworkOptions) Complete(args []string) error {
 			NodesBroadcastAddressType:   scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType),
 			ClientsBroadcastAddressType: scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType),
 		},
+		StorageClassName: o.ScyllaClusterOptionsUntyped.StorageClassName,
 	}
 
 	if len(o.GCSServiceAccountKeyPath) > 0 {

--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -25,6 +25,9 @@ spec:
       members: 1
       storage:
         capacity: 1Gi
+        {{- if .storageClassName }}
+        storageClassName: {{ .storageClassName }}
+        {{- end }}
       resources:
         requests:
           cpu: 10m

--- a/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
@@ -26,6 +26,9 @@ spec:
       members: 1
       storage:
         capacity: 1Gi
+        {{- if $.storageClassName }}
+        storageClassName: {{ $.storageClassName }}
+        {{- end }}
       resources:
         requests:
           cpu: 10m

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -106,6 +106,7 @@ func (f *Framework) GetDefaultScyllaCluster() *scyllav1.ScyllaCluster {
 		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
 		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
+		"storageClassName":            TestContext.ScyllaClusterOptions.StorageClassName,
 	}
 
 	sc, _, err := scyllafixture.ScyllaClusterTemplate.RenderObject(renderArgs)
@@ -119,6 +120,7 @@ func (f *Framework) GetDefaultZonalScyllaClusterWithThreeRacks() *scyllav1.Scyll
 		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
 		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
+		"storageClassName":            TestContext.ScyllaClusterOptions.StorageClassName,
 		"rackNames":                   []string{"a", "b", "c"},
 	}
 

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -24,7 +24,8 @@ type IngressController struct {
 }
 
 type ScyllaClusterOptions struct {
-	ExposeOptions ExposeOptions
+	ExposeOptions    ExposeOptions
+	StorageClassName string
 }
 
 type ExposeOptions struct {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR addresses the issue of ScyllaClusters in our manifests, examples, scripts and tests often depending on the presence of a default StorageClass. This is problematic because there can only be one, indicated with an annotation, so setting/unsetting a default tends to break immutability.

Simultaneously I've tried not to break existing workflows and not have to change all of our CI jobs by expecting a StorageClass to be set explicitly. Therefore:
- test options are extended with an optional `scyllacluster-storageclass-name` flag, which defaults to empty string, which is then interpreted as falling back to default storageclass (not setting storageClassName),
- all ScyllaClusters in our manifests and examples have `storageClassName` set to `scylladb-local-xfs` by default
- e2e/deploy scripts take `SO_SCYLLACLUSTER_STORAGECLASS_NAME` which propagates to Scylla Manager's and tests' clusters; if `SO_SCYLLACLUSTER_STORAGECLASS_NAME` is explicitly set and empty, `storageClassName` is not set, falling back to default storageclass
 
**Which issue is resolved by this Pull Request:**
Resolves #1990 

/kind feature
/priority important-soon

/cc
