### PR TITLE
Extend node tune controller with status conditions

### DIFF
--- a/pkg/controller/nodeconfig/status.go
+++ b/pkg/controller/nodeconfig/status.go
@@ -4,18 +4,105 @@ package nodeconfig
 
 import (
 	"context"
+	"fmt"
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
-func (ncc *Controller) calculateStatus(nc *scyllav1alpha1.NodeConfig) *scyllav1alpha1.NodeConfigStatus {
+func (ncc *Controller) calculateStatus(nc *scyllav1alpha1.NodeConfig, matchingNodes []*corev1.Node) *scyllav1alpha1.NodeConfigStatus {
 	status := nc.Status.DeepCopy()
 	status.ObservedGeneration = nc.Generation
 
+	statusConditions := nc.Status.Conditions.ToMetaV1Conditions()
+
+	unknownNodeControllerConditionFuncs := []func(*corev1.Node) metav1.Condition{
+		func(node *corev1.Node) metav1.Condition {
+			return metav1.Condition{
+				Type:               fmt.Sprintf(internalapi.NodeSetupAvailableConditionFormat, node.Name),
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: nc.Generation,
+				Reason:             internalapi.AwaitingConditionReason,
+				Message:            fmt.Sprintf("Awaiting Available condition of node setup for node %q to be set.", naming.ObjRef(node)),
+			}
+		},
+		func(node *corev1.Node) metav1.Condition {
+			return metav1.Condition{
+				Type:               fmt.Sprintf(internalapi.NodeSetupProgressingConditionFormat, node.Name),
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: nc.Generation,
+				Reason:             internalapi.AwaitingConditionReason,
+				Message:            fmt.Sprintf("Awaiting Progressing condition of node setup for node %q to be set.", naming.ObjRef(node)),
+			}
+		},
+		func(node *corev1.Node) metav1.Condition {
+			return metav1.Condition{
+				Type:               fmt.Sprintf(internalapi.NodeSetupDegradedConditionFormat, node.Name),
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: nc.Generation,
+				Reason:             internalapi.AwaitingConditionReason,
+				Message:            fmt.Sprintf("Awaiting Degraded condition of node setup for node %q to be set.", naming.ObjRef(node)),
+			}
+		},
+		func(node *corev1.Node) metav1.Condition {
+			return metav1.Condition{
+				Type:               fmt.Sprintf(internalapi.NodeTuneAvailableConditionFormat, node.Name),
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: nc.Generation,
+				Reason:             internalapi.AwaitingConditionReason,
+				Message:            fmt.Sprintf("Awaiting Available condition of node tune for node %q to be set.", naming.ObjRef(node)),
+			}
+		},
+		func(node *corev1.Node) metav1.Condition {
+			return metav1.Condition{
+				Type:               fmt.Sprintf(internalapi.NodeTuneProgressingConditionFormat, node.Name),
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: nc.Generation,
+				Reason:             internalapi.AwaitingConditionReason,
+				Message:            fmt.Sprintf("Awaiting Progressing condition of node tune for node %q to be set.", naming.ObjRef(node)),
+			}
+		},
+		func(node *corev1.Node) metav1.Condition {
+			return metav1.Condition{
+				Type:               fmt.Sprintf(internalapi.NodeTuneDegradedConditionFormat, node.Name),
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: nc.Generation,
+				Reason:             internalapi.AwaitingConditionReason,
+				Message:            fmt.Sprintf("Awaiting Degraded condition of node tune for node %q to be set.", naming.ObjRef(node)),
+			}
+		},
+	}
+
+	unknownNodeControllerConditions := makeUnknownNodeControllerConditions(matchingNodes, statusConditions, unknownNodeControllerConditionFuncs)
+	for _, c := range unknownNodeControllerConditions {
+		apimeta.SetStatusCondition(&statusConditions, c)
+	}
+
+	status.Conditions = scyllav1alpha1.NewNodeConfigConditions(statusConditions)
+
 	return status
+}
+
+func makeUnknownNodeControllerConditions(nodes []*corev1.Node, conditions []metav1.Condition, unknownNodeControllerConditionFuncs []func(*corev1.Node) metav1.Condition) []metav1.Condition {
+	var unknownNodeControllerConditions []metav1.Condition
+
+	for _, n := range nodes {
+		for _, f := range unknownNodeControllerConditionFuncs {
+			unknownNodeControllerCondition := f(n)
+			existingNodeControllerCondition := apimeta.FindStatusCondition(conditions, unknownNodeControllerCondition.Type)
+			if existingNodeControllerCondition == nil || existingNodeControllerCondition.ObservedGeneration < unknownNodeControllerCondition.ObservedGeneration {
+				unknownNodeControllerConditions = append(unknownNodeControllerConditions, unknownNodeControllerCondition)
+			}
+		}
+	}
+
+	return unknownNodeControllerConditions
 }
 
 func (ncc *Controller) updateStatus(ctx context.Context, currentNodeConfig *scyllav1alpha1.NodeConfig, status *scyllav1alpha1.NodeConfigStatus) error {

--- a/pkg/controller/nodesetup/conditions.go
+++ b/pkg/controller/nodesetup/conditions.go
@@ -3,15 +3,28 @@
 package nodesetup
 
 const (
-	raidControllerNodeProgressingConditionFormat = "RaidControllerNode%sProgressing"
-	raidControllerNodeDegradedConditionFormat    = "RaidControllerNode%sDegraded"
+	raidControllerNodeSetupProgressingConditionFormat = "RaidControllerNodeSetup%sProgressing"
+	raidControllerNodeSetupDegradedConditionFormat    = "RaidControllerNodeSetup%sDegraded"
 
-	filesystemControllerNodeProgressingConditionFormat = "FilesystemControllerNode%sProgressing"
-	filesystemControllerNodeDegradedConditionFormat    = "FilesystemControllerNode%sDegraded"
+	filesystemControllerNodeSetupProgressingConditionFormat = "FilesystemControllerNodeSetup%sProgressing"
+	filesystemControllerNodeSetupDegradedConditionFormat    = "FilesystemControllerNodeSetup%sDegraded"
 
-	mountControllerNodeProgressingConditionFormat = "MountControllerNode%sProgressing"
-	mountControllerNodeDegradedConditionFormat    = "MountControllerNode%sDegraded"
+	mountControllerNodeSetupProgressingConditionFormat = "MountControllerNodeSetup%sProgressing"
+	mountControllerNodeSetupDegradedConditionFormat    = "MountControllerNodeSetup%sDegraded"
 
-	loopDeviceControllerNodeProgressingConditionFormat = "LoopDeviceControllerNode%sProgressing"
-	loopDeviceControllerNodeDegradedConditionFormat    = "LoopDeviceControllerNode%sDegraded"
+	loopDeviceControllerNodeSetupProgressingConditionFormat = "LoopDeviceControllerNodeSetup%sProgressing"
+	loopDeviceControllerNodeSetupDegradedConditionFormat    = "LoopDeviceControllerNodeSetup%sDegraded"
+
+	//TODO(rzetelskik): remove deprecated conditions in >=1.16
+	deprecatedRaidControllerNodeSetupProgressingConditionFormat = "RaidControllerNode%sProgressing"
+	deprecatedRaidControllerNodeSetupDegradedConditionFormat    = "RaidControllerNode%sDegraded"
+
+	deprecatedFilesystemControllerNodeSetupProgressingConditionFormat = "FilesystemControllerNode%sProgressing"
+	deprecatedFilesystemControllerNodeSetupDegradedConditionFormat    = "FilesystemControllerNode%sDegraded"
+
+	deprecatedMountControllerNodeSetupProgressingConditionFormat = "MountControllerNode%sProgressing"
+	deprecatedMountControllerNodeSetupDegradedConditionFormat    = "MountControllerNode%sDegraded"
+
+	deprecatedLoopDeviceControllerNodeSetupProgressingConditionFormat = "LoopDeviceControllerNode%sProgressing"
+	deprecatedLoopDeviceControllerNodeSetupDegradedConditionFormat    = "LoopDeviceControllerNode%sDegraded"
 )

--- a/pkg/controller/nodesetup/sync.go
+++ b/pkg/controller/nodesetup/sync.go
@@ -48,8 +48,8 @@ func (nsc *Controller) sync(ctx context.Context) error {
 	var errs []error
 	err = controllerhelpers.RunSync(
 		&statusConditions,
-		fmt.Sprintf(loopDeviceControllerNodeProgressingConditionFormat, nsc.nodeName),
-		fmt.Sprintf(loopDeviceControllerNodeDegradedConditionFormat, nsc.nodeName),
+		fmt.Sprintf(loopDeviceControllerNodeSetupProgressingConditionFormat, nsc.nodeName),
+		fmt.Sprintf(loopDeviceControllerNodeSetupDegradedConditionFormat, nsc.nodeName),
 		nc.Generation,
 		func() ([]metav1.Condition, error) {
 			return nsc.syncLoopDevices(ctx, nc)
@@ -61,8 +61,8 @@ func (nsc *Controller) sync(ctx context.Context) error {
 
 	err = controllerhelpers.RunSync(
 		&statusConditions,
-		fmt.Sprintf(raidControllerNodeProgressingConditionFormat, nsc.nodeName),
-		fmt.Sprintf(raidControllerNodeDegradedConditionFormat, nsc.nodeName),
+		fmt.Sprintf(raidControllerNodeSetupProgressingConditionFormat, nsc.nodeName),
+		fmt.Sprintf(raidControllerNodeSetupDegradedConditionFormat, nsc.nodeName),
 		nc.Generation,
 		func() ([]metav1.Condition, error) {
 			return nsc.syncRAIDs(ctx, nc)
@@ -74,8 +74,8 @@ func (nsc *Controller) sync(ctx context.Context) error {
 
 	err = controllerhelpers.RunSync(
 		&statusConditions,
-		fmt.Sprintf(filesystemControllerNodeProgressingConditionFormat, nsc.nodeName),
-		fmt.Sprintf(filesystemControllerNodeDegradedConditionFormat, nsc.nodeName),
+		fmt.Sprintf(filesystemControllerNodeSetupProgressingConditionFormat, nsc.nodeName),
+		fmt.Sprintf(filesystemControllerNodeSetupDegradedConditionFormat, nsc.nodeName),
 		nc.Generation,
 		func() ([]metav1.Condition, error) {
 			return nsc.syncFilesystems(ctx, nc)
@@ -87,8 +87,8 @@ func (nsc *Controller) sync(ctx context.Context) error {
 
 	err = controllerhelpers.RunSync(
 		&statusConditions,
-		fmt.Sprintf(mountControllerNodeProgressingConditionFormat, nsc.nodeName),
-		fmt.Sprintf(mountControllerNodeDegradedConditionFormat, nsc.nodeName),
+		fmt.Sprintf(mountControllerNodeSetupProgressingConditionFormat, nsc.nodeName),
+		fmt.Sprintf(mountControllerNodeSetupDegradedConditionFormat, nsc.nodeName),
 		nc.Generation,
 		func() ([]metav1.Condition, error) {
 			return nsc.syncMounts(ctx, nc)
@@ -100,11 +100,11 @@ func (nsc *Controller) sync(ctx context.Context) error {
 
 	// Aggregate node conditions.
 	var aggregationErrs []error
-	nodeAvailableConditionType := fmt.Sprintf(internalapi.NodeAvailableConditionFormat, nsc.nodeName)
-	nodeAvailableCondition, err := controllerhelpers.AggregateStatusConditions(
-		controllerhelpers.FindStatusConditionsWithSuffix(statusConditions, nodeAvailableConditionType),
+	nodeSetupAvailableConditionType := fmt.Sprintf(internalapi.NodeSetupAvailableConditionFormat, nsc.nodeName)
+	nodeSetupAvailableCondition, err := controllerhelpers.AggregateStatusConditions(
+		controllerhelpers.FindStatusConditionsWithSuffix(statusConditions, nodeSetupAvailableConditionType),
 		metav1.Condition{
-			Type:               nodeAvailableConditionType,
+			Type:               nodeSetupAvailableConditionType,
 			Status:             metav1.ConditionTrue,
 			Reason:             internalapi.AsExpectedReason,
 			Message:            "",
@@ -112,14 +112,14 @@ func (nsc *Controller) sync(ctx context.Context) error {
 		},
 	)
 	if err != nil {
-		aggregationErrs = append(aggregationErrs, fmt.Errorf("can't aggregate available node status conditions: %w", err))
+		aggregationErrs = append(aggregationErrs, fmt.Errorf("can't aggregate available node setup status conditions: %w", err))
 	}
 
-	nodeProgressingConditionType := fmt.Sprintf(internalapi.NodeProgressingConditionFormat, nsc.nodeName)
-	nodeProgressingCondition, err := controllerhelpers.AggregateStatusConditions(
-		controllerhelpers.FindStatusConditionsWithSuffix(statusConditions, nodeProgressingConditionType),
+	nodeSetupProgressingConditionType := fmt.Sprintf(internalapi.NodeSetupProgressingConditionFormat, nsc.nodeName)
+	nodeSetupProgressingCondition, err := controllerhelpers.AggregateStatusConditions(
+		controllerhelpers.FindStatusConditionsWithSuffix(statusConditions, nodeSetupProgressingConditionType),
 		metav1.Condition{
-			Type:               nodeProgressingConditionType,
+			Type:               nodeSetupProgressingConditionType,
 			Status:             metav1.ConditionFalse,
 			Reason:             internalapi.AsExpectedReason,
 			Message:            "",
@@ -127,14 +127,14 @@ func (nsc *Controller) sync(ctx context.Context) error {
 		},
 	)
 	if err != nil {
-		aggregationErrs = append(aggregationErrs, fmt.Errorf("can't aggregate progressing node status conditions: %w", err))
+		aggregationErrs = append(aggregationErrs, fmt.Errorf("can't aggregate progressing node setup status conditions: %w", err))
 	}
 
-	nodeDegradedConditionType := fmt.Sprintf(internalapi.NodeDegradedConditionFormat, nsc.nodeName)
-	nodeDegradedCondition, err := controllerhelpers.AggregateStatusConditions(
-		controllerhelpers.FindStatusConditionsWithSuffix(statusConditions, nodeDegradedConditionType),
+	nodeSetupDegradedConditionType := fmt.Sprintf(internalapi.NodeSetupDegradedConditionFormat, nsc.nodeName)
+	nodeSetupDegradedCondition, err := controllerhelpers.AggregateStatusConditions(
+		controllerhelpers.FindStatusConditionsWithSuffix(statusConditions, nodeSetupDegradedConditionType),
 		metav1.Condition{
-			Type:               nodeDegradedConditionType,
+			Type:               nodeSetupDegradedConditionType,
 			Status:             metav1.ConditionFalse,
 			Reason:             internalapi.AsExpectedReason,
 			Message:            "",
@@ -142,7 +142,7 @@ func (nsc *Controller) sync(ctx context.Context) error {
 		},
 	)
 	if err != nil {
-		aggregationErrs = append(aggregationErrs, fmt.Errorf("can't aggregate degraded node status conditions: %w", err))
+		aggregationErrs = append(aggregationErrs, fmt.Errorf("can't aggregate degraded node setup status conditions: %w", err))
 	}
 
 	if len(aggregationErrs) > 0 {
@@ -150,9 +150,9 @@ func (nsc *Controller) sync(ctx context.Context) error {
 		return utilerrors.NewAggregate(errs)
 	}
 
-	apimeta.SetStatusCondition(&statusConditions, nodeAvailableCondition)
-	apimeta.SetStatusCondition(&statusConditions, nodeProgressingCondition)
-	apimeta.SetStatusCondition(&statusConditions, nodeDegradedCondition)
+	apimeta.SetStatusCondition(&statusConditions, nodeSetupAvailableCondition)
+	apimeta.SetStatusCondition(&statusConditions, nodeSetupProgressingCondition)
+	apimeta.SetStatusCondition(&statusConditions, nodeSetupDegradedCondition)
 
 	status.Conditions = scyllav1alpha1.NewNodeConfigConditions(statusConditions)
 	err = nsc.updateStatus(ctx, nc, status)

--- a/pkg/controller/nodesetup/sync_mounts.go
+++ b/pkg/controller/nodesetup/sync_mounts.go
@@ -51,7 +51,7 @@ func (nsc *Controller) syncMounts(ctx context.Context, nc *scyllav1alpha1.NodeCo
 	progressingMessages, err := nsc.systemdUnitManager.EnsureUnits(ctx, nc, nsc.eventRecorder, mountUnits, nsc.systemdControl)
 	if len(progressingMessages) > 0 {
 		progressingConditions = append(progressingConditions, metav1.Condition{
-			Type:               fmt.Sprintf(mountControllerNodeProgressingConditionFormat, nsc.nodeName),
+			Type:               fmt.Sprintf(mountControllerNodeSetupProgressingConditionFormat, nsc.nodeName),
 			Status:             metav1.ConditionTrue,
 			Reason:             "WaitingForMountUnitsSync",
 			Message:            strings.Join(progressingMessages, "\n"),

--- a/pkg/controller/nodesetup/sync_raids.go
+++ b/pkg/controller/nodesetup/sync_raids.go
@@ -167,7 +167,7 @@ func listBlockDevices(ctx context.Context, executor exec.Interface, nc *scyllav1
 				}
 
 				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               raidControllerNodeProgressingConditionFormat,
+					Type:               raidControllerNodeSetupProgressingConditionFormat,
 					Status:             metav1.ConditionTrue,
 					Reason:             "AwaitingLoopDevice",
 					Message:            fmt.Sprintf("Loop device %q not created yet", lc.Name),

--- a/pkg/controller/nodetune/conditions.go
+++ b/pkg/controller/nodetune/conditions.go
@@ -1,0 +1,8 @@
+// Copyright (C) 2024 ScyllaDB
+
+package nodetune
+
+const (
+	jobControllerNodeTuneProgressingConditionFormat = "JobControllerNodeTune%sProgressing"
+	jobControllerNodeTuneDegradedConditionFormat    = "JobControllerNodeTune%sDegraded"
+)

--- a/pkg/controller/nodetune/status.go
+++ b/pkg/controller/nodetune/status.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2024 ScyllaDB
+
+package nodetune
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+func (ncdc *Controller) calculateStatus(nc *v1alpha1.NodeConfig) *v1alpha1.NodeConfigStatus {
+	status := nc.Status.DeepCopy()
+
+	return status
+}
+
+func (ncdc *Controller) updateStatus(ctx context.Context, currentNC *v1alpha1.NodeConfig, status *v1alpha1.NodeConfigStatus) error {
+	if apiequality.Semantic.DeepEqual(currentNC.Status, status) {
+		return nil
+	}
+
+	nc := currentNC.DeepCopy()
+	nc.Status = *status
+
+	klog.V(2).InfoS("Updating status", "NodeConfig", klog.KObj(currentNC), "Node", ncdc.nodeName)
+
+	_, err := ncdc.scyllaClient.ScyllaV1alpha1().NodeConfigs().UpdateStatus(ctx, nc, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("can't update node config status %q: %w", ncdc.nodeConfigName, err)
+	}
+
+	klog.V(2).InfoS("Status updated", "NodeConfig", klog.KObj(currentNC), "Node", ncdc.nodeName)
+
+	return nil
+}

--- a/pkg/internalapi/conditions.go
+++ b/pkg/internalapi/conditions.go
@@ -5,6 +5,14 @@ const (
 	NodeProgressingConditionFormat = "Node%sProgressing"
 	NodeDegradedConditionFormat    = "Node%sDegraded"
 
+	NodeSetupAvailableConditionFormat   = "NodeSetup%sAvailable"
+	NodeSetupProgressingConditionFormat = "NodeSetup%sProgressing"
+	NodeSetupDegradedConditionFormat    = "NodeSetup%sDegraded"
+
+	NodeTuneAvailableConditionFormat   = "NodeTune%sAvailable"
+	NodeTuneProgressingConditionFormat = "NodeTune%sProgressing"
+	NodeTuneDegradedConditionFormat    = "NodeTune%sDegraded"
+
 	AsExpectedReason        = "AsExpected"
 	ErrorReason             = "Error"
 	ProgressingReason       = "Progressing"

--- a/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
@@ -143,7 +143,6 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 			nc.Name,
 			controllerhelpers.WaitForStateOptions{TolerateDelete: false},
 			utils.IsNodeConfigRolledOut,
-			utils.IsNodeConfigDoneWithNodeTuningFunc(matchingNodes),
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -231,7 +230,6 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 			nc.Name,
 			controllerhelpers.WaitForStateOptions{TolerateDelete: false},
 			utils.IsNodeConfigRolledOut,
-			utils.IsNodeConfigDoneWithNodeTuningFunc(matchingNodes),
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -294,7 +292,12 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 					return false, nil
 				}
 
-				nodeMountControllerConditionType := fmt.Sprintf("MountControllerNode%sDegraded", n.GetName())
+				nodeSetupDegradedConditionType := fmt.Sprintf(internalapi.NodeSetupDegradedConditionFormat, n.GetName())
+				if !helpers.IsStatusConditionPresentAndTrue(statusConditions, nodeSetupDegradedConditionType, nc.Generation) {
+					return false, nil
+				}
+
+				nodeMountControllerConditionType := fmt.Sprintf("MountControllerNodeSetup%sDegraded", n.GetName())
 				if !helpers.IsStatusConditionPresentAndTrue(statusConditions, nodeMountControllerConditionType, nc.Generation) {
 					return false, nil
 				}
@@ -311,7 +314,6 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 			f.ScyllaAdminClient().ScyllaV1alpha1().NodeConfigs(),
 			nc.Name,
 			controllerhelpers.WaitForStateOptions{TolerateDelete: false},
-			utils.IsNodeConfigDoneWithNodeTuningFunc(matchingNodes),
 			isNodeConfigMountControllerDegraded,
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -341,7 +343,6 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 			nc.Name,
 			controllerhelpers.WaitForStateOptions{TolerateDelete: false},
 			utils.IsNodeConfigRolledOut,
-			utils.IsNodeConfigDoneWithNodeTuningFunc(matchingNodes),
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	},

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -81,7 +81,6 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 			nc.Name,
 			controllerhelpers.WaitForStateOptions{TolerateDelete: false},
 			utils.IsNodeConfigRolledOut,
-			utils.IsNodeConfigDoneWithNodeTuningFunc(matchingNodes),
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -356,12 +355,13 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 			nc.Name,
 			controllerhelpers.WaitForStateOptions{TolerateDelete: false},
 			utils.IsNodeConfigRolledOut,
-			utils.IsNodeConfigDoneWithNodeTuningFunc(matchingNodes),
-			utils.IsNodeConfigDoneWithContainerTuningFunc(pod.Spec.NodeName, scyllaContainerID),
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyNodeConfig(ctx, f.KubeAdminClient(), nc)
+
+		isNodeTunedForScyllaContainer := controllerhelpers.IsNodeTunedForContainer(nc, pod.Spec.NodeName, scyllaContainerID)
+		o.Expect(isNodeTunedForScyllaContainer).To(o.BeTrue())
 
 		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
 		ctx4, ctx4Cancel := utils.ContextForRollout(ctx, sc)

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -77,24 +77,6 @@ func GetMatchingNodesForNodeConfig(ctx context.Context, nodeGetter corev1client.
 	return matchingNodes, nil
 }
 
-func IsNodeConfigDoneWithContainerTuningFunc(nodeName, containerID string) func(nc *scyllav1alpha1.NodeConfig) (bool, error) {
-	return func(nc *scyllav1alpha1.NodeConfig) (bool, error) {
-		containerTuned := controllerhelpers.IsNodeTunedForContainer(nc, nodeName, containerID)
-		return containerTuned, nil
-	}
-}
-
-func IsNodeConfigDoneWithNodeTuningFunc(nodes []*corev1.Node) func(nc *scyllav1alpha1.NodeConfig) (bool, error) {
-	return func(nc *scyllav1alpha1.NodeConfig) (bool, error) {
-		for _, node := range nodes {
-			if !controllerhelpers.IsNodeTuned(nc.Status.NodeStatuses, node.Name) {
-				return false, nil
-			}
-		}
-		return true, nil
-	}
-}
-
 func RolloutTimeoutForScyllaCluster(sc *scyllav1.ScyllaCluster) time.Duration {
 	return SyncTimeout + time.Duration(GetMemberCount(sc))*memberRolloutTimeout + cleanupJobTimeout
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Node tune controller does not currently set status conditions on NodeConfig's reconciliation. Instead it only set status' NodeStatuses. While this is enough for checking the status programmatically, setting and aggregating status conditions allows for a better UX, by giving the users an option to query NodeConfig conditions.
This PR extends the node tune controller with per-node status conditions and further aggregates them with the existing ones in NodeConfig controller.

It also adds handlers for NodeConfig events to node tune controller and aligns the existing e2e tests with the changes.

**Which issue is resolved by this Pull Request:**
Resolves #1920 

/kind feature
/priority important-longterm
/cc