### PR TITLE
Remove support for deprecated `cpuset` field

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1217,7 +1217,7 @@ spec:
                     type: object
                   type: array
                 cpuset:
-                  description: 'cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.'
+                  description: 'cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.'
                   type: boolean
                 datacenter:
                   description: datacenter holds a specification of a datacenter.

--- a/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -92,7 +92,7 @@ object
      - backups specifies backup tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
    * - cpuset
      - boolean
-     - cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.
+     - cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.
    * - :ref:`datacenter<api-scylla.scylladb.com-scyllaclusters-v1-.spec.datacenter>`
      - object
      - datacenter holds a specification of a datacenter.

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -281,7 +281,7 @@
           "type": "array"
         },
         "cpuset": {
-          "description": "cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.",
+          "description": "cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.",
           "type": "boolean"
         },
         "datacenter": {

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -170,7 +170,7 @@
       "type": "array"
     },
     "cpuset": {
-      "description": "cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.",
+      "description": "cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.",
       "type": "boolean"
     },
     "datacenter": {

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -176,7 +176,7 @@ spec:
                     type: object
                   type: array
                 cpuset:
-                  description: 'cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated and may be ignored in the future.'
+                  description: 'cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.'
                   type: boolean
                 datacenter:
                   description: datacenter holds a specification of a datacenter.

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -64,7 +64,7 @@ type ScyllaClusterSpec struct {
 	DeveloperMode bool `json:"developerMode,omitempty"`
 
 	// cpuset determines if the cluster will use cpu-pinning.
-	// Deprecated: `cpuset` is deprecated and may be ignored in the future.
+	// Deprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.
 	// +optional
 	CpuSet bool `json:"cpuset,omitempty"`
 


### PR DESCRIPTION
It is now treated as if it is always set to true regardless of its value.
Validation of ScyllaCluster resources is relaxed to not require full cores and resource requests == limits.
Conditions for getting Guaranteed QoS class are explained in documentation.

Fixes #2140
