### PR TITLE
Use Scylla Manager cluster labels for cluster reconciliation

### DIFF
--- a/pkg/controller/manager/status.go
+++ b/pkg/controller/manager/status.go
@@ -6,13 +6,35 @@ import (
 	"context"
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
-func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, managerState *state) *scyllav1.ScyllaClusterStatus {
+func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, state *managerClusterState) *scyllav1.ScyllaClusterStatus {
 	status := sc.Status.DeepCopy()
+
+	status.ManagerID = pointer.Ptr("")
+	status.Backups = []scyllav1.BackupTaskStatus{}
+	status.Repairs = []scyllav1.RepairTaskStatus{}
+
+	if state.Cluster == nil {
+		return status
+	}
+
+	ownerUIDLabelValue, hasOwnerUIDLabel := state.Cluster.Labels[naming.OwnerUIDLabel]
+	if !hasOwnerUIDLabel {
+		klog.Warningf("Cluster %q is missing an owner UID label.", state.Cluster.Name)
+	}
+
+	if ownerUIDLabelValue != string(sc.UID) {
+		// Cluster is not owned by ScyllaCluster, do not propagate its status.
+		return status
+	}
+
+	status.ManagerID = pointer.Ptr(state.Cluster.ID)
 
 	repairTaskClientErrorMap := map[string]string{}
 	for _, rts := range status.Repairs {
@@ -21,7 +43,6 @@ func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, managerState *s
 		}
 	}
 
-	status.Repairs = []scyllav1.RepairTaskStatus{}
 	for _, rt := range sc.Spec.Repairs {
 		repairTaskStatus := scyllav1.RepairTaskStatus{
 			TaskStatus: scyllav1.TaskStatus{
@@ -29,7 +50,7 @@ func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, managerState *s
 			},
 		}
 
-		managerTaskStatus, isInManagerState := managerState.RepairTasks[rt.Name]
+		managerTaskStatus, isInManagerState := state.RepairTasks[rt.Name]
 		if isInManagerState {
 			repairTaskStatus = managerTaskStatus
 		} else {
@@ -52,7 +73,6 @@ func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, managerState *s
 		}
 	}
 
-	status.Backups = []scyllav1.BackupTaskStatus{}
 	for _, bt := range sc.Spec.Backups {
 		backupTaskStatus := scyllav1.BackupTaskStatus{
 			TaskStatus: scyllav1.TaskStatus{
@@ -60,7 +80,7 @@ func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, managerState *s
 			},
 		}
 
-		managerTaskStatus, isInManagerState := managerState.BackupTasks[bt.Name]
+		managerTaskStatus, isInManagerState := state.BackupTasks[bt.Name]
 		if isInManagerState {
 			backupTaskStatus = managerTaskStatus
 		} else {

--- a/pkg/controller/manager/sync_test.go
+++ b/pkg/controller/manager/sync_test.go
@@ -4,485 +4,451 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestManagerSynchronization(t *testing.T) {
-	const (
-		clusterAuthToken = "token"
-		namespace        = "test"
-		name             = "cluster"
-		clusterName      = "test/cluster"
-		clusterID        = "cluster-id"
-	)
+func Test_runSync(t *testing.T) {
+	t.Parallel()
 
-	tcs := []struct {
-		Name   string
-		Spec   scyllav1.ScyllaClusterSpec
-		Status scyllav1.ScyllaClusterStatus
-		State  state
-
-		Actions []action
-		Requeue bool
+	tt := []struct {
+		name            string
+		sc              *scyllav1.ScyllaCluster
+		authToken       string
+		state           *managerClusterState
+		expectedActions []action
+		expectedRequeue bool
+		expectedErr     error
 	}{
 		{
-			Name:   "Empty manager, empty spec, add cluster and requeue",
-			Spec:   scyllav1.ScyllaClusterSpec{},
-			Status: scyllav1.ScyllaClusterStatus{},
-			State:  state{},
-
-			Requeue: true,
-			Actions: []action{&addClusterAction{cluster: &managerclient.Cluster{Name: clusterName}}},
-		},
-		{
-			Name: "Empty manager, task in spec, add cluster and requeue",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{},
+			name:      "no cluster in state, no tasks in state, return add cluster action and requeue",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: nil,
 			},
-			Status: scyllav1.ScyllaClusterStatus{},
-			State:  state{},
-
-			Requeue: true,
-			Actions: []action{&addClusterAction{cluster: &managerclient.Cluster{Name: clusterName}}},
-		},
-		{
-			Name:   "Cluster registered in manager do nothing",
-			Spec:   scyllav1.ScyllaClusterSpec{},
-			Status: scyllav1.ScyllaClusterStatus{},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-			},
-
-			Requeue: false,
-			Actions: nil,
-		},
-		{
-			Name: "Cluster registered in manager but auth token is different, update and requeue",
-			Spec: scyllav1.ScyllaClusterSpec{},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: "different-auth-token",
-				}},
-			},
-
-			Requeue: true,
-			Actions: []action{&updateClusterAction{cluster: &managerclient.Cluster{ID: clusterID}}},
-		},
-		{
-			Name: "Name collision, delete old one, add new and requeue",
-			Spec: scyllav1.ScyllaClusterSpec{},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:   "different-id",
-					Name: clusterName,
-				}},
-			},
-
-			Requeue: true,
-			Actions: []action{
-				&deleteClusterAction{clusterID: "different-id"},
-				&addClusterAction{cluster: &managerclient.Cluster{Name: clusterName}},
-			},
-		},
-		{
-			Name: "Schedule repair task",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "my-repair",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
-								Interval:  pointer.Ptr("0"),
-							},
+			expectedActions: []action{
+				&addClusterAction{
+					Cluster: &managerclient.Cluster{
+						AuthToken:              "token",
+						ForceNonSslSessionPort: true,
+						ForceTLSDisabled:       true,
+						Host:                   "test-client.test.svc",
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+							"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
 						},
-						SmallTableThreshold: "1GiB",
-						DC:                  []string{"dc1"},
-						FailFast:            false,
-						Intensity:           "0.5",
-						Keyspace:            []string{"keyspace1"},
+						Name: "test/test",
 					},
 				},
 			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-			},
