### PR TITLE
Set managed hash labels in manager tasks and only update tasks when managed hash changes

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3221,6 +3221,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: labels reflects the labels of a task.
+                        type: object
                       location:
                         description: location reflects a list of backup locations in the format [<dc>:]<provider>:<name> ex. s3:my-bucket.
                         items:
@@ -3405,6 +3410,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: labels reflects the labels of a task.
+                        type: object
                       name:
                         description: name reflects the name of a task.
                         type: string

--- a/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/api-reference/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -4801,6 +4801,9 @@ object
    * - keyspace
      - array (string)
      - keyspace reflects a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+   * - :ref:`labels<api-scylla.scylladb.com-scyllaclusters-v1-.status.backups[].labels>`
+     - object
+     - labels reflects the labels of a task.
    * - location
      - array (string)
      - location reflects a list of backup locations in the format [<dc>:]<provider>:<name> ex. s3:my-bucket.
@@ -4828,6 +4831,20 @@ object
    * - uploadParallel
      - array (string)
      - uploadParallel reflects a list of upload parallelism limits in the format [<dc>:]<limit>.
+
+.. _api-scylla.scylladb.com-scyllaclusters-v1-.status.backups[].labels:
+
+.status.backups[].labels
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Description
+"""""""""""
+labels reflects the labels of a task.
+
+Type
+""""
+object
+
 
 .. _api-scylla.scylladb.com-scyllaclusters-v1-.status.conditions[]:
 
@@ -4933,6 +4950,9 @@ object
    * - keyspace
      - array (string)
      - keyspace reflects a list of keyspace/tables glob patterns, e.g. 'keyspace,!keyspace.table_prefix_*' used to include or exclude keyspaces from repair.
+   * - :ref:`labels<api-scylla.scylladb.com-scyllaclusters-v1-.status.repairs[].labels>`
+     - object
+     - labels reflects the labels of a task.
    * - name
      - string
      - name reflects the name of a task.
@@ -4951,6 +4971,20 @@ object
    * - timezone
      - string
      - timezone reflects the timezone of cron field.
+
+.. _api-scylla.scylladb.com-scyllaclusters-v1-.status.repairs[].labels:
+
+.status.repairs[].labels
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Description
+"""""""""""
+labels reflects the labels of a task.
+
+Type
+""""
+object
+
 
 .. _api-scylla.scylladb.com-scyllaclusters-v1-.status.upgrade:
 

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -2180,6 +2180,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: labels reflects the labels of a task.
+                        type: object
                       location:
                         description: location reflects a list of backup locations in the format [<dc>:]<provider>:<name> ex. s3:my-bucket.
                         items:
