### PR TITLE
Set open file limit for ScyllaDB processes

### DIFF
--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -44,6 +44,7 @@ func NewOperatorCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(NewMustGatherCmd(streams))
 	cmd.AddCommand(probeserver.NewServeProbesCmd(streams))
 	cmd.AddCommand(NewIgnitionCmd(streams))
+	cmd.AddCommand(NewRlimitsJobCmd(streams))
 
 	// TODO: wrap help func for the root command and every subcommand to add a line about automatic env vars and the prefix.
 

--- a/pkg/cmd/operator/nodesetupdaemon.go
+++ b/pkg/cmd/operator/nodesetupdaemon.go
@@ -40,6 +40,7 @@ type NodeSetupDaemonOptions struct {
 	NodeConfigName       string
 	NodeConfigUID        string
 	ScyllaImage          string
+	OperatorImage        string
 	DisableOptimizations bool
 
 	CRIEndpoints                []string
@@ -103,6 +104,7 @@ func NewNodeSetupCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVarP(&o.DisableOptimizations, "disable-optimizations", "", o.DisableOptimizations, "Controls if optimizations are disabled")
 	cmd.Flags().StringArrayVarP(&o.CRIEndpoints, "cri-endpoint", "", o.CRIEndpoints, "CRI endpoint to connect to. It will try to connect to any of them, in the given order.")
 	cmd.Flags().StringVarP(&o.KubeletPodResourcesEndpoint, "kubelet-pod-resources-endpoint", "", o.KubeletPodResourcesEndpoint, "Endpoint to kubelet PodResources API server")
+	cmd.Flags().StringVarP(&o.OperatorImage, "operator-image", "", o.OperatorImage, "Operator image used for running tuning.")
 
 	return cmd
 }
