### PR TITLE
Pin Scylla Manager version using sha reference

### DIFF
--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -251,7 +251,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.3.0
+        image: docker.io/scylladb/scylla-manager:3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -251,7 +251,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.3.0
+        image: docker.io/scylladb/scylla-manager:3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/dev/50_manager_deployment.yaml
+++ b/deploy/manager/dev/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.3.0
+        image: docker.io/scylladb/scylla-manager:3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/prod/50_manager_deployment.yaml
+++ b/deploy/manager/prod/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.3.0
+        image: docker.io/scylladb/scylla-manager:3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 image:
   repository: scylladb
   pullPolicy: IfNotPresent
-  tag: 3.3.0
+  tag: 3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
 
 # Allows to customize Scylla Manager Controller image
 controllerImage:


### PR DESCRIPTION
This pins used Scylla Manager version to particular sha reference instead using just the tag.

At the time of writing this commit message, 3.3.0 tag is overwritten by image built from unknown version and breaks our E2E tests. SHA used in this PR is a working version before the image change. 