### PR TITLE
Make parallelism configurable in e2e lib

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -195,6 +195,7 @@ function run-e2e {
 
   FIELD_MANAGER="${FIELD_MANAGER:-run-e2e-script}"
   SO_BUCKET_NAME="${SO_BUCKET_NAME:-}"
+  SO_E2E_PARALLELISM="${SO_E2E_PARALLELISM:-0}"
 
   kubectl create namespace e2e --dry-run=client -o=yaml | kubectl_create -f=-
   kubectl create clusterrolebinding e2e --clusterrole=cluster-admin --serviceaccount=e2e:default --dry-run=client -o=yaml | kubectl_create -f=-
@@ -252,6 +253,7 @@ spec:
     - --loglevel=2
     - --color=false
     - --artifacts-dir=/tmp/artifacts
+    - "--parallelism=${SO_E2E_PARALLELISM}"
     - "--feature-gates=${SCYLLA_OPERATOR_FEATURE_GATES}"
     - "--ingress-controller-address=${ingress_controller_address}"
     - "--ingress-controller-ingress-class-name=${ingress_class_name}"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR makes parallelism of e2e tests runner configurable in the e2e lib. It stems from https://github.com/scylladb/scylla-operator/issues/1997.

**Which issue is resolved by this Pull Request:**
Resolves #

/priority important-soon
/kind feature
