### PR TITLE
Move snitch config generation to Operator

### DIFF
--- a/assets/scylladb/registry.go
+++ b/assets/scylladb/registry.go
@@ -20,4 +20,10 @@ var (
 	ScyllaDBManagedConfigTemplate       = lazy.New(func() *assets.ObjectTemplate[*corev1.ConfigMap] {
 		return ParseObjectTemplateOrDie[*corev1.ConfigMap]("scylladb-managed-config", scyllaDBManagedConfigTemplateString)
 	})
+
+	//go:embed "snitchconfig.cm.yaml"
+	scyllaDBSnitchConfigTemplateString string
+	ScyllaDBSnitchConfigTemplate       = lazy.New(func() *assets.ObjectTemplate[*corev1.ConfigMap] {
+		return ParseObjectTemplateOrDie[*corev1.ConfigMap]("scylladb-snitch-config", scyllaDBSnitchConfigTemplateString)
+	})
 )

--- a/assets/scylladb/snitchconfig.cm.yaml
+++ b/assets/scylladb/snitchconfig.cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: "{{ .Namespace }}"
+  name: "{{ .Name }}"
+data:
+  {{ .SnitchConfigName }}: |
+    dc={{ .DatacenterName }}
+    rack={{ .RackName }}
+    prefer_local=false

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -502,6 +502,17 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 								},
 							},
 							{
+								Name: "scylladb-snitch-config",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: naming.GetScyllaDBRackSnitchConfigCMName(sdc, &rack),
+										},
+										Optional: pointer.Ptr(false),
+									},
+								},
+							},
+							{
 								Name: scyllaAgentConfigVolumeName,
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
@@ -732,6 +743,11 @@ exec /mnt/shared/scylla-operator sidecar \
 										Name:      "scylladb-managed-config",
 										MountPath: naming.ScyllaDBManagedConfigDir,
 										ReadOnly:  true,
+									},
+									{
+										Name:      "scylladb-snitch-config",
+										ReadOnly:  true,
+										MountPath: naming.ScyllaDBSnitchConfigDir,
 									},
 									{
 										Name:      "scylla-client-config-volume",
@@ -1693,6 +1709,76 @@ func MakeJobs(sdc *scyllav1alpha1.ScyllaDBDatacenter, services map[string]*corev
 	}
 
 	return jobs, progressingConditions, nil
+}
+
+func MakeManagedScyllaDBConfigMaps(sdc *scyllav1alpha1.ScyllaDBDatacenter) ([]*corev1.ConfigMap, error) {
+	var managedCMs []*corev1.ConfigMap
+
+	scyllaDBConfigCM, err := MakeManagedScyllaDBConfig(sdc)
+	if err != nil {
+		return nil, fmt.Errorf("can't make managed scylladb config: %w", err)
+	}
+
+	managedCMs = append(managedCMs, scyllaDBConfigCM)
+
+	scyllaDBSnitchConfigCMs, err := MakeManagedScyllaDBSnitchConfig(sdc)
+	if err != nil {
+		return nil, fmt.Errorf("can't make managed scylladb snitch config: %w", err)
+	}
+
+	managedCMs = append(managedCMs, scyllaDBSnitchConfigCMs...)
+
+	return managedCMs, nil
+}
+
+func MakeManagedScyllaDBSnitchConfig(sdc *scyllav1alpha1.ScyllaDBDatacenter) ([]*corev1.ConfigMap, error) {
+	snitchConfigsCMs := make([]*corev1.ConfigMap, 0, len(sdc.Spec.Racks))
+
+	for _, rack := range sdc.Spec.Racks {
+		cm, _, err := scylladbassets.ScyllaDBSnitchConfigTemplate.Get().RenderObject(
+			map[string]any{
+				"Namespace":        sdc.Namespace,
+				"Name":             naming.GetScyllaDBRackSnitchConfigCMName(sdc, &rack),
+				"SnitchConfigName": naming.ScyllaRackDCPropertiesName,
+				"DatacenterName":   naming.GetScyllaDBDatacenterGossipDatacenterName(sdc),
+				"RackName":         rack.Name,
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("can't render scylladb snitch config for rack %q: %w", rack.Name, err)
+		}
+
+		cm.SetOwnerReferences([]metav1.OwnerReference{
+			{
+				APIVersion:         scyllaDBDatacenterControllerGVK.GroupVersion().String(),
+				Kind:               scyllaDBDatacenterControllerGVK.Kind,
+				Name:               sdc.Name,
+				UID:                sdc.UID,
+				Controller:         pointer.Ptr(true),
+				BlockOwnerDeletion: pointer.Ptr(true),
+			},
+		})
+
+		if cm.Labels == nil {
+			cm.Labels = map[string]string{}
+		}
+		maps.Copy(cm.Labels, sdc.Labels)
+		maps.Copy(cm.Labels, naming.ClusterLabels(sdc))
+
+		if cm.Annotations == nil {
+			cm.Annotations = map[string]string{}
+		}
+		// As ScyllaDBDatacenter may be managed object (when user is using scyllav1.ScyllaCluster API), managed
+		// hash from it shouldn't propagate into dependency objects to not trigger unnecessary double rollouts.
+		sdcAnnotations := maps.Clone(sdc.Annotations)
+		delete(sdcAnnotations, naming.ManagedHash)
+
+		maps.Copy(cm.Annotations, sdcAnnotations)
+
+		snitchConfigsCMs = append(snitchConfigsCMs, cm)
+	}
+
+	return snitchConfigsCMs, nil
 }
 
 func MakeManagedScyllaDBConfig(sdc *scyllav1alpha1.ScyllaDBDatacenter) (*corev1.ConfigMap, error) {

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -127,6 +127,7 @@ const (
 	ScyllaAgentConfigDefaultFile = "/etc/scylla-manager-agent/scylla-manager-agent.yaml"
 	ScyllaClientConfigDirName    = "/mnt/scylla-client-config"
 	ScyllaDBManagedConfigDir     = "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/managed-config"
+	ScyllaDBSnitchConfigDir      = "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/snitch-config"
 	ScyllaConfigName             = "scylla.yaml"
 	ScyllaDBManagedConfigName    = "scylladb-managed-config.yaml"
 	ScyllaManagedConfigPath      = ScyllaDBManagedConfigDir + "/" + ScyllaDBManagedConfigName

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -236,6 +236,10 @@ func GetScyllaDBManagedConfigCMName(clusterName string) string {
 	return fmt.Sprintf("%s-managed-config", clusterName)
 }
 
+func GetScyllaDBRackSnitchConfigCMName(sdc *scyllav1alpha1.ScyllaDBDatacenter, rack *scyllav1alpha1.RackSpec) string {
+	return fmt.Sprintf("%s-%s-snitch-config", sdc.Name, rack.Name)
+}
+
 func GetScyllaDBDatacenterGossipDatacenterName(sdc *scyllav1alpha1.ScyllaDBDatacenter) string {
 	if sdc.Spec.DatacenterName != nil && len(*sdc.Spec.DatacenterName) != 0 {
 		return *sdc.Spec.DatacenterName


### PR DESCRIPTION
**Description of your changes:**

Moved the generation of snitch configuration from the sidecar to the Operator.
ScyllaDB's GossipingPropertyFileSnitch, which is set as the default by the Operator-managed configuration, supports specifying only three properties: "rack", "dc", and "prefer_local".
The fourth possible property, "dc_suffix", previously taken from the user-provided configuration, is not supported by GossipingPropertyFileSnitch.
However users can still provide their own snitch configuration through a ScyllaDB ConfigMap reference in the rack specification and override the snitch type setting.
These custom configurations are preserved and missing setting is applied from the user-provided configuration.

**Which issue is resolved by this Pull Request:**
Resolves #1720 

/cc 
