### PR TITLE
Verify ScyllaCluster after each rollout in every test

### DIFF
--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -19,6 +19,7 @@ import (
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -155,6 +156,8 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		defer ctx1Cancel()
 		sc, err = controllerhelpers.WaitForScyllaClusterState(ctx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 
 		framework.By("Validating soft file limit of Scylla process")
 		podName := fmt.Sprintf("%s-%d", naming.StatefulSetNameForRackForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc), 0)
@@ -368,6 +371,8 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		defer ctx4Cancel()
 		sc, err = controllerhelpers.WaitForScyllaClusterState(ctx4, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 
 		framework.By("Verifying ConfigMap content")
 		ctx5, ctx5Cancel := context.WithTimeout(ctx, apiCallTimeout)

--- a/test/e2e/set/scyllacluster/multi_datacenter_scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/multi_datacenter_scyllacluster_external_seeds.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -41,15 +42,15 @@ var _ = g.Describe("MultiDC cluster", framework.MultiDatacenter, func() {
 		sc0, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, ns0Client.ScyllaClient().ScyllaV1().ScyllaClusters(sc0.Namespace), sc0.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, ns0Client.KubeClient(), ns0Client.ScyllaClient(), sc0)
-		waitForFullQuorum(ctx, ns0Client.KubeClient().CoreV1(), sc0)
+		scyllaclusterverification.Verify(ctx, ns0Client.KubeClient(), ns0Client.ScyllaClient(), sc0)
+		scyllaclusterverification.WaitForFullQuorum(ctx, ns0Client.KubeClient().CoreV1(), sc0)
 
 		hosts0, hostIDs0, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, ns0Client.KubeClient().CoreV1(), sc0)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts0).To(o.HaveLen(int(utils.GetMemberCount(sc0))))
 		o.Expect(hostIDs0).To(o.HaveLen(int(utils.GetMemberCount(sc0))))
 
-		di0 := insertAndVerifyCQLData(ctx, hosts0)
+		di0 := scyllaclusterverification.InsertAndVerifyCQLData(ctx, hosts0)
 		defer di0.Close()
 
 		seeds0, err := utils.GetBroadcastAddresses(ctx, ns0Client.KubeClient().CoreV1(), sc0)
@@ -74,14 +75,14 @@ var _ = g.Describe("MultiDC cluster", framework.MultiDatacenter, func() {
 		sc1, err = controllerhelpers.WaitForScyllaClusterState(waitCtx2, ns1Client.ScyllaClient().ScyllaV1().ScyllaClusters(ns1.GetName()), sc1.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, ns1Client.KubeClient(), ns1Client.ScyllaClient(), sc1)
+		scyllaclusterverification.Verify(ctx, ns1Client.KubeClient(), ns1Client.ScyllaClient(), sc1)
 
 		framework.By("Verifying a multi-datacenter cluster was formed with ScyllaCluster #0")
 		dcClientMap := make(map[string]corev1client.CoreV1Interface, 2)
 		dcClientMap[sc0.Spec.Datacenter.Name] = ns0Client.KubeClient().CoreV1()
 		dcClientMap[sc1.Spec.Datacenter.Name] = ns1Client.KubeClient().CoreV1()
 
-		waitForFullMultiDCQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1})
+		scyllaclusterverification.WaitForFullMultiDCQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1})
 
 		hostsByDC, hostIDsByDC, err := utils.GetBroadcastRPCAddressesAndUUIDsByDC(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1})
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -92,11 +93,11 @@ var _ = g.Describe("MultiDC cluster", framework.MultiDatacenter, func() {
 
 		hostIDs1 := hostIDsByDC[sc1.Spec.Datacenter.Name]
 
-		di1 := insertAndVerifyCQLDataByDC(ctx, hostsByDC)
+		di1 := scyllaclusterverification.InsertAndVerifyCQLDataByDC(ctx, hostsByDC)
 		defer di1.Close()
 
 		framework.By("Verifying data of datacenter %q", sc0.Spec.Datacenter.Name)
-		verifyCQLData(ctx, di0)
+		scyllaclusterverification.VerifyCQLData(ctx, di0)
 
 		framework.By("Verifying datacenter allocation of hosts")
 		scyllaClient, _, err := utils.GetScyllaClient(ctx, ns1Client.KubeClient().CoreV1(), sc1)
@@ -133,7 +134,7 @@ var _ = g.Describe("MultiDC cluster", framework.MultiDatacenter, func() {
 		sc2, err = controllerhelpers.WaitForScyllaClusterState(waitCtx3, ns2Client.ScyllaClient().ScyllaV1().ScyllaClusters(sc2.Namespace), sc2.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, ns2Client.KubeClient(), ns2Client.ScyllaClient(), sc2)
+		scyllaclusterverification.Verify(ctx, ns2Client.KubeClient(), ns2Client.ScyllaClient(), sc2)
 
 		framework.By("Verifying a multi-datacenter cluster was formed with ScyllaClusters #0 and #1")
 		dcClientMap = make(map[string]corev1client.CoreV1Interface, 3)
@@ -141,7 +142,7 @@ var _ = g.Describe("MultiDC cluster", framework.MultiDatacenter, func() {
 		dcClientMap[sc1.Spec.Datacenter.Name] = ns1Client.KubeClient().CoreV1()
 		dcClientMap[sc2.Spec.Datacenter.Name] = ns2Client.KubeClient().CoreV1()
 
-		waitForFullMultiDCQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1, sc2})
+		scyllaclusterverification.WaitForFullMultiDCQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1, sc2})
 
 		hostsByDC, hostIDsByDC, err = utils.GetBroadcastRPCAddressesAndUUIDsByDC(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc0, sc1, sc2})
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -152,14 +153,14 @@ var _ = g.Describe("MultiDC cluster", framework.MultiDatacenter, func() {
 		o.Expect(hostIDsByDC[sc1.Spec.Datacenter.Name]).To(o.ConsistOf(hostIDs1))
 		o.Expect(hostIDsByDC[sc2.Spec.Datacenter.Name]).To(o.HaveLen(int(utils.GetMemberCount(sc2))))
 
-		di2 := insertAndVerifyCQLDataByDC(ctx, hostsByDC)
+		di2 := scyllaclusterverification.InsertAndVerifyCQLDataByDC(ctx, hostsByDC)
 		defer di2.Close()
 
 		framework.By("Verifying data of datacenter %q", sc0.Spec.Datacenter.Name)
-		verifyCQLData(ctx, di0)
+		scyllaclusterverification.VerifyCQLData(ctx, di0)
 
 		framework.By("Verifying data of datacenter %q", sc1.Spec.Datacenter.Name)
-		verifyCQLData(ctx, di1)
+		scyllaclusterverification.VerifyCQLData(ctx, di1)
 
 		framework.By("Verifying datacenter allocation of hosts")
 		scyllaClient, _, err = utils.GetScyllaClient(ctx, ns2Client.KubeClient().CoreV1(), sc2)

--- a/test/e2e/set/scyllacluster/scyllacluster_alternator.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_alternator.go
@@ -30,6 +30,7 @@ import (
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	"github.com/scylladb/scylla-operator/test/e2e/verification"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -103,7 +104,7 @@ authorizer: CassandraAuthorizer
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 
 		svcIP, err := utils.GetIdentityServiceIP(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,7 +56,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 
 		framework.By("Validating no cleanup jobs were created")
 		jobEvents, err := jobObserver.Stop()
@@ -86,7 +87,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx2, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 
 		framework.By("Validating cleanup jobs were created for all nodes except last one")
 		jobEvents, err = jobObserver.Stop()
@@ -139,7 +140,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 
 		tokenRingHash, err = utils.GetCurrentTokenRingHash(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/set/scyllacluster/scyllacluster_evictions.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_evictions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -34,13 +35,13 @@ var _ = g.Describe("ScyllaCluster evictions", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(2))
-		di := insertAndVerifyCQLData(ctx, hosts)
+		di := scyllaclusterverification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 
 		framework.By("Allowing the first pod to be evicted")

--- a/test/e2e/set/scyllacluster/scyllacluster_hostid.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_hostid.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,13 +36,13 @@ var _ = g.Describe("ScyllaCluster HostID", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(2))
-		di := insertAndVerifyCQLData(ctx, hosts)
+		di := scyllaclusterverification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 
 		framework.By("Verifying annotations")

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -19,6 +19,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -271,13 +272,13 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, _, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(3))
-		di := insertAndVerifyCQLData(ctx, hosts)
+		di := scyllaclusterverification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 
 		framework.By("Simulating a PV on node that's gone")
@@ -349,13 +350,13 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx4, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, err = utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(3))
-		verifyCQLData(ctx, di)
+		scyllaclusterverification.VerifyCQLData(ctx, di)
 
 		// Stop fake provisioner
 		provisionerCancel()

--- a/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,13 +43,13 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(membersCount))
-		di := insertAndVerifyCQLData(ctx, hosts)
+		di := scyllaclusterverification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 
 		framework.By("Deleting the ScyllaCluster")
@@ -103,8 +104,8 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		oldHosts := hosts
 		hosts, err = utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
@@ -112,6 +113,6 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(hosts).To(o.HaveLen(len(oldHosts)))
 		err = di.SetClientEndpoints(hosts)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		verifyCQLData(ctx, di)
+		scyllaclusterverification.VerifyCQLData(ctx, di)
 	})
 })

