### PR TITLE
Set explicit storageClassName in monitoring examples and docs

### DIFF
--- a/docs/source/monitoring.md
+++ b/docs/source/monitoring.md
@@ -20,6 +20,7 @@ spec:
       storage:
         volumeClaimTemplate:
           spec:
+            storageClassName: scylladb-local-xfs
             resources:
               requests:
                 storage: 1Gi

--- a/examples/monitoring/v1alpha1/scylladbmonitoring.yaml
+++ b/examples/monitoring/v1alpha1/scylladbmonitoring.yaml
@@ -15,6 +15,7 @@ spec:
         volumeClaimTemplate:
           spec:
             resources:
+              storageClassName: scylladb-local-xfs
               requests:
                 storage: 1Gi
     grafana:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** When adding explicit storageClassNames to our manifests we forgot about prometheus storage, so if a user tries to follow the docs or use the examples without a default storage class they'll get stuck on no storage provisioning. This PR adds the explicit storageClassNames to monitoring manifests in our examples and docs.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-longterm