@@ -2364,6 +2369,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: labels reflects the labels of a task.
+                        type: object
                       name:
                         description: name reflects the name of a task.
                         type: string

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -632,6 +632,10 @@ type TaskStatus struct {
 	// +optional
 	ID *string `json:"id,omitempty"`
 
+	// labels reflects the labels of a task.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// error holds the task error, if any.
 	// +optional
 	Error *string `json:"error,omitempty"`

--- a/pkg/api/scylla/v1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1/zz_generated.deepcopy.go
@@ -1048,6 +1048,13 @@ func (in *TaskStatus) DeepCopyInto(out *TaskStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Error != nil {
 		in, out := &in.Error, &out.Error
 		*out = new(string)

--- a/pkg/controller/manager/status.go
+++ b/pkg/controller/manager/status.go
@@ -31,7 +31,7 @@ func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, managerState *s
 
 		managerTaskStatus, isInManagerState := managerState.RepairTasks[rt.Name]
 		if isInManagerState {
-			repairTaskStatus = scyllav1.RepairTaskStatus(managerTaskStatus)
+			repairTaskStatus = managerTaskStatus
 		} else {
 			// Retain the error from client.
 			err, hasClientError := repairTaskClientErrorMap[rt.Name]
@@ -62,7 +62,7 @@ func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, managerState *s
 
 		managerTaskStatus, isInManagerState := managerState.BackupTasks[bt.Name]
 		if isInManagerState {
-			backupTaskStatus = scyllav1.BackupTaskStatus(managerTaskStatus)
+			backupTaskStatus = managerTaskStatus
 		} else {
 			// Retain the error from client.
 			err, hasClientError := backupTaskClientErrorMap[bt.Name]

--- a/pkg/controller/manager/sync.go
+++ b/pkg/controller/manager/sync.go
@@ -30,8 +30,8 @@ func (c *Controller) getManagerState(ctx context.Context, clusterID string) (*st
 		return nil, err
 	}
 	var (
-		repairTasks map[string]RepairTaskStatus
-		backupTasks map[string]BackupTaskStatus
+		repairTasks map[string]scyllav1.RepairTaskStatus
+		backupTasks map[string]scyllav1.BackupTaskStatus
 	)
 
 	if clusterID != "" {
@@ -48,7 +48,7 @@ func (c *Controller) getManagerState(ctx context.Context, clusterID string) (*st
 				return nil, err
 			}
 
-			repairTasks = make(map[string]RepairTaskStatus, len(managerRepairTasks.TaskListItemSlice))
+			repairTasks = make(map[string]scyllav1.RepairTaskStatus, len(managerRepairTasks.TaskListItemSlice))
 			for _, managerRepairTask := range managerRepairTasks.TaskListItemSlice {
 				rts, err := NewRepairStatusFromManager(managerRepairTask)
 				if err != nil {
@@ -62,7 +62,7 @@ func (c *Controller) getManagerState(ctx context.Context, clusterID string) (*st
 				return nil, err
 			}
 
-			backupTasks = make(map[string]BackupTaskStatus, len(managerBackupTasks.TaskListItemSlice))
+			backupTasks = make(map[string]scyllav1.BackupTaskStatus, len(managerBackupTasks.TaskListItemSlice))
 			for _, managerBackupTask := range managerBackupTasks.TaskListItemSlice {
 				bts, err := NewBackupStatusFromManager(managerBackupTask)
 				if err != nil {

--- a/pkg/controller/manager/sync_test.go
+++ b/pkg/controller/manager/sync_test.go
@@ -211,7 +211,7 @@ func TestManagerSynchronization(t *testing.T) {
 					Name:      clusterName,
 					AuthToken: clusterAuthToken,
 				}},
-				RepairTasks: map[string]RepairTaskStatus{
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
 					"repair": {
 						TaskStatus: scyllav1.TaskStatus{
 							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
@@ -256,7 +256,7 @@ func TestManagerSynchronization(t *testing.T) {
 					Name:      clusterName,
 					AuthToken: clusterAuthToken,
 				}},
-				RepairTasks: map[string]RepairTaskStatus{
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
 					"repair": {
 						TaskStatus: scyllav1.TaskStatus{
 							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
@@ -265,6 +265,9 @@ func TestManagerSynchronization(t *testing.T) {
 							},
 							Name: "repair",
 							ID:   pointer.Ptr("repair-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "9gAqa0Ngh483/n6qTDn3FMKGvyMXrUKqPS3Jp5RDp8RJ1/58h8p5oYrtP7r6rYmNoRY1neKQHvV1IIzmMr6hBg==",
+							},
 						},
 						FailFast:            pointer.Ptr(false),
 						Intensity:           pointer.Ptr("666"),
@@ -287,7 +290,7 @@ func TestManagerSynchronization(t *testing.T) {
 					Name:      clusterName,
 					AuthToken: clusterAuthToken,
 				}},
-				RepairTasks: map[string]RepairTaskStatus{
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
 					"other-repair": {
 						TaskStatus: scyllav1.TaskStatus{
 							Name: "other-repair",
@@ -330,7 +333,7 @@ func TestManagerSynchronization(t *testing.T) {
 					Name:      clusterName,
 					AuthToken: clusterAuthToken,
 				}},
-				RepairTasks: map[string]RepairTaskStatus{
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
 					"repair": {
 						TaskStatus: scyllav1.TaskStatus{
 							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
@@ -339,6 +342,9 @@ func TestManagerSynchronization(t *testing.T) {
 							},
 							Name: "repair",
 							ID:   pointer.Ptr("repair-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "QAYSzOPRCIVGqS04NfnFslWujYbjmjwNjH//peQawBxry6I6M/scdCaHR2qgNOL9YJQsGjnD846eO0oULMyJ8A==",
+							},
 						},
 						FailFast:            pointer.Ptr(false),
 						Intensity:           pointer.Ptr("666"),
@@ -377,7 +383,7 @@ func TestManagerSynchronization(t *testing.T) {
 					Name:      clusterName,
 					AuthToken: clusterAuthToken,
 				}},
-				RepairTasks: map[string]RepairTaskStatus{
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
 					"repair": {
 						TaskStatus: scyllav1.TaskStatus{
 							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
@@ -396,6 +402,225 @@ func TestManagerSynchronization(t *testing.T) {
 			},
 
 			Actions: []action{&updateTaskAction{clusterID: clusterID, task: &managerclient.Task{ID: "repair-id"}}},
+		},
+		{
+			Name: "Task gets updated when managed hash is missing",
+			Spec: scyllav1.ScyllaClusterSpec{
+				Repairs: []scyllav1.RepairTaskSpec{
+					{
+						TaskSpec: scyllav1.TaskSpec{
+							Name: "repair",
+							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+								Interval:  pointer.Ptr("0"),
+							},
+						},
+						SmallTableThreshold: "1GiB",
+						Intensity:           "666",
+						Parallel:            0,
+					},
+				},
+			},
+			Status: scyllav1.ScyllaClusterStatus{
+				ManagerID: pointer.Ptr(clusterID),
+			},
+			State: state{
+				Clusters: []*managerclient.Cluster{{
+					ID:        clusterID,
+					Name:      clusterName,
+					AuthToken: clusterAuthToken,
+				}},
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
+					"repair": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+								Interval:  pointer.Ptr("0"),
+							},
+							Name:   "repair",
+							ID:     pointer.Ptr("repair-id"),
+							Labels: map[string]string{},
+						},
+						FailFast:            pointer.Ptr(false),
+						Intensity:           pointer.Ptr("666"),
+						Parallel:            pointer.Ptr[int64](0),
+						SmallTableThreshold: pointer.Ptr("1GiB"),
+					},
+				},
+			},
+			Actions: []action{&updateTaskAction{clusterID: clusterID, task: &managerclient.Task{ID: "repair-id"}}},
+		},
+		{
+			Name: "Task gets updated when managed hash is empty",
+			Spec: scyllav1.ScyllaClusterSpec{
+				Repairs: []scyllav1.RepairTaskSpec{
+					{
+						TaskSpec: scyllav1.TaskSpec{
+							Name: "repair",
+							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+								Interval:  pointer.Ptr("0"),
+							},
+						},
+						SmallTableThreshold: "1GiB",
+						Intensity:           "666",
+						Parallel:            0,
+					},
+				},
+			},
+			Status: scyllav1.ScyllaClusterStatus{
+				ManagerID: pointer.Ptr(clusterID),
+			},
+			State: state{
+				Clusters: []*managerclient.Cluster{{
+					ID:        clusterID,
+					Name:      clusterName,
+					AuthToken: clusterAuthToken,
+				}},
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
+					"repair": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+								Interval:  pointer.Ptr("0"),
+							},
+							Name: "repair",
+							ID:   pointer.Ptr("repair-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "",
+							},
+						},
+						FailFast:            pointer.Ptr(false),
+						Intensity:           pointer.Ptr("666"),
+						Parallel:            pointer.Ptr[int64](0),
+						SmallTableThreshold: pointer.Ptr("1GiB"),
+					},
+				},
+			},
+			Actions: []action{&updateTaskAction{clusterID: clusterID, task: &managerclient.Task{ID: "repair-id"}}},
+		},
+		{
+			Name: "Task gets updated when managed hash does not match",
+			Spec: scyllav1.ScyllaClusterSpec{
+				Repairs: []scyllav1.RepairTaskSpec{
+					{
+						TaskSpec: scyllav1.TaskSpec{
+							Name: "repair",
+							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+								Interval:  pointer.Ptr("0"),
+							},
+						},
+						SmallTableThreshold: "1GiB",
+						Intensity:           "666",
+						Parallel:            0,
+					},
+				},
+			},
+			Status: scyllav1.ScyllaClusterStatus{
+				ManagerID: pointer.Ptr(clusterID),
+			},
+			State: state{
+				Clusters: []*managerclient.Cluster{{
+					ID:        clusterID,
+					Name:      clusterName,
+					AuthToken: clusterAuthToken,
+				}},
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
+					"repair": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+								Interval:  pointer.Ptr("0"),
+							},
+							Name: "repair",
+							ID:   pointer.Ptr("repair-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "non-matching-hash",
+							},
+						},
+						FailFast:            pointer.Ptr(false),
+						Intensity:           pointer.Ptr("666"),
+						Parallel:            pointer.Ptr[int64](0),
+						SmallTableThreshold: pointer.Ptr("1GiB"),
+					},
+				},
+			},
+			Actions: []action{&updateTaskAction{clusterID: clusterID, task: &managerclient.Task{ID: "repair-id"}}},
+		},
+		{
+			Name: "Tasks do not get updated when in-manager state differs but managed hashes match specs",
+			Spec: scyllav1.ScyllaClusterSpec{
+				Repairs: []scyllav1.RepairTaskSpec{
+					{
+						TaskSpec: scyllav1.TaskSpec{
+							Name: "repair",
+							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+							},
+						},
+						SmallTableThreshold: "10GiB",
+						Intensity:           "666",
+						Parallel:            3,
+					},
+				},
+				Backups: []scyllav1.BackupTaskSpec{
+					{
+						TaskSpec: scyllav1.TaskSpec{
+							Name: "backup",
+							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+							},
+						},
+						Location:  []string{"s3:backup"},
+						Retention: 3,
+					},
+				},
+			},
+			Status: scyllav1.ScyllaClusterStatus{
+				ManagerID: pointer.Ptr(clusterID),
+			},
+			State: state{
+				Clusters: []*managerclient.Cluster{{
+					ID:        clusterID,
+					Name:      clusterName,
+					AuthToken: clusterAuthToken,
+				}},
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
+					"repair": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
+							},
+							Name: "repair",
+							ID:   pointer.Ptr("repair-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "JcrUPldfq9/FT/tAaXzdY2aclZFsjTlRsYDh7LEjM3K5XRbl8w+jUGvZdBHRRSZ28TdWu2dsa/L5LBxxWjIpHw==",
+							},
+						},
+						SmallTableThreshold: pointer.Ptr("1GiB"),
+						Intensity:           pointer.Ptr("1"),
+						Parallel:            pointer.Ptr[int64](1),
+					},
+				},
+				BackupTasks: map[string]scyllav1.BackupTaskStatus{
+					"backup": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
+							},
+							Name: "backup",
+							ID:   pointer.Ptr("backup-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "NpboZYiDmzZfS84omU0kgZxxDzg5p3IEhKCWU0sS6G0QpSh2KZFPHB7AlJohyqo+RjBG2aEIqbBW8GiDo18uxw==",
+							},
+						},
+						Location:  []string{"s3:other-backup"},
+						Retention: pointer.Ptr[int64](1),
+					},
+				},
+			},
+			Actions: nil,
 		},
 	}
 
