### PR TITLE
Do not set ScyllaCluster's ManagerID to empty string when calculating status

### DIFF
--- a/pkg/controller/manager/status.go
+++ b/pkg/controller/manager/status.go
@@ -16,7 +16,7 @@ import (
 func (c *Controller) calculateStatus(sc *scyllav1.ScyllaCluster, state *managerClusterState) *scyllav1.ScyllaClusterStatus {
 	status := sc.Status.DeepCopy()
 
-	status.ManagerID = pointer.Ptr("")
+	status.ManagerID = nil
 	status.Backups = []scyllav1.BackupTaskStatus{}
 	status.Repairs = []scyllav1.RepairTaskStatus{}
 

--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -50,13 +50,9 @@ var _ = g.Describe("Scylla Manager integration", func() {
 		defer di.Close()
 
 		framework.By("Waiting for ScyllaCluster to register with Scylla Manager")
-		registeredInManagerCond := func(sc *scyllav1.ScyllaCluster) (bool, error) {
-			return sc.Status.ManagerID != nil, nil
-		}
-
 		waitCtx2, waitCtx2Cancel := utils.ContextForManagerSync(ctx, sc)
 		defer waitCtx2Cancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx2, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, registeredInManagerCond)
+		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx2, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRegisteredWithManager)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Scheduling a repair task")

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -780,3 +780,7 @@ func WaitForScyllaOperatorConfigStatus(ctx context.Context, client scyllav1alpha
 		},
 	)
 }
+
+func IsScyllaClusterRegisteredWithManager(sc *scyllav1.ScyllaCluster) (bool, error) {
+	return sc.Status.ManagerID != nil && len(*sc.Status.ManagerID) > 0, nil
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Manager integration e2es have been flaking on manager's ClusterID missing on manual schema restore task registration. This is due to a change introduced in #2156 which was causing the field in status to be intermittently set to an empty string. This, together with not bulletproof enough assertions in our e2es, caused the tests to try and register the tasks too early, before the cluster was even registered with manager. 
This PR  fixes it by setting the status manager ID field to nil instead of an empty string, fixing the e2e assertions and adding dedicated sanity checks before scheduling the restore tasks.

**Which issue is resolved by this Pull Request:**
Resolves #2161 

/kind flake
/priority important-soon
/cc