### PR TITLE
Fix accidental ignition and stuck graceful termination

### DIFF
--- a/pkg/controller/ignition/controller.go
+++ b/pkg/controller/ignition/controller.go
@@ -196,22 +196,21 @@ func (c *Controller) Sync(ctx context.Context) error {
 
 	if ignited {
 		klog.V(2).InfoS("Ignition successful", "SignalFile", naming.ScyllaDBIgnitionDonePath)
+		err = helpers.TouchFile(naming.ScyllaDBIgnitionDonePath)
+		if err != nil {
+			return fmt.Errorf("can't touch signal file %q: %w", naming.ScyllaDBIgnitionDonePath, err)
+		}
 	} else {
 		klog.V(2).InfoS("Waiting for ignition to complete.", "SignalFile", naming.ScyllaDBIgnitionDonePath)
 	}
 
-	klog.V(2).InfoS("Updating ignition", "Ignited", ignited, "SignalFile", naming.ScyllaDBIgnitionDonePath)
+	klog.V(2).InfoS("Updating ignition", "Ignited", ignited)
 
 	oldIgnited := c.ignited.Load()
 	if ignited != oldIgnited {
 		klog.InfoS("Ignition state has changed", "New", ignited, "Old", oldIgnited)
 	}
 	c.ignited.Store(ignited)
-
-	err = helpers.TouchFile(naming.ScyllaDBIgnitionDonePath)
-	if err != nil {
-		return fmt.Errorf("can't touch signal file %q: %w", naming.ScyllaDBIgnitionDonePath, err)
-	}
 
 	return nil
 }

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -890,7 +890,7 @@ wait
 							},
 						},
 						{
-							Name:            "scylladb-ignition",
+							Name:            naming.ScyllaDBIgnitionContainerName,
 							Image:           sidecarImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command: []string{

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -634,9 +634,12 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 									"inherit_errexit",
 									"-c",
 									strings.TrimSpace(`
+trap 'kill $( jobs -p ); exit 0' TERM
+
 printf 'INFO %s ignition - Waiting for /mnt/shared/ignition.done\n' "$( date '+%Y-%m-%d %H:%M:%S,%3N' )" > /dev/stderr
 until [[ -f "/mnt/shared/ignition.done" ]]; do
-  sleep 1;
+  sleep 1 &
+  wait
 done
 printf 'INFO %s ignition - Ignited. Starting ScyllaDB...\n' "$( date '+%Y-%m-%d %H:%M:%S,%3N' )" > /dev/stderr
 
@@ -834,7 +837,9 @@ exec /mnt/shared/scylla-operator sidecar \
 											"inherit_errexit",
 											"-c",
 											strings.TrimSpace(`
-trap 'rm /mnt/shared/ignition.done' EXIT
+trap 'kill $( jobs -p ); exit 0' TERM
+trap 'rm -f /mnt/shared/ignition.done' EXIT
+
 nodetool drain &
 sleep ` + strconv.Itoa(minTerminationGracePeriodSeconds) + ` &
 wait
@@ -1164,7 +1169,7 @@ func getScyllaDBManagerAgentContainer(r scyllav1alpha1.RackSpec, sdc *scyllav1al
 	}
 
 	cnt := &corev1.Container{
-		Name:            "scylla-manager-agent",
+		Name:            naming.ScyllaManagerAgentContainerName,
 		Image:           *sdc.Spec.ScyllaDBManagerAgent.Image,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		// There is no point in starting scylla-manager before ScyllaDB is tuned and ignited. The manager agent fails after 60 attempts and hits backoff unnecessarily.
@@ -1176,13 +1181,16 @@ func getScyllaDBManagerAgentContainer(r scyllav1alpha1.RackSpec, sdc *scyllav1al
 			"inherit_errexit",
 			"-c",
 			strings.TrimSpace(`
+trap 'kill $( jobs -p ); exit 0' TERM
+
 printf '{"L":"INFO","T":"%s","M":"Waiting for /mnt/shared/ignition.done"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
 until [[ -f "/mnt/shared/ignition.done" ]]; do
-  sleep 1;
+  sleep 1 &
+  wait
 done
 printf '{"L":"INFO","T":"%s","M":"Ignited. Starting ScyllaDB Manager Agent"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
 
-scylla-manager-agent \
+exec scylla-manager-agent \
 -c ` + fmt.Sprintf("%q ", naming.ScyllaAgentConfigDefaultFile) + `\
 -c ` + fmt.Sprintf("%q ", path.Join(naming.ScyllaAgentConfigDirName, naming.ScyllaAgentConfigFileName)) + `\
 -c ` + fmt.Sprintf("%q ", path.Join(naming.ScyllaAgentConfigDirName, naming.ScyllaAgentAuthTokenFileName)) + `

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -110,11 +110,12 @@ const (
 
 // Configuration Values
 const (
-	ScyllaContainerName          = "scylla"
-	SidecarInjectorContainerName = "sidecar-injection"
-	PerftuneContainerName        = "perftune"
-	CleanupContainerName         = "cleanup"
-	RLimitsContainerName         = "rlimits"
+	ScyllaContainerName           = "scylla"
+	ScyllaDBIgnitionContainerName = "scylladb-ignition"
+	SidecarInjectorContainerName  = "sidecar-injection"
+	PerftuneContainerName         = "perftune"
+	CleanupContainerName          = "cleanup"
+	RLimitsContainerName          = "rlimits"
 
 	PVCTemplateName = "data"
 

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -26,6 +26,9 @@ const (
 	// Readiness check will always fail when this label is added to member service.
 	NodeMaintenanceLabel = "scylla/node-maintenance"
 
+	// ForceIgnitionValueAnnotation allows to force ignition state. The value can be either "true" or "false".
+	ForceIgnitionValueAnnotation = "internal.scylla-operator.scylladb.com/force-ignition-value"
+
 	LabelValueTrue  = "true"
 	LabelValueFalse = "false"
 )
@@ -110,12 +113,13 @@ const (
 
 // Configuration Values
 const (
-	ScyllaContainerName           = "scylla"
-	ScyllaDBIgnitionContainerName = "scylladb-ignition"
-	SidecarInjectorContainerName  = "sidecar-injection"
-	PerftuneContainerName         = "perftune"
-	CleanupContainerName          = "cleanup"
-	RLimitsContainerName          = "rlimits"
+	ScyllaContainerName             = "scylla"
+	ScyllaDBIgnitionContainerName   = "scylladb-ignition"
+	ScyllaManagerAgentContainerName = "scylla-manager-agent"
+	SidecarInjectorContainerName    = "sidecar-injection"
+	PerftuneContainerName           = "perftune"
+	CleanupContainerName            = "cleanup"
+	RLimitsContainerName            = "rlimits"
 
 	PVCTemplateName = "data"
 

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -61,6 +61,10 @@ func MemberServiceNameForScyllaCluster(r scyllav1.RackSpec, sc *scyllav1.ScyllaC
 	return fmt.Sprintf("%s-%d", StatefulSetNameForRackForScyllaCluster(r, sc), idx)
 }
 
+func PodNameForScyllaCluster(r scyllav1.RackSpec, sc *scyllav1.ScyllaCluster, idx int) string {
+	return MemberServiceNameForScyllaCluster(r, sc, idx)
+}
+
 func IdentityServiceName(sdc *scyllav1alpha1.ScyllaDBDatacenter) string {
 	return fmt.Sprintf("%s-client", sdc.Name)
 }

--- a/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
@@ -154,14 +154,14 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 		o.Eventually(func(g o.Gomega) {
 			for _, ldName := range loopDeviceNames {
 				loopDevicePath := path.Join(hostLoopsDir, ldName)
-				stdout, stderr, err := executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "stat", loopDevicePath)
+				stdout, stderr, err := executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "stat", loopDevicePath)
 				g.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 			}
 		}).WithPolling(1 * time.Second).WithTimeout(3 * time.Minute).Should(o.Succeed())
 
 		var findmntOutput string
 		o.Eventually(func(g o.Gomega) {
-			stdout, stderr, err := executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "findmnt", "--raw", "--output=SOURCE", "--noheadings", hostMountPath)
+			stdout, stderr, err := executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "findmnt", "--raw", "--output=SOURCE", "--noheadings", hostMountPath)
 			g.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 			findmntOutput = stdout
 		}).WithPolling(10 * time.Second).WithTimeout(3 * time.Minute).Should(o.Succeed())
@@ -173,15 +173,15 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 
 		framework.By("Checking if RAID device has been created at %q", discoveredRaidDevice)
 		o.Eventually(func(g o.Gomega) {
-			stdout, stderr, err := executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "stat", discoveredRaidDeviceOnHost)
+			stdout, stderr, err := executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "stat", discoveredRaidDeviceOnHost)
 			g.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
-			stdout, stderr, err = executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "readlink", "-f", discoveredRaidDeviceOnHost)
+			stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "readlink", "-f", discoveredRaidDeviceOnHost)
 			g.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 			raidDeviceName := path.Base(discoveredRaidDeviceOnHost)
 
-			stdout, stderr, err = executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "cat", fmt.Sprintf("/sys/block/%s/md/level", raidDeviceName))
+			stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "cat", fmt.Sprintf("/sys/block/%s/md/level", raidDeviceName))
 			g.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 			raidLevel := strings.TrimSpace(stdout)
@@ -190,7 +190,7 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 
 		framework.By("Checking if RAID device has been formatted")
 		o.Eventually(func(g o.Gomega) {
-			stdout, stderr, err := executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "blkid", "--output=value", "--match-tag=TYPE", discoveredRaidDeviceOnHost)
+			stdout, stderr, err := executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "blkid", "--output=value", "--match-tag=TYPE", discoveredRaidDeviceOnHost)
 			g.Expect(err).NotTo(o.HaveOccurred(), stderr)
 
 			g.Expect(strings.TrimSpace(stdout)).To(o.Equal("xfs"))
@@ -198,7 +198,7 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 
 		framework.By("Checking if RAID was mounted at the provided location with correct options")
 		o.Eventually(func(g o.Gomega) {
-			stdout, stderr, err := executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mount")
+			stdout, stderr, err := executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mount")
 			g.Expect(err).NotTo(o.HaveOccurred(), stderr)
 
 			// mount output format
@@ -437,22 +437,22 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				framework.By("Creating a temp directory on host")
-				stdout, stderr, err := executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mktemp", "--tmpdir=/host/tmp/", "--directory")
+				stdout, stderr, err := executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mktemp", "--tmpdir=/host/tmp/", "--directory")
 				o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 				hostTMPDir := strings.TrimSpace(stdout)
 
 				framework.By("Creating the target mount point on host")
-				stdout, stderr, err = executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mkdir", hostMountPath)
+				stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mkdir", hostMountPath)
 				o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 				framework.By("Bind mounting temp directory on host to target mount point")
-				stdout, stderr, err = executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mount", "--bind", hostTMPDir, hostMountPath)
+				stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mount", "--bind", hostTMPDir, hostMountPath)
 				o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 				cleanupFunc := func(ctx context.Context) {
 					framework.By("Unmounting bind mounted target")
-					stdout, stderr, err = executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "umount", hostMountPath)
+					stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "umount", hostMountPath)
 					o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 				}
 
@@ -509,15 +509,15 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				framework.By("Verifying XFS filesystem integrity")
-				stdout, stderr, err := executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-o", "force_geometry", "-f", "-n", hostDevicePath)
+				stdout, stderr, err := executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-o", "force_geometry", "-f", "-n", hostDevicePath)
 				o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 				framework.By("Corrupting XFS filesystem")
-				stdout, stderr, err = executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_db", "-x", "-c", "blockget", "-c", "blocktrash -s 12345678 -n 1000", hostDevicePath)
+				stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_db", "-x", "-c", "blockget", "-c", "blocktrash -s 12345678 -n 1000", hostDevicePath)
 				o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 				framework.By("Verifying that XFS filesystem is corrupted")
-				stdout, stderr, err = executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-o", "force_geometry", "-f", "-n", hostDevicePath)
+				stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-o", "force_geometry", "-f", "-n", hostDevicePath)
 				o.Expect(err).To(o.HaveOccurred())
 
 				framework.By("Patching NodeConfig's mount configuration with a mount over a corrupted filesystem")
@@ -589,8 +589,8 @@ func newClientPod(nc *scyllav1alpha1.NodeConfig) *corev1.Pod {
 	}
 }
 
-func executeInPod(config *rest.Config, client corev1client.CoreV1Interface, pod *corev1.Pod, command string, args ...string) (string, string, error) {
-	return utils.ExecWithOptions(config, client, utils.ExecOptions{
+func executeInPod(ctx context.Context, config *rest.Config, client corev1client.CoreV1Interface, pod *corev1.Pod, command string, args ...string) (string, string, error) {
+	return utils.ExecWithOptions(ctx, config, client, utils.ExecOptions{
 		Command:       append([]string{command}, args...),
 		Namespace:     pod.Namespace,
 		PodName:       pod.Name,

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -165,7 +165,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		scyllaPod, err := f.KubeClient().CoreV1().Pods(sc.Namespace).Get(ctx, podName, metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		stdout, stderr, err := executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), scyllaPod,
+		stdout, stderr, err := executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), scyllaPod,
 			"bash",
 			"-euExo",
 			"pipefail",
@@ -180,7 +180,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		o.Expect(stdout).To(o.Equal(nrOpenLimit))
 
 		framework.By("Validating hard file limit of Scylla process")
-		stdout, stderr, err = executeInPod(f.ClientConfig(), f.KubeClient().CoreV1(), scyllaPod,
+		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), scyllaPod,
 			"bash",
 			"-euExo",
 			"pipefail",

--- a/test/e2e/set/scyllacluster/scyllacluster_restarts.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_restarts.go
@@ -1,0 +1,214 @@
+// Copyright (C) 2024 ScyllaDB
+
+package scyllacluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// terminationTimeout is the amount of time that the pod needs to terminate gracefully.
+	// In addition to process termination, this needs to account for kubelet sending signals, state propagation
+	// and generally being busy in the CI.
+	terminationTimeout = 5 * time.Minute
+	// A high enough grace period so it can never terminate gracefully in an e2e run.
+	gracePeriod = terminationTimeout + (7 * 24 * time.Hour)
+)
+
+var _ = g.Describe("ScyllaCluster graceful termination", func() {
+	f := framework.NewFramework("scyllacluster")
+
+	// This test verifies correct signal handling in the bash wait routine
+	// which oscillates between a sleep (external program) and a file check.
+	// The "problematic" external program (sleep) runs a majority of the time, but not all.
+	// To be reasonably sure, we should run this multiple times in a single test run
+	// and avoid an accidental merge that could bork the test / CI.
+	g.It("should work while waiting for ignition", g.MustPassRepeatedly(3), func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		sc := f.GetDefaultScyllaCluster()
+		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		sc.Spec.Datacenter.Racks[0].Members = 1
+		if sc.Spec.ExposeOptions == nil {
+			sc.Spec.ExposeOptions = &scyllav1.ExposeOptions{}
+		}
+		if sc.Spec.ExposeOptions.NodeService == nil {
+			sc.Spec.ExposeOptions.NodeService = &scyllav1.NodeServiceTemplate{}
+		}
+		if sc.Spec.ExposeOptions.NodeService.Annotations == nil {
+			sc.Spec.ExposeOptions.NodeService.Annotations = map[string]string{}
+		}
+		sc.Spec.ExposeOptions.NodeService.Annotations[naming.ForceIgnitionValueAnnotation] = "false"
+
+		framework.By("Creating a ScyllaCluster with blocked ignition")
+		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaCluster Pod to be running")
+		podName := naming.PodNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, 0)
+		waitRunningCtx, waitRunningCtxCancel := context.WithTimeoutCause(ctx, 10*time.Minute, fmt.Errorf("timed out waiting for ScyllaDB Pod to be running"))
+		defer waitRunningCtxCancel()
+		pod, err := controllerhelpers.WaitForPodState(waitRunningCtx, f.KubeClient().CoreV1().Pods(f.Namespace()), podName, controllerhelpers.WaitForStateOptions{}, utils.PodIsRunning)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		execCtx, execCtxCancel := context.WithTimeoutCause(ctx, 2*time.Minute, errors.New("ignition probe didn't return expected status in time"))
+		defer execCtxCancel()
+		framework.By("Executing into %q container and verifying it's not ignited using the probe", naming.ScyllaDBIgnitionContainerName)
+		stdout, stderr, err := utils.ExecWithOptions(execCtx, f.ClientConfig(), f.KubeClient().CoreV1(), utils.ExecOptions{
+			Command: []string{
+				"/usr/bin/timeout",
+				"1m",
+				"/usr/bin/bash",
+				"-euxEo",
+				"pipefail",
+				"-O",
+				"inherit_errexit",
+				"-c",
+				strings.TrimSpace(`
+while [[ "$( curl -s -o /dev/null -w '%{http_code}' -G http://localhost:42081/readyz )" != "503" ]]; do
+  sleep 1 &
+  wait;
+done
+				`),
+			},
+			Namespace:     pod.Namespace,
+			PodName:       pod.Name,
+			ContainerName: naming.ScyllaDBIgnitionContainerName,
+			CaptureStdout: true,
+			CaptureStderr: true,
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("* stdout:\n%q\n* stderr:\n%s\n* Cause: %s", stdout, stderr, context.Cause(execCtx)))
+
+		sleepTime := 30 * time.Second
+		framework.By("Sleeping for %v to give kubelet time to update the probes", sleepTime)
+		// The sleep also waits for nodeconfigpod controller to unblock tuning, in case the override would be broken.
+		time.Sleep(sleepTime)
+
+		framework.By("Validating container readiness")
+		pod, err = f.KubeClient().CoreV1().Pods(f.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		crm := utils.GetContainerReadinessMap(pod)
+		o.Expect(crm).To(
+			o.And(
+				o.HaveKeyWithValue(naming.ScyllaContainerName, false),
+				o.HaveKeyWithValue(naming.ScyllaDBIgnitionContainerName, false),
+				o.HaveKeyWithValue(naming.ScyllaManagerAgentContainerName, false),
+			),
+			fmt.Sprintf("container(s) in Pod %q don't match the expected state", pod.Name),
+		)
+
+		framework.By("Deleting the ScyllaDB Pod")
+		err = f.KubeClient().CoreV1().Pods(f.Namespace()).Delete(
+			ctx,
+			pod.Name,
+			metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{
+					UID: pointer.Ptr(pod.UID),
+				},
+				GracePeriodSeconds: pointer.Ptr(int64(gracePeriod.Seconds())),
+			},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaDB Pod to be deleted")
+		deletionCtx, deletionCtxCancel := context.WithTimeoutCause(
+			ctx,
+			terminationTimeout,
+			fmt.Errorf("pod %q has not finished termination in time", naming.ObjRef(pod)),
+		)
+		defer deletionCtxCancel()
+		err = framework.WaitForObjectDeletion(
+			deletionCtx,
+			f.DynamicClient(),
+			corev1.SchemeGroupVersion.WithResource("pods"),
+			pod.Namespace,
+			pod.Name,
+			pointer.Ptr(pod.UID),
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("should work when a cluster is fully rolled out", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		sc := f.GetDefaultScyllaCluster()
+		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+		sc.Spec.Datacenter.Racks[0].Members = 1
+
+		framework.By("Creating a ScyllaCluster")
+		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
+		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
+		defer waitCtx1Cancel()
+		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+
+		framework.By("Fetching the Pod and validating container readiness")
+		podName := naming.PodNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, 0)
+		pod, err := f.KubeClient().CoreV1().Pods(f.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		crm := utils.GetContainerReadinessMap(pod)
+		o.Expect(crm).To(
+			o.And(
+				o.HaveKeyWithValue(naming.ScyllaContainerName, true),
+				o.HaveKeyWithValue(naming.ScyllaDBIgnitionContainerName, true),
+				o.HaveKeyWithValue(naming.ScyllaManagerAgentContainerName, true),
+			),
+			fmt.Sprintf("container(s) in Pod %q don't match the expected state", pod.Name),
+		)
+
+		framework.By("Deleting the ScyllaDB Pod")
+		err = f.KubeClient().CoreV1().Pods(f.Namespace()).Delete(
+			ctx,
+			pod.Name,
+			metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{
+					UID: pointer.Ptr(pod.UID),
+				},
+				GracePeriodSeconds: pointer.Ptr(int64(gracePeriod.Seconds())),
+			},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaDB Pod to be deleted")
+		deletionCtx, deletionCtxCancel := context.WithTimeoutCause(
+			ctx,
+			terminationTimeout,
+			fmt.Errorf("pod %q has not finished termination in time", naming.ObjRef(pod)),
+		)
+		defer deletionCtxCancel()
+		err = framework.WaitForObjectDeletion(
+			deletionCtx,
+			f.DynamicClient(),
+			corev1.SchemeGroupVersion.WithResource("pods"),
+			pod.Namespace,
+			pod.Name,
+			pointer.Ptr(pod.UID),
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})

--- a/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
@@ -104,7 +104,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 			for i := range connectionAttempts {
 				framework.By("Establishing connection number %d to shard number %d", i, shard)
-				stdout, stderr, err := utils.ExecWithOptions(f.ClientConfig(), f.KubeClient().CoreV1(), utils.ExecOptions{
+				stdout, stderr, err := utils.ExecWithOptions(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), utils.ExecOptions{
 					Command: []string{
 						"/usr/bin/bash",
 						"-euEo",

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -354,7 +354,7 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		scyllaManagerPod := scyllaManagerPods.Items[0]
 
 		framework.By("Creating a schema restore task")
-		stdout, stderr, err := utils.ExecWithOptions(f.AdminClientConfig(), f.KubeAdminClient().CoreV1(), utils.ExecOptions{
+		stdout, stderr, err := utils.ExecWithOptions(ctx, f.AdminClientConfig(), f.KubeAdminClient().CoreV1(), utils.ExecOptions{
 			Command: []string{
 				"sctool",
 				"restore",
@@ -419,7 +419,7 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		}
 
 		framework.By("Creating a tables restore task")
-		stdout, stderr, err = utils.ExecWithOptions(f.AdminClientConfig(), f.KubeAdminClient().CoreV1(), utils.ExecOptions{
+		stdout, stderr, err = utils.ExecWithOptions(ctx, f.AdminClientConfig(), f.KubeAdminClient().CoreV1(), utils.ExecOptions{
 			Command: []string{
 				"sctool",
 				"restore",

--- a/test/e2e/utils/exec.go
+++ b/test/e2e/utils/exec.go
@@ -4,6 +4,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 
@@ -28,7 +29,7 @@ type ExecOptions struct {
 // ExecWithOptions executes a command in the specified container,
 // returning stdout, stderr and error. `options` allowed for
 // additional parameters to be passed.
-func ExecWithOptions(config *rest.Config, client corev1client.CoreV1Interface, options ExecOptions) (string, string, error) {
+func ExecWithOptions(ctx context.Context, config *rest.Config, client corev1client.CoreV1Interface, options ExecOptions) (string, string, error) {
 	const tty = false
 
 	req := client.RESTClient().Post().
@@ -52,12 +53,14 @@ func ExecWithOptions(config *rest.Config, client corev1client.CoreV1Interface, o
 	if err != nil {
 		return "", "", err
 	}
-	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:  options.Stdin,
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Tty:    tty,
-	})
+	err = exec.StreamWithContext(
+		ctx,
+		remotecommand.StreamOptions{
+			Stdin:  options.Stdin,
+			Stdout: &stdout,
+			Stderr: &stderr,
+			Tty:    tty,
+		})
 
 	return stdout.String(), stderr.String(), err
 }

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -787,3 +787,19 @@ func WaitForScyllaOperatorConfigStatus(ctx context.Context, client scyllav1alpha
 func IsScyllaClusterRegisteredWithManager(sc *scyllav1.ScyllaCluster) (bool, error) {
 	return sc.Status.ManagerID != nil && len(*sc.Status.ManagerID) > 0, nil
 }
+
+func GetContainerReadinessMap(pod *corev1.Pod) map[string]bool {
+	res := map[string]bool{}
+
+	for _, statusSet := range [][]corev1.ContainerStatus{
+		pod.Status.InitContainerStatuses,
+		pod.Status.ContainerStatuses,
+		pod.Status.EphemeralContainerStatuses,
+	} {
+		for _, cs := range statusSet {
+			res[cs.Name] = cs.Ready
+		}
+	}
+
+	return res
+}


### PR DESCRIPTION
**Description of your changes:**
This PR fixes the ignition touching the file before it's actually ignited and adds e2e coverage to prevent it from happening again. (Looks like it got broken in the early iterations.)

It also fixes stuck graceful termination *before* ignition is done because fixing one surfaces the other is broken and they can't be split without disabling some tests. (For this reason the ignition file is changed twice - best viewed as an overall diff then "by commit"). It also fixes graceful termination *after* ignition that was broken because of the manager agent container wasn't using `exec`. (@rzetelskik found that previously and it also failed in the test I wrote.)

**Which issue is resolved by this Pull Request:**
Resolves #2213