### PR TITLE
Add support for S3 object storage to e2e test runner, framework and set

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -142,6 +142,8 @@ func (f *Framework) GetObjectStorageProvider() string {
 	switch TestContext.ObjectStorageType {
 	case ObjectStorageTypeGCS:
 		return "gcs"
+	case ObjectStorageTypeS3:
+		return "s3"
 	default:
 		return ""
 	}
@@ -153,6 +155,10 @@ func (f *Framework) GetObjectStorageBucket() string {
 
 func (f *Framework) GetGCSServiceAccountKey() []byte {
 	return TestContext.GCSServiceAccountKey
+}
+
+func (f *Framework) GetS3CredentialsFile() []byte {
+	return TestContext.S3CredentialsFile
 }
 
 func (f *Framework) defaultCluster() *Cluster {

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -39,6 +39,7 @@ type ObjectStorageType string
 const (
 	ObjectStorageTypeNone ObjectStorageType = "None"
 	ObjectStorageTypeGCS  ObjectStorageType = "GCS"
+	ObjectStorageTypeS3   ObjectStorageType = "S3"
 )
 
 type TestContextType struct {
@@ -50,4 +51,5 @@ type TestContextType struct {
 	ObjectStorageType     ObjectStorageType
 	ObjectStorageBucket   string
 	GCSServiceAccountKey  []byte
+	S3CredentialsFile     []byte
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR extends object storage support in our e2e test runner, framework and set with S3.
To provide access to the S3 buckets to Scylla Manager agent containers, it makes use of [shared AWS `credentials` file](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html), leaving the possibility of adding the shared AWS `config` file in the future.

**Which issue is resolved by this Pull Request:**
Resolves #https://github.com/scylladb/scylla-operator/issues/1988

/kind feature
/priority important-soon
