### PR TITLE
TMP: check SM regression fix

### DIFF
--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
   annotations:
    bar: foo
 spec:
-  agentVersion: 3.3.0
+  agentVersion: 3.4.0-dev-0.20240902.c3ca05a61
   version: 6.1.0
   developerMode: true
   exposeOptions:

--- a/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
   annotations:
    bar: foo
 spec:
-  agentVersion: 3.3.0
+  agentVersion: 3.4.0-dev-0.20240902.c3ca05a61
   version: 6.1.0
   developerMode: true
   exposeOptions:


### PR DESCRIPTION
This tmp commit job is to validate that the fix from
https://github.com/scylladb/scylla-manager/pull/4000
indeed fixes the 3.3.1 SM regression reported in
https://github.com/scylladb/scylla-manager/issues/3989.

This PR is not supposed to be merged, it's here just to run the CI.