### PR TITLE
[WIP] Use dedicated nodeconfig in serial suite to keep our storage setup working

### DIFF
--- a/test/e2e/fixture/scylla/nodeconfig.yaml
+++ b/test/e2e/fixture/scylla/nodeconfig.yaml
@@ -1,7 +1,7 @@
 apiVersion: scylla.scylladb.com/v1alpha1
 kind: NodeConfig
 metadata:
-  name: cluster
+  name: e2e-cluster
 spec:
   placement:
     nodeSelector:


### PR DESCRIPTION
**Description of your changes:**
This PR allows to have a pre-existing nodeconfig to keep storage setup working and still run `serial` e2e suite. (For more details see #2045.)

**Which issue is resolved by this Pull Request:**
Resolves #2045

/cc