@@ -252,6 +254,7 @@ func (o *NodeSetupDaemonOptions) Run(streams genericclioptions.IOStreams, cmd *c
 		o.NodeConfigName,
 		types.UID(o.NodeConfigUID),
 		o.ScyllaImage,
+		o.OperatorImage,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create node config instance controller: %w", err)

--- a/pkg/cmd/operator/rlimitsjob.go
+++ b/pkg/cmd/operator/rlimitsjob.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/signals"
+	"github.com/scylladb/scylla-operator/pkg/version"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+)
+
+type RlimitsJobOptions struct {
+	PID int
+
+	procfsPath string
+}
+
+func NewRlimitsJobOptions(streams genericclioptions.IOStreams) *RlimitsJobOptions {
+	return &RlimitsJobOptions{
+		procfsPath: "/proc",
+	}
+}
+
+func NewRlimitsJobCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewRlimitsJobOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "rlimits-job",
+		Short: "Changes rlimits of process.",
+		Long:  "Changes rlimits of process.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate()
+			if err != nil {
+				return err
+			}
+
+			err = o.Complete()
+			if err != nil {
+				return err
+			}
+
+			err = o.Run(streams, cmd)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	cmd.Flags().IntVarP(&o.PID, "pid", "", o.PID, "PID of the target process for which rlimit should be changed")
+
+	return cmd
+}
+
+func (o *RlimitsJobOptions) Validate() error {
+	var errs []error
+
+	if o.PID == 0 {
+		errs = append(errs, fmt.Errorf("pid cannot be zero"))
+	}
+
+	return apierrors.NewAggregate(errs)
+}
+
+func (o *RlimitsJobOptions) Complete() error {
+	return nil
+}
+
+func (o *RlimitsJobOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Command) error {
+	klog.InfoS("Starting rlimits Job", "version", version.Get())
+
+	defer func(startTime time.Time) {
+		klog.InfoS("Rlimits Job completed", "duration", time.Since(startTime))
+	}(time.Now())
+
+	cliflag.PrintFlags(cmd.Flags())
+
+	stopCh := signals.StopChannel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	err := o.changeRlimits(ctx)
+	if err != nil {
+		return fmt.Errorf("can't change rlimits: %w", err)
+	} else {
+		klog.InfoS("Rlimits were changed successfully")
+	}
+
+	return nil
+}
+
+func (o *RlimitsJobOptions) changeRlimits(ctx context.Context) error {
+	klog.InfoS("Checking maximum possible nofile limit")
+
+	maxNofileLimit, err := getSysctlFSNROpen(o.procfsPath)
+	if err != nil {
+		return fmt.Errorf("can't check maximum possible nofile limit: %w", err)
+	}
+
+	klog.InfoS("Changing process nofile rlimits", "PID", o.PID, "nofile", maxNofileLimit)
+	err = unix.Prlimit(o.PID, unix.RLIMIT_NOFILE, &unix.Rlimit{
+		// Soft limit
+		Cur: maxNofileLimit,
+		// Hard limit
+		Max: maxNofileLimit,
+	}, nil)
+
+	if err != nil {
+		return fmt.Errorf("can't set nofile rlimit of %d process: %w", o.PID, err)
+	}
+
+	return nil
+}
+
+func getSysctlFSNROpen(procfsPath string) (uint64, error) {
+	fsNROpenPath := filepath.Join(procfsPath, "/sys/fs/nr_open")
+
+	fsNROpenStr, err := os.ReadFile(fsNROpenPath)
+	if err != nil {
+		return 0, fmt.Errorf("can't read %q: %w", fsNROpenPath, err)
+	}
+
+	maxNofileLimit, err := strconv.ParseUint(strings.TrimSpace(string(fsNROpenStr)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("can't parse %q to uint64: %w", fsNROpenStr, err)
+	}
+
+	return maxNofileLimit, nil
+}

--- a/pkg/cmd/operator/rlimitsjob_test.go
+++ b/pkg/cmd/operator/rlimitsjob_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package operator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+func TestGetSysctlFsNrOpen(t *testing.T) {
+	t.Parallel()
+
+	makeFSNROpenFunc := func(fileContent string) func(procFs string) {
+		return func(procFs string) {
+			procSysFsPath := filepath.Join(procFs, "/sys/fs/")
+			err := os.MkdirAll(procSysFsPath, 0777)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = os.WriteFile(filepath.Join(procSysFsPath, "/nr_open"), []byte(fileContent), 0777)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	tt := []struct {
+		name            string
+		makeFS          func(procFs string)
+		expectedValue   uint64
+		makeExpectedErr func(procFs string) error
+	}{
+		{
+			name:          "spaces around value",
+			makeFS:        makeFSNROpenFunc(" 123   "),
+			expectedValue: 123,
+			makeExpectedErr: func(procFs string) error {
+				return nil
+			},
+		},
+		{
+			name:          "new line after value",
+			makeFS:        makeFSNROpenFunc("321\n"),
+			expectedValue: 321,
+			makeExpectedErr: func(procFs string) error {
+				return nil
+			},
+		},
+		{
+			name:          "empty file",
+			makeFS:        makeFSNROpenFunc(""),
+			expectedValue: 0,
+			makeExpectedErr: func(procFs string) error {
+				return fmt.Errorf(`can't parse "" to uint64: %w`, &strconv.NumError{Func: "ParseUint", Num: "", Err: strconv.ErrSyntax})
+			},
+		},
+		{
+			name: "missing file",
+			makeFS: func(tempDir string) {
+
+			},
+			expectedValue: 0,
+			makeExpectedErr: func(procFs string) error {
+				fsNROpenFilePath := filepath.Join(procFs, "/sys/fs/nr_open")
+				return fmt.Errorf("can't read %q: %w", fsNROpenFilePath, &os.PathError{Op: "open", Path: fsNROpenFilePath, Err: syscall.Errno(0x02)})
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			procFS := t.TempDir()
+			tc.makeFS(procFS)
+			expectedErr := tc.makeExpectedErr(procFS)
+			v, err := getSysctlFSNROpen(procFS)
+			if !reflect.DeepEqual(expectedErr, err) {
+				t.Errorf("expected %v error, got %v", expectedErr, err)
+			}
+			if v != tc.expectedValue {
+				t.Errorf("expected %d, got %d", tc.expectedValue, v)
+			}
+		})
+	}
+}

--- a/pkg/controller/nodeconfig/resource.go
+++ b/pkg/controller/nodeconfig/resource.go
@@ -50,6 +50,18 @@ func makePerftuneServiceAccount() *corev1.ServiceAccount {
 	}
 }
 
+func makeRlimitsServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Name:      naming.RlimitsJobServiceAccountName,
+			Labels: map[string]string{
+				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
+			},
+		},
+	}
+}
+
 func NodeConfigClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