@@ -446,198 +671,93 @@ func actionComparer(a action, b action) bool {
 	return false
 }
 
-func TestBackupTaskChanged(t *testing.T) {
+func TestEvaluateDates(t *testing.T) {
 	ts := []struct {
-		name        string
-		spec        *BackupTaskSpec
-		managerTask *BackupTaskStatus
-		expected    *BackupTaskStatus
+		name     string
+		spec     *scyllav1.TaskSpec
+		status   *scyllav1.TaskStatus
+		expected scyllav1.TaskStatus
 	}{
 		{
 			name: "Task startDate is changed to one from manager state when it's not provided",
-			spec: &BackupTaskSpec{
-				TaskSpec: scyllav1.TaskSpec{
-					SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{},
+			spec: &scyllav1.TaskSpec{
+				SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{},
+			},
+			status: &scyllav1.TaskStatus{
+				SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+					StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
 				},
 			},
-			managerTask: &BackupTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
+			expected: scyllav1.TaskStatus{
+				SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+					StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
 				},
-			},
-			expected: &BackupTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
-				},
-				Retention: pointer.Ptr[int64](0),
 			},
 		},
 		{
 			name: "Task startDate is changed to one from manager state when it's an empty string",
-			spec: &BackupTaskSpec{
-				TaskSpec: scyllav1.TaskSpec{
-					SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-						StartDate: pointer.Ptr(""),
-					},
-				}},
-			managerTask: &BackupTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
-				}},
-			expected: &BackupTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
+			spec: &scyllav1.TaskSpec{
+				SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+					StartDate: pointer.Ptr(""),
 				},
