### PR TITLE
Unify the use of taints and tolerations in deploy, docs, examples and tests

### DIFF
--- a/docs/source/resources/scyllaclusters/multidc/multidc.md
+++ b/docs/source/resources/scyllaclusters/multidc/multidc.md
@@ -164,10 +164,10 @@ spec:
                 values:
                 - scylla
         tolerations:
-        - key: role
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
           operator: Equal
-          value: scylla-clusters
-          effect: NoSchedule
+          value: scyllaclusters
     - name: b
       members: 1
       storage:
@@ -208,10 +208,10 @@ spec:
                 values:
                 - scylla
         tolerations:
-        - key: role
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
           operator: Equal
-          value: scylla-clusters
-          effect: NoSchedule
+          value: scyllaclusters
     - name: c
       members: 1
       storage:
@@ -252,10 +252,10 @@ spec:
                 values:
                 - scylla
         tolerations:
-        - key: role
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
           operator: Equal
-          value: scylla-clusters
-          effect: NoSchedule
+          value: scyllaclusters
 ```
 
 Apply the manifest:
@@ -418,10 +418,10 @@ spec:
                 values:
                 - scylla
         tolerations:
-        - key: role
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
           operator: Equal
-          value: scylla-clusters
-          effect: NoSchedule
+          value: scyllaclusters
     - name: b
       members: 1
       storage:
@@ -462,10 +462,10 @@ spec:
                 values:
                 - scylla
         tolerations:
-        - key: role
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
           operator: Equal
-          value: scylla-clusters
-          effect: NoSchedule
+          value: scyllaclusters
     - name: c
       members: 1
       storage:
@@ -506,10 +506,10 @@ spec:
                 values:
                 - scylla
         tolerations:
-        - key: role
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
           operator: Equal
-          value: scylla-clusters
-          effect: NoSchedule
+          value: scyllaclusters
 ```
 
 To apply the manifest, run:

--- a/examples/common/nodeconfig-alpha.yaml
+++ b/examples/common/nodeconfig-alpha.yaml
@@ -6,3 +6,8 @@ spec:
   placement:
     nodeSelector:
       scylla.scylladb.com/node-type: scylla
+    tolerations:
+    - effect: NoSchedule
+      key: scylla-operator.scylladb.com/dedicated
+      operator: Equal
+      value: scyllaclusters

--- a/examples/eks/scyllacluster.yaml
+++ b/examples/eks/scyllacluster.yaml
@@ -33,10 +33,10 @@ spec:
                       values:
                         - scylla
           tolerations:
-            - key: role
+            - effect: NoSchedule
+              key: scylla-operator.scylladb.com/dedicated
               operator: Equal
-              value: scylla-clusters
-              effect: NoSchedule
+              value: scyllaclusters
       - name: b
         members: 1
         storage:
@@ -60,10 +60,10 @@ spec:
                       values:
                         - scylla
           tolerations:
-            - key: role
+            - effect: NoSchedule
+              key: scylla-operator.scylladb.com/dedicated
               operator: Equal
-              value: scylla-clusters
-              effect: NoSchedule
+              value: scyllaclusters
       - name: c
         members: 1
         storage:
@@ -87,7 +87,7 @@ spec:
                       values:
                         - scylla
           tolerations:
-            - key: role
+            - effect: NoSchedule
+              key: scylla-operator.scylladb.com/dedicated
               operator: Equal
-              value: scylla-clusters
-              effect: NoSchedule
+              value: scyllaclusters

--- a/examples/generic/nodeconfig-alpha.yaml
+++ b/examples/generic/nodeconfig-alpha.yaml
@@ -18,10 +18,9 @@ spec:
       - prjquota
   placement:
     nodeSelector:
-      kubernetes.io/os: linux
       scylla.scylladb.com/node-type: scylla
     tolerations:
     - effect: NoSchedule
-      key: role
+      key: scylla-operator.scylladb.com/dedicated
       operator: Equal
-      value: scylla-clusters
+      value: scyllaclusters

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -19,3 +19,9 @@ racks:
       requests:
         cpu: 1
         memory: 1Gi
+    placement:
+      tolerations:
+      - effect: NoSchedule
+        key: scylla-operator.scylladb.com/dedicated
+        operator: Equal
+        value: scyllaclusters

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -21,7 +21,7 @@ racks:
         memory: 1Gi
     placement:
       tolerations:
-      - effect: NoSchedule
-        key: scylla-operator.scylladb.com/dedicated
-        operator: Equal
-        value: scyllaclusters
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -40,7 +40,7 @@ scylla:
           memory: 200Mi
       placement:
         tolerations:
-        - effect: NoSchedule
-          key: scylla-operator.scylladb.com/dedicated
-          operator: Equal
-          value: scyllaclusters
+          - effect: NoSchedule
+            key: scylla-operator.scylladb.com/dedicated
+            operator: Equal
+            value: scyllaclusters

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -38,3 +38,9 @@ scylla:
         requests:
           cpu: 1
           memory: 200Mi
