### PR TITLE
Explicitly disable developerMode when it's not set in the API object

### DIFF
--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -621,6 +621,8 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 
 								if sdc.Spec.ScyllaDB.EnableDeveloperMode != nil && *sdc.Spec.ScyllaDB.EnableDeveloperMode {
 									positionalArgs = append(positionalArgs, "--developer-mode=1")
+								} else {
+									positionalArgs = append(positionalArgs, "--developer-mode=0")
 								}
 
 								cmd := []string{
@@ -673,19 +675,12 @@ exec /mnt/shared/scylla-operator sidecar \
 
 											return strings.Join(optionalArgs, ` \`)
 										}() +
-										func() string {
-											if len(positionalArgs) > 0 {
-												return ` -- "$@"`
-											}
-											return ""
-										}(),
+										` -- "$@"`,
 									),
 								}
 
-								if len(positionalArgs) > 0 {
-									cmd = append(cmd, "--")
-									cmd = append(cmd, positionalArgs...)
-								}
+								cmd = append(cmd, "--")
+								cmd = append(cmd, positionalArgs...)
 
 								return cmd
 							}(),

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -744,7 +744,10 @@ exec /mnt/shared/scylla-operator sidecar \
 --service-name=$(SERVICE_NAME) \
 --cpu-count=$(CPU_COUNT) \
 --loglevel=2 \
+ -- "$@"
 `),
+										"--",
+										"--developer-mode=0",
 									}
 								}(),
 								Env: []corev1.EnvVar{
@@ -1309,7 +1312,12 @@ scylla-manager-agent \
 			expectedStatefulSet: func() *appsv1.StatefulSet {
 				sts := newBasicStatefulSet()
 
-				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command[len(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command)-1] += "\n--external-seeds=10.0.1.1,10.0.1.2,10.0.1.3"
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command[len(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command)-3] = strings.Replace(
+					sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command[len(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command)-3],
+					` -- "$@"`,
+					"--external-seeds=10.0.1.1,10.0.1.2,10.0.1.3 -- \"$@\"",
+					1,
+				)
 
 				return sts
 			}(),
@@ -1332,8 +1340,7 @@ scylla-manager-agent \
 			expectedStatefulSet: func() *appsv1.StatefulSet {
 				sts := newBasicStatefulSet()
 
-				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command[len(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command)-1] += "\n -- \"$@\""
-				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command = append(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command, "--", "--batch-size-warn-threshold-in-kb=128", "--batch-size-fail-threshold-in-kb", "1024", "--commitlog-sync=\"batch\"")
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command = append(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command[:len(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command)-1], "--batch-size-warn-threshold-in-kb=128", "--batch-size-fail-threshold-in-kb", "1024", "--commitlog-sync=\"batch\"", "--developer-mode=0")
 
 				return sts
 			}(),
@@ -1351,8 +1358,7 @@ scylla-manager-agent \
 			expectedStatefulSet: func() *appsv1.StatefulSet {
 				sts := newBasicStatefulSet()
 
-				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command[len(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command)-1] += "\n -- \"$@\""
-				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command = append(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command, "--", "--developer-mode=1")
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command[len(sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Command)-1] = "--developer-mode=1"
 
 				return sts
 			}(),


### PR DESCRIPTION
ScyllaDB contianer image enables developerMode if it's not explicitly disabled. It's the opposite logic to what we had in the past, which was changed in #2137 by mistake. This restores previous logic of explicitly disabling developerMode unless it's enabled in the API object.

Resolves #2237
