### PR TITLE
Substitute unbound SO_SCYLLACLUSTER_STORAGECLASS_NAME var in ci-deploy script

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -71,7 +71,7 @@ else
   kubectl_create -n=local-csi-driver -f="${SO_CSI_DRIVER_PATH}"
 fi
 
-if [[ -n "${SO_SCYLLACLUSTER_STORAGECLASS_NAME}" ]]; then
+if [[ -n "${SO_SCYLLACLUSTER_STORAGECLASS_NAME:-}" ]]; then
   yq e --inplace '.spec.datacenter.racks[0].storage.storageClassName = env(SO_SCYLLACLUSTER_STORAGECLASS_NAME)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"
 elif [[ -n "${SO_SCYLLACLUSTER_STORAGECLASS_NAME+x}" ]]; then
   yq e --inplace 'del(.spec.datacenter.racks[0].storage.storageClassName)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** In cases where SO_SCYLLACLUSTER_STORAGECLASS_NAME is unbound, hack/ci-deploy.sh script will now fail with an error:
```
./hack/ci-deploy.sh: line 74: SO_SCYLLACLUSTER_STORAGECLASS_NAME: unbound variable
```

This is not the intended behaviour and it now requires providing the value explicitly, which is not the intended behaviour.

This PR substitutes that variable, so that the default intended behaviour is executed for an unset var.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-longterm