@@ -117,6 +129,19 @@ func makePerftuneRole() *rbacv1.Role {
 	}
 }
 
+func makeRlimitsRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Name:      naming.RlimitsJobServiceAccountName,
+			Labels: map[string]string{
+				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
+			},
+		},
+		Rules: []rbacv1.PolicyRule{},
+	}
+}
+
 func makeNodeConfigClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -160,6 +185,30 @@ func makePerftuneRoleBinding() *rbacv1.RoleBinding {
 				Kind:      "ServiceAccount",
 				Namespace: naming.ScyllaOperatorNodeTuningNamespace,
 				Name:      naming.PerftuneServiceAccountName,
+			},
+		},
+	}
+}
+
+func makeRlimitsRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Name:      naming.RlimitsJobServiceAccountName,
+			Labels: map[string]string{
+				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     naming.RlimitsJobServiceAccountName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+				Name:      naming.RlimitsJobServiceAccountName,
 			},
 		},
 	}
@@ -319,6 +368,7 @@ exec chroot ./ /scylla-operator/usr/bin/scylla-operator node-setup-daemon \
 --node-config-name=` + fmt.Sprintf("%q", nc.Name) + ` \
 --node-config-uid=` + fmt.Sprintf("%q", nc.UID) + ` \
 --scylla-image=` + fmt.Sprintf("%q", scyllaImage) + ` \