-
-			Actions: []action{&addTaskAction{clusterID: clusterID, task: &managerclient.Task{Name: "my-repair"}}},
+			expectedRequeue: true,
+			expectedErr:     nil,
 		},
 		{
-			Name: "Schedule backup task",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Backups: []scyllav1.BackupTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "my-backup",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
-								Interval:  pointer.Ptr("0"),
-							},
+			name:      "cluster in state, missing owner UID label, no tasks in state, return delete cluster action and requeue",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedActions: []action{
+				&deleteClusterAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedRequeue: true,
+			expectedErr:     nil,
+		},
+		{
+			name:      "cluster in state, empty owner UID label, no tasks in state, return delete cluster action and requeue",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedActions: []action{
+				&deleteClusterAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedRequeue: true,
+			expectedErr:     nil,
+		},
+		{
+			name:      "cluster in state, mismatching owner UID label, no tasks in state, return delete cluster action and requeue",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "other-uid",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedActions: []action{
+				&deleteClusterAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedRequeue: true,
+			expectedErr:     nil,
+		},
+		{
+			name:      "cluster in state, matching owner UID label, missing managed hash label, no tasks in state, return update cluster action and requeue",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid": "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedActions: []action{
+				&updateClusterAction{
+					Cluster: &managerclient.Cluster{
+						AuthToken:              "token",
+						ForceNonSslSessionPort: true,
+						ForceTLSDisabled:       true,
+						Host:                   "test-client.test.svc",
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+							"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
 						},
-						DC:               []string{"dc1"},
-						Keyspace:         []string{"keyspace1"},
-						Location:         []string{"s3:abc"},
-						RateLimit:        []string{"dc1:1"},
-						Retention:        3,
-						SnapshotParallel: []string{"dc1:1"},
-						UploadParallel:   []string{"dc1:1"},
+						Name: "test/test",
+						ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
 					},
 				},
 			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-			},
-
-			Actions: []action{&addTaskAction{clusterID: clusterID, task: &managerclient.Task{Name: "my-backup"}}},
+			expectedRequeue: true,
+			expectedErr:     nil,
 		},
 		{
-			Name: "Update repair if it's already registered in Manager",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "repair",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
-								Interval:  pointer.Ptr("0"),
-							},
+			name:      "cluster in state, matching owner UID label, empty managed hash label, no tasks in state, return update cluster action and requeue",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedActions: []action{
+				&updateClusterAction{
+					Cluster: &managerclient.Cluster{
+						AuthToken:              "token",
+						ForceNonSslSessionPort: true,
+						ForceTLSDisabled:       true,
+						Host:                   "test-client.test.svc",
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+							"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
 						},
-						SmallTableThreshold: "1GiB",
-						Intensity:           "0",
+						Name: "test/test",
+						ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
 					},
 				},
 			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-				Repairs: []scyllav1.RepairTaskStatus{
-					{
+			expectedRequeue: true,
+			expectedErr:     nil,
+		},
+		{
+			name:      "cluster in state, matching owner UID label, mismatching managed hash label, no tasks in state, return update cluster action and requeue",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "other-managed-hash",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedActions: []action{
+				&updateClusterAction{
+					Cluster: &managerclient.Cluster{
+						AuthToken:              "token",
+						ForceNonSslSessionPort: true,
+						ForceTLSDisabled:       true,
+						Host:                   "test-client.test.svc",
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+							"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+						},
+						Name: "test/test",
+						ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					},
+				},
+			},
+			expectedRequeue: true,
+			expectedErr:     nil,
+		},
+		{
+			name:      "cluster in state, missing clusterID, return err",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "",
+				},
+			},
+			expectedActions: nil,
+			expectedRequeue: false,
+			expectedErr:     fmt.Errorf(`can't sync cluster "test/test": %w`, fmt.Errorf(`manager cluster is missing an id`)),
+		},
+		{
+			name:      "matching cluster in state, no tasks in state, return add task actions",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+			},
+			expectedActions: []action{
+				&addTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					Task: &managerclient.Task{
+						Enabled: true,
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/managed-hash": "e6nOWps39EWcHS4BmiEti8MfyH6PL5Yt3kpM4Vej1Rd0SAsCM39CXe/XH1Yjhsi3b611nx7yfK9paShMxaNqGw==",
+						},
+						Name: "repair",
+						Properties: map[string]any{
+							"intensity":             float64(0.5),
+							"parallel":              int64(0),
+							"small_table_threshold": int64(1073741824),
+						},
+						Schedule: &managerclient.Schedule{
+							StartDate: validDateTime,
+						},
+						Type: "repair",
+					},
+				},
+				&addTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					Task: &managerclient.Task{
+						Enabled: true,
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/managed-hash": "c+YqtlphqYcYveZmyspNBzt77JuW9zNWKMdUPv8AGbP+9j3Gi4KvQqJyBrq5DPFDV6E8rWxcyXHF2mNYFzwIaA==",
+						},
+						Name: "backup",
+						Properties: map[string]any{
+							"location":  []string{"gcs:location"},
+							"retention": int64(0),
+						},
+						Schedule: &managerclient.Schedule{
+							StartDate: validDateTime,
+						},
+						Type: "backup",
+					},
+				},
+			},
+			expectedRequeue: false,
+			expectedErr:     nil,
+		},
+		{
+			name:      "matching cluster in state, tasks in state, missing managed hash labels, return update task actions",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+				BackupTasks: map[string]scyllav1.BackupTaskStatus{
+					"backup": {
 						TaskStatus: scyllav1.TaskStatus{
 							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
-								Interval:  pointer.Ptr("0"),
+								StartDate: pointer.Ptr(validDate),
 							},
-							Name:  "repair",
-							ID:    pointer.Ptr("repair-id"),
-							Error: nil,
+							Name:   "backup",
+							ID:     pointer.Ptr("backup-id"),
+							Labels: map[string]string{},
 						},
-						Intensity:           pointer.Ptr("666"),
-						SmallTableThreshold: pointer.Ptr("1GiB"),
+						Location: []string{"gcs:location"},
 					},
 				},
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
 				RepairTasks: map[string]scyllav1.RepairTaskStatus{
 					"repair": {
 						TaskStatus: scyllav1.TaskStatus{
 							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-							Name: "repair",
-							ID:   pointer.Ptr("repair-id"),
-						},
-						Intensity:           pointer.Ptr("123"),
-						SmallTableThreshold: pointer.Ptr("1GiB"),
-					},
-				},
-			},
-
-			Actions: []action{&updateTaskAction{clusterID: clusterID, task: &managerclient.Task{ID: "repair-id"}}},
-		},
-		{
-			Name: "Do not update task when it didn't change",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "repair",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-						},
-						SmallTableThreshold: "1GiB",
-						Intensity:           "666",
-						Parallel:            0,
-					},
-				},
-			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-				RepairTasks: map[string]scyllav1.RepairTaskStatus{
-					"repair": {
-						TaskStatus: scyllav1.TaskStatus{
-							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-							Name: "repair",
-							ID:   pointer.Ptr("repair-id"),
-							Labels: map[string]string{
-								"scylla-operator.scylladb.com/managed-hash": "9gAqa0Ngh483/n6qTDn3FMKGvyMXrUKqPS3Jp5RDp8RJ1/58h8p5oYrtP7r6rYmNoRY1neKQHvV1IIzmMr6hBg==",
-							},
-						},
-						FailFast:            pointer.Ptr(false),
-						Intensity:           pointer.Ptr("666"),
-						Parallel:            pointer.Ptr[int64](0),
-						SmallTableThreshold: pointer.Ptr("1GiB"),
-					},
-				},
-			},
-			Actions: nil,
-		},
-		{
-			Name: "Delete tasks from Manager unknown to spec",
-			Spec: scyllav1.ScyllaClusterSpec{},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-				RepairTasks: map[string]scyllav1.RepairTaskStatus{
-					"other-repair": {
-						TaskStatus: scyllav1.TaskStatus{
-							Name: "other-repair",
-							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-							ID: pointer.Ptr("other-repair-id"),
-						},
-					},
-				},
-			},
-
-			Actions: []action{&deleteTaskAction{clusterID: clusterID, taskID: "other-repair-id"}},
-		},
-		{
-			Name: "Special 'now' startDate is not compared during update decision",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "repair",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("now"),
-								Interval:  pointer.Ptr("0"),
-							},
-						},
-						Intensity:           "666",
-						SmallTableThreshold: "1GiB",
-						Parallel:            0,
-					},
-				},
-			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-				RepairTasks: map[string]scyllav1.RepairTaskStatus{
-					"repair": {
-						TaskStatus: scyllav1.TaskStatus{
-							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-							Name: "repair",
-							ID:   pointer.Ptr("repair-id"),
-							Labels: map[string]string{
-								"scylla-operator.scylladb.com/managed-hash": "QAYSzOPRCIVGqS04NfnFslWujYbjmjwNjH//peQawBxry6I6M/scdCaHR2qgNOL9YJQsGjnD846eO0oULMyJ8A==",
-							},
-						},
-						FailFast:            pointer.Ptr(false),
-						Intensity:           pointer.Ptr("666"),
-						Parallel:            pointer.Ptr[int64](0),
-						SmallTableThreshold: pointer.Ptr("1GiB"),
-					},
-				},
-			},
-
-			Actions: nil,
-		},
-		{
-			Name: "Task gets updated when startDate is changed",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "repair",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-						},
-						Intensity:           "666",
-						SmallTableThreshold: "1GiB",
-						Parallel:            0,
-					},
-				},
-			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-				RepairTasks: map[string]scyllav1.RepairTaskStatus{
-					"repair": {
-						TaskStatus: scyllav1.TaskStatus{
-							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-							Name: "repair",
-							ID:   pointer.Ptr("repair-id"),
-						},
-						FailFast:            pointer.Ptr(false),
-						Intensity:           pointer.Ptr("666"),
-						Parallel:            pointer.Ptr[int64](0),
-						SmallTableThreshold: pointer.Ptr("1GiB"),
-					},
-				},
-			},
-
-			Actions: []action{&updateTaskAction{clusterID: clusterID, task: &managerclient.Task{ID: "repair-id"}}},
-		},
-		{
-			Name: "Task gets updated when managed hash is missing",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "repair",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-						},
-						SmallTableThreshold: "1GiB",
-						Intensity:           "666",
-						Parallel:            0,
-					},
-				},
-			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-				RepairTasks: map[string]scyllav1.RepairTaskStatus{
-					"repair": {
-						TaskStatus: scyllav1.TaskStatus{
-							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
+								StartDate: pointer.Ptr(validDate),
 							},
 							Name:   "repair",
 							ID:     pointer.Ptr("repair-id"),
 							Labels: map[string]string{},
 						},
-						FailFast:            pointer.Ptr(false),
-						Intensity:           pointer.Ptr("666"),
+						Intensity:           pointer.Ptr("0.5"),
 						Parallel:            pointer.Ptr[int64](0),
 						SmallTableThreshold: pointer.Ptr("1GiB"),
 					},
 				},
 			},
