### PR TITLE
Switch runtime image to the new UBI base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/scylladb/scylla-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM quay.io/scylladb/scylla-operator-images:base-ubuntu-22.04
+FROM quay.io/scylladb/scylla-operator-images:base-ubi-9.4-minimal
 
 LABEL org.opencontainers.image.title="Scylla Operator" \
       org.opencontainers.image.description="ScyllaDB Operator for Kubernetes" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ LABEL org.opencontainers.image.title="Scylla Operator" \
       org.opencontainers.image.url="https://hub.docker.com/r/scylladb/scylla-operator" \
       org.opencontainers.image.vendor="ScyllaDB"
 
+RUN microdnf install -y procps-ng && \
+    microdnf clean all && \
+    rm -rf /var/cache/dnf/*
+
 COPY --from=builder /go/src/github.com/scylladb/scylla-operator/scylla-operator /usr/bin/
 COPY --from=builder /go/src/github.com/scylladb/scylla-operator/scylla-operator-tests /usr/bin/
 ENTRYPOINT ["/usr/bin/scylla-operator"]


### PR DESCRIPTION
**Description of your changes:**
We have stopped building Ubuntu base images in https://github.com/scylladb/scylla-operator-images/pull/54 and replaced the with UBI. This PR follows up on that effort and switches the runtime image to UBI.

**Which issue is resolved by this Pull Request:**
Resolves #1192 

fyi @ylebi 

### Requires
- [x] https://github.com/scylladb/scylla-operator-images/issues/67
- [x] https://github.com/scylladb/scylla-operator-images/pull/73
- [x] https://github.com/scylladb/scylla-operator-images/pull/75