### PR TITLE
Fix manager tasks' status errors not being cleared on failed status updates for tasks present in manager state

### DIFF
--- a/pkg/controller/manager/status.go
+++ b/pkg/controller/manager/status.go
@@ -32,16 +32,14 @@ func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, managerState *s
 		managerTaskStatus, isInManagerState := managerState.RepairTasks[rt.Name]
 		if isInManagerState {
 			repairTaskStatus = scyllav1.RepairTaskStatus(managerTaskStatus)
-		}
+		} else {
+			// Retain the error from client.
+			err, hasClientError := repairTaskClientErrorMap[rt.Name]
+			if !hasClientError {
+				continue
+			}
 
-		// Retain the error from client.
-		err, hasClientError := repairTaskClientErrorMap[rt.Name]
-		if hasClientError {
 			repairTaskStatus.Error = &err
-		}
-
-		if !isInManagerState && !hasClientError {
-			continue
 		}
 
 		status.Repairs = append(status.Repairs, repairTaskStatus)
@@ -65,16 +63,14 @@ func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, managerState *s
 		managerTaskStatus, isInManagerState := managerState.BackupTasks[bt.Name]
 		if isInManagerState {
 			backupTaskStatus = scyllav1.BackupTaskStatus(managerTaskStatus)
-		}
+		} else {
+			// Retain the error from client.
+			err, hasClientError := backupTaskClientErrorMap[bt.Name]
+			if !hasClientError {
+				continue
+			}
 
-		// Retain the error from client.
-		err, hasClientError := backupTaskClientErrorMap[bt.Name]
-		if hasClientError {
 			backupTaskStatus.Error = &err
-		}
-
-		if !isInManagerState && !hasClientError {
-			continue
 		}
 
 		status.Backups = append(status.Backups, backupTaskStatus)

--- a/pkg/controller/manager/sync_action.go
+++ b/pkg/controller/manager/sync_action.go
@@ -367,8 +367,6 @@ func (a *deleteTaskAction) Execute(ctx context.Context, client *managerclient.Cl
 		return fmt.Errorf("can't stop and delete task %q: %w", a.taskName, err)
 	}
 
-	clearTaskStatusError(a.taskType, a.taskName, status)
-
 	return nil
 }
 
@@ -407,8 +405,6 @@ func (a *addTaskAction) Execute(ctx context.Context, client *managerclient.Clien
 		return fmt.Errorf("can't create task %q: %w", a.task.Name, err)
 	}
 
-	clearTaskStatusError(a.task.Type, a.task.Name, status)
-
 	return nil
 }
 
@@ -428,8 +424,6 @@ func (a *updateTaskAction) Execute(ctx context.Context, client *managerclient.Cl
 		return fmt.Errorf("can't update task %q: %w", a.task.Name, err)
 	}
 
-	clearTaskStatusError(a.task.Type, a.task.Name, status)
-
 	return nil
 }
 
@@ -443,25 +437,6 @@ func messageOf(err error) string {
 		return v.GetPayload().Message
 	}
 	return err.Error()
-}
-
-func clearTaskStatusError(taskType string, taskName string, status *scyllav1.ScyllaClusterStatus) {
-	switch taskType {
-	case managerclient.RepairTask:
-		_, i, ok := slices.Find(status.Repairs, func(rts scyllav1.RepairTaskStatus) bool {
-			return rts.Name == taskName
-		})
-		if ok {
-			status.Repairs[i].Error = nil
-		}
-	case managerclient.BackupTask:
-		_, i, ok := slices.Find(status.Backups, func(bts scyllav1.BackupTaskStatus) bool {
-			return bts.Name == taskName
-		})
-		if ok {
-			status.Backups[i].Error = nil
-		}
-	}
 }
 
 func setTaskStatusError(taskType string, taskName string, taskErr string, status *scyllav1.ScyllaClusterStatus) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Manager task errors shouldn't be kept when building status for tasks existing in manager state and only cleared on status update, since if the status update fails, the error is retained even though the error no longer occurs. For tasks in manager state, if the error reappears, it will be propagated again. This bug is currently being covered by the logic comparing our spec with manager state (hot loop), but with https://github.com/scylladb/scylla-operator/pull/2143 this will no longer be the case, hence this is a prerequisite for https://github.com/scylladb/scylla-operator/pull/2143.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-soon
/cc