-			Actions: []action{&updateTaskAction{clusterID: clusterID, task: &managerclient.Task{ID: "repair-id"}}},
-		},
-		{
-			Name: "Task gets updated when managed hash is empty",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "repair",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
-							},
+			expectedActions: []action{
+				&updateTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					Task: &managerclient.Task{
+						ID:      "repair-id",
+						Enabled: true,
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/managed-hash": "e6nOWps39EWcHS4BmiEti8MfyH6PL5Yt3kpM4Vej1Rd0SAsCM39CXe/XH1Yjhsi3b611nx7yfK9paShMxaNqGw==",
 						},
-						SmallTableThreshold: "1GiB",
-						Intensity:           "666",
-						Parallel:            0,
+						Name: "repair",
+						Properties: map[string]any{
+							"intensity":             float64(0.5),
+							"parallel":              int64(0),
+							"small_table_threshold": int64(1073741824),
+						},
+						Schedule: &managerclient.Schedule{
+							StartDate: validDateTime,
+						},
+						Type: "repair",
+					},
+				},
+				&updateTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					Task: &managerclient.Task{
+						ID:      "backup-id",
+						Enabled: true,
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/managed-hash": "c+YqtlphqYcYveZmyspNBzt77JuW9zNWKMdUPv8AGbP+9j3Gi4KvQqJyBrq5DPFDV6E8rWxcyXHF2mNYFzwIaA==",
+						},
+						Name: "backup",
+						Properties: map[string]any{
+							"location":  []string{"gcs:location"},
+							"retention": int64(0),
+						},
+						Schedule: &managerclient.Schedule{
+							StartDate: validDateTime,
+						},
+						Type: "backup",
 					},
 				},
 			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