--- a/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
@@ -16,6 +16,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/util/cql"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,8 +60,8 @@ var _ = g.Describe("ScyllaCluster", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/tools"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -39,13 +40,13 @@ var _ = g.Describe("ScyllaCluster sysctl", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(1))
-		di := insertAndVerifyCQLData(ctx, hosts)
+		di := scyllaclusterverification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 
 		framework.By("Checking the sysctl value")

--- a/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,13 +89,13 @@ var _ = g.Describe("ScyllaCluster webhook", func() {
 		validSC, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(validSC.Namespace), validSC.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), validSC)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), validSC)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), validSC)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), validSC)
 
 		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), validSC)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(1))
-		di := insertAndVerifyCQLData(ctx, hosts)
+		di := scyllaclusterverification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 
 		framework.By("Rejecting an update of ScyllaCluster's repo")

--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -40,13 +41,13 @@ var _ = g.Describe("Scylla Manager integration", func() {
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(1))
-		di := insertAndVerifyCQLData(ctx, hosts)
+		di := scyllaclusterverification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 
 		framework.By("Waiting for ScyllaCluster to register with Scylla Manager")

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -21,6 +21,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -80,13 +81,13 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		sourceSC, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sourceSC.Namespace), sourceSC.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sourceSC)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sourceSC)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sourceSC)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sourceSC)
 
 		sourceHosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sourceSC)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(sourceHosts).To(o.HaveLen(int(utils.GetMemberCount(sourceSC))))
