### PR TITLE
Add duration to certificate creation logs

### DIFF
--- a/pkg/kubecrypto/certs.go
+++ b/pkg/kubecrypto/certs.go
@@ -198,12 +198,13 @@ func makeCertificate(ctx context.Context, name string, certCreator ocrypto.CertC
 	}
 
 	if len(refreshReason) != 0 {
+		startTime := time.Now()
 		klog.V(2).InfoS("Creating certificate", "Secret", naming.ObjRef(tlsSecret.GetSecret()), "Reason", refreshReason)
 		cert, key, err := certCreator.MakeCertificate(ctx, keyGetter, signer, validity)
 		if err != nil {
 			return nil, fmt.Errorf("can't create certificate: %w", err)
 		}
-		klog.V(2).InfoS("Certificate created", "Secret", naming.ObjRef(tlsSecret.GetSecret()))
+		klog.V(2).InfoS("Certificate created", "Secret", naming.ObjRef(tlsSecret.GetSecret()), "ElapsedTime", time.Now().Sub(startTime))
 
 		certBytes, err := ocrypto.EncodeCertificates(cert)
 		if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR adds duration to certificate creation logs for ease of debugging in scenarios similar to https://github.com/scylladb/scylla-operator/issues/1997. At the moment the pre and post-creation logs have to be matched to asses the time it took to create the certificate, which can be a long running action.

```
I0725 14:09:06.446762       1 kubecrypto/certs.go:201] "Creating certificate" Secret="e2e-test-scyllacluster-2fws8-0-cs67t/basic-7xzt6-local-client-ca" Reason="needs new cert"
I0725 14:09:48.664868       1 kubecrypto/certs.go:206] "Certificate created" Secret="e2e-test-scyllacluster-2fws8-0-cs67t/basic-7xzt6-local-client-ca"
```

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-longterm