### PR TITLE
Make 'shared' volume mount read-write for Scylla container

### DIFF
--- a/pkg/controller/scyllacluster/resource.go
+++ b/pkg/controller/scyllacluster/resource.go
@@ -606,7 +606,6 @@ exec /mnt/shared/scylla-operator sidecar \
 									{
 										Name:      "shared",
 										MountPath: naming.SharedDirName,
-										ReadOnly:  true,
 									},
 									{
 										Name:      "scylla-config-volume",

--- a/pkg/controller/scyllacluster/resource_test.go
+++ b/pkg/controller/scyllacluster/resource_test.go
@@ -826,7 +826,6 @@ exec /mnt/shared/scylla-operator sidecar \
 										{
 											Name:      "shared",
 											MountPath: "/mnt/shared",
-											ReadOnly:  true,
 										},
 										{
 											Name:      "scylla-config-volume",


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Scylla container's PreStop hook fails because it tries to remove a file from a read-only filesystem. This PR make the volume mount read-write. 

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2111
