### PR TITLE
Collect, snapshot and gracefully restore global objects in e2e test

### DIFF
--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -13,15 +13,13 @@ import (
 )
 
 func ManualRef(namespace, name string) string {
+	if len(namespace) == 0 {
+		return name
+	}
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
 func ObjRef(obj metav1.Object) string {
-	namespace := obj.GetNamespace()
-	if len(namespace) == 0 {
-		return obj.GetName()
-	}
-
 	return ManualRef(obj.GetNamespace(), obj.GetName())
 }
 

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -1,0 +1,231 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	"github.com/scylladb/scylla-operator/pkg/gather/collect"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+type CleanupInterface interface {
+	CollectToLog(ctx context.Context)
+	Collect(ctx context.Context, artifactsDir string, ginkgoNamespace string)
+	Cleanup(ctx context.Context)
+}
+
+type NamespaceCleaner struct {
+	Client        kubernetes.Interface
+	DynamicClient dynamic.Interface
+	NS            *corev1.Namespace
+}
+
+var _ CleanupInterface = &NamespaceCleaner{}
+
+func (nc *NamespaceCleaner) CollectToLog(ctx context.Context) {
+	// Log events if the test failed.
+	if g.CurrentSpecReport().Failed() {
+		By(fmt.Sprintf("Collecting events from namespace %q.", nc.NS.Name))
+		DumpEventsInNamespace(ctx, nc.Client, nc.NS.Name)
+	}
+}
+
+func (nc *NamespaceCleaner) Collect(ctx context.Context, artifactsDir string, _ string) {
+	By(fmt.Sprintf("Collecting dumps from namespace %q.", nc.NS.Name))
+
+	err := DumpNamespace(ctx, cacheddiscovery.NewMemCacheClient(nc.Client.Discovery()), nc.DynamicClient, nc.Client.CoreV1(), artifactsDir, nc.NS.Name)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func (nc *NamespaceCleaner) Cleanup(ctx context.Context) {
+	By("Destroying namespace %q.", nc.NS.Name)
+	err := nc.Client.CoreV1().Namespaces().Delete(
+		ctx,
+		nc.NS.Name,
+		metav1.DeleteOptions{
+			GracePeriodSeconds: pointer.Ptr[int64](0),
+			PropagationPolicy:  pointer.Ptr(metav1.DeletePropagationForeground),
+			Preconditions: &metav1.Preconditions{
+				UID: &nc.NS.UID,
+			},
+		},
+	)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// We have deleted only the namespace object, but it can still be there with deletionTimestamp set.
+	By("Waiting for namespace %q to be removed.", nc.NS.Name)
+	err = WaitForObjectDeletion(ctx, nc.DynamicClient, corev1.SchemeGroupVersion.WithResource("namespaces"), "", nc.NS.Name, &nc.NS.UID)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	klog.InfoS("Namespace removed.", "Namespace", nc.NS.Name)
+}
+
+type RestoreStrategy string
+
+const (
+	RestoreStrategyRecreate RestoreStrategy = "Recreate"
+	RestoreStrategyUpdate   RestoreStrategy = "Update"
+)
+
+type RestoringCleaner struct {
+	client        kubernetes.Interface
+	dynamicClient dynamic.Interface
+	resourceInfo  collect.ResourceInfo
+	object        *unstructured.Unstructured
+	strategy      RestoreStrategy
+}
+
+var _ CleanupInterface = &RestoringCleaner{}
+
+func NewRestoringCleaner(ctx context.Context, client kubernetes.Interface, dynamicClient dynamic.Interface, resourceInfo collect.ResourceInfo, namespace string, name string, strategy RestoreStrategy) *RestoringCleaner {
+	g.By(fmt.Sprintf("Snapshotting object %s %q", resourceInfo.Resource, naming.ManualRef(namespace, name)))
+
+	if resourceInfo.Scope.Name() == meta.RESTScopeNameNamespace {
+		o.Expect(namespace).NotTo(o.BeEmpty())
+	}
+
+	obj, err := dynamicClient.Resource(resourceInfo.Resource).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.InfoS("No existing object found", "GVR", resourceInfo.Resource, "Instance", naming.ManualRef(namespace, name))
+		obj = &unstructured.Unstructured{
+			Object: map[string]interface{}{},
+		}
+		obj.SetNamespace(namespace)
+		obj.SetName(name)
+		obj.SetUID("")
+	} else {
+		o.Expect(err).NotTo(o.HaveOccurred())
+		klog.InfoS("Snapshotted object", "GVR", resourceInfo.Resource, "Instance", naming.ManualRef(namespace, name), "UID", obj.GetUID())
+	}
+
+	return &RestoringCleaner{
+		client:        client,
+		dynamicClient: dynamicClient,
+		resourceInfo:  resourceInfo,
+		object:        obj,
+		strategy:      strategy,
+	}
+}
+
+func (rc *RestoringCleaner) getCleansedObject() *unstructured.Unstructured {
+	obj := rc.object.DeepCopy()
+	obj.SetResourceVersion("")
+	obj.SetUID("")
+	obj.SetCreationTimestamp(metav1.Time{})
+	obj.SetDeletionTimestamp(nil)
+	return obj
+}
+
+func (rc *RestoringCleaner) CollectToLog(ctx context.Context) {}
+
+func (rc *RestoringCleaner) Collect(ctx context.Context, clusterArtifactsDir string, ginkgoNamespace string) {
+	artifactsDir := clusterArtifactsDir
+	if len(artifactsDir) != 0 && rc.resourceInfo.Scope.Name() == meta.RESTScopeNameRoot {
+		// We have to prevent global object dumps being overwritten with each "It" block.
+		artifactsDir = filepath.Join(artifactsDir, "cluster-scoped-per-ns", ginkgoNamespace)
+	}
+
+	By(fmt.Sprintf("Collecting global %s %q for namespace %q.", rc.resourceInfo.Resource, naming.ObjRef(rc.object), ginkgoNamespace))
+
+	err := DumpResource(
+		ctx,
+		rc.client.Discovery(),
+		rc.dynamicClient,
+		rc.client.CoreV1(),
+		artifactsDir,
+		&rc.resourceInfo,
+		rc.object.GetNamespace(),
+		rc.object.GetName(),
+	)
+	if apierrors.IsNotFound(err) {
+		klog.V(2).InfoS("Skipping object collection because it no longer exists", "Ref", naming.ObjRef(rc.object), "Resource", rc.resourceInfo.Resource)
+	} else {
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+}
+
+func (rc *RestoringCleaner) DeleteObject(ctx context.Context, ignoreNotFound bool) {
+	By("Deleting object %s %q.", rc.resourceInfo.Resource, naming.ObjRef(rc.object))
+	err := rc.dynamicClient.Resource(rc.resourceInfo.Resource).Namespace(rc.object.GetNamespace()).Delete(
+		ctx,
+		rc.object.GetName(),
+		metav1.DeleteOptions{
+			GracePeriodSeconds: pointer.Ptr[int64](0),
+			PropagationPolicy:  pointer.Ptr(metav1.DeletePropagationForeground),
+		},
+	)
+	if apierrors.IsNotFound(err) && ignoreNotFound {
+		return
+	}
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// We have deleted only the object, but it can still be there with deletionTimestamp set.
+	By("Waiting for object %s %q to be removed.", rc.resourceInfo.Resource, naming.ObjRef(rc.object))
+	err = WaitForObjectDeletion(ctx, rc.dynamicClient, rc.resourceInfo.Resource, rc.object.GetNamespace(), rc.object.GetName(), nil)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	By("Object %s %q has been removed.", rc.resourceInfo.Resource, naming.ObjRef(rc.object))
+}
+
+func (rc *RestoringCleaner) recreateObject(ctx context.Context) {
+	o.Expect(rc.object.GetUID()).NotTo(o.BeEmpty())
+
+	rc.DeleteObject(ctx, true)
+
+	_, err := rc.dynamicClient.Resource(rc.resourceInfo.Resource).Namespace(rc.object.GetNamespace()).Create(ctx, rc.getCleansedObject(), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func (rc *RestoringCleaner) replaceObject(ctx context.Context) {
+	o.Expect(rc.object.GetUID()).NotTo(o.BeEmpty())
+	var err error
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var freshObj *unstructured.Unstructured
+		freshObj, err = rc.dynamicClient.Resource(rc.resourceInfo.Resource).Namespace(rc.object.GetNamespace()).Get(ctx, rc.object.GetName(), metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			_, err = rc.dynamicClient.Resource(rc.resourceInfo.Resource).Namespace(rc.object.GetNamespace()).Create(ctx, rc.getCleansedObject(), metav1.CreateOptions{})
+			return err
+		}
+
+		obj := rc.getCleansedObject()
+		obj.SetResourceVersion(freshObj.GetResourceVersion())
+
+		o.Expect(err).NotTo(o.HaveOccurred())
+		_, err = rc.dynamicClient.Resource(rc.resourceInfo.Resource).Namespace(obj.GetNamespace()).Update(ctx, obj, metav1.UpdateOptions{})
+		return err
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func (rc *RestoringCleaner) restoreObject(ctx context.Context) {
+	By("Restoring original object %s %q.", rc.resourceInfo.Resource, naming.ObjRef(rc.object))
+	switch rc.strategy {
+	case RestoreStrategyRecreate:
+		rc.recreateObject(ctx)
+	case RestoreStrategyUpdate:
+		rc.replaceObject(ctx)
+	default:
+		g.Fail(fmt.Sprintf("unexpected strategy %q", rc.strategy))
+	}
+}
+
+func (rc *RestoringCleaner) Cleanup(ctx context.Context) {
+	if len(rc.object.GetUID()) == 0 {
+		rc.DeleteObject(ctx, true)
+		return
+	}
+
+	rc.restoreObject(ctx)
+}

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -4,19 +4,10 @@ package framework
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path"
 
-	g "github.com/onsi/ginkgo/v2"
-	o "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
 )
 
 type ClusterInterface interface {
@@ -30,18 +21,20 @@ type createNamespaceFunc func(ctx context.Context, adminClient kubernetes.Interf
 type Cluster struct {
 	AdminClient
 
-	name string
+	name         string
+	artifactsDir string
 
-	createNamespace    createNamespaceFunc
-	defaultNamespace   *corev1.Namespace
-	defaultClient      Client
-	namespacesToDelete []*corev1.Namespace
+	createNamespace  createNamespaceFunc
+	defaultNamespace *corev1.Namespace
+	defaultClient    Client
+
+	cleaners []CleanupInterface
 }
 
 var _ AdminClientInterface = &Cluster{}
 var _ ClusterInterface = &Cluster{}
 
-func NewCluster(name string, restConfig *restclient.Config, createNamespace createNamespaceFunc) *Cluster {
+func NewCluster(name string, artifactsDir string, restConfig *restclient.Config, createNamespace createNamespaceFunc) *Cluster {
 	adminClientConfig := restclient.CopyConfig(restConfig)
 
 	return &Cluster{
@@ -49,14 +42,15 @@ func NewCluster(name string, restConfig *restclient.Config, createNamespace crea
 			Config: adminClientConfig,
 		},
 
-		name: name,
+		name:         name,
+		artifactsDir: artifactsDir,
 
 		createNamespace:  createNamespace,
 		defaultNamespace: nil,
 		defaultClient: Client{
 			Config: nil,
 		},
-		namespacesToDelete: []*corev1.Namespace{},
+		cleaners: nil,
 	}
 }
 
@@ -68,89 +62,39 @@ func (c *Cluster) DefaultNamespaceIfAny() (*corev1.Namespace, Client, bool) {
 	return c.defaultNamespace, c.defaultClient, true
 }
 
+func (c *Cluster) AddCleaners(cleaners ...CleanupInterface) {
+	c.cleaners = append(c.cleaners, cleaners...)
+}
+
+func (c *Cluster) GetArtifactsDir() string {
+	return c.artifactsDir
+}
+
 func (c *Cluster) CreateUserNamespace(ctx context.Context) (*corev1.Namespace, Client) {
 	ns, nsClient := c.createNamespace(ctx, c.KubeAdminClient(), c.AdminClientConfig())
 
-	c.namespacesToDelete = append(c.namespacesToDelete, ns)
+	c.AddCleaners(&NamespaceCleaner{
+		Client:        c.KubeAdminClient(),
+		DynamicClient: c.DynamicAdminClient(),
+		NS:            ns,
+	})
 
 	return ns, nsClient
 }
 
+func (c *Cluster) Collect(ctx context.Context, ginkgoNamespace string) {
+	for _, cleaner := range c.cleaners {
+		cleaner.CollectToLog(ctx)
+		if len(c.artifactsDir) != 0 {
+			cleaner.Collect(ctx, c.artifactsDir, ginkgoNamespace)
+		}
+	}
+}
+
 func (c *Cluster) Cleanup(ctx context.Context) {
-	for _, ns := range c.namespacesToDelete {
-		collectAndDeleteNamespace(ctx, c.KubeAdminClient(), c.DynamicAdminClient(), ns)
+	for _, cleaner := range c.cleaners {
+		cleaner.Cleanup(ctx)
 	}
 
-	c.namespacesToDelete = []*corev1.Namespace{}
-}
-
-func collectAndDeleteNamespace(ctx context.Context, adminClient kubernetes.Interface, dynamicAdminClient dynamic.Interface, ns *corev1.Namespace) {
-	defer func() {
-		keepNamespace := false
-		switch TestContext.DeleteTestingNSPolicy {
-		case DeleteTestingNSPolicyNever:
-			keepNamespace = true
-		case DeleteTestingNSPolicyOnSuccess:
-			if g.CurrentSpecReport().Failed() {
-				keepNamespace = true
-			}
-		case DeleteTestingNSPolicyAlways:
-		default:
-		}
-
-		if keepNamespace {
-			By("Keeping namespace %q for debugging", ns.Name)
-			return
-		}
-
-		deleteNamespace(ctx, adminClient, dynamicAdminClient, ns)
-
-	}()
-
-	// Print events if the test failed.
-	if g.CurrentSpecReport().Failed() {
-		By(fmt.Sprintf("Collecting events from namespace %q.", ns.Name))
-		DumpEventsInNamespace(ctx, adminClient, ns.Name)
-	}
-
-	// CI can't keep namespaces alive because it could get out of resources for the other tests
-	// so we need to collect the namespaced dump before destroying the namespace.
-	// Collecting artifacts even for successful runs helps to verify if it went
-	// as expected and the amount of data is bearable.
-	if len(TestContext.ArtifactsDir) != 0 {
-		By(fmt.Sprintf("Collecting dumps from namespace %q.", ns.Name))
-
-		d := path.Join(TestContext.ArtifactsDir, "e2e")
-		err := os.Mkdir(d, 0777)
-		if err != nil && !os.IsExist(err) {
-			o.Expect(err).NotTo(o.HaveOccurred())
-		}
-
-		err = DumpNamespace(ctx, cacheddiscovery.NewMemCacheClient(adminClient.Discovery()), dynamicAdminClient, adminClient.CoreV1(), d, ns.Name)
-		o.Expect(err).NotTo(o.HaveOccurred())
-	}
-}
-
-func deleteNamespace(ctx context.Context, adminClient kubernetes.Interface, dynamicAdminClient dynamic.Interface, ns *corev1.Namespace) {
-	By("Destroying namespace %q.", ns.Name)
-	var gracePeriod int64 = 0
-	var propagation = metav1.DeletePropagationForeground
-	err := adminClient.CoreV1().Namespaces().Delete(
-		ctx,
-		ns.Name,
-		metav1.DeleteOptions{
-			GracePeriodSeconds: &gracePeriod,
-			PropagationPolicy:  &propagation,
-			Preconditions: &metav1.Preconditions{
-				UID: &ns.UID,
-			},
-		},
-	)
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	// We have deleted only the namespace object but it is still there with deletionTimestamp set.
-	By("Waiting for namespace %q to be removed.", ns.Name)
-	err = WaitForObjectDeletion(ctx, dynamicAdminClient, corev1.SchemeGroupVersion.WithResource("namespaces"), "", ns.Name, &ns.UID)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	klog.InfoS("Namespace removed.", "Namespace", ns.Name)
+	c.cleaners = c.cleaners[:0]
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -5,6 +5,8 @@ package framework
 import (
 	"context"
 	"fmt"
+	"os"
+	"path"
 	"strconv"
 	"time"
 
@@ -33,7 +35,8 @@ const (
 type Framework struct {
 	FullClient
 
-	name string
+	name            string
+	e2eArtifactsDir string
 
 	clusters []*Cluster
 }
@@ -42,28 +45,51 @@ var _ FullClientInterface = &Framework{}
 var _ ClusterInterface = &Framework{}
 
 func NewFramework(namePrefix string) *Framework {
+	var err error
+
 	f := &Framework{
-		name:       names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", namePrefix)),
-		FullClient: FullClient{},
+		name:            names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", namePrefix)),
+		e2eArtifactsDir: "",
+		FullClient:      FullClient{},
+		clusters:        make([]*Cluster, 0, len(TestContext.RestConfigs)),
 	}
 
-	clusters := make([]*Cluster, 0, len(TestContext.RestConfigs))
+	if len(TestContext.ArtifactsDir) != 0 {
+		f.e2eArtifactsDir = path.Join(TestContext.ArtifactsDir, "e2e")
+		err = os.Mkdir(f.e2eArtifactsDir, 0777)
+		if !os.IsExist(err) {
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+	}
+
+	o.Expect(TestContext.RestConfigs).NotTo(o.BeEmpty())
 	for i, restConfig := range TestContext.RestConfigs {
 		clusterName := fmt.Sprintf("%s-%d", f.name, i)
+
+		clusterE2EArtifactsDir := ""
+		if len(f.e2eArtifactsDir) != 0 {
+			clusterE2EArtifactsDir = path.Join(f.e2eArtifactsDir, fmt.Sprintf("cluster-%d", i))
+			err = os.Mkdir(clusterE2EArtifactsDir, 0777)
+			if !os.IsExist(err) {
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+		}
+
 		c := NewCluster(
 			clusterName,
+			clusterE2EArtifactsDir,
 			restConfig,
 			func(ctx context.Context, adminClient kubernetes.Interface, adminClientConfig *restclient.Config) (*corev1.Namespace, Client) {
 				return CreateUserNamespace(ctx, clusterName, f.CommonLabels(), adminClient, adminClientConfig)
 			},
 		)
-		clusters = append(clusters, c)
+		f.clusters = append(f.clusters, c)
 	}
-	f.clusters = clusters
 
 	f.FullClient.AdminClient.Config = f.defaultCluster().AdminClientConfig()
 
 	g.BeforeEach(f.beforeEach)
+	g.JustAfterEach(f.justAfterEach)
 	g.AfterEach(f.afterEach)
 
 	return f
@@ -80,6 +106,10 @@ func (f *Framework) Namespace() string {
 
 func (f *Framework) DefaultNamespaceIfAny() (*corev1.Namespace, Client, bool) {
 	return f.defaultCluster().DefaultNamespaceIfAny()
+}
+
+func (f *Framework) GetDefaultArtifactsDir() string {
+	return f.defaultCluster().GetArtifactsDir()
 }
 
 func (f *Framework) GetIngressAddress(hostname string) string {
@@ -130,6 +160,10 @@ func (f *Framework) GetDefaultZonalScyllaClusterWithThreeRacks() *scyllav1.Scyll
 	return sc
 }
 
+func (f *Framework) AddCleaners(cleaners ...CleanupInterface) {
+	f.defaultCluster().AddCleaners(cleaners...)
+}
+
 func (f *Framework) CreateUserNamespace(ctx context.Context) (*corev1.Namespace, Client) {
 	return f.defaultCluster().CreateUserNamespace(ctx)
 }
@@ -162,6 +196,7 @@ func (f *Framework) GetS3CredentialsFile() []byte {
 }
 
 func (f *Framework) defaultCluster() *Cluster {
+	o.Expect(f.clusters).NotTo(o.BeEmpty())
 	return f.clusters[0]
 }
 
@@ -170,6 +205,13 @@ func (f *Framework) beforeEach(ctx context.Context) {
 	f.defaultCluster().defaultNamespace = ns
 	f.defaultCluster().defaultClient = nsClient
 	f.FullClient.Client = nsClient
+}
+
+func (f *Framework) justAfterEach(ctx context.Context) {
+	ginkgoNamespace := f.defaultCluster().defaultNamespace.Name
+	for _, c := range f.clusters {
+		c.Collect(ctx, ginkgoNamespace)
+	}
 }
 
 func (f *Framework) afterEach(ctx context.Context) {
@@ -181,8 +223,23 @@ func (f *Framework) afterEach(ctx context.Context) {
 	f.defaultCluster().defaultClient = nilClient
 	f.FullClient.Client = nilClient
 
-	for _, c := range f.clusters {
-		c.Cleanup(ctx)
+	shouldCleanup := true
+	switch TestContext.CleanupPolicy {
+	case CleanupPolicyNever:
+		shouldCleanup = false
+	case CleanupPolicyOnSuccess:
+		if g.CurrentSpecReport().Failed() {
+			shouldCleanup = false
+		}
+	case CleanupPolicyAlways:
+	default:
+		g.Fail(fmt.Sprintf("unexpected cleanup policy %q", TestContext.CleanupPolicy))
+	}
+
+	if shouldCleanup {
+		for _, c := range f.clusters {
+			c.Cleanup(ctx)
+		}
 	}
 }
 

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -9,12 +9,12 @@ import (
 
 var TestContext *TestContextType
 
-type DeleteTestingNSPolicyType string
+type CleanupPolicyType string
 
 var (
-	DeleteTestingNSPolicyAlways    DeleteTestingNSPolicyType = "Always"
-	DeleteTestingNSPolicyOnSuccess DeleteTestingNSPolicyType = "OnSuccess"
-	DeleteTestingNSPolicyNever     DeleteTestingNSPolicyType = "Never"
+	CleanupPolicyAlways    CleanupPolicyType = "Always"
+	CleanupPolicyOnSuccess CleanupPolicyType = "OnSuccess"
+	CleanupPolicyNever     CleanupPolicyType = "Never"
 )
 
 type IngressController struct {
@@ -43,13 +43,13 @@ const (
 )
 
 type TestContextType struct {
-	RestConfigs           []*restclient.Config
-	ArtifactsDir          string
-	DeleteTestingNSPolicy DeleteTestingNSPolicyType
-	IngressController     *IngressController
-	ScyllaClusterOptions  *ScyllaClusterOptions
-	ObjectStorageType     ObjectStorageType
-	ObjectStorageBucket   string
-	GCSServiceAccountKey  []byte
-	S3CredentialsFile     []byte
+	RestConfigs          []*restclient.Config
+	ArtifactsDir         string
+	CleanupPolicy        CleanupPolicyType
+	IngressController    *IngressController
+	ScyllaClusterOptions *ScyllaClusterOptions
+	ObjectStorageType    ObjectStorageType
+	ObjectStorageBucket  string
+	GCSServiceAccountKey []byte
+	S3CredentialsFile    []byte
 }

--- a/test/e2e/set/nodeconfig/config.go
+++ b/test/e2e/set/nodeconfig/config.go
@@ -2,10 +2,35 @@
 
 package nodeconfig
 
-import "time"
+import (
+	"time"
+
+	"github.com/scylladb/scylla-operator/pkg/gather/collect"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 const (
 	testTimeout              = 15 * time.Minute
 	nodeConfigRolloutTimeout = 5 * time.Minute
 	apiCallTimeout           = 5 * time.Second
+)
+
+var (
+	nodeConfigResourceInfo = collect.ResourceInfo{
+		Resource: schema.GroupVersionResource{
+			Group:    "scylla.scylladb.com",
+			Version:  "v1alpha1",
+			Resource: "nodeconfigs",
+		},
+		Scope: meta.RESTScopeRoot,
+	}
+	resourceQuotaResourceInfo = collect.ResourceInfo{
+		Resource: schema.GroupVersionResource{
+			Group:    "",
+			Version:  "v1",
+			Resource: "resourcequotas",
+		},
+		Scope: meta.RESTScopeNamespace,
+	}
 )


### PR DESCRIPTION
**Description of your changes:**
This PR extends our e2e framework to be able to snapshot, collect and restore global resources like NodeConfigs or ScyllaOperator configs. This is very important to be able to debug the disruptive serial suites that use the same object in multiple tests and the final dump just shows the last test.

This also no longer requires the NodeConfig or Resource quotas to be missing before running the e2e suite an depending on the cleanup policy and whether the object has existed before, it will be restored after the test. This also help not to mess up local setups too much but more importantly it allows you to specify a cleanup policy to avoid deleting e.g. the NodeConfig used during the test.

Also this hooks extra dumps for the artifacts dir, e.g. `e2e/cluster-0/cluster-scoped-per-ns/e2e-test-nodesetup-q6bhx-0-d7s4w/cluster-scoped/nodeconfigs.scylla.scylladb.com/cluster.yaml`


**Which issue is resolved by this Pull Request:**
Resolves #2045

### Requires
- [x] #2101 