+			expectedRequeue: false,
+			expectedErr:     nil,
+		},
+		{
+			name:      "matching cluster in state, tasks in state, empty managed hash labels, return update task actions",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+				BackupTasks: map[string]scyllav1.BackupTaskStatus{
+					"backup": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr(validDate),
+							},
+							Name: "backup",
+							ID:   pointer.Ptr("backup-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "",
+							},
+						},
+						Location: []string{"gcs:location"},
+					},
+				},
 				RepairTasks: map[string]scyllav1.RepairTaskStatus{
 					"repair": {
 						TaskStatus: scyllav1.TaskStatus{
 							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
+								StartDate: pointer.Ptr(validDate),
 							},
 							Name: "repair",
 							ID:   pointer.Ptr("repair-id"),
@@ -490,189 +456,377 @@ func TestManagerSynchronization(t *testing.T) {
 								"scylla-operator.scylladb.com/managed-hash": "",
 							},
 						},
-						FailFast:            pointer.Ptr(false),
-						Intensity:           pointer.Ptr("666"),
+						Intensity:           pointer.Ptr("0.5"),
 						Parallel:            pointer.Ptr[int64](0),
 						SmallTableThreshold: pointer.Ptr("1GiB"),
 					},
 				},
 			},
-			Actions: []action{&updateTaskAction{clusterID: clusterID, task: &managerclient.Task{ID: "repair-id"}}},
+			expectedActions: []action{
+				&updateTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					Task: &managerclient.Task{
+						ID:      "repair-id",
+						Enabled: true,
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/managed-hash": "e6nOWps39EWcHS4BmiEti8MfyH6PL5Yt3kpM4Vej1Rd0SAsCM39CXe/XH1Yjhsi3b611nx7yfK9paShMxaNqGw==",
+						},
+						Name: "repair",
+						Properties: map[string]any{
+							"intensity":             float64(0.5),
+							"parallel":              int64(0),
+							"small_table_threshold": int64(1073741824),
+						},
+						Schedule: &managerclient.Schedule{
+							StartDate: validDateTime,
+						},
+						Type: "repair",
+					},
+				},
+				&updateTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					Task: &managerclient.Task{
+						ID:      "backup-id",
+						Enabled: true,
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/managed-hash": "c+YqtlphqYcYveZmyspNBzt77JuW9zNWKMdUPv8AGbP+9j3Gi4KvQqJyBrq5DPFDV6E8rWxcyXHF2mNYFzwIaA==",
+						},
+						Name: "backup",
+						Properties: map[string]any{
+							"location":  []string{"gcs:location"},
+							"retention": int64(0),
+						},
+						Schedule: &managerclient.Schedule{
+							StartDate: validDateTime,
+						},
+						Type: "backup",
+					},
+				},
+			},
+			expectedRequeue: false,
+			expectedErr:     nil,
 		},
 		{
-			Name: "Task gets updated when managed hash does not match",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "repair",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-						},
-						SmallTableThreshold: "1GiB",
-						Intensity:           "666",
-						Parallel:            0,
+			name:      "matching cluster in state, tasks in state, mismatching managed hash labels, return update task actions",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
 					},
