### PR TITLE
Parametrize webhook command

### DIFF
--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -35,7 +35,7 @@ func NewOperatorCommand(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.AddCommand(versioncmd.NewCmd(streams))
 	cmd.AddCommand(NewOperatorCmd(streams))
-	cmd.AddCommand(NewWebhookCmd(streams))
+	cmd.AddCommand(NewWebhookCmd(streams, DefaultValidators))
 	cmd.AddCommand(NewSidecarCmd(streams))
 	cmd.AddCommand(NewManagerControllerCmd(streams))
 	cmd.AddCommand(NewNodeSetupCmd(streams))

--- a/pkg/cmd/operator/webhooks_test.go
+++ b/pkg/cmd/operator/webhooks_test.go
@@ -48,7 +48,7 @@ func TestWebhookOptionsRun(t *testing.T) {
 		{
 			Name: "valid webhook options",
 			WebhookOptions: func() *WebhookOptions {
-				wo := NewWebhookOptions(genericclioptions.IOStreams{})
+				wo := NewWebhookOptions(genericclioptions.IOStreams{}, DefaultValidators)
 				wo.Port = 65535
 				wo.InsecureGenerateLocalhostCerts = true
 
@@ -59,7 +59,7 @@ func TestWebhookOptionsRun(t *testing.T) {
 		{
 			Name: "invalid port",
 			WebhookOptions: func() *WebhookOptions {
-				wo := NewWebhookOptions(genericclioptions.IOStreams{})
+				wo := NewWebhookOptions(genericclioptions.IOStreams{}, DefaultValidators)
 				wo.Port = 65536
 				wo.InsecureGenerateLocalhostCerts = true
 
@@ -128,7 +128,7 @@ func TestWebhookOptionsRunWithReload(t *testing.T) {
 		t.Fatalf("can't create a file: %v", err)
 	}
 
-	wo := NewWebhookOptions(genericclioptions.IOStreams{})
+	wo := NewWebhookOptions(genericclioptions.IOStreams{}, DefaultValidators)
 	wo.TLSCertFile = tlsCertFile
 	wo.TLSKeyFile = tlsKeyFile
 	wo.Port = 0


### PR DESCRIPTION
Webhook command accepts a map of validators making this command be reusable and easily extensible.


