### PR TITLE
Move resolution of developerMode and additionalScyllaDBArguments to Operator 

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13092,6 +13092,9 @@ rules:
   - list
   - patch
   - watch
+# Sidecar no longer fetches ScyllaClusters. Necessary information is provided by the Operator to sidecar via ScyllaDB config or arguments.
+# However, to ensure smooth Operator updates, this cannot be removed earlier than in 1.16.
+# TODO: remove this permission in Operator >=1.16 (https://github.com/scylladb/scylla-operator/issues/2141)
 - apiGroups:
   - scylla.scylladb.com
   resources:

--- a/deploy/operator/00_scyllacluster_member_clusterrole_def.yaml
+++ b/deploy/operator/00_scyllacluster_member_clusterrole_def.yaml
@@ -47,6 +47,9 @@ rules:
   - list
   - patch
   - watch
+# Sidecar no longer fetches ScyllaClusters. Necessary information is provided by the Operator to sidecar via ScyllaDB config or arguments.
+# However, to ensure smooth Operator updates, this cannot be removed earlier than in 1.16.
+# TODO: remove this permission in Operator >=1.16 (https://github.com/scylladb/scylla-operator/issues/2141)
 - apiGroups:
   - scylla.scylladb.com
   resources:

--- a/helm/scylla-operator/templates/scyllacluster_member_clusterrole_def.yaml
+++ b/helm/scylla-operator/templates/scyllacluster_member_clusterrole_def.yaml
@@ -47,6 +47,9 @@ rules:
   - list
   - patch
   - watch
+# Sidecar no longer fetches ScyllaClusters. Necessary information is provided by the Operator to sidecar via ScyllaDB config or arguments.
+# However, to ensure smooth Operator updates, this cannot be removed earlier than in 1.16.
+# TODO: remove this permission in Operator >=1.16 (https://github.com/scylladb/scylla-operator/issues/2141)
 - apiGroups:
   - scylla.scylladb.com
   resources:

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -11,7 +11,6 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
-	"github.com/scylladb/scylla-operator/pkg/semver"
 	"github.com/scylladb/scylla-operator/pkg/util/duration"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -157,13 +156,6 @@ func ValidateScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *field.
 
 	if spec.Alternator != nil {
 		allErrs = append(allErrs, ValidateAlternatorSpec(spec.Alternator, fldPath.Child("alternator"))...)
-	}
-
-	if len(spec.ScyllaArgs) > 0 {
-		version := semver.NewScyllaVersion(spec.Version)
-		if !version.SupportFeatureUnsafe(semver.ScyllaVersionThatSupportsArgs) {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("scyllaArgs"), fmt.Sprintf("ScyllaArgs is only supported starting from %s", semver.ScyllaVersionThatSupportsArgs)))
-		}
 	}
 
 	for i, rack := range spec.Datacenter.Racks {

--- a/pkg/semver/version.go
+++ b/pkg/semver/version.go
@@ -21,8 +21,6 @@ import (
 )
 
 var (
-	ScyllaVersionThatSupportsArgs                    = semver.MustParse("4.2.0")
-	ScyllaVersionThatSupportsDisablingIOTuning       = semver.MustParse("4.3.0")
 	ScyllaVersionThatSupportsDisablingWritebackCache = semver.MustParse("2021.0.0")
 )
 

--- a/pkg/sidecar/identity/member.go
+++ b/pkg/sidecar/identity/member.go
@@ -29,14 +29,15 @@ type Member struct {
 	ServiceLabels map[string]string
 	PodID         string
 
-	Overprovisioned     bool
-	BroadcastRPCAddress string
-	BroadcastAddress    string
+	Overprovisioned             bool
+	BroadcastRPCAddress         string
+	BroadcastAddress            string
+	AdditionalScyllaDBArguments []string
 
 	NodesBroadcastAddressType scyllav1alpha1.BroadcastAddressType
 }
 
-func NewMember(service *corev1.Service, pod *corev1.Pod, nodesAddressType, clientAddressType scyllav1alpha1.BroadcastAddressType) (*Member, error) {
+func NewMember(service *corev1.Service, pod *corev1.Pod, nodesAddressType, clientAddressType scyllav1alpha1.BroadcastAddressType, additionalScyllaDBArguments []string) (*Member, error) {
 	rackOrdinalString, ok := pod.Labels[naming.RackOrdinalLabel]
 	if !ok {
 		return nil, fmt.Errorf("pod %q is missing %q label", naming.ObjRef(pod), naming.RackOrdinalLabel)
@@ -47,16 +48,17 @@ func NewMember(service *corev1.Service, pod *corev1.Pod, nodesAddressType, clien
 	}
 
 	m := &Member{
-		Namespace:                 service.Namespace,
-		Name:                      service.Name,
-		Rack:                      pod.Labels[naming.RackNameLabel],
-		RackOrdinal:               rackOrdinal,
-		Datacenter:                pod.Labels[naming.DatacenterNameLabel],
-		Cluster:                   pod.Labels[naming.ClusterNameLabel],
-		ServiceLabels:             service.Labels,
-		PodID:                     string(pod.UID),
-		Overprovisioned:           pod.Status.QOSClass != corev1.PodQOSGuaranteed,
-		NodesBroadcastAddressType: nodesAddressType,
+		Namespace:                   service.Namespace,
+		Name:                        service.Name,
+		Rack:                        pod.Labels[naming.RackNameLabel],
+		RackOrdinal:                 rackOrdinal,
+		Datacenter:                  pod.Labels[naming.DatacenterNameLabel],
+		Cluster:                     pod.Labels[naming.ClusterNameLabel],
+		ServiceLabels:               service.Labels,
+		PodID:                       string(pod.UID),
+		Overprovisioned:             pod.Status.QOSClass != corev1.PodQOSGuaranteed,
+		NodesBroadcastAddressType:   nodesAddressType,
+		AdditionalScyllaDBArguments: additionalScyllaDBArguments,
 	}
 
 	m.BroadcastAddress, err = controllerhelpers.GetScyllaBroadcastAddress(nodesAddressType, service, pod)

--- a/pkg/sidecar/identity/member_test.go
+++ b/pkg/sidecar/identity/member_test.go
@@ -398,7 +398,7 @@ func TestMember_GetSeeds(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			member, err := NewMember(test.memberService, test.memberPod, test.memberNodesBroadcastType, test.memberClientsBroadcastType)
+			member, err := NewMember(test.memberService, test.memberPod, test.memberNodesBroadcastType, test.memberClientsBroadcastType, nil)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Moves the resolution of `developerMode` and `additionalScyllaDBArguments` from the sidecar to the Operator.
This change addresses an issue where modifications to these arguments did not trigger a rolling restart of the ScyllaDB cluster.
By moving the logic to the Operator, any changes to these fields now correctly trigger a rolling restart as intended.

Since the sidecar no longer needs to fetch the ScyllaCluster resource for these parameters, it no longer requires permissions to perform GET operations on ScyllaCluster objects.
However, to ensure a safe rolling upgrade of the Operator, these permissions are not removed yet.

Additionally, this commit removes support for the deprecated `cpuset` field. It is now treated as if it is always set to true regardless of its value.

Requires:

- [x] #2139 


Fixes #1389