-		di := insertAndVerifyCQLData(ctx, sourceHosts)
+		di := scyllaclusterverification.InsertAndVerifyCQLData(ctx, sourceHosts)
 		defer di.Close()
 
 		framework.By("Waiting for source ScyllaCluster to register with Scylla Manager")
@@ -314,8 +315,8 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		targetSC, err = controllerhelpers.WaitForScyllaClusterState(waitCtx7, f.ScyllaClient().ScyllaV1().ScyllaClusters(targetSC.Namespace), targetSC.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), targetSC)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), targetSC)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), targetSC)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), targetSC)
 
 		framework.By("Verifying that target cluster is missing the source cluster data")
 		targetHosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), targetSC)
@@ -410,8 +411,8 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		o.Expect(targetSC.Status.ManagerID).NotTo(o.BeNil())
 		o.Expect(*targetSC.Status.ManagerID).NotTo(o.BeEmpty())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), targetSC)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), targetSC)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), targetSC)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), targetSC)
 
 		if e.postSchemaRestoreHook != nil {
 			e.postSchemaRestoreHook(ctx, f, targetSC)
@@ -453,7 +454,7 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		err = di.SetClientEndpoints(targetHosts)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyCQLData(ctx, di)
+		scyllaclusterverification.VerifyCQLData(ctx, di)
 	},
 		g.Entry("using default ScyllaDB version", entry{}),
 		// Restoring schema with ScyllaDB OS 5.4.X or ScyllaDB Enterprise 2024.1.X and consistent_cluster_management isn’t supported.