+--operator-image=` + fmt.Sprintf("%q", operatorImage) + ` \
 --disable-optimizations=` + fmt.Sprintf("%t", nc.Spec.DisableOptimizations) + ` \
 --loglevel=` + fmt.Sprintf("%d", 4) + `
 							`},

--- a/pkg/controller/nodeconfig/sync_rolebindings.go
+++ b/pkg/controller/nodeconfig/sync_rolebindings.go
@@ -23,6 +23,7 @@ func (ncc *Controller) syncRoleBindings(
 
 	requiredRoleBindings := []*rbacv1.RoleBinding{
 		makePerftuneRoleBinding(),
+		makeRlimitsRoleBinding(),
 	}
 
 	// Delete any excessive RoleBindings.

--- a/pkg/controller/nodeconfig/sync_roles.go
+++ b/pkg/controller/nodeconfig/sync_roles.go
@@ -19,6 +19,7 @@ func (ncc *Controller) syncRoles(ctx context.Context, nc *scyllav1alpha1.NodeCon
 
 	requiredRoles := []*rbacv1.Role{
 		makePerftuneRole(),
+		makeRlimitsRole(),
 	}
 
 	// Delete any excessive Roles.

--- a/pkg/controller/nodeconfig/sync_serviceaccounts.go
+++ b/pkg/controller/nodeconfig/sync_serviceaccounts.go
@@ -18,6 +18,7 @@ func (ncc *Controller) makeServiceAccounts() []*corev1.ServiceAccount {
 	serviceAccounts := []*corev1.ServiceAccount{
 		makeNodeConfigServiceAccount(),
 		makePerftuneServiceAccount(),
+		makeRlimitsServiceAccount(),
 	}
 
 	return serviceAccounts

--- a/pkg/controller/nodeconfigpod/sync_configmaps.go
+++ b/pkg/controller/nodeconfigpod/sync_configmaps.go
@@ -75,10 +75,6 @@ func (ncpc *Controller) makeConfigMap(ctx context.Context, pod *corev1.Pod) (*co
 				continue
 			}
 
-			if !controllerhelpers.IsPodTunable(pod) {
-				continue
-			}
-
 			if controllerhelpers.IsNodeTunedForContainer(nc, node.Name, containerID) {
 				continue
 			}

--- a/pkg/controller/nodetune/controller.go
+++ b/pkg/controller/nodetune/controller.go
@@ -75,6 +75,7 @@ type Controller struct {
 	nodeConfigName string
 	nodeConfigUID  types.UID
 	scyllaImage    string
+	operatorImage  string
 
 	cachesToSync []cache.InformerSynced
 
@@ -100,6 +101,7 @@ func NewController(
 	nodeConfigName string,
 	nodeConfigUID types.UID,
 	scyllaImage string,
+	operatorImage string,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -124,6 +126,7 @@ func NewController(
 		nodeConfigName: nodeConfigName,
 		nodeConfigUID:  nodeConfigUID,
 		scyllaImage:    scyllaImage,
+		operatorImage:  operatorImage,
 
 		cachesToSync: []cache.InformerSynced{
 			nodeConfigInformer.Informer().HasSynced,

--- a/pkg/controller/nodetune/sync_jobs.go
+++ b/pkg/controller/nodetune/sync_jobs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/c9s/goprocinfo/linux"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	"github.com/scylladb/scylla-operator/pkg/semver"
@@ -20,6 +21,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/util/network"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
@@ -52,6 +54,11 @@ func (ncdc *Controller) makeJobsForNode(ctx context.Context) ([]*batchv1.Job, er
 }
 
 func (ncdc *Controller) makePerftuneJobForContainers(ctx context.Context, podSpec *corev1.PodSpec, optimizablePods []*corev1.Pod, scyllaContainerIDs []string) (*batchv1.Job, error) {
+	if len(optimizablePods) == 0 {
+		klog.V(2).InfoS("No optimizable pod found on this node")
+		return nil, nil
+	}
+
 	cpuInfo, err := linux.ReadCPUInfo("/proc/cpuinfo")
 	if err != nil {
 		return nil, fmt.Errorf("can't parse cpuinfo from %q: %w", "/proc/cpuinfo", err)
@@ -138,30 +145,66 @@ func (ncdc *Controller) makePerftuneJobForContainers(ctx context.Context, podSpe
 	)
 }
 
-func (ncdc *Controller) makeJobForContainers(ctx context.Context) (*batchv1.Job, error) {
+func (ncdc *Controller) makeResourceLimitJobsForContainers(ctx context.Context, podSpec *corev1.PodSpec, scyllaPods []*corev1.Pod) ([]*batchv1.Job, error) {
+	cr, err := ncdc.newOwningDSControllerRef()
+	if err != nil {
+		return nil, fmt.Errorf("can't get controller ref: %w", err)
+	}
+
+	rlimitsJobs := make([]*batchv1.Job, 0, len(scyllaPods))
+
+	for _, scyllaPod := range scyllaPods {
+		containerID, err := getScyllaContainerIDInCRIFormat(scyllaPod)
+		if err != nil {
+			return nil, fmt.Errorf("can't get scylla containerID in CRI format: %w", err)
+		}
+
+		containerStatus, err := ncdc.criClient.Inspect(ctx, containerID)
+		if err != nil {
+			return nil, fmt.Errorf("can't inspect Scylla Pod %q container %q: %w", naming.ObjRef(scyllaPod), containerID, err)
+		}
+
+		if containerStatus.Info.PID == nil {
+			klog.Errorf("can't determine Scylla container process PIDs from CRI, their resource process limits won't be raised")
+			continue
+		}
+
+		rlimitsJob, err := makeRlimitsJobForContainer(cr, ncdc.namespace, ncdc.nodeConfigName, ncdc.nodeName, ncdc.nodeUID, ncdc.operatorImage, podSpec, scyllaPod, *containerStatus.Info.PID)
+		if err != nil {
+			return nil, fmt.Errorf("can't make rlimits jobs: %w", err)
+		}
+
+		rlimitsJobs = append(rlimitsJobs, rlimitsJob)
+	}
+
+	return rlimitsJobs, nil
+}
+
+func (ncdc *Controller) makeJobsForContainers(ctx context.Context) ([]*batchv1.Job, error) {
 	localScyllaPods, err := ncdc.localScyllaPodsLister.List(naming.ScyllaSelector())
 	if err != nil {
 		return nil, fmt.Errorf("can't list local scylla pods: %w", err)
 	}
 
+	localScyllaPods = slices.FilterOut(localScyllaPods, func(pod *corev1.Pod) bool {
+		return pod.DeletionTimestamp != nil
+	})
+
+	// Container Jobs are created based on Pods' fields.
+	// Pods are sorted to make sure the generated Job specs are consistent across reconciliations for an equal set of Pods.
+	sort.Slice(localScyllaPods, func(i, j int) bool {
+		return localScyllaPods[i].Name < localScyllaPods[j].Name
+	})
+
 	var optimizablePods []*corev1.Pod
-	var scyllaContainerIDs []string
+	var runningScyllaPods []*corev1.Pod
+	var optimizableScyllaContainerIDs []string
 
-	for i := range localScyllaPods {
-		scyllaPod := localScyllaPods[i]
-
-		if !controllerhelpers.IsPodTunable(scyllaPod) {
-			klog.V(4).Infof("Pod %q isn't a subject for optimizations", naming.ObjRef(scyllaPod))
-			continue
-		}
-
+	for _, scyllaPod := range localScyllaPods {
 		if !controllerhelpers.IsScyllaContainerRunning(scyllaPod) {
 			klog.V(4).Infof("Pod %q is a candidate for optimizations but scylla container isn't running yet", naming.ObjRef(scyllaPod))
 			continue
 		}
-
-		klog.V(4).Infof("Pod %s is subject for optimizations", naming.ObjRef(scyllaPod))
-		optimizablePods = append(optimizablePods, scyllaPod)
 
 		containerID, err := controllerhelpers.GetScyllaContainerID(scyllaPod)
 		if err != nil || len(containerID) == 0 {
@@ -169,23 +212,42 @@ func (ncdc *Controller) makeJobForContainers(ctx context.Context) (*batchv1.Job,
 			continue
 		}
 
-		scyllaContainerIDs = append(scyllaContainerIDs, containerID)
-	}
+		runningScyllaPods = append(runningScyllaPods, scyllaPod)
 
-	if len(optimizablePods) == 0 {
-		klog.V(2).InfoS("No optimizable pod found on this node")
-		return nil, nil
-	}
+		if !controllerhelpers.IsPodTunable(scyllaPod) {
+			klog.V(4).Infof("Pod %q isn't a subject for optimizations", naming.ObjRef(scyllaPod))
+			continue
+		}
 
-	// Sort container IDs to have stable representation for the same set of containers.
-	sort.Strings(scyllaContainerIDs)
+		klog.V(4).Infof("Pod %s is subject for optimizations", naming.ObjRef(scyllaPod))
+		optimizablePods = append(optimizablePods, scyllaPod)
+		optimizableScyllaContainerIDs = append(optimizableScyllaContainerIDs, containerID)
+	}
 
 	selfPod, err := ncdc.selfPodLister.Pods(ncdc.namespace).Get(ncdc.podName)
 	if err != nil {
 		return nil, fmt.Errorf("can't get Pod %q: %w", naming.ManualRef(ncdc.namespace, ncdc.podName), err)
 	}
 
-	return ncdc.makePerftuneJobForContainers(ctx, &selfPod.Spec, optimizablePods, scyllaContainerIDs)
+	perftuneJob, err := ncdc.makePerftuneJobForContainers(ctx, &selfPod.Spec, optimizablePods, optimizableScyllaContainerIDs)
+	if err != nil {
+		return nil, fmt.Errorf("can't make perftune jobs: %w", err)
+	}
+
+	resourceLimitsJobs, err := ncdc.makeResourceLimitJobsForContainers(ctx, &selfPod.Spec, runningScyllaPods)
+	if err != nil {
+		return nil, fmt.Errorf("can't make resource limits jobs: %w", err)
+	}
+
+	var containerJobs []*batchv1.Job
+	if perftuneJob != nil {
+		containerJobs = append(containerJobs, perftuneJob)
+	}
+	if resourceLimitsJobs != nil {
+		containerJobs = append(containerJobs, resourceLimitsJobs...)
+	}
+
+	return containerJobs, nil
 }
 
 func (ncdc *Controller) syncJobs(ctx context.Context, jobs map[string]*batchv1.Job, nodeStatus *scyllav1alpha1.NodeConfigNodeStatus) error {
@@ -194,25 +256,29 @@ func (ncdc *Controller) syncJobs(ctx context.Context, jobs map[string]*batchv1.J
 		return fmt.Errorf("can't make Jobs for node: %w", err)
 	}
 
-	requiredForContainers, err := ncdc.makeJobForContainers(ctx)
+	requiredForContainers, err := ncdc.makeJobsForContainers(ctx)
 	if err != nil {
 		return fmt.Errorf("can't make Jobs for containers: %w", err)
 	}
 
-	required := make([]*batchv1.Job, 0, len(requiredForNode)+1)
-	required = append(required, requiredForNode...)
+	var requiredJobs []*batchv1.Job
+	requiredJobs = append(requiredJobs, requiredForNode...)
 	if requiredForContainers != nil {
-		required = append(required, requiredForContainers)
+		requiredJobs = append(requiredJobs, requiredForContainers...)
 	}
 
-	err = ncdc.pruneJobs(ctx, jobs, required)
+	err = ncdc.pruneJobs(ctx, jobs, requiredJobs)
 	if err != nil {
 		return fmt.Errorf("can't prune Jobs: %w", err)
 	}
 
 	finished := true
-	klog.V(4).InfoS("Required jobs", "Count", len(required))
-	for _, j := range required {
+
+	containerRequiredJobTypes := make(map[string][]naming.NodeConfigJobType)
+	containerCompletedJobTypes := make(map[string][]naming.NodeConfigJobType)
+
+	klog.V(4).InfoS("Required jobs", "Count", len(requiredJobs))
+	for _, j := range requiredJobs {
 		fresh, _, err := resourceapply.ApplyJob(ctx, ncdc.kubeClient.BatchV1(), ncdc.namespacedJobLister, ncdc.eventRecorder, j, resourceapply.ApplyOptions{})
 		if err != nil {
 			return fmt.Errorf("can't create job %s: %w", naming.ObjRef(j), err)
@@ -223,7 +289,7 @@ func (ncdc *Controller) syncJobs(ctx context.Context, jobs map[string]*batchv1.J
 			return fmt.Errorf("job %q is missing %q label", naming.ObjRef(j), naming.NodeConfigJobTypeLabel)
 		}
 
-		switch naming.NodeConfigJobType(t) {
+		switch jobType := naming.NodeConfigJobType(t); jobType {
 		case naming.NodeConfigJobTypeNode:
 			// FIXME: Extract into a function and double check how jobs report status.
 			if fresh.Status.CompletionTime == nil {
@@ -233,26 +299,42 @@ func (ncdc *Controller) syncJobs(ctx context.Context, jobs map[string]*batchv1.J
 			}
 			klog.V(4).InfoS("Job is completed", "Job", klog.KObj(fresh))
 
-		case naming.NodeConfigJobTypeContainers:
+		case naming.NodeConfigJobTypeContainerPerftune, naming.NodeConfigJobTypeContainerResourceLimits:
 			// We have successfully applied the job definition so the data should always be present at this point.
 			nodeConfigJobDataString, found := fresh.Annotations[naming.NodeConfigJobData]
 			if !found {
 				return fmt.Errorf("internal error: job %q is missing %q annotation", klog.KObj(fresh), naming.NodeConfigJobData)
 			}
 
-			jobData := &perftuneJobForContainersData{}
+			jobData := &containerJobData{}
 			err = json.Unmarshal([]byte(nodeConfigJobDataString), jobData)
 			if err != nil {
 				return fmt.Errorf("internal error: can't unmarshal node config data for job %q: %w", klog.KObj(fresh), err)
 			}
-			nodeStatus.TunedContainers = jobData.ContainerIDs
 
+			for _, containerID := range jobData.ContainerIDs {
+				containerRequiredJobTypes[containerID] = append(containerRequiredJobTypes[containerID], jobType)
+				if fresh.Status.CompletionTime != nil {
+					containerCompletedJobTypes[containerID] = append(containerCompletedJobTypes[containerID], jobType)
+				}
+			}
+
+			if fresh.Status.CompletionTime == nil {
+				klog.V(4).InfoS("Job isn't completed yet", "Job", klog.KObj(fresh))
+				break
+			}
 		default:
 			return fmt.Errorf("job %q has an unkown type %q", naming.ObjRef(j), t)
 		}
 	}
 
 	nodeStatus.TunedNode = finished
+	for containerID, requiredContainerJobTypes := range containerRequiredJobTypes {
+		if equality.Semantic.DeepEqual(containerCompletedJobTypes[containerID], requiredContainerJobTypes) {
+			nodeStatus.TunedContainers = append(nodeStatus.TunedContainers, containerID)
+		}
+	}
+	sort.Strings(nodeStatus.TunedContainers)
 
 	return nil
 }

--- a/pkg/cri/client.go
+++ b/pkg/cri/client.go
@@ -190,6 +190,7 @@ type ContainerStatusInfoRuntimeSpec struct {
 
 type ContainerStatusInfo struct {
 	RuntimeSpec *ContainerStatusInfoRuntimeSpec `json:"runtimeSpec,omitempty"`
+	PID         *int                            `json:"pid,omitempty"`
 }
 
 type ContainerStatus struct {

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -114,6 +114,7 @@ const (
 	SidecarInjectorContainerName = "sidecar-injection"
 	PerftuneContainerName        = "perftune"
 	CleanupContainerName         = "cleanup"
+	RLimitsContainerName         = "rlimits"
 
 	PVCTemplateName = "data"
 
@@ -155,15 +156,17 @@ const (
 
 	SingletonName = "cluster"
 
-	PerftuneJobPrefixName      = "perftune"
-	PerftuneServiceAccountName = "perftune"
+	PerftuneJobPrefixName        = "perftune"
+	PerftuneServiceAccountName   = "perftune"
+	RlimitsJobServiceAccountName = "rlimits"
 )
 
 type NodeConfigJobType string
 
 const (
-	NodeConfigJobTypeNode       NodeConfigJobType = "Node"
-	NodeConfigJobTypeContainers NodeConfigJobType = "Containers"
+	NodeConfigJobTypeNode                    NodeConfigJobType = "Node"
+	NodeConfigJobTypeContainerPerftune       NodeConfigJobType = "ContainerPerftune"
+	NodeConfigJobTypeContainerResourceLimits NodeConfigJobType = "ContainerResourceLimits"
 )
 
 type ConfigMapType string


### PR DESCRIPTION
**Description of your changes:**

ScyllaDB, during regular operation, may need to manage millions of open files due to the nature of its workload and architecture. The open file limit (rlimit) for containers is inherited from the CRI and systemd, both of which tend to set conservative limits to avoid misbehavior in other programs when high limits are applied. Simply setting fs.nr_open using ScyllaCluster sysctls API is insufficient to raise these limits for ScyllaDB process.

To automate setting it, Scylla Operator `NodeConfig` container optimization was extended with additional Job discovering the maximum possible limit and setting it on main process of ScyllaDB containers. ScyllaDB Pods await until limit is changed before starting ScyllaDB process. Any forks (sidecar starter or hypervisor) should inherit the limits.

Users should increase `fs.nr_open` to at least value [recommended by ScyllaDB](https://github.com/scylladb/scylladb/blob/master/dist/common/sysctl.d/99-scylla-filemax.conf#L5), because defaults of popular Container Runtimes are ~1024 times lower. Sysctls can currenly be changed via `scylladbcluster.spec.sysctls` field. Note that this tuning is applied only on Nodes matching deployed NodeConfig selector.

**Which issue is resolved by this Pull Request:**
Resolves #2131
