### PR TITLE
Fix prunning of tuning related Roles and RoleBindings

### DIFF
--- a/pkg/controller/nodeconfig/sync_rolebindings.go
+++ b/pkg/controller/nodeconfig/sync_rolebindings.go
@@ -8,6 +8,7 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,7 @@ func (ncc *Controller) syncRoleBindings(
 		requiredRoleBindings,
 		roleBindings,
 		&controllerhelpers.PruneControlFuncs{
-			DeleteFunc: ncc.kubeClient.RbacV1().RoleBindings(nc.Namespace).Delete,
+			DeleteFunc: ncc.kubeClient.RbacV1().RoleBindings(naming.ScyllaOperatorNodeTuningNamespace).Delete,
 		},
 		ncc.eventRecorder)
 	if err != nil {

--- a/pkg/controller/nodeconfig/sync_roles.go
+++ b/pkg/controller/nodeconfig/sync_roles.go
@@ -8,6 +8,7 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ func (ncc *Controller) syncRoles(ctx context.Context, nc *scyllav1alpha1.NodeCon
 		requiredRoles,
 		roles,
 		&controllerhelpers.PruneControlFuncs{
-			DeleteFunc: ncc.kubeClient.RbacV1().Roles(nc.Namespace).Delete,
+			DeleteFunc: ncc.kubeClient.RbacV1().Roles(naming.ScyllaOperatorNodeTuningNamespace).Delete,
 		},
 		ncc.eventRecorder)
 	if err != nil {


### PR DESCRIPTION
Prunning functions of Role and RoleBinding were using namespace from non-namespaced resource. It was changed to namespace used by our tuning resources.

