### PR TITLE
Set an explicit key for gcs-service-account-credentials secret in e2e scripts

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -215,7 +215,7 @@ function run-e2e {
   gcs_sa_in_container_path=""
   if [[ -n "${SO_GCS_SERVICE_ACCOUNT_CREDENTIALS_PATH+x}" ]]; then
     gcs_sa_in_container_path=/var/run/secrets/gcs-service-account-credentials/gcs-service-account.json
-    kubectl create -n=e2e secret generic gcs-service-account-credentials --from-file="${SO_GCS_SERVICE_ACCOUNT_CREDENTIALS_PATH}" --dry-run=client -o=yaml | kubectl_create -f=-
+    kubectl create -n=e2e secret generic gcs-service-account-credentials --from-file=gcs-service-account.json="${SO_GCS_SERVICE_ACCOUNT_CREDENTIALS_PATH}" --dry-run=client -o=yaml | kubectl_create -f=-
   else
     kubectl create -n=e2e secret generic gcs-service-account-credentials --dry-run=client -o=yaml | kubectl_create -f=-
   fi


### PR DESCRIPTION
**Description of your changes:** This PR modifies the gcs-service-account-credentials secret creation kubectl command by giving it an explicit key so that the credentials file passed through SO_GCS_SERVICE_ACCOUNT_CREDENTIALS_PATH doesn't have to have a matching name. This is helpful for local development.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-longterm
