### PR TITLE
Drop GinkgoRecover from ginkgo's container nodes

### DIFF
--- a/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
@@ -32,7 +32,6 @@ import (
 )
 
 var _ = g.Describe("Node Setup", framework.Serial, func() {
-	defer g.GinkgoRecover()
 	f := framework.NewFramework("nodesetup")
 
 	ncTemplate := scyllafixture.NodeConfig.ReadOrFail()

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -32,8 +32,6 @@ const (
 // These tests modify global resource affecting global cluster state.
 // They must not be run asynchronously with other tests.
 var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("nodeconfig")
 
 	ncTemplate := scyllafixture.NodeConfig.ReadOrFail()

--- a/test/e2e/set/scyllacluster/scyllacluster_alternator.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_alternator.go
@@ -60,8 +60,6 @@ func (movie Movie) GetKey() map[string]types.AttributeValue {
 }
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should set up Alternator API when enabled", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_auth.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_auth.go
@@ -22,8 +22,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster authentication", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("agent requires authentication", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -22,8 +22,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("nodes are cleaned up after horizontal scaling", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_evictions.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_evictions.go
@@ -15,8 +15,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster evictions", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should allow one disruption", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -40,8 +40,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should connect to cluster via Ingresses", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
@@ -16,8 +16,6 @@ import (
 )
 
 var _ = g.Describe("MultiDC cluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should form when external seeds are provided to ScyllaClusters", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_hostid.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_hostid.go
@@ -15,8 +15,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster HostID", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should be reflected as a Service annotation", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
@@ -18,7 +18,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
 
 	f := framework.NewFramework("scyllacluster")
 

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -20,8 +20,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	const (

--- a/test/e2e/set/scyllacluster/scyllacluster_sa.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sa.go
@@ -19,8 +19,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should claim preexisting member ServiceAccount and RoleBinding", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -19,8 +19,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should support scaling", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
@@ -24,8 +24,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should allow to build connection pool using shard aware ports", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
@@ -17,8 +17,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster sysctl", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should set container sysctl", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_tls.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_tls.go
@@ -35,8 +35,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should setup and maintain up to date TLS certificates", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_updates.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_updates.go
@@ -29,8 +29,6 @@ func addQuantity(lhs resource.Quantity, rhs resource.Quantity) *resource.Quantit
 }
 
 var _ = g.Describe("ScyllaCluster", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should rolling restart cluster when forceRedeploymentReason is changed", func() {

--- a/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
@@ -17,8 +17,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster upgrades", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	type entry struct {

--- a/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
@@ -19,8 +19,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster webhook", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should forbid invalid requests", func() {

--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -21,8 +21,6 @@ import (
 )
 
 var _ = g.Describe("Scylla Manager integration", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	g.It("should register cluster and sync repair tasks", func() {

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -28,8 +28,6 @@ import (
 )
 
 var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage, func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scyllacluster")
 
 	type entry struct {

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
@@ -27,8 +27,6 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBMonitoring", func() {
-	defer g.GinkgoRecover()
-
 	f := framework.NewFramework("scylladbmonitoring")
 
 	g.It("should setup monitoring stack", func() {


### PR DESCRIPTION
**Description of your changes:** GinkgoRecover should only be called when we're spawning goroutines from within a run spec. We are currently calling it from almost every container node, which, in case of a failed assertion in a container node (which shouldn't happen either way, see discussion in https://github.com/scylladb/scylla-operator/issues/2098), results in silencing an error from run spec tree construction: see e.g. https://github.com/onsi/ginkgo/issues/931#issuecomment-1040512693. It only doesn't happen now on broken framework initialization because we have two container nodes which don't call GinkgoRecover.
This PR drops the GinkgoRecover calls from the remaining container nodes.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-soon
/cc