### PR TITLE
Update golang to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/scylladb/scylla-operator-images:golang-1.22 AS builder
+FROM quay.io/scylladb/scylla-operator-images:golang-1.23 AS builder
 WORKDIR /go/src/github.com/scylladb/scylla-operator
 COPY . .
 RUN make build --warn-undefined-variables

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scylladb/scylla-operator
 
-go 1.22.3
+go 1.23
 
 require (
 	cloud.google.com/go/compute/metadata v0.5.0


### PR DESCRIPTION
**Description of your changes:**
This PR updates golang to 1.23.

#### Requires
- [x] https://github.com/golang/go/issues/67089
- [x] https://github.com/scylladb/scylla-operator-release/pull/335