-				Retention: pointer.Ptr[int64](0),
+			},
+			status: &scyllav1.TaskStatus{
+				SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+					StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+				},
+			},
+			expected: scyllav1.TaskStatus{
+				SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+					StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+				},
+			},
+		},
+		{
+			name: "Task startDate is changed to one from manager state when it's 'now' literal",
+			spec: &scyllav1.TaskSpec{
+				SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+					StartDate: pointer.Ptr("now"),
+				},
+			},
+			status: &scyllav1.TaskStatus{
+				SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+					StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+				},
+			},
+			expected: scyllav1.TaskStatus{
+				SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+					StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
+				},
 			},
 		},
 		{
 			name: "Task startDate is changed to one from manager state when prefix is 'now'",
-			spec: &BackupTaskSpec{
-				TaskSpec: scyllav1.TaskSpec{
-					SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-						StartDate: pointer.Ptr("now"),
-					},
+			spec: &scyllav1.TaskSpec{
+				SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+					StartDate: pointer.Ptr("now+3d2h10m"),
 				},
 			},
-			managerTask: &BackupTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
+			status: &scyllav1.TaskStatus{
+				SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+					StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
 				},
 			},
-			expected: &BackupTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
+			expected: scyllav1.TaskStatus{
+				SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+					StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
 				},
