### PR TITLE
Fix cert-manager URL in deploy release CI script

### DIFF
--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -42,7 +42,7 @@ mkdir -p "${ARTIFACTS_DEPLOY_DIR}/"{operator,manager}
 kubectl_create -n=prometheus-operator -f="${source_url}/${revision}/examples/third-party/prometheus-operator.yaml"
 kubectl_create -n=haproxy-ingress -f="${source_url}/${revision}/examples/third-party/haproxy-ingress.yaml"
 
-kubectl_create -f="${source_url}/${revision}/examples/common/cert-manager.yaml"
+kubectl_create -f="${source_url}/${revision}/examples/third-party/cert-manager.yaml"
 # Wait for cert-manager crd and webhooks
 kubectl wait --for condition=established --timeout=60s crd/certificates.cert-manager.io crd/issuers.cert-manager.io
 for d in cert-manager{,-cainjector,-webhook}; do

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -28,7 +28,7 @@ cp ./deploy/manager/dev/*.yaml "${DEPLOY_DIR}/manager"
 cp ./deploy/operator/*.yaml "${DEPLOY_DIR}/operator"
 cp ./examples/third-party/prometheus-operator/*.yaml "${DEPLOY_DIR}/prometheus-operator"
 cp ./examples/third-party/haproxy-ingress/*.yaml "${DEPLOY_DIR}/haproxy-ingress"
-cp ./examples/common/cert-manager.yaml "${DEPLOY_DIR}/"
+cp ./examples/third-party/cert-manager.yaml "${DEPLOY_DIR}/"
 
 for f in $( find "${DEPLOY_DIR}"/ -type f -name '*.yaml' ); do
     sed -i -E -e "s~docker\.io/scylladb/scylla-operator:[^ @]+$~${OPERATOR_IMAGE_REF}~" "${f}"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
https://github.com/scylladb/scylla-operator/commit/1fbdf0339dbe0ad842d1840f528fb55357484277 moved one of our dependencies and changed the existing one to a symlink, which broke downloading cert-manager in CI deploy release script.
This PR fixes the url.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2218

/kind bug
/priority important-soon
/assign tnozicka