### PR TITLE
Update Git Clone command

### DIFF
--- a/docs/source/generic.md
+++ b/docs/source/generic.md
@@ -32,7 +32,7 @@ eval $(minikube docker-env)
 ## Download Scylla Operator
 In this guide you will be using the examples and manifests from [Scylla Operator repository](https://github.com/scylladb/scylla-operator), so start off by cloning it to your local machine.
 ```console
-git clone git@github.com:scylladb/scylla-operator.git
+git clone https://github.com/scylladb/scylla-operator.git
 cd scylla-operator
 ```
 


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Changing git clone from ssh to https

**Which issue is resolved by this Pull Request:**
Resolves #
If you are not logged into to GH then git clone using ssh throws an access denied error which can lead to a poor user experience. Changing to https://github.com/scylladb/scylla-operator.git allows it to work without authentication.
