### PR TITLE
Add support for service monitors' custom labels in Scylla Helm chart

### DIFF
--- a/helm/scylla-manager/templates/manager_servicemonitor.yaml
+++ b/helm/scylla-manager/templates/manager_servicemonitor.yaml
@@ -4,6 +4,10 @@ kind: ServiceMonitor
 metadata:
   name: scylla-manager
   namespace: scylla-manager
+  {{- if .Values.serviceMonitor.labels }}
+  labels:
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+  {{- end }}
 spec:
   jobLabel: "app"
   selector:

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -3056,6 +3056,9 @@
       "properties": {
         "create": {
           "type": "boolean"
+        },
+        "labels": {
+          "type": "object"
         }
       }
     }

--- a/helm/scylla-manager/values.schema.template.json
+++ b/helm/scylla-manager/values.schema.template.json
@@ -126,6 +126,9 @@
       "properties": {
         "create": {
           "type": "boolean"
+        },
+        "labels": {
+          "type": "object"
         }
       }
     }

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -80,3 +80,4 @@ scylla:
 # Whether to create Prometheus ServiceMonitor
 serviceMonitor:
   create: false
+  labels: {}

--- a/helm/scylla/templates/servicemonitor.yaml
+++ b/helm/scylla/templates/servicemonitor.yaml
@@ -4,6 +4,10 @@ kind: ServiceMonitor
 metadata:
   name: {{ printf "%s-service-monitor" (include "scylla.fullname" .) }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceMonitor.labels }}
+  labels:
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+  {{- end }}
 spec:
   jobLabel: "app"
   targetLabels: ["scylla/cluster"]

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -69,3 +69,4 @@ racks:
 # Whether to create Prometheus ServiceMonitor
 serviceMonitor:
   create: false
+  labels: {}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR aims to support custom labels for service monitors created by the Helm chart. This is needed because we only consider Prometheus service monitors with a specific label and currently service monitors created by the Scylla Helm chart don't have any label.

**Which issue is resolved by this Pull Request:**
Resolves #1194 