+      placement:
+        tolerations:
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters

--- a/examples/monitoring/v1alpha1/scylladbmonitoring.yaml
+++ b/examples/monitoring/v1alpha1/scylladbmonitoring.yaml
@@ -18,6 +18,12 @@ spec:
             resources:
               requests:
                 storage: 1Gi
+      placement:
+        tolerations:
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
     grafana:
       exposeOptions:
         webInterface:

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -24,3 +24,9 @@ spec:
           limits:
             cpu: 1
             memory: 1Gi
+        placement:
+          tolerations:
+          - effect: NoSchedule
+            key: scylla-operator.scylladb.com/dedicated
+            operator: Equal
+            value: scyllaclusters

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -26,7 +26,7 @@ spec:
             memory: 1Gi
         placement:
           tolerations:
-          - effect: NoSchedule
-            key: scylla-operator.scylladb.com/dedicated
-            operator: Equal
-            value: scyllaclusters
+            - effect: NoSchedule
+              key: scylla-operator.scylladb.com/dedicated
+              operator: Equal
+              value: scyllaclusters

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -79,10 +79,10 @@ scylla:
           memory: 200Mi
       placement:
         tolerations:
-        - effect: NoSchedule
-          key: scylla-operator.scylladb.com/dedicated
-          operator: Equal
-          value: scyllaclusters
+          - effect: NoSchedule
+            key: scylla-operator.scylladb.com/dedicated
+            operator: Equal
+            value: scyllaclusters
 # Whether to create Prometheus ServiceMonitor
 serviceMonitor:
   create: false

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -77,6 +77,12 @@ scylla:
         requests:
           cpu: 1
           memory: 200Mi
+      placement:
+        tolerations:
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
 # Whether to create Prometheus ServiceMonitor
 serviceMonitor:
   create: false

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -68,10 +68,10 @@ racks:
         memory: 4Gi
     placement:
       tolerations:
-      - effect: NoSchedule
-        key: scylla-operator.scylladb.com/dedicated
-        operator: Equal
-        value: scyllaclusters
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
 # Whether to create Prometheus ServiceMonitor
 serviceMonitor:
   create: false

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -66,6 +66,12 @@ racks:
       requests:
         cpu: 1
         memory: 4Gi
+    placement:
+      tolerations:
+      - effect: NoSchedule
+        key: scylla-operator.scylladb.com/dedicated
+        operator: Equal
+        value: scyllaclusters
 # Whether to create Prometheus ServiceMonitor
 serviceMonitor:
   create: false

--- a/test/e2e/fixture/scylla/nodeconfig.yaml
+++ b/test/e2e/fixture/scylla/nodeconfig.yaml
@@ -6,3 +6,8 @@ spec:
   placement:
     nodeSelector:
       scylla.scylladb.com/node-type: scylla
+    tolerations:
+    - effect: NoSchedule
+      key: scylla-operator.scylladb.com/dedicated
+      operator: Equal
+      value: scyllaclusters

--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -35,3 +35,9 @@ spec:
         limits:
           cpu: 1
           memory: 1Gi
+      placement:
+        tolerations:
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters

--- a/test/e2e/fixture/scylla/scylladbcluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbcluster.yaml.tmpl
@@ -34,6 +34,12 @@ spec:
       nodes: 1
     racks:
     - name: a
+    placement:
+      tolerations:
+      - effect: NoSchedule
+        key: scylla-operator.scylladb.com/dedicated
+        operator: Equal
+        value: scyllaclusters
   datacenters:
   {{- range $rkcIdx, $rkc := .remoteKubernetesClusters }}
   - name: dc-{{ $rkcIdx }}

--- a/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
@@ -40,5 +40,11 @@ spec:
         type: {{ .clientsBroadcastAddressType }}
   rackTemplate:
     nodes: 1
+    placement:
+      tolerations:
+      - effect: NoSchedule
+        key: scylla-operator.scylladb.com/dedicated
+        operator: Equal
+        value: scyllaclusters
   racks:
   - name: us-east-1a

--- a/test/e2e/fixture/scylla/scylladbmonitoring.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbmonitoring.yaml.tmpl
@@ -28,6 +28,12 @@ spec:
             resources:
               requests:
                 storage: 1Gi
+      placement:
+        tolerations:
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
     grafana:
       exposeOptions:
         webInterface:

--- a/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
@@ -36,6 +36,12 @@ spec:
         limits:
           cpu: 1
           memory: 1Gi
+      placement:
+        tolerations:
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
     {{- end }}
   sysctls:
    - fs.aio-max-nr=30000000


### PR DESCRIPTION
**Description of your changes:** This PR unifies the use of taints and tolerations in our manifests, tests and docs.
All of the workloads requiring storage tolerate `scylla-operator.scylladb.com/dedicated:scyllaclusters:NoSchedule` taint.

/kind cleanup
/priority important-longterm

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2049