-				Retention: pointer.Ptr[int64](0),
 			},
 		},
 	}
 
-	for _, test := range ts {
-		t.Run(test.name, func(t *testing.T) {
+	for _, tc := range ts {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			evaluateDates(test.spec, test.managerTask)
-			got := test.spec.ToStatus()
-			if !reflect.DeepEqual(got, test.expected) {
-				t.Errorf("expected and got repair task statuses differ: %s", cmp.Diff(test.expected, got))
-			}
-		})
-	}
-}
-
-func TestRepairTaskChanged(t *testing.T) {
-	ts := []struct {
-		name        string
-		spec        *RepairTaskSpec
-		managerTask *RepairTaskStatus
-		expected    *RepairTaskStatus
-	}{
-		{
-			name: "Task startDate is changed to one from manager state when it's not provided",
-			spec: &RepairTaskSpec{
-				TaskSpec: scyllav1.TaskSpec{
-					SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{},
-				},
-			},
-			managerTask: &RepairTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
-				},
-			},
-			expected: &RepairTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
-				},
-				FailFast:            pointer.Ptr(false),
-				Intensity:           pointer.Ptr(""),
-				Parallel:            pointer.Ptr[int64](0),
-				SmallTableThreshold: pointer.Ptr(""),
-			},
-		},
-		{
-			name: "Task startDate is changed to one from manager state when it's an empty string",
-			spec: &RepairTaskSpec{
-				TaskSpec: scyllav1.TaskSpec{
-					SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-						StartDate: pointer.Ptr(""),
-					},
-				},
-			},
-			managerTask: &RepairTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
-				},
-			},
-			expected: &RepairTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
-				},
-				FailFast:            pointer.Ptr(false),
-				Intensity:           pointer.Ptr(""),
-				Parallel:            pointer.Ptr[int64](0),
-				SmallTableThreshold: pointer.Ptr(""),
-			},
-		},
-		{
-			name: "Task startDate is changed to one from manager state when prefix is 'now'",
-			spec: &RepairTaskSpec{
-				TaskSpec: scyllav1.TaskSpec{
-					SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-						StartDate: pointer.Ptr("now"),
-					},
-				},
-			},
-			managerTask: &RepairTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
-				},
-			},
-			expected: &RepairTaskStatus{
-				TaskStatus: scyllav1.TaskStatus{
-					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-						StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-					},
-				},
-				FailFast:            pointer.Ptr(false),
-				Intensity:           pointer.Ptr(""),
-				Parallel:            pointer.Ptr[int64](0),
-				SmallTableThreshold: pointer.Ptr(""),
-			},
-		},
-	}
-
-	for _, test := range ts {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			evaluateDates(test.spec, test.managerTask)
-			got := test.spec.ToStatus()
-			if !reflect.DeepEqual(got, test.expected) {
-				t.Errorf("expected and got backup task statuses differ: %s", cmp.Diff(test.expected, got))
+			evaluateDates(tc.spec, tc.status)
+			got := taskSpecToStatus(tc.spec)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("expected and got repair task statuses differ: %s", cmp.Diff(tc.expected, got))
 			}
 		})
 	}

--- a/pkg/controller/manager/types_old_test.go
+++ b/pkg/controller/manager/types_old_test.go
@@ -152,17 +152,20 @@ func TestRepairTask_FromManager(t *testing.T) {
 	tt := []struct {
 		name          string
 		managerTask   *managerclient.TaskListItem
-		expected      *RepairTaskStatus
+		expected      *scyllav1.RepairTaskStatus
 		expectedError error
 	}{
 		{
 			name: "fields and properties are propagated",
 			managerTask: &managerclient.TaskListItem{
-				ClusterID:      "cluster_id",
-				Name:           "repair_task_name",
-				Enabled:        true,
-				ErrorCount:     1,
-				ID:             "repair_task_id",
+				ClusterID:  "cluster_id",
+				Name:       "repair_task_name",
+				Enabled:    true,
+				ErrorCount: 1,
+				ID:         "repair_task_id",
+				Labels: map[string]string{
+					"scylla-operator.scylladb.com/managed-hash": "managed-hash-value",
+				},
 				LastError:      validDateTime,
 				LastSuccess:    validDateTime,
 				NextActivation: validDateTime,
@@ -192,7 +195,7 @@ func TestRepairTask_FromManager(t *testing.T) {
 				Suspended:    false,
 				Type:         managerclient.RepairTask,
 			},
-			expected: &RepairTaskStatus{
+			expected: &scyllav1.RepairTaskStatus{
 				TaskStatus: scyllav1.TaskStatus{
 					Name: "repair_task_name",
 					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
@@ -204,6 +207,9 @@ func TestRepairTask_FromManager(t *testing.T) {
 					},
 					ID:    pointer.Ptr("repair_task_id"),
 					Error: nil,
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/managed-hash": "managed-hash-value",
+					},
 				},
 				DC:                  []string{"us-east1"},
 				FailFast:            pointer.Ptr(true),
@@ -334,19 +340,22 @@ func TestBackupTask_FromManager(t *testing.T) {
 	tt := []struct {
 		name          string
 		managerTask   *managerclient.TaskListItem
-		expected      *BackupTaskStatus
+		expected      *scyllav1.BackupTaskStatus
 		expectedError error
 	}{
 		{
 			name: "fields and properties are propagated",
 			managerTask: &managerclient.TaskListItem{
-				ClusterID:      "cluster_id",
-				Enabled:        true,
-				ErrorCount:     1,
-				ID:             "backup_task_id",
-				LastError:      validDateTime,
-				LastSuccess:    validDateTime,
-				Name:           "backup_task_name",
+				ClusterID:   "cluster_id",
+				Enabled:     true,
+				ErrorCount:  1,
+				ID:          "backup_task_id",
+				LastError:   validDateTime,
+				LastSuccess: validDateTime,
+				Name:        "backup_task_name",
+				Labels: map[string]string{
+					"scylla-operator.scylladb.com/managed-hash": "managed-hash-value",
+				},
 				NextActivation: validDateTime,
 				Properties: map[string]interface{}{
 					"location": []string{
@@ -383,7 +392,7 @@ func TestBackupTask_FromManager(t *testing.T) {
 				Suspended:    false,
 				Type:         managerclient.BackupTask,
 			},
-			expected: &BackupTaskStatus{
+			expected: &scyllav1.BackupTaskStatus{
 				TaskStatus: scyllav1.TaskStatus{
 					Name: "backup_task_name",
 					SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
@@ -395,6 +404,9 @@ func TestBackupTask_FromManager(t *testing.T) {
 					},
 					ID:    pointer.Ptr("backup_task_id"),
 					Error: nil,
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/managed-hash": "managed-hash-value",
+					},
 				},
 				DC:               []string{"us-east1"},
 				Keyspace:         []string{"test"},


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Currently, Scylla Manager integration controller decides to update the tasks defined in ScyllaCluster's spec by checking for deep equality between the task definition in ScyllaCluster's spec and the task status obtained from the Manager's state.
Due to some discrepancies between how we and Scylla Manager keep tasks' properties, and the fact that some values would be converted, but not converted back when reading the status, this would often lead to task update hot loops, where a task update requests would be sent despite no changes in spec.

Such scenario can be observed by specifying a repair task with e.g. `smallTableThreshold` set:
```
  repairs:
  - failFast: true
    intensity: "1"
    name: repair
    numRetries: 1
    parallel: 1
    smallTableThreshold: 1GiB
```

The threshold would be converted to bytes, so that the corresponding status would be:
```
  repairs:
  - cron: '{"spec":"","start_date":"0001-01-01T00:00:00Z"}'
    failFast: true
    id: d0550c36-f799-4ac4-8b01-aab7aaf042bf
    intensity: "1"
    interval: ""
    name: repair
    numRetries: 0
    parallel: 1
    smallTableThreshold: "1073741824"
    startDate: "2024-10-02T15:39:22.907Z"
    timezone: ""
```

The value would not be converted back, causing the deep equality test to always return false, and so an update would be triggered on every comparison, causing a hot loop. 

There were also cases reported by users in which we suspected the constant updates were causing a high cpu load: https://github.com/scylladb/scylla-manager/issues/3920.

This PR addresses this issue by making use of `labels` recently added to the manager's task API. Similarily to how we handle managed k8s resources, the scylla-manager controller now computes a hash from the task's spec and sets a managed hash label. Therefore, an update request is only sent when a task spec changes in ScyllaCluster and the managed hash no longer matches the one set in scylla manager's state (and correspondingly, ScyllaCluster's status). 
Changes in the manager's state which are not reflected in our API (e.g. when a user manually updates a task with sctool) will not trigger an update, but they will be overwritten when we eventually reconcile.

This PR does not extend ScyllaCluster's API with the `labels` field for Scylla Manager's tasks, at this point we're only using them internally and don't expose them in spec to the users of our API. If there ever is a need to do add it, the managed hash would take precedence over colliding labels.

As this PR further extends the logic invoked on every task sync, some parts of the code are deduplicated to reduce the bug-prone surface. Consequently we're loosing some of the duplicated unit tests and unnecessary wrappers/interfaces.

A few new unit tests are added to test that the changes in task's state do not trigger an update unless the managed hash doesn't match.

These changes also uncovered a bug being hidden by the hotloop.

Requires:

- [x] https://github.com/scylladb/scylla-operator/pull/2143

**Which issue is resolved by this Pull Request:**
Resolves #1827 

/kind bug
/priority important-soon
/cc
