### PR TITLE
Remove IP Address based node replace procedure

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -96,23 +96,6 @@ func MemberService(sc *scyllav1.ScyllaCluster, rackName, name string, oldService
 	svcLabels[naming.RackNameLabel] = rackName
 	svcLabels[naming.ScyllaServiceTypeLabel] = string(naming.ScyllaServiceTypeMember)
 
-	var replaceAddr string
-	var hasReplaceLabel bool
-	if oldService != nil {
-		replaceAddr, hasReplaceLabel = oldService.Labels[naming.ReplaceLabel]
-	}
-
-	// Only new service should get the replace address, old service keeps "" until deleted.
-	if !hasReplaceLabel || len(replaceAddr) != 0 {
-		rackStatus, ok := sc.Status.Racks[rackName]
-		if ok {
-			replaceAddr := rackStatus.ReplaceAddressFirstBoot[name]
-			if len(replaceAddr) != 0 {
-				svcLabels[naming.ReplaceLabel] = replaceAddr
-			}
-		}
-	}
-
 	svcAnnotations := map[string]string{}
 	if sc.Spec.ExposeOptions != nil && sc.Spec.ExposeOptions.NodeService.Annotations != nil {
 		maps.Copy(svcAnnotations, sc.Spec.ExposeOptions.NodeService.Annotations)

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -158,80 +158,6 @@ func TestMemberService(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "new service with saved IP",
-			scyllaCluster: func() *scyllav1.ScyllaCluster {
-				sc := basicSC.DeepCopy()
-				sc.Status.Racks[basicRackName] = scyllav1.RackStatus{
-					ReplaceAddressFirstBoot: map[string]string{
-						basicSVCName: "10.0.0.1",
-					},
-				}
-				return sc
-			}(),
-			rackName:   basicRackName,
-			svcName:    basicSVCName,
-			oldService: nil,
-			jobs:       nil,
-			expectedService: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = "10.0.0.1"
-						return labels
-					}(),
-					Annotations:     basicSVCAnnotations(),
-					OwnerReferences: basicSCOwnerRefs,
-				},
-				Spec: corev1.ServiceSpec{
-					Type:                     corev1.ServiceTypeClusterIP,
-					Selector:                 basicSVCSelector,
-					PublishNotReadyAddresses: true,
-					Ports:                    basicPorts,
-				},
-			},
-		},
-		{
-			name: "new service with saved IP and existing replace address",
-			scyllaCluster: func() *scyllav1.ScyllaCluster {
-				sc := basicSC.DeepCopy()
-				sc.Status.Racks[basicRackName] = scyllav1.RackStatus{
-					ReplaceAddressFirstBoot: map[string]string{
-						basicSVCName: "10.0.0.1",
-					},
-				}
-				return sc
-			}(),
-			rackName: basicRackName,
-			svcName:  basicSVCName,
-			oldService: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						naming.ReplaceLabel: "10.0.0.1",
-					},
-				},
-			},
-			jobs: nil,
-			expectedService: &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: basicSVCName,
-					Labels: func() map[string]string {
-						labels := basicSVCLabels()
-						labels[naming.ReplaceLabel] = "10.0.0.1"
-						return labels
-					}(),
-					Annotations:     basicSVCAnnotations(),
-					OwnerReferences: basicSCOwnerRefs,
-				},
-				Spec: corev1.ServiceSpec{
-					Type:                     corev1.ServiceTypeClusterIP,
-					Selector:                 basicSVCSelector,
-					PublishNotReadyAddresses: true,
-					Ports:                    basicPorts,
-				},
-			},
-		},
 		// This behaviour is based on the fact the we merge labels on apply.
 		// TODO: to be addressed with https://github.com/scylladb/scylla-operator/issues/1440.
 		{
@@ -263,18 +189,10 @@ func TestMemberService(t *testing.T) {
 			},
 		},
 		{
-			name: "existing initial service with IP",
-			scyllaCluster: func() *scyllav1.ScyllaCluster {
-				sc := basicSC.DeepCopy()
-				sc.Status.Racks[basicRackName] = scyllav1.RackStatus{
-					ReplaceAddressFirstBoot: map[string]string{
-						basicSVCName: "10.0.0.1",
-					},
-				}
-				return sc
-			}(),
-			rackName: basicRackName,
-			svcName:  basicSVCName,
+			name:          "existing initial service with IP",
+			scyllaCluster: basicSC.DeepCopy(),
+			rackName:      basicRackName,
+			svcName:       basicSVCName,
 			oldService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -221,14 +221,6 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 		"broadcast-rpc-address": &m.BroadcastRPCAddress,
 	}
 
-	// If node is being replaced
-	if addr, ok := m.ServiceLabels[naming.ReplaceLabel]; ok {
-		if len(addr) == 0 {
-			klog.Warningf("Service %q have unexpectedly empty label %q, skipping replace", m.Name, naming.ReplaceLabel)
-		} else {
-			args["replace-address-first-boot"] = pointer.Ptr(addr)
-		}
-	}
 	if hostID, ok := m.ServiceLabels[naming.ReplacingNodeHostIDLabel]; ok {
 		if len(hostID) == 0 {
 			klog.Warningf("Service %q have unexpectedly empty label %q, skipping replace", m.Name, naming.ReplacingNodeHostIDLabel)


### PR DESCRIPTION
**Description of your changes:**

Procedure which was executed for ScyllaDB versions <5.2 and <2023.1 is removed, as these versions are no longer supported. Nodes are going to be replaced only using HostID based procedure.

**Which issue is resolved by this Pull Request:**
Resolves #2026
