### PR TITLE
Update Scylla Manager version to 3.3.3

### DIFF
--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -6,8 +6,8 @@ operator:
   scyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride: "2024.1.8"
   # TODO: scyllaDBUtils image can't be bumped until scylladb/scylladb#17787 is fixed.
   scyllaDBUtilsImage: "docker.io/scylladb/scylla:5.4.0@sha256:b9070afdb2be0d5c59b1c196e1bb66660351403cb30d5c6ba446ef8c3b0754f1"
-  scyllaDBManagerVersion: "3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf"
-  scyllaDBManagerAgentVersion: "3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b"
+  scyllaDBManagerVersion: "3.3.3@sha256:b7b342bf0a8bd1e2374b733a3d40e43504e75ef1b9c21fe85c21e08bd08d47e0"
+  scyllaDBManagerAgentVersion: "3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920"
   bashToolsImage: "registry.access.redhat.com/ubi9/ubi:9.3-1361.1699548029@sha256:6b95efc134c2af3d45472c0a2f88e6085433df058cc210abb2bb061ac4d74359"
   grafanaImage: "docker.io/grafana/grafana:9.5.12@sha256:7d2f2a8b7aebe30bf3f9ae0f190e508e571b43f65753ba3b1b1adf0800bc9256"
   prometheusVersion: "v2.44.0"

