### PR TITLE
Remove default annotation from scylladb-local-xfs StorageClass in CI manifests

### DIFF
--- a/hack/.ci/manifests/namespaces/local-csi-driver/00_scylladb-local-xfs.storageclass.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/00_scylladb-local-xfs.storageclass.yaml
@@ -2,8 +2,6 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: scylladb-local-xfs
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: local.csi.scylladb.com
 volumeBindingMode: WaitForFirstConsumer
 parameters:


### PR DESCRIPTION
**Description of your changes:** With https://github.com/scylladb/scylla-operator/pull/2009, our CI shouldn't depend on the presence of `storageclass.kubernetes.io/is-default-class: "true"` annotation in our manifests. This PR removes it from `scylladb-local-xfs` StorageClass manifest.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind cleanup
/priority important-longterm