-				},
-			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-				RepairTasks: map[string]scyllav1.RepairTaskStatus{
-					"repair": {
-						TaskStatus: scyllav1.TaskStatus{
-							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-								Interval:  pointer.Ptr("0"),
-							},
-							Name: "repair",
-							ID:   pointer.Ptr("repair-id"),
-							Labels: map[string]string{
-								"scylla-operator.scylladb.com/managed-hash": "non-matching-hash",
-							},
-						},
-						FailFast:            pointer.Ptr(false),
-						Intensity:           pointer.Ptr("666"),
-						Parallel:            pointer.Ptr[int64](0),
-						SmallTableThreshold: pointer.Ptr("1GiB"),
-					},
-				},
-			},
-			Actions: []action{&updateTaskAction{clusterID: clusterID, task: &managerclient.Task{ID: "repair-id"}}},
-		},
-		{
-			Name: "Tasks do not get updated when in-manager state differs but managed hashes match specs",
-			Spec: scyllav1.ScyllaClusterSpec{
-				Repairs: []scyllav1.RepairTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "repair",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-							},
-						},
-						SmallTableThreshold: "10GiB",
-						Intensity:           "666",
-						Parallel:            3,
-					},
-				},
-				Backups: []scyllav1.BackupTaskSpec{
-					{
-						TaskSpec: scyllav1.TaskSpec{
-							Name: "backup",
-							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-								StartDate: pointer.Ptr("2021-01-01T11:11:11Z"),
-							},
-						},
-						Location:  []string{"s3:backup"},
-						Retention: 3,
-					},
-				},
-			},
-			Status: scyllav1.ScyllaClusterStatus{
-				ManagerID: pointer.Ptr(clusterID),
-			},
-			State: state{
-				Clusters: []*managerclient.Cluster{{
-					ID:        clusterID,
-					Name:      clusterName,
-					AuthToken: clusterAuthToken,
-				}},
-				RepairTasks: map[string]scyllav1.RepairTaskStatus{
-					"repair": {
-						TaskStatus: scyllav1.TaskStatus{
-							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
-							},
-							Name: "repair",
-							ID:   pointer.Ptr("repair-id"),
-							Labels: map[string]string{
-								"scylla-operator.scylladb.com/managed-hash": "JcrUPldfq9/FT/tAaXzdY2aclZFsjTlRsYDh7LEjM3K5XRbl8w+jUGvZdBHRRSZ28TdWu2dsa/L5LBxxWjIpHw==",
-							},
-						},
-						SmallTableThreshold: pointer.Ptr("1GiB"),
-						Intensity:           pointer.Ptr("1"),
-						Parallel:            pointer.Ptr[int64](1),
-					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
 				},
 				BackupTasks: map[string]scyllav1.BackupTaskStatus{
 					"backup": {
 						TaskStatus: scyllav1.TaskStatus{
 							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
-								StartDate: pointer.Ptr("2006-01-02T15:04:05Z"),
+								StartDate: pointer.Ptr(validDate),
 							},
 							Name: "backup",
 							ID:   pointer.Ptr("backup-id"),
 							Labels: map[string]string{
-								"scylla-operator.scylladb.com/managed-hash": "NpboZYiDmzZfS84omU0kgZxxDzg5p3IEhKCWU0sS6G0QpSh2KZFPHB7AlJohyqo+RjBG2aEIqbBW8GiDo18uxw==",
+								"scylla-operator.scylladb.com/managed-hash": "other-managed-hash",
 							},
 						},
-						Location:  []string{"s3:other-backup"},
-						Retention: pointer.Ptr[int64](1),
+						Location: []string{"gcs:location"},
+					},
+				},
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
+					"repair": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr(validDate),
+							},
+							Name: "repair",
+							ID:   pointer.Ptr("repair-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "other-managed-hash",
+							},
+						},
+						Intensity:           pointer.Ptr("0.5"),
+						Parallel:            pointer.Ptr[int64](0),
+						SmallTableThreshold: pointer.Ptr("1GiB"),
 					},
 				},
 			},