--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -251,7 +251,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
+        image: docker.io/scylladb/scylla-manager:3.3.3@sha256:b7b342bf0a8bd1e2374b733a3d40e43504e75ef1b9c21fe85c21e08bd08d47e0
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager
@@ -283,7 +283,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 6.1.1
-  agentVersion: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  agentVersion: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -251,7 +251,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
+        image: docker.io/scylladb/scylla-manager:3.3.3@sha256:b7b342bf0a8bd1e2374b733a3d40e43504e75ef1b9c21fe85c21e08bd08d47e0
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager
@@ -283,7 +283,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 6.1.1
-  agentVersion: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  agentVersion: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager/dev/50_manager_deployment.yaml
+++ b/deploy/manager/dev/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
+        image: docker.io/scylladb/scylla-manager:3.3.3@sha256:b7b342bf0a8bd1e2374b733a3d40e43504e75ef1b9c21fe85c21e08bd08d47e0
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 6.1.1
-  agentVersion: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  agentVersion: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager/prod/50_manager_deployment.yaml
+++ b/deploy/manager/prod/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
+        image: docker.io/scylladb/scylla-manager:3.3.3@sha256:b7b342bf0a8bd1e2374b733a3d40e43504e75ef1b9c21fe85c21e08bd08d47e0
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 6.1.1
-  agentVersion: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  agentVersion: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -158,7 +158,7 @@ This requires a small change in the cluster definition.
 Change the `cluster.yaml` file from this:
 ```yaml
 spec:
-  agentVersion: 3.3.0
+  agentVersion: 3.3.3
   version: 6.1.1
   developerMode: true
   datacenter:
@@ -171,7 +171,7 @@ spec:
   alternator:
     port: 8000
     writeIsolation: only_rmw_uses_lwt
-  agentVersion: 3.3.0
+  agentVersion: 3.3.3
   developerMode: true
   datacenter:
     name: us-east-1

--- a/docs/source/multidc/multidc.md
+++ b/docs/source/multidc/multidc.md
@@ -107,7 +107,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.3.0
+  agentVersion: 3.3.3
   version: 6.1.1
   cpuset: true
   sysctls:
@@ -357,7 +357,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.3.0
+  agentVersion: 3.3.3
   version: 6.1.1
   cpuset: true
   sysctls:

--- a/docs/source/nodeoperations/restore.md
+++ b/docs/source/nodeoperations/restore.md
@@ -21,7 +21,7 @@ kind: ScyllaCluster
 metadata:
   name: source
 spec:
-  agentVersion: 3.3.0
+  agentVersion: 3.3.3
   version: 6.1.1
   developerMode: true
   backups:
@@ -50,7 +50,7 @@ kind: ScyllaCluster
 metadata:
   name: target
 spec:
-  agentVersion: 3.3.0
+  agentVersion: 3.3.3
   version: 6.1.1
   developerMode: true
   datacenter:

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -74,7 +74,7 @@ metadata:
   name: guaranteed-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.3.0
+  agentVersion: 3.3.3
   version: 6.1.1
   datacenter:
     name: us-east-1

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -11,7 +11,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  agentVersion: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   version: 6.1.1
   sysctls:
     - fs.aio-max-nr=2097152

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -13,7 +13,7 @@ metadata:
   name: simple-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  agentVersion: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   version: 6.1.1
   developerMode: true
   datacenter:

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -11,7 +11,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  agentVersion: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   version: 6.1.1
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -2,7 +2,7 @@
 scyllaImage:
   tag: 6.1.1
 agentImage:
-  tag: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  tag: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
 # Cluster information
 developerMode: true
 datacenter: us-east-1

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -1,6 +1,6 @@
 # Scylla Manager image
 image:
-  tag: 3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
+  tag: 3.3.3@sha256:b7b342bf0a8bd1e2374b733a3d40e43504e75ef1b9c21fe85c21e08bd08d47e0
 # Resources allocated to Scylla Manager pods
 resources:
   limits:
@@ -23,7 +23,7 @@ scylla:
   scyllaImage:
     tag: 6.1.1
   agentImage:
-    tag: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+    tag: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   datacenter: manager-dc
   racks:
     - name: manager-rack

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -3,7 +3,7 @@ kind: ScyllaCluster
 metadata:
   name: scylla
 spec:
-  agentVersion: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  agentVersion: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   version: 6.1.1
   developerMode: true
   automaticOrphanedNodeCleanup: true

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -1,7 +1,7 @@
 # Scylla Manager image
 image:
   repository: docker.io/scylladb
-  tag: 3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
+  tag: 3.3.3@sha256:b7b342bf0a8bd1e2374b733a3d40e43504e75ef1b9c21fe85c21e08bd08d47e0
 controllerImage:
   repository: docker.io/scylladb
 logLevel: info
@@ -22,7 +22,7 @@ scylla:
     repository: docker.io/scylladb/scylla
     tag: 6.1.1
   agentImage:
-    tag: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+    tag: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
     repository: docker.io/scylladb/scylla-manager-agent
   developerMode: true
   cpuset: true

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 image:
   repository: scylladb
   pullPolicy: IfNotPresent
-  tag: 3.3.0@sha256:e8c5b62c9330f91dfca24f109b033df78113d3ffaac306edf6d3c4346e1fa0bf
+  tag: 3.3.3@sha256:b7b342bf0a8bd1e2374b733a3d40e43504e75ef1b9c21fe85c21e08bd08d47e0
 # Allows to customize Scylla Manager Controller image
 controllerImage:
   repository: scylladb
@@ -62,7 +62,7 @@ scylla:
   scyllaImage:
     tag: 6.1.1
   agentImage:
-    tag: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+    tag: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
   datacenter: manager-dc
   racks:
     - name: manager-rack

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -11,7 +11,7 @@ scyllaImage:
 agentImage:
   repository: scylladb/scylla-manager-agent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.3.0@sha256:dc2684f51e961d88da5a8eac2d9f165cb7a960cbf91f67f49332e7224317c96b
+  tag: 3.3.3@sha256:40e31739e8fb1d48af87abaeaa8ee29f71607964daa8434fe2526dfc6f665920
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** ~This PR updates the version in our docs, examples and manifests to [3.3.1](https://github.com/scylladb/scylla-manager/releases/tag/v3.3.1), which was tagged today. It also pins the agent version in the examples and manifests.~ ~Edit: 3.3.1 had a regression, so this PR bumps the version to 3.3.2 instead which should fix it.~ Edit: 3.3.2 also had a regression, so it updates the version to 3.3.3

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-longterm
