### PR TITLE
Update ScyllaDB versions to 6.1.0 and 2024.1.7

### DIFF
--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -282,7 +282,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.4.3
+  version: 6.1.0
   agentVersion: 3.3.0
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -282,7 +282,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.4.3
+  version: 6.1.0
   agentVersion: 3.3.0
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.4.3
+  version: 6.1.0
   agentVersion: 3.3.0
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 5.4.3
+  version: 6.1.0
   agentVersion: 3.3.0
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -159,7 +159,7 @@ Change the `cluster.yaml` file from this:
 ```yaml
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.1.0
   developerMode: true
   datacenter:
     name: us-east-1
@@ -167,7 +167,7 @@ spec:
 to this:
 ```yaml
 spec:
-  version: 5.4.3
+  version: 6.1.0
   alternator:
     port: 8000
     writeIsolation: only_rmw_uses_lwt

--- a/docs/source/multidc/multidc.md
+++ b/docs/source/multidc/multidc.md
@@ -108,7 +108,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.1.0
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"
@@ -358,7 +358,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.1.0
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"

--- a/docs/source/nodeoperations/restore.md
+++ b/docs/source/nodeoperations/restore.md
@@ -22,7 +22,7 @@ metadata:
   name: source
 spec:
   agentVersion: 3.3.0
-  version: 5.4.1
+  version: 6.1.0
   developerMode: true
   backups:
   - name: foo
@@ -51,7 +51,7 @@ metadata:
   name: target
 spec:
   agentVersion: 3.3.0
-  version: 5.4.1
+  version: 6.1.0
   developerMode: true
   datacenter:
     name: us-east-1

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -75,7 +75,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.1.0
   datacenter:
     name: us-east-1
     racks:

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.1.0
   sysctls:
   - "fs.aio-max-nr=2097152"
   datacenter:

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.1.0
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.1.0
   automaticOrphanedNodeCleanup: true
   sysctls:
     - "fs.aio-max-nr=2097152"

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -1,6 +1,6 @@
 # Version information
 scyllaImage:
-  tag: 5.4.3
+  tag: 6.1.0
 agentImage:
   tag: 3.3.0
 

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -23,7 +23,7 @@ controllerResources:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 5.4.3
+    tag: 6.1.0
   agentImage:
     tag: 3.3.0
   datacenter: manager-dc

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.1.0
   developerMode: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -23,7 +23,7 @@ scylla:
   fullnameOverride: scylla-manager-cluster
   scyllaImage:
     repository: docker.io/scylladb/scylla
-    tag: 5.4.3
+    tag: 6.1.0
   agentImage:
     tag: 3.3.0
     repository: docker.io/scylladb/scylla-manager-agent

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -73,7 +73,7 @@ controllerServiceAccount:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 5.4.3
+    tag: 6.1.0
   agentImage:
     tag: 3.3.0
   datacenter: manager-dc

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 scyllaImage:
   repository: scylladb/scylla
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 5.4.3
+  tag: 6.1.0
 # Allows to customize Scylla image
 agentImage:
   repository: scylladb/scylla-manager-agent

--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
    bar: foo
 spec:
   agentVersion: 3.3.0
-  version: 6.0.1
+  version: 6.1.0
   developerMode: true
   exposeOptions:
     nodeService:

--- a/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
    bar: foo
 spec:
   agentVersion: 3.3.0
-  version: 5.4.3
+  version: 6.1.0
   developerMode: true
   exposeOptions:
     nodeService:

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	updateFromScyllaVersion  = "6.0.0"
-	updateToScyllaVersion    = "6.0.1"
-	upgradeFromScyllaVersion = "5.4.7"
-	upgradeToScyllaVersion   = "6.0.1"
+	updateFromScyllaVersion  = "6.0.1"
+	updateToScyllaVersion    = "6.0.2"
+	upgradeFromScyllaVersion = "6.0.2"
+	upgradeToScyllaVersion   = "6.1.0"
 
 	testTimeout = 45 * time.Minute
 

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -457,7 +457,7 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		// This test validates a workaround explained in the docs - https://operator.docs.scylladb.com/stable/nodeoperations/restore.html
 		g.Entry("using workaround for consistent_cluster_management for ScyllaDB Enterprise 2024.1.X", entry{
 			scyllaRepository: "docker.io/scylladb/scylla-enterprise",
-			scyllaVersion:    "2024.1.5",
+			scyllaVersion:    "2024.1.7",
 			preTargetClusterCreateHook: func(targetCluster *scyllav1.ScyllaCluster) {
 				targetCluster.Spec.ScyllaArgs = "--consistent-cluster-management=false"
 			},


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR updates the default ScyllaDB version used in our tests, manifests, examples and docs to 6.1.0. It also bumps the version used for ScyllaDB Manager restore procedure test for versions 2024.1.Z or older to 2024.1.7. We should be testing against the most recent releases.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-longterm