### PR TITLE
Update node setup image digest to latest multiplatform

### DIFF
--- a/test/e2e/utils/image/manifests.go
+++ b/test/e2e/utils/image/manifests.go
@@ -44,7 +44,7 @@ const (
 func initImageConfigs(list RegistryList) map[int]Config {
 	configs := map[int]Config{}
 	configs[BusyBox] = Config{registry: list.DockerLibraryRegistry, name: "busybox", version: "1.35"}
-	configs[OperatorNodeSetup] = Config{registry: list.QuayScyllaDB, name: "scylla-operator-images", version: "node-setup-v0.0.1@sha256:a25e77c769605bbb1f9c8b0b29723bb6b1d9990982d43c908779a0717dc10cb4"}
+	configs[OperatorNodeSetup] = Config{registry: list.QuayScyllaDB, name: "scylla-operator-images", version: "node-setup-v0.0.2@sha256:210b1dd9bd60a5bf4056783f3132bdeef0cf9ab0a19eff0b620b2dfa5c4e5d61"}
 
 	return configs
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Digest used for node-setup image config in e2e utils points to a single image built for amd64, which causes the tests to fail on arm64. This PR updates it to latest multiplatform manifest list.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2021

/kind bug
/priority critical-urgent