@@ -481,8 +482,8 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 				targetSC, err = controllerhelpers.WaitForScyllaClusterState(waitCtx, f.ScyllaClient().ScyllaV1().ScyllaClusters(targetSC.Namespace), targetSC.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), targetSC)
-				waitForFullQuorum(ctx, f.KubeClient().CoreV1(), targetSC)
+				scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), targetSC)
+				scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), targetSC)
 			},
 		}),
 	)
@@ -522,13 +523,13 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyScyllaCluster(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		waitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(1))
-		di := insertAndVerifyCQLData(ctx, hosts)
+		di := scyllaclusterverification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 
 		framework.By("Waiting for ScyllaCluster to register with Scylla Manager")

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
@@ -31,6 +31,7 @@ import (
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	"github.com/scylladb/scylla-operator/test/e2e/verification"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -180,6 +181,8 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 		defer waitCtx1Cancel()
 		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 
 		framework.By("Waiting for the ScyllaDBMonitoring to roll out (RV=%s)", sm.ResourceVersion)
 		waitCtx2, waitCtx2Cancel := context.WithTimeout(ctx, 5*time.Minute)

--- a/test/e2e/utils/verification/scyllacluster/cql.go
+++ b/test/e2e/utils/verification/scyllacluster/cql.go
@@ -1,0 +1,128 @@
+package scyllacluster
+
+import (
+	"context"
+
+	o "github.com/onsi/gomega"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	cqlclientv1alpha1 "github.com/scylladb/scylla-operator/pkg/scylla/api/cqlclient/v1alpha1"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/scheme"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func WaitForFullQuorum(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) {
+	dcClientMap := make(map[string]corev1client.CoreV1Interface, 1)
+	dcClientMap[sc.Spec.Datacenter.Name] = client
+	WaitForFullMultiDCQuorum(ctx, dcClientMap, []*scyllav1.ScyllaCluster{sc})
+}
+
+func WaitForFullMultiDCQuorum(ctx context.Context, dcClientMap map[string]corev1client.CoreV1Interface, scs []*scyllav1.ScyllaCluster) {
+	framework.By("Waiting for the ScyllaCluster(s) to reach consistency ALL")
+	err := utils.WaitForFullMultiDCQuorum(ctx, dcClientMap, scs)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func VerifyCQLData(ctx context.Context, di *utils.DataInserter) {
+	err := di.AwaitSchemaAgreement(ctx)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	framework.By("Verifying the data")
+	data, err := di.Read()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(data).To(o.Equal(di.GetExpected()))
+}
+
+func InsertAndVerifyCQLData(ctx context.Context, hosts []string, options ...utils.DataInserterOption) *utils.DataInserter {
+	framework.By("Inserting data")
+	di, err := utils.NewDataInserter(hosts, options...)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	InsertAndVerifyCQLDataUsingDataInserter(ctx, di)
+	return di
+}
+
+func InsertAndVerifyCQLDataByDC(ctx context.Context, hosts map[string][]string) *utils.DataInserter {
+	di, err := utils.NewMultiDCDataInserter(hosts)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	InsertAndVerifyCQLDataUsingDataInserter(ctx, di)
+	return di
+}
+
+func InsertAndVerifyCQLDataUsingDataInserter(ctx context.Context, di *utils.DataInserter) *utils.DataInserter {
+	framework.By("Inserting data")
+	err := di.Insert()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	VerifyCQLData(ctx, di)
+
+	return di
+}
+
+type VerifyCQLConnectionConfigsOptions struct {
+	Domains               []string
+	Datacenters           []string
+	ServingCAData         []byte
+	ClientCertificateData []byte
+	ClientKeyData         []byte
+}
+
+func VerifyAndParseCQLConnectionConfigs(secret *corev1.Secret, options VerifyCQLConnectionConfigsOptions) map[string]*cqlclientv1alpha1.CQLConnectionConfig {
+	o.Expect(secret.Type).To(o.Equal(corev1.SecretType("Opaque")))
+	o.Expect(secret.Data).To(o.HaveLen(len(options.Domains)))
+
+	connectionConfigs := make(map[string]*cqlclientv1alpha1.CQLConnectionConfig, len(secret.Data))
+	for _, domain := range options.Domains {
+		o.Expect(secret.Data).To(o.HaveKey(domain))
+		obj, err := runtime.Decode(
+			scheme.Codecs.DecoderToVersion(scheme.Codecs.UniversalDeserializer(), cqlclientv1alpha1.GroupVersion),
+			secret.Data[domain],
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		cfg := obj.(*cqlclientv1alpha1.CQLConnectionConfig)
+
+		o.Expect(cfg.Datacenters).NotTo(o.BeEmpty())
+		o.Expect(cfg.Datacenters).To(o.HaveLen(len(options.Datacenters)))
+		for _, dcName := range options.Datacenters {
+			o.Expect(cfg.Datacenters).To(o.HaveKey(dcName))
+			dc := cfg.Datacenters[dcName]
+			o.Expect(dc.Server).To(o.Equal("cql." + domain))
+			o.Expect(dc.NodeDomain).To(o.Equal("cql." + domain))
+			o.Expect(dc.InsecureSkipTLSVerify).To(o.BeFalse())
+			o.Expect(dc.CertificateAuthorityData).To(o.Equal(options.ServingCAData))
+			o.Expect(dc.CertificateAuthorityPath).To(o.BeEmpty())
+			o.Expect(dc.ProxyURL).To(o.BeEmpty())
+		}
+
+		o.Expect(cfg.AuthInfos).To(o.HaveLen(1))
+		o.Expect(cfg.AuthInfos).To(o.HaveKey("admin"))
+		admAuthInfo := cfg.AuthInfos["admin"]
+		o.Expect(admAuthInfo.Username).To(o.Equal("cassandra"))
+		o.Expect(admAuthInfo.Password).To(o.Equal("cassandra"))
+		o.Expect(admAuthInfo.ClientCertificateData).To(o.Equal(options.ClientCertificateData))
+		o.Expect(admAuthInfo.ClientCertificatePath).To(o.BeEmpty())
+		o.Expect(admAuthInfo.ClientKeyData).To(o.Equal(options.ClientKeyData))
+		o.Expect(admAuthInfo.ClientKeyPath).To(o.BeEmpty())
+
+		o.Expect(cfg.Contexts).To(o.HaveLen(1))
+		o.Expect(cfg.Contexts).To(o.HaveKey("default"))
+		defaultContext := cfg.Contexts["default"]
+		o.Expect(defaultContext.DatacenterName).To(o.Equal(options.Datacenters[0]))
+		o.Expect(defaultContext.AuthInfoName).To(o.Equal("admin"))
+
+		o.Expect(cfg.CurrentContext).To(o.Equal("default"))
+
+		o.Expect(cfg.Parameters).NotTo(o.BeNil())
+		o.Expect(cfg.Parameters.DefaultConsistency).To(o.BeEquivalentTo("QUORUM"))
+		o.Expect(cfg.Parameters.DefaultSerialConsistency).To(o.BeEquivalentTo("SERIAL"))
+
+		connectionConfigs[domain] = cfg
+	}
+
+	return connectionConfigs
+}


### PR DESCRIPTION
**Description of your changes:**
Some of the other tests put the ScyllaCluster through some corner cases and we should ensure the invariants hold everywhere. The PR add ScyllaCluster verification after every tests case that waits for ScyllCluster rollout.

Resolves #2226 