### PR TITLE
Use client CA bundle as truststore

### DIFF
--- a/assets/scylladb/managedconfig.cm.yaml
+++ b/assets/scylladb/managedconfig.cm.yaml
@@ -19,7 +19,7 @@ data:
       certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
       keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
       require_client_auth: true
-      truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+      truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
     {{- end }}
     {{- if .Spec.ScyllaDB.AlternatorOptions }}
     alternator_write_isolation: {{ or .Spec.ScyllaDB.AlternatorOptions.WriteIsolation "always_use_lwt" }}

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -546,8 +546,10 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 								{
 									Name: scylladbClientCAVolumeName,
 									VolumeSource: corev1.VolumeSource{
-										Secret: &corev1.SecretVolumeSource{
-											SecretName: naming.GetScyllaClusterLocalClientCAName(sdc.Name),
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: naming.GetScyllaClusterLocalClientCAName(sdc.Name),
+											},
 										},
 									},
 								},
@@ -746,7 +748,7 @@ exec /mnt/shared/scylla-operator sidecar \
 										},
 										{
 											Name:      scylladbClientCAVolumeName,
-											MountPath: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca",
+											MountPath: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca",
 											ReadOnly:  true,
 										},
 										{

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -627,8 +627,10 @@ func TestStatefulSetForRack(t *testing.T) {
 									{
 										Name: "scylladb-client-ca",
 										VolumeSource: corev1.VolumeSource{
-											Secret: &corev1.SecretVolumeSource{
-												SecretName: "basic-local-client-ca",
+											ConfigMap: &corev1.ConfigMapVolumeSource{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "basic-local-client-ca",
+												},
 											},
 										},
 									},
@@ -813,7 +815,7 @@ exec /mnt/shared/scylla-operator sidecar \
 											},
 											{
 												Name:      "scylladb-client-ca",
-												MountPath: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca",
+												MountPath: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca",
 												ReadOnly:  true,
 											},
 											{
@@ -2845,7 +2847,7 @@ client_encryption_options:
   certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
   keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
   require_client_auth: true
-  truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+  truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
 `, "\n"),
 				},
 			},
@@ -2910,7 +2912,7 @@ client_encryption_options:
   certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
   keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
   require_client_auth: true
-  truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+  truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
 alternator_write_isolation: always_use_lwt
 alternator_enforce_authorization: true
 alternator_https_port: 8043
@@ -2987,7 +2989,7 @@ client_encryption_options:
   certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
   keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
   require_client_auth: true
-  truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+  truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
 alternator_write_isolation: always_use_lwt
 alternator_enforce_authorization: true
 alternator_https_port: 8043
@@ -3064,7 +3066,7 @@ client_encryption_options:
   certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
   keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
   require_client_auth: true
-  truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+  truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
 alternator_write_isolation: always_use_lwt
 alternator_enforce_authorization: true
 alternator_port: 8000
@@ -3142,7 +3144,7 @@ client_encryption_options:
   certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
   keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
   require_client_auth: true
-  truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+  truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
 alternator_write_isolation: always_use_lwt
 alternator_enforce_authorization: false
 alternator_port: 42
@@ -3222,7 +3224,7 @@ client_encryption_options:
   certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
   keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
   require_client_auth: true
-  truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+  truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
 alternator_write_isolation: always_use_lwt
 alternator_enforce_authorization: true
 alternator_port: 42
@@ -3302,7 +3304,7 @@ client_encryption_options:
   certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
   keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
   require_client_auth: true
-  truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+  truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
 alternator_write_isolation: always_use_lwt
 alternator_enforce_authorization: false
 alternator_port: 42
@@ -3382,7 +3384,7 @@ client_encryption_options:
   certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
   keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
   require_client_auth: true
-  truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+  truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
 alternator_write_isolation: always_use_lwt
 alternator_enforce_authorization: true
 alternator_port: 42
@@ -3460,7 +3462,7 @@ client_encryption_options:
   certificate: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.crt"
   keyfile: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/serving-certs/tls.key"
   require_client_auth: true
-  truststore: "/var/run/secrets/scylla-operator.scylladb.com/scylladb/client-ca/tls.crt"
+  truststore: "/var/run/configmaps/scylla-operator.scylladb.com/scylladb/client-ca/ca-bundle.crt"
 alternator_write_isolation: always_use_lwt
 alternator_enforce_authorization: false
 alternator_https_port: 8043


### PR DESCRIPTION
**Description of your changes:** When going over the changes necessary for pausing clusters support, I noticed that ScyllaDB's truststore is only configured with the most recent client CA. We should be configuring it with the CA bundle not to invalidate client certs in case the CA cert rolls.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/cc