### PR TITLE
Add tolerations to workaround sysctl DaemonSet

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -153,6 +153,11 @@ spec:
           wait
       nodeSelector:
         scylla.scylladb.com/node-type: scylla
+      tolerations:
+      - effect: NoSchedule
+        key: scylla-operator.scylladb.com/dedicated
+        operator: Equal
+        value: scyllaclusters
 EOF
   kubectl -n=default rollout status daemonset/sysctl
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** @zimnx noticed that https://github.com/scylladb/scylla-operator/pull/2235 didn't add tolerations to the workaround DaemonSet for setting sysctl, which prevents it from running on scylla dedicated nodes and causes scylla containers to fail. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority critical-urgent
/cc zimnx
