### PR TITLE
Create a deploy directory per kubeconfig in CI release scripts

### DIFF
--- a/hack/.ci/run-e2e-gke-release.sh
+++ b/hack/.ci/run-e2e-gke-release.sh
@@ -27,7 +27,7 @@ SCYLLA_OPERATOR_FEATURE_GATES="${SCYLLA_OPERATOR_FEATURE_GATES:-AllAlpha=true,Al
 export SCYLLA_OPERATOR_FEATURE_GATES
 
 for i in "${!KUBECONFIGS[@]}"; do
-  KUBECONFIG="${KUBECONFIGS[$i]}" timeout --foreground -v 10m "${parent_dir}/../ci-deploy-release.sh" "${SO_IMAGE}" &
+  KUBECONFIG="${KUBECONFIGS[$i]}" ARTIFACTS_DEPLOY_DIR="${ARTIFACTS}/deploy/${i}" timeout --foreground -v 10m "${parent_dir}/../ci-deploy-release.sh" "${SO_IMAGE}" &
   ci_deploy_bg_pids["${i}"]=$!
 done
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR modifies the CI release scripts to create a deploy directory per kubeconfig to support multiple kubeconfigs used in multi-datacenter tests.

**Which issue is resolved by this Pull Request:**
Resolves #2019 

/kind bug
/priority important-soon