### PR TITLE
Update ScyllaDB versions to 6.1.1 and 2024.1.8

### DIFF
--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -1,9 +1,9 @@
 operator:
-  scyllaDBVersion: "6.1.0"
+  scyllaDBVersion: "6.1.1"
   # scyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride sets enterprise version
   # that requires consistent_cluster_management workaround for restore.
   # In the future, enterprise versions should be run as a different config instance in its own run.
-  scyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride: "2024.1.7"
+  scyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride: "2024.1.8"
   # TODO: scyllaDBUtils image can't be bumped until scylladb/scylladb#17787 is fixed.
   scyllaDBUtilsImage: "docker.io/scylladb/scylla:5.4.0@sha256:b9070afdb2be0d5c59b1c196e1bb66660351403cb30d5c6ba446ef8c3b0754f1"
   scyllaDBManagerVersion: "3.3.0"
@@ -12,6 +12,6 @@ operator:
   prometheusVersion: "v2.44.0"
 operatorTests:
   scyllaDBVersions:
-    updateFrom: "6.1.0-rc1"
+    updateFrom: "6.1.0"
     upgradeFrom: "6.0.2"
   nodeSetupImage: "quay.io/scylladb/scylla-operator-images:node-setup-v0.0.2@sha256:210b1dd9bd60a5bf4056783f3132bdeef0cf9ab0a19eff0b620b2dfa5c4e5d61"

--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -282,7 +282,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 6.1.0
+  version: 6.1.1
   agentVersion: 3.3.0
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -282,7 +282,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 6.1.0
+  version: 6.1.1
   agentVersion: 3.3.0
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 6.1.0
+  version: 6.1.1
   agentVersion: 3.3.0
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 6.1.0
+  version: 6.1.1
   agentVersion: 3.3.0
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -159,7 +159,7 @@ Change the `cluster.yaml` file from this:
 ```yaml
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   developerMode: true
   datacenter:
     name: us-east-1
@@ -167,7 +167,7 @@ spec:
 to this:
 ```yaml
 spec:
-  version: 6.1.0
+  version: 6.1.1
   alternator:
     port: 8000
     writeIsolation: only_rmw_uses_lwt

--- a/docs/source/multidc/multidc.md
+++ b/docs/source/multidc/multidc.md
@@ -108,7 +108,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"
@@ -358,7 +358,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"

--- a/docs/source/nodeoperations/restore.md
+++ b/docs/source/nodeoperations/restore.md
@@ -22,7 +22,7 @@ metadata:
   name: source
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   developerMode: true
   backups:
   - name: foo
@@ -51,7 +51,7 @@ metadata:
   name: target
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   developerMode: true
   datacenter:
     name: us-east-1

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -75,7 +75,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   datacenter:
     name: us-east-1
     racks:

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   sysctls:
     - fs.aio-max-nr=2097152
   datacenter:

--- a/examples/generic/cluster.yaml
+++ b/examples/generic/cluster.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   developerMode: true
   datacenter:
     name: us-east-1

--- a/examples/gke/cluster.yaml
+++ b/examples/gke/cluster.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: scylla
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   automaticOrphanedNodeCleanup: true
   sysctls:
     - fs.aio-max-nr=2097152

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -1,6 +1,6 @@
 # Version information
 scyllaImage:
-  tag: 6.1.0
+  tag: 6.1.1
 agentImage:
   tag: 3.3.0
 # Cluster information

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -21,7 +21,7 @@ controllerResources:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 6.1.0
+    tag: 6.1.1
   agentImage:
     tag: 3.3.0
   datacenter: manager-dc

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla
 spec:
   agentVersion: 3.3.0
-  version: 6.1.0
+  version: 6.1.1
   developerMode: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -19,7 +19,7 @@ scylla:
   fullnameOverride: scylla-manager-cluster
   scyllaImage:
     repository: docker.io/scylladb/scylla
-    tag: 6.1.0
+    tag: 6.1.1
   agentImage:
     tag: 3.3.0
     repository: docker.io/scylladb/scylla-manager-agent

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -60,7 +60,7 @@ controllerServiceAccount:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 6.1.0
+    tag: 6.1.1
   agentImage:
     tag: 3.3.0
   datacenter: manager-dc

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 scyllaImage:
   repository: scylladb/scylla
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 6.1.0
+  tag: 6.1.1
 # Allows to customize Scylla image
 agentImage:
   repository: scylladb/scylla-manager-agent


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR updates the default ScyllaDB version used in our tests, manifests, examples and docs to 6.1.0. It also bumps the version used for ScyllaDB Manager restore procedure test for versions 2024.1.Z or older to 2024.1.7. We should be testing against the most recent releases. ScyllaDB OS 6.1.1 and Enterprise 2024.1.8 were released today.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-longterm