### PR TITLE
Fix sidecar annotation controller rate limits for better response times

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	go.uber.org/config v1.4.0
 	golang.org/x/oauth2 v0.24.0
 	golang.org/x/sys v0.27.0
+	golang.org/x/time v0.8.0
 	google.golang.org/grpc v1.68.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.11
@@ -178,7 +179,6 @@ require (
 	golang.org/x/sync v0.9.0 // indirect
 	golang.org/x/term v0.26.0 // indirect
 	golang.org/x/text v0.20.0 // indirect
-	golang.org/x/time v0.8.0 // indirect
 	golang.org/x/tools v0.27.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241118233622-e639e219e697 // indirect
 	google.golang.org/protobuf v1.35.2 // indirect


### PR DESCRIPTION
**Description of your changes:**
The sidecar controller is syncing a single key for the ScyllaDB node where it's running. By design its retries will marginally differ from what you need for a shared queue, yet that's what we had. This means that in cases where it got failing, it could be rate limited up to 1000s at which point it is not responsive and may cause issues with probes as well.

