### PR TITLE
Add scylla-manager-agent readiness probe

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -930,6 +930,13 @@ func agentContainer(r scyllav1.RackSpec, c *scyllav1.ScyllaCluster) corev1.Conta
 				ContainerPort: 10001,
 			},
 		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt32(10001),
+				},
+			},
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      naming.PVCTemplateName,

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -969,6 +969,13 @@ func TestStatefulSetForRack(t *testing.T) {
 										ContainerPort: 10001,
 									},
 								},
+								ReadinessProbe: &corev1.Probe{
+									ProbeHandler: corev1.ProbeHandler{
+										TCPSocket: &corev1.TCPSocketAction{
+											Port: intstr.FromInt32(10001),
+										},
+									},
+								},
 								VolumeMounts: []corev1.VolumeMount{
 									{
 										Name:      "data",


### PR DESCRIPTION
**Description of your changes:**
This PR adds a readiness probe for scylla-manager-agent to better project the container state.

**Which issue is resolved by this Pull Request:**
Resolves #2060
