### PR TITLE
Use canonical CRD locations in helm CRD symlinks

### DIFF
--- a/helm/scylla-operator/crds/00_scylla.scylladb.com_scyllaclusters.yaml
+++ b/helm/scylla-operator/crds/00_scylla.scylladb.com_scyllaclusters.yaml
@@ -1,1 +1,1 @@
-../../../deploy/operator/00_scylla.scylladb.com_scyllaclusters.yaml
+../../../pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml

--- a/helm/scylla-operator/crds/00_scylla.scylladb.com_scyllaoperatorconfigs.yaml
+++ b/helm/scylla-operator/crds/00_scylla.scylladb.com_scyllaoperatorconfigs.yaml
@@ -1,1 +1,1 @@
-../../../deploy/operator/00_scylla.scylladb.com_scyllaoperatorconfigs.yaml
+../../../pkg/api/scylla/v1alpha1/scylla.scylladb.com_scyllaoperatorconfigs.yaml


### PR DESCRIPTION
**Description of your changes:**
This PR fixes the helm CRD symlinks to point to the actual API definitions and removes a cycle on the `./deploy` dir that is generated from the helm templates.

**Which issue is resolved by this Pull Request:**
Resolves #2043