### PR TITLE
Deprecate cpuset field in v1.ScyllaCluster

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1205,7 +1205,7 @@ spec:
                     type: object
                   type: array
                 cpuset:
-                  description: cpuset determines if the cluster will use cpu-pinning for max performance.
+                  description: 'cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.'
                   type: boolean
                 datacenter:
                   description: datacenter holds a specification of a datacenter.

--- a/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -92,7 +92,7 @@ object
      - backups specifies backup tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
    * - cpuset
      - boolean
-     - cpuset determines if the cluster will use cpu-pinning for max performance.
+     - cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.
    * - :ref:`datacenter<api-scylla.scylladb.com-scyllaclusters-v1-.spec.datacenter>`
      - object
      - datacenter holds a specification of a datacenter.

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -15,7 +15,6 @@ metadata:
 spec:
   agentVersion: 3.3.0
   version: 5.4.3
-  cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"
   datacenter:

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -15,7 +15,6 @@ metadata:
 spec:
   agentVersion: 3.3.0
   version: 5.4.3
-  cpuset: true
   automaticOrphanedNodeCleanup: true
   sysctls:
     - "fs.aio-max-nr=2097152"

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -281,7 +281,7 @@
           "type": "array"
         },
         "cpuset": {
-          "description": "cpuset determines if the cluster will use cpu-pinning for max performance.",
+          "description": "cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.",
           "type": "boolean"
         },
         "datacenter": {

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -170,7 +170,7 @@
       "type": "array"
     },
     "cpuset": {
-      "description": "cpuset determines if the cluster will use cpu-pinning for max performance.",
+      "description": "cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.",
       "type": "boolean"
     },
     "datacenter": {

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -176,7 +176,7 @@ spec:
                     type: object
                   type: array
                 cpuset:
-                  description: cpuset determines if the cluster will use cpu-pinning for max performance.
+                  description: 'cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.'
                   type: boolean
                 datacenter:
                   description: datacenter holds a specification of a datacenter.

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -63,7 +63,8 @@ type ScyllaClusterSpec struct {
 	// +optional
 	DeveloperMode bool `json:"developerMode,omitempty"`
 
-	// cpuset determines if the cluster will use cpu-pinning for max performance.
+	// cpuset determines if the cluster will use cpu-pinning.
+	// Deprecated: `cpuset` is deprecated and may be ignored in the future.
 	// +optional
 	CpuSet bool `json:"cpuset,omitempty"`
 


### PR DESCRIPTION
**Description of your changes:**

This deprecates `scyllacluster.spec.cpuset` field and removes mentions of it from examples and documentation.

**Which issue is resolved by this Pull Request:**
Resolves #508 
