### PR TITLE
Fix storageClassName field location in monitoring example

### DIFF
--- a/examples/monitoring/v1alpha1/scylladbmonitoring.yaml
+++ b/examples/monitoring/v1alpha1/scylladbmonitoring.yaml
@@ -14,8 +14,8 @@ spec:
       storage:
         volumeClaimTemplate:
           spec:
+            storageClassName: scylladb-local-xfs
             resources:
-              storageClassName: scylladb-local-xfs
               requests:
                 storage: 1Gi
     grafana:


### PR DESCRIPTION
**Description of your changes:**
This PR fixes the location of `storageClassName` in the ScyllaDBMonitoring manifest to match the schema.

**Which issue is resolved by this Pull Request:**
Resolves #2150
