### PR TITLE
Fix NodeConfig e2e race check with node setup daemon

### DIFF
--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -101,6 +101,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		framework.By("Waiting for the NodeConfig to deploy")
 		ctx1, ctx1Cancel := context.WithTimeout(ctx, nodeConfigRolloutTimeout)
 		defer ctx1Cancel()
+		o.Expect(matchingNodes).NotTo(o.BeEmpty())
 		nc, err = controllerhelpers.WaitForNodeConfigState(
 			ctx1,
 			f.ScyllaAdminClient().ScyllaV1alpha1().NodeConfigs(),
@@ -108,6 +109,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 			controllerhelpers.WaitForStateOptions{TolerateDelete: false},
 			utils.IsNodeConfigRolledOut,
 			utils.IsNodeConfigDoneWithNodeTuningFunc(matchingNodes),
+			utils.IsNodeConfigDoneWithNodes(matchingNodes),
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -71,6 +71,10 @@ func IsNodeConfigDoneWithNodes(nodes []*corev1.Node) func(nc *scyllav1alpha1.Nod
 	)
 
 	return func(nc *scyllav1alpha1.NodeConfig) (bool, error) {
+		if len(nodes) == 0 {
+			return true, fmt.Errorf("nodes can't be empty")
+		}
+
 		for _, node := range nodes {
 			if nc.Status.ObservedGeneration < nc.Generation {
 				return false, nil
@@ -93,6 +97,7 @@ func IsNodeConfigDoneWithNodes(nodes []*corev1.Node) func(nc *scyllav1alpha1.Nod
 				return false, nil
 			}
 		}
+
 		return true, nil
 	}
 }


### PR DESCRIPTION
**Description of your changes:**
This PR fixes a race where NodeConfig e2es weren't waiting for all daemons to update NodeConfig status before calling `verifyNodeConfig` which failed on conditions check.
