### PR TITLE
Fix ScyllaDBDatacenter controller selector and resource naming

### DIFF
--- a/assets/scylladb/managedconfig.cm.yaml
+++ b/assets/scylladb/managedconfig.cm.yaml
@@ -3,8 +3,6 @@ kind: ConfigMap
 metadata:
   namespace: "{{ .Namespace }}"
   name: "{{ .Name }}"
-  labels:
-    "scylla/cluster": "{{ .ClusterName }}"
 data:
   {{ .ManagedConfigName | printf "%q" }}: |
     cluster_name: "{{ .ClusterName }}"

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -1691,7 +1691,7 @@ func MakeManagedScyllaDBConfig(sdc *scyllav1alpha1.ScyllaDBDatacenter) (*corev1.
 	cm, _, err := scylladbassets.ScyllaDBManagedConfigTemplate.RenderObject(
 		map[string]any{
 			"Namespace":                              sdc.Namespace,
-			"Name":                                   naming.GetScyllaDBManagedConfigCMName(sdc.Spec.ClusterName),
+			"Name":                                   naming.GetScyllaDBManagedConfigCMName(sdc.Name),
 			"ClusterName":                            sdc.Spec.ClusterName,
 			"ManagedConfigName":                      naming.ScyllaDBManagedConfigName,
 			"EnableTLS":                              utilfeature.DefaultMutableFeatureGate.Enabled(features.AutomaticTLSCertificates),
@@ -1720,6 +1720,7 @@ func MakeManagedScyllaDBConfig(sdc *scyllav1alpha1.ScyllaDBDatacenter) (*corev1.
 		cm.Labels = map[string]string{}
 	}
 	maps.Copy(cm.Labels, sdc.Labels)
+	maps.Copy(cm.Labels, naming.ClusterLabels(sdc))
 
 	if cm.Annotations == nil {
 		cm.Annotations = map[string]string{}

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -2699,7 +2699,7 @@ func Test_MakeManagedScyllaDBConfig(t *testing.T) {
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 				},
 			},
 			enableTLSFeatureGate: false,
@@ -2712,8 +2712,11 @@ func Test_MakeManagedScyllaDBConfig(t *testing.T) {
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -2728,7 +2731,7 @@ func Test_MakeManagedScyllaDBConfig(t *testing.T) {
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"
@@ -2749,7 +2752,7 @@ internode_compression: "all"
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 				},
 			},
 			enableTLSFeatureGate: true,
@@ -2762,8 +2765,11 @@ internode_compression: "all"
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -2778,7 +2784,7 @@ internode_compression: "all"
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"
@@ -2808,7 +2814,7 @@ client_encryption_options:
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 					ScyllaDB: scyllav1alpha1.ScyllaDB{
 						AlternatorOptions: &scyllav1alpha1.AlternatorOptions{},
 					},
@@ -2824,8 +2830,11 @@ client_encryption_options:
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -2840,7 +2849,7 @@ client_encryption_options:
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"
@@ -2879,7 +2888,7 @@ alternator_encryption_options:
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 					ScyllaDB: scyllav1alpha1.ScyllaDB{
 						AlternatorOptions: &scyllav1alpha1.AlternatorOptions{},
 					},
@@ -2895,8 +2904,11 @@ alternator_encryption_options:
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					Annotations: map[string]string{
 						"internal.scylla-operator.scylladb.com/alternator-insecure-enable-http": "false",
@@ -2914,7 +2926,7 @@ alternator_encryption_options:
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"
@@ -2953,7 +2965,7 @@ alternator_encryption_options:
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 					ScyllaDB: scyllav1alpha1.ScyllaDB{
 						AlternatorOptions: &scyllav1alpha1.AlternatorOptions{},
 					},
@@ -2969,8 +2981,11 @@ alternator_encryption_options:
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					Annotations: map[string]string{
 						"internal.scylla-operator.scylladb.com/alternator-insecure-enable-http": "true",
@@ -2988,7 +3003,7 @@ alternator_encryption_options:
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"
@@ -3028,7 +3043,7 @@ alternator_encryption_options:
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 					ScyllaDB: scyllav1alpha1.ScyllaDB{
 						AlternatorOptions: &scyllav1alpha1.AlternatorOptions{},
 					},
@@ -3044,8 +3059,11 @@ alternator_encryption_options:
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					Annotations: map[string]string{
 						"internal.scylla-operator.scylladb.com/alternator-port": "42",
@@ -3063,7 +3081,7 @@ alternator_encryption_options:
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"
@@ -3104,7 +3122,7 @@ alternator_encryption_options:
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 					ScyllaDB: scyllav1alpha1.ScyllaDB{
 						AlternatorOptions: &scyllav1alpha1.AlternatorOptions{},
 					},
@@ -3120,8 +3138,11 @@ alternator_encryption_options:
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					Annotations: map[string]string{
 						"internal.scylla-operator.scylladb.com/alternator-port":                           "42",
@@ -3140,7 +3161,7 @@ alternator_encryption_options:
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"
@@ -3181,7 +3202,7 @@ alternator_encryption_options:
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 					ScyllaDB: scyllav1alpha1.ScyllaDB{
 						AlternatorOptions: &scyllav1alpha1.AlternatorOptions{},
 					},
@@ -3197,8 +3218,11 @@ alternator_encryption_options:
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					Annotations: map[string]string{
 						"internal.scylla-operator.scylladb.com/alternator-port":                           "42",
@@ -3217,7 +3241,7 @@ alternator_encryption_options:
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"
@@ -3258,7 +3282,7 @@ alternator_encryption_options:
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 					ScyllaDB: scyllav1alpha1.ScyllaDB{
 						AlternatorOptions: &scyllav1alpha1.AlternatorOptions{},
 					},
@@ -3274,8 +3298,11 @@ alternator_encryption_options:
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					Annotations: map[string]string{
 						"internal.scylla-operator.scylladb.com/alternator-port":                           "42",
@@ -3294,7 +3321,7 @@ alternator_encryption_options:
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"
@@ -3334,7 +3361,7 @@ alternator_encryption_options:
 					},
 				},
 				Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-					ClusterName: "foo",
+					ClusterName: "foo-cluster",
 					ScyllaDB: scyllav1alpha1.ScyllaDB{
 						AlternatorOptions: &scyllav1alpha1.AlternatorOptions{},
 					},
@@ -3350,8 +3377,11 @@ alternator_encryption_options:
 					Namespace: "foo-ns",
 					Name:      "foo-managed-config",
 					Labels: map[string]string{
-						"scylla/cluster": "foo",
-						"user-label":     "user-label-value",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla/cluster":               "foo",
+						"user-label":                   "user-label-value",
 					},
 					Annotations: map[string]string{
 						"internal.scylla-operator.scylladb.com/alternator-insecure-disable-authorization": "true",
@@ -3369,7 +3399,7 @@ alternator_encryption_options:
 				},
 				Data: map[string]string{
 					"scylladb-managed-config.yaml": strings.TrimPrefix(`
-cluster_name: "foo"
+cluster_name: "foo-cluster"
 rpc_address: "0.0.0.0"
 endpoint_snitch: "GossipingPropertyFileSnitch"
 internode_compression: "all"

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -70,6 +70,9 @@ const (
 
 // Generic Labels used on objects created by the operator.
 const (
+	// ClusterNameLabel specifies ScyllaCluster name. It's used as a selector by both ScyllaCluster and ScyllaDBDatacenter controllers.
+	// As controller selector cannot be changed, this may be misleading in the context of ScyllaDBDatacenter. It should
+	// specify the ScyllaCluster object name ScyllaDBDatacenter originated from or object name in case it wasn't migrated.
 	ClusterNameLabel             = "scylla/cluster"
 	DatacenterNameLabel          = "scylla/datacenter"
 	RackNameLabel                = "scylla/rack"

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -11,7 +11,7 @@ import (
 // for the given Cluster.
 func ClusterLabels(sdc *scyllav1alpha1.ScyllaDBDatacenter) map[string]string {
 	labels := ScyllaLabels()
-	labels[ClusterNameLabel] = sdc.Spec.ClusterName
+	labels[ClusterNameLabel] = sdc.Name
 	return labels
 }
 

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -29,7 +29,7 @@ func ObjRefWithUID(obj metav1.Object) string {
 }
 
 func StatefulSetNameForRack(r scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.ScyllaDBDatacenter) string {
-	return fmt.Sprintf("%s-%s-%s", sdc.Spec.ClusterName, GetScyllaDBDatacenterGossipDatacenterName(sdc), r.Name)
+	return fmt.Sprintf("%s-%s-%s", sdc.Name, GetScyllaDBDatacenterGossipDatacenterName(sdc), r.Name)
 }
 
 func StatefulSetNameForRackForScyllaCluster(r scyllav1.RackSpec, sc *scyllav1.ScyllaCluster) string {
@@ -42,13 +42,13 @@ func PodNameFromService(svc *corev1.Service) string {
 }
 
 func AgentAuthTokenSecretName(sdc *scyllav1alpha1.ScyllaDBDatacenter) string {
-	return fmt.Sprintf("%s-auth-token", sdc.Spec.ClusterName)
+	return fmt.Sprintf("%s-auth-token", sdc.Name)
 }
 
 func AgentAuthTokenSecretNameForScyllaCluster(sc *scyllav1.ScyllaCluster) string {
 	return AgentAuthTokenSecretName(&scyllav1alpha1.ScyllaDBDatacenter{
-		Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-			ClusterName: sc.Name,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sc.Name,
 		},
 	})
 }
@@ -62,7 +62,7 @@ func MemberServiceNameForScyllaCluster(r scyllav1.RackSpec, sc *scyllav1.ScyllaC
 }
 
 func IdentityServiceName(sdc *scyllav1alpha1.ScyllaDBDatacenter) string {
-	return fmt.Sprintf("%s-client", sdc.Spec.ClusterName)
+	return fmt.Sprintf("%s-client", sdc.Name)
 }
 
 func IdentityServiceNameForScyllaCluster(sc *scyllav1.ScyllaCluster) string {
@@ -70,7 +70,7 @@ func IdentityServiceNameForScyllaCluster(sc *scyllav1.ScyllaCluster) string {
 }
 
 func PodDisruptionBudgetName(sdc *scyllav1alpha1.ScyllaDBDatacenter) string {
-	return sdc.Spec.ClusterName
+	return sdc.Name
 }
 
 func PodDisruptionBudgetNameForScyllaCluster(sc *scyllav1.ScyllaCluster) string {
@@ -94,7 +94,7 @@ func PVCNameForService(svcName string) string {
 }
 
 func PVCNamePrefix(sdc *scyllav1alpha1.ScyllaDBDatacenter) string {
-	return fmt.Sprintf("%s-%s-", PVCTemplateName, sdc.Spec.ClusterName)
+	return fmt.Sprintf("%s-%s-", PVCTemplateName, sdc.Name)
 }
 
 func PVCNamePrefixForScyllaCluster(sc *scyllav1.ScyllaCluster) string {


### PR DESCRIPTION
Controller selector should be in sync with selector labels added to managed resources.
It wasn't catched before because ScyllaCluster migrating controller used ScyllaCluster name as ScyllaDBDatacenter.spec.clusterName.
In case when ScyllaDBDatacenter would be created with different name than clusterName specified in it's spec, resources would've been orphaned immediately and managed objects couldn't progress.
To prevent two ScyllaDBDatacenters having the same clusterName in their spec colliding with each other, managed resources names were changed to use object name instead clusterName.