### PR TITLE
Use a portable method to get systemd unit statuses

### DIFF
--- a/pkg/systemd/unit.go
+++ b/pkg/systemd/unit.go
@@ -97,8 +97,9 @@ func (m *UnitManager) WriteStatus(status *unitManagerStatus) error {
 const (
 	loadStateNotFound = "not-found"
 
-	activeStateActive = "active"
-	activeStateFailed = "failed"
+	activeStateActive   = "active"
+	activeStateInactive = "inactive"
+	activeStateFailed   = "failed"
 )
 
 type UnitStatus struct {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Use a more portable `ListUnits` method to get unit statuses in systemd package.
The currently used `'ListUnitsByNames'` is only supported by systemd v230 or higher, which breaks EKS NodeConfig deployments with even the most recent Amazon Linux 2.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2180

/kind bug
/priority critical-urgent
/cc