-			Actions: nil,
+			expectedActions: []action{
+				&updateTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					Task: &managerclient.Task{
+						ID:      "repair-id",
+						Enabled: true,
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/managed-hash": "e6nOWps39EWcHS4BmiEti8MfyH6PL5Yt3kpM4Vej1Rd0SAsCM39CXe/XH1Yjhsi3b611nx7yfK9paShMxaNqGw==",
+						},
+						Name: "repair",
+						Properties: map[string]any{
+							"intensity":             float64(0.5),
+							"parallel":              int64(0),
+							"small_table_threshold": int64(1073741824),
+						},
+						Schedule: &managerclient.Schedule{
+							StartDate: validDateTime,
+						},
+						Type: "repair",
+					},
+				},
+				&updateTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					Task: &managerclient.Task{
+						ID:      "backup-id",
+						Enabled: true,
+						Labels: map[string]string{
+							"scylla-operator.scylladb.com/managed-hash": "c+YqtlphqYcYveZmyspNBzt77JuW9zNWKMdUPv8AGbP+9j3Gi4KvQqJyBrq5DPFDV6E8rWxcyXHF2mNYFzwIaA==",
+						},
+						Name: "backup",
+						Properties: map[string]any{
+							"location":  []string{"gcs:location"},
+							"retention": int64(0),
+						},
+						Schedule: &managerclient.Schedule{
+							StartDate: validDateTime,
+						},
+						Type: "backup",
+					},
+				},
+			},
+			expectedRequeue: false,
+			expectedErr:     nil,
+		},
+		{
+			name:      "matching cluster in state, tasks in state, matching managed hash labels, return no actions",
+			sc:        newBasicScyllaClusterWithBackupAndRepairTasks(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+				BackupTasks: map[string]scyllav1.BackupTaskStatus{
+					"backup": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr(validDate),
+							},
+							Name: "backup",
+							ID:   pointer.Ptr("backup-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "c+YqtlphqYcYveZmyspNBzt77JuW9zNWKMdUPv8AGbP+9j3Gi4KvQqJyBrq5DPFDV6E8rWxcyXHF2mNYFzwIaA==",
+							},
+						},
+						Location: []string{"gcs:location"},
+					},
+				},
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
+					"repair": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr(validDate),
+							},
+							Name: "repair",
+							ID:   pointer.Ptr("repair-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "e6nOWps39EWcHS4BmiEti8MfyH6PL5Yt3kpM4Vej1Rd0SAsCM39CXe/XH1Yjhsi3b611nx7yfK9paShMxaNqGw==",
+							},
+						},
+						Intensity:           pointer.Ptr("0.5"),
+						Parallel:            pointer.Ptr[int64](0),
+						SmallTableThreshold: pointer.Ptr("1GiB"),
+					},
+				},
+			},
+			expectedActions: nil,
+			expectedRequeue: false,
+			expectedErr:     nil,
+		},
+		{
+			name: "matching cluster in state, tasks in state, tasks with 'now' startDate and matching managed hash labels, return no actions",
+			sc: func() *scyllav1.ScyllaCluster {
+				sc := newBasicScyllaCluster()
+
+				sc.Spec.Backups = []scyllav1.BackupTaskSpec{
+					{
+						TaskSpec: scyllav1.TaskSpec{
+							Name: "backup",
+							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+								StartDate: pointer.Ptr("now"),
+							},
+						},
+						Location: []string{"gcs:location"},
+					},
+				}
+
+				sc.Spec.Repairs = []scyllav1.RepairTaskSpec{
+					{
+						TaskSpec: scyllav1.TaskSpec{
+							Name: "repair",
+							SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+								StartDate: pointer.Ptr("now"),
+							},
+						},
+						SmallTableThreshold: "1GiB",
+						Intensity:           "0.5",
+					},
+				}
+
+				return sc
+			}(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+				BackupTasks: map[string]scyllav1.BackupTaskStatus{
+					"backup": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr(validDate),
+							},
+							Name: "backup",
+							ID:   pointer.Ptr("backup-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "0aeio9mEaSKenZ7/GRW4l0TFm7f9kY2w7A3wpO3du5+EfjM9zIqJunon9vT+VvGNcwYxQQqF4gmZW1GSLpZU6g==",
+							},
+						},
+						Location: []string{"gcs:location"},
+					},
+				},
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
+					"repair": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr(validDate),
+							},
+							Name: "repair",
+							ID:   pointer.Ptr("repair-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "Il1bCvnHQAs7fjjuE4OHn6Au6tvMxNsVrfvdbwg3uYeNZPzYR+qgvDyAEjVrwakzfOTu/e+viMTWzaCRLqYetA==",
+							},
+						},
+						Intensity:           pointer.Ptr("0.5"),
+						Parallel:            pointer.Ptr[int64](0),
+						SmallTableThreshold: pointer.Ptr("1GiB"),
+					},
+				},
+			},
+			expectedActions: nil,
+			expectedRequeue: false,
+			expectedErr:     nil,
+		},
+		{
+			name:      "matching cluster in state, superfluous tasks in state, return delete task actions",
+			sc:        newBasicScyllaCluster(),
+			authToken: "token",
+			state: &managerClusterState{
+				Cluster: &managerclient.Cluster{
+					AuthToken:              "token",
+					ForceNonSslSessionPort: true,
+					ForceTLSDisabled:       true,
+					Host:                   "test-client.test.svc",
+					Labels: map[string]string{
+						"scylla-operator.scylladb.com/owner-uid":    "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+						"scylla-operator.scylladb.com/managed-hash": "UfHEc1kxt3UHl1r2ETXinXfhAtyYrha5RRJn544zkvY6bLDyzl1Q7wSskU355iHlIuwFHyeePE80I0ZOSmoChA==",
+					},
+					Name: "test/test",
+					ID:   "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+				},
+				BackupTasks: map[string]scyllav1.BackupTaskStatus{
+					"backup": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr(validDate),
+							},
+							Name: "backup",
+							ID:   pointer.Ptr("backup-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "0aeio9mEaSKenZ7/GRW4l0TFm7f9kY2w7A3wpO3du5+EfjM9zIqJunon9vT+VvGNcwYxQQqF4gmZW1GSLpZU6g==",
+							},
+						},
+						Location: []string{"gcs:location"},
+					},
+				},
+				RepairTasks: map[string]scyllav1.RepairTaskStatus{
+					"repair": {
+						TaskStatus: scyllav1.TaskStatus{
+							SchedulerTaskStatus: scyllav1.SchedulerTaskStatus{
+								StartDate: pointer.Ptr(validDate),
+							},
+							Name: "repair",
+							ID:   pointer.Ptr("repair-id"),
+							Labels: map[string]string{
+								"scylla-operator.scylladb.com/managed-hash": "Il1bCvnHQAs7fjjuE4OHn6Au6tvMxNsVrfvdbwg3uYeNZPzYR+qgvDyAEjVrwakzfOTu/e+viMTWzaCRLqYetA==",
+							},
+						},
+						Intensity:           pointer.Ptr("0.5"),
+						Parallel:            pointer.Ptr[int64](0),
+						SmallTableThreshold: pointer.Ptr("1GiB"),
+					},
+				},
+			},
+			expectedActions: []action{
+				&deleteTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					TaskType:  "repair",
+					TaskID:    "repair-id",
+				},
+				&deleteTaskAction{
+					ClusterID: "bead6247-d9e4-401c-84b4-ad0bffe36eac",
+					TaskType:  "backup",
+					TaskID:    "backup-id",
+				},
+			},
+			expectedRequeue: false,
+			expectedErr:     nil,
 		},
 	}
 
-	for _, test := range tcs {
-		t.Run(test.Name, func(t *testing.T) {
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctx := context.Background()
-			cluster := &scyllav1.ScyllaCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-				Spec:       test.Spec,
-				Status:     test.Status,
+			actions, requeue, err := runSync(ctx, tc.sc, tc.authToken, tc.state)
+			if !reflect.DeepEqual(err, tc.expectedErr) {
+				t.Fatalf("expected and got errors differ:\n%s", cmp.Diff(tc.expectedErr, err, cmpopts.EquateErrors()))
 			}
-			actions, requeue, err := runSync(ctx, cluster, clusterAuthToken, &test.State)
-			if err != nil {
-				t.Error(err)
+			if requeue != tc.expectedRequeue {
+				t.Errorf("expected requeue %t, got %t", tc.expectedRequeue, requeue)
 			}
-			if requeue != test.Requeue {
-				t.Error(err, "Unexpected requeue")
-			}
-			if !cmp.Equal(actions, test.Actions, cmp.Comparer(actionComparer)) {
-				t.Error(err, "Unexpected actions", cmp.Diff(actions, test.Actions, cmp.Comparer(actionComparer)))
+			if !reflect.DeepEqual(actions, tc.expectedActions) {
+				t.Errorf("expected and got actions differ:\n%s", cmp.Diff(tc.expectedActions, actions))
 			}
 		})
 	}
 }
 
-func actionComparer(a action, b action) bool {
-	switch va := a.(type) {
-	case *addClusterAction:
-		vb := b.(*addClusterAction)
-		return va.cluster.Name == vb.cluster.Name
-	case *updateClusterAction:
-		vb := b.(*updateClusterAction)
-		return va.cluster.ID == vb.cluster.ID
-	case *deleteClusterAction:
-		vb := b.(*deleteClusterAction)
-		return va.clusterID == vb.clusterID
-	case *updateTaskAction:
-		vb := b.(*updateTaskAction)
-		return va.clusterID == vb.clusterID && va.task.ID == vb.task.ID
-	case *addTaskAction:
-		vb := b.(*addTaskAction)
-		return va.clusterID == vb.clusterID && va.task.Name == vb.task.Name
-	case *deleteTaskAction:
-		vb := b.(*deleteTaskAction)
-		return va.clusterID == vb.clusterID && va.taskID == vb.taskID
-	default:
-	}
-	return false
-}
+func Test_evaluateDates(t *testing.T) {
+	t.Parallel()
 
-func TestEvaluateDates(t *testing.T) {
-	ts := []struct {
+	tt := []struct {
 		name     string
 		spec     *scyllav1.TaskSpec
 		status   *scyllav1.TaskStatus
@@ -750,15 +904,58 @@ func TestEvaluateDates(t *testing.T) {
 		},
 	}
 
-	for _, tc := range ts {
+	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			evaluateDates(tc.spec, tc.status)
 			got := taskSpecToStatus(tc.spec)
 			if !reflect.DeepEqual(got, tc.expected) {
-				t.Errorf("expected and got repair task statuses differ: %s", cmp.Diff(tc.expected, got))
+				t.Errorf("expected and got repair task statuses differ:\n%s", cmp.Diff(tc.expected, got))
 			}
 		})
+	}
+}
+
+func newBasicScyllaClusterWithBackupAndRepairTasks() *scyllav1.ScyllaCluster {
+	sc := newBasicScyllaCluster()
+
+	sc.Spec.Backups = []scyllav1.BackupTaskSpec{
+		{
+			TaskSpec: scyllav1.TaskSpec{
+				Name: "backup",
+				SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+					StartDate: pointer.Ptr(validDate),
+				},
+			},
+			Location: []string{"gcs:location"},
+		},
+	}
+
+	sc.Spec.Repairs = []scyllav1.RepairTaskSpec{
+		{
+			TaskSpec: scyllav1.TaskSpec{
+				Name: "repair",
+				SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+					StartDate: pointer.Ptr(validDate),
+				},
+			},
+			SmallTableThreshold: "1GiB",
+			Intensity:           "0.5",
+		},
+	}
+
+	return sc
+}
+
+func newBasicScyllaCluster() *scyllav1.ScyllaCluster {
+	return &scyllav1.ScyllaCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			UID:       "1bbeb48b-101f-4d49-8ba4-67adc9878721",
+		},
+		Spec:   scyllav1.ScyllaClusterSpec{},
+		Status: scyllav1.ScyllaClusterStatus{},
 	}
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Currently, when the manager controller fails to save manager's cluster ID in ScyllaCluster's status after cluster's registration with manager, the cluster is deleted and recreated again. As update conflicts are not a rare occurrence, this often causes many unnecessary recreation attempts.
To make the reconciliation more robust, this PR changes this behaviour. Instead of using the ID from status, labels from manager state are used. A cluster is created with a label holding the owner's UID, which allows us to maintain and recognize cluster's identity without relying on the status of our API resources. In turn clusters are only deleted when the owner UID labels is not matching the UID of the current owner, in order to avoid name collisions.

The labels are also extended with a managed hash label to align the cluster update logic with changes recently introduced in https://github.com/scylladb/scylla-operator/pull/2142.

The logic related to creating "actions" is modified to produce one cluster-related action at once and requeue in order to only schedule any further actions on next iteration. The reasoning behind it is to try avoiding errors related to task actions in case of a required cluster action, e.g. when auth token needs to be updated first.

Additionally, the manager state computed in each reconciliation loop is reduced to only one cluster, since cluster names in manager are unique and propagating additional clusters to the state is redundant.

Unit tests are also extended to cover these scenarios and unified for consistency.

**Which issue is resolved by this Pull Request:**
Resolves #1902 

/kind bug
/priority important-soon
/cc
