### PR TITLE
Add RemoteKubernetesCluster finalizer

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -436,6 +436,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		o.kubeClient,
 		o.scyllaClient.ScyllaV1alpha1(),
 		scyllaInformers.Scylla().V1alpha1().RemoteKubernetesClusters(),
+		scyllaInformers.Scylla().V1alpha1().ScyllaDBClusters(),
 		kubeInformers.Core().V1().Secrets(),
 		[]remoteclient.DynamicClusterInterface{
 			&o.clusterKubeClient,

--- a/pkg/controller/remotekubernetescluster/conditions.go
+++ b/pkg/controller/remotekubernetescluster/conditions.go
@@ -7,4 +7,7 @@ const (
 	clientHealthcheckControllerAvailableCondition   = "ClientHealthcheckControllerAvailable"
 	clientHealthcheckControllerProgressingCondition = "ClientHealthcheckControllerProgressing"
 	clientHealthcheckControllerDegradedCondition    = "ClientHealthcheckControllerDegraded"
+
+	remoteKubernetesClusterFinalizerProgressingCondition = "RemoteKubernetesClusterFinalizerProgressing"
+	remoteKubernetesClusterFinalizerDegradedCondition    = "RemoteKubernetesClusterFinalizerDegraded"
 )

--- a/pkg/controller/remotekubernetescluster/sync_finalizer.go
+++ b/pkg/controller/remotekubernetescluster/sync_finalizer.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package remotekubernetescluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+func (rkcc *Controller) syncFinalizer(ctx context.Context, rkc *scyllav1alpha1.RemoteKubernetesCluster) ([]metav1.Condition, error) {
+	var progressingConditions []metav1.Condition
+	var err error
+
+	if !slices.ContainsItem(rkc.GetFinalizers(), naming.RemoteKubernetesClusterFinalizer) {
+		klog.V(4).InfoS("Object is already finalized", "RemoteKubernetesCluster", klog.KObj(rkc), "UID", rkc.UID)
+		return progressingConditions, nil
+	}
+
+	klog.V(4).InfoS("Finalizing object", "RemoteKubernetesCluster", klog.KObj(rkc), "UID", rkc.UID)
+
+	isUsed, users, err := rkcc.isBeingUsed(ctx, rkc)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't check if RemoteKubernetesCluster %q is being used: %w", naming.ObjRef(rkc), err)
+	}
+
+	if isUsed {
+		klog.V(2).InfoS("Keeping RemoteKubernetesCluster because it's being used", "RemoteKubernetesCluster", klog.KObj(rkc))
+
+		progressingConditions = append(progressingConditions, metav1.Condition{
+			Type:               remoteKubernetesClusterFinalizerProgressingCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "IsBeingUsed",
+			Message:            fmt.Sprintf("Object is being used by following ScyllaDBCluster(s): %s", strings.Join(users, ",")),
+			ObservedGeneration: rkc.Generation,
+		})
+
+		return progressingConditions, nil
+	}
+
+	err = rkcc.removeFinalizer(ctx, rkc)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't remove finalizer from RemoteKubernetesCluster %q: %w", naming.ObjRef(rkc), err)
+	}
+	return progressingConditions, nil
+}
+
+func (rkcc *Controller) addFinalizer(ctx context.Context, rkc *scyllav1alpha1.RemoteKubernetesCluster) error {
+	patch, err := controllerhelpers.AddFinalizerPatch(rkc, naming.RemoteKubernetesClusterFinalizer)
+	if err != nil {
+		return fmt.Errorf("can't create add finalizer patch: %w", err)
+	}
+
+	_, err = rkcc.scyllaClient.RemoteKubernetesClusters().Patch(ctx, rkc.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("can't patch RemoteKubernetesCluster %q: %w", naming.ObjRef(rkc), err)
+	}
+
+	klog.V(2).InfoS("Added finalizer to RemoteKubernetesCluster", "RemoteKubernetesCluster", klog.KObj(rkc))
+	return nil
+}
+
+func (rkcc *Controller) removeFinalizer(ctx context.Context, rkc *scyllav1alpha1.RemoteKubernetesCluster) error {
+	patch, err := controllerhelpers.RemoveFinalizerPatch(rkc, naming.RemoteKubernetesClusterFinalizer)
+	if err != nil {
+		return fmt.Errorf("can't create remove finalizer patch: %w", err)
+	}
+
+	_, err = rkcc.scyllaClient.RemoteKubernetesClusters().Patch(ctx, rkc.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("can't patch RemoteKubernetesCluster %q: %w", naming.ObjRef(rkc), err)
+	}
+
+	klog.V(2).InfoS("Removed finalizer from RemoteKubernetesCluster", "RemoteKubernetesCluster", klog.KObj(rkc))
+	return nil
+}
+
+func (rkcc *Controller) isBeingUsed(ctx context.Context, rkc *scyllav1alpha1.RemoteKubernetesCluster) (bool, []string, error) {
+	scs, err := rkcc.scyllaDBClusterLister.List(labels.Everything())
+	if err != nil {
+		return false, nil, fmt.Errorf("can't list all ScyllaClusters using lister: %w", err)
+	}
+
+	var scyllaDBClusterReferents []string
+	for _, sc := range scs {
+		for _, dc := range sc.Spec.Datacenters {
+			if dc.RemoteKubernetesClusterName == rkc.Name {
+				scyllaDBClusterReferents = append(scyllaDBClusterReferents, naming.ObjRef(sc))
+			}
+		}
+	}
+
+	if len(scyllaDBClusterReferents) != 0 {
+		klog.V(4).InfoS("Listed ScyllaClusters using Informer and found ScyllaDBCluster's referencing it", "RemoteKubernetesCluster", klog.KObj(rkc), "ScyllaDBClusters", scyllaDBClusterReferents)
+		return true, scyllaDBClusterReferents, nil
+	}
+
+	klog.V(4).InfoS("No ScyllaClusters referencing RemoteKubernetesCluster found in the Informer cache", "RemoteKubernetesCluster", klog.KObj(rkc))
+
+	// Live list ScyllaClusters to be 100% sure before we delete. Informer cache might not be updated yet.
+	scList, err := rkcc.scyllaClient.ScyllaDBClusters(corev1.NamespaceAll).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.Everything().String(),
+	})
+	if err != nil {
+		return false, nil, fmt.Errorf("list all ScyllaClusters using lister: %w", err)
+	}
+
+	scyllaDBClusterReferents = scyllaDBClusterReferents[:0]
+	for _, sc := range scList.Items {
+		for _, dc := range sc.Spec.Datacenters {
+			if dc.RemoteKubernetesClusterName == rkc.Name {
+				scyllaDBClusterReferents = append(scyllaDBClusterReferents, naming.ObjRef(&sc))
+			}
+		}
+	}
+
+	if len(scyllaDBClusterReferents) != 0 {
+		klog.V(4).InfoS("Listed ScyllaClusters using live call and found ScyllaCluster's referencing it", "RemoteKubernetesCluster", klog.KObj(rkc), "ScyllaClusters", scyllaDBClusterReferents)
+		return true, scyllaDBClusterReferents, nil
+	}
+
+	klog.V(2).InfoS("RemoteKubernetesCluster doesn't have any referents", "RemoteKubernetesCluster", klog.KObj(rkc))
+
+	return false, nil, nil
+}

--- a/pkg/controllerhelpers/finalizers.go
+++ b/pkg/controllerhelpers/finalizers.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package controllerhelpers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type objectForFinalizersPatch struct {
+	objectMetaForFinalizersPatch `json:"metadata"`
+}
+
+// objectMetaForFinalizersPatch defines object meta struct for finalizers patch operation.
+type objectMetaForFinalizersPatch struct {
+	ResourceVersion string   `json:"resourceVersion"`
+	Finalizers      []string `json:"finalizers"`
+}
+
+func RemoveFinalizerPatch(obj metav1.Object, finalizer string) ([]byte, error) {
+	if !HasFinalizer(obj, finalizer) {
+		return nil, nil
+	}
+
+	finalizers := obj.GetFinalizers()
+	var newFinalizers []string
+
+	for _, f := range finalizers {
+		if f == finalizer {
+			continue
+		}
+		newFinalizers = append(newFinalizers, f)
+	}
+
+	patch, err := json.Marshal(&objectForFinalizersPatch{
+		objectMetaForFinalizersPatch: objectMetaForFinalizersPatch{
+			ResourceVersion: obj.GetResourceVersion(),
+			Finalizers:      newFinalizers,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't marshal finalizer remove patch: %w", err)
+	}
+
+	return patch, nil
+}
+
+func AddFinalizerPatch(obj metav1.Object, finalizer string) ([]byte, error) {
+	if HasFinalizer(obj, finalizer) {
+		return nil, nil
+	}
+	newFinalizers := make([]string, 0, len(obj.GetFinalizers())+1)
+	for _, f := range obj.GetFinalizers() {
+		newFinalizers = append(newFinalizers, f)
+	}
+	newFinalizers = append(newFinalizers, finalizer)
+
+	patch, err := json.Marshal(&objectForFinalizersPatch{
+		objectMetaForFinalizersPatch: objectMetaForFinalizersPatch{
+			ResourceVersion: obj.GetResourceVersion(),
+			Finalizers:      newFinalizers,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't marshal finalizer add patch: %w", err)
+	}
+
+	return patch, nil
+}
+
+func HasFinalizer(obj metav1.Object, finalizer string) bool {
+	found := false
+	for _, f := range obj.GetFinalizers() {
+		if f == finalizer {
+			found = true
+			break
+		}
+	}
+	return found
+}

--- a/pkg/controllerhelpers/finalizers_test.go
+++ b/pkg/controllerhelpers/finalizers_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package controllerhelpers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAddFinalizerPatch(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name          string
+		obj           metav1.Object
+		finalizer     string
+		expectedPatch []byte
+		expectedError error
+	}{
+		{
+			name:          "object has empty finalizers",
+			obj:           &metav1.ObjectMeta{ResourceVersion: "123", Finalizers: []string{}},
+			finalizer:     "my-finalizer",
+			expectedPatch: []byte(`{"metadata":{"resourceVersion":"123","finalizers":["my-finalizer"]}}`),
+			expectedError: nil,
+		},
+		{
+			name:          "duplicate finalizer",
+			obj:           &metav1.ObjectMeta{ResourceVersion: "123", Finalizers: []string{"a", "my-finalizer", "c"}},
+			finalizer:     "my-finalizer",
+			expectedPatch: nil,
+			expectedError: nil,
+		},
+	}
+
+	for i := range tt {
+		tc := tt[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			patch, err := AddFinalizerPatch(tc.obj, tc.finalizer)
+			if err != tc.expectedError {
+				t.Errorf("expected error %s, got %s", tc.expectedError, err)
+			}
+			if !equality.Semantic.DeepEqual(patch, tc.expectedPatch) {
+				t.Errorf("expected patch %s, got %s", string(tc.expectedPatch), string(patch))
+			}
+		})
+	}
+}
+
+func TestRemoveFinalizerPatch(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name          string
+		obj           metav1.Object
+		finalizer     string
+		expectedPatch []byte
+		expectedError error
+	}{
+		{
+			name:          "object is missing given finalizer",
+			obj:           &metav1.ObjectMeta{ResourceVersion: "123", Finalizers: []string{}},
+			finalizer:     "my-finalizer",
+			expectedPatch: nil,
+			expectedError: nil,
+		},
+		{
+			name:          "patch removes finalizer",
+			obj:           &metav1.ObjectMeta{ResourceVersion: "123", Finalizers: []string{"a", "my-finalizer", "c"}},
+			finalizer:     "my-finalizer",
+			expectedPatch: []byte(`{"metadata":{"resourceVersion":"123","finalizers":["a","c"]}}`),
+			expectedError: nil,
+		},
+		{
+			name:          "patch removes last finalizer",
+			obj:           &metav1.ObjectMeta{ResourceVersion: "123", Finalizers: []string{"my-finalizer"}},
+			finalizer:     "my-finalizer",
+			expectedPatch: []byte(`{"metadata":{"resourceVersion":"123","finalizers":null}}`),
+			expectedError: nil,
+		},
+	}
+
+	for i := range tt {
+		tc := tt[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			patch, err := RemoveFinalizerPatch(tc.obj, tc.finalizer)
+			if err != tc.expectedError {
+				t.Errorf("expected error %s, got %s", tc.expectedError, err)
+			}
+			if !equality.Semantic.DeepEqual(patch, tc.expectedPatch) {
+				t.Errorf("expected patch %s, got %s", string(tc.expectedPatch), string(patch))
+			}
+		})
+	}
+}
+
+func TestHasFinalizer(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name           string
+		obj            metav1.Object
+		finalizer      string
+		expectedResult bool
+	}{
+		{
+			name:           "false when empty finalizer list",
+			obj:            &metav1.ObjectMeta{Finalizers: []string{}},
+			finalizer:      "my-finalizer",
+			expectedResult: false,
+		},
+		{
+			name:           "true when object contains finalizer",
+			obj:            &metav1.ObjectMeta{Finalizers: []string{"a", "b", "my-finalizer", "c"}},
+			finalizer:      "my-finalizer",
+			expectedResult: true,
+		},
+	}
+
+	for i := range tt {
+		tc := tt[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := HasFinalizer(tc.obj, tc.finalizer)
+			if got != tc.expectedResult {
+				t.Errorf("expected %v, got %v", tc.expectedResult, got)
+			}
+		})
+	}
+}

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -232,3 +232,7 @@ const (
 const (
 	OperatorAppNameWithDomain = "scylla-operator.scylladb.com"
 )
+
+const (
+	RemoteKubernetesClusterFinalizer = "scylla-operator.scylladb.com/remotekubernetescluster-protection"
+)

--- a/test/e2e/set/remotekubernetescluster/config.go
+++ b/test/e2e/set/remotekubernetescluster/config.go
@@ -1,9 +1,27 @@
 package remotekubernetescluster
 
-import "time"
+import (
+	"time"
+
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/gather/collect"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 const (
 	testSetupTimeout    = 1 * time.Minute
 	testTeardownTimeout = 1 * time.Minute
-	testTimeout         = 3 * time.Minute
+	testTimeout         = 30 * time.Minute
+)
+
+var (
+	remoteKubernetesClusterResourceInfo = collect.ResourceInfo{
+		Resource: schema.GroupVersionResource{
+			Group:    scyllav1alpha1.GroupName,
+			Version:  scyllav1alpha1.GroupVersion.Version,
+			Resource: "remotekubernetesclusters",
+		},
+		Scope: meta.RESTScopeRoot,
+	}
 )

--- a/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
+++ b/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package remotekubernetescluster
+
+import (
+	"context"
+	"fmt"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("RemoteKubernetesCluster finalizer", func() {
+	f := framework.NewFramework("remotekubernetescluster")
+
+	g.It("should block deletion when there are ScyllaDBClusters referencing the object", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		idx := 0
+		cluster := f.Cluster(idx)
+		userNs, _ := cluster.CreateUserNamespace(ctx)
+
+		rkcName := fmt.Sprintf("%s-%d", f.Namespace(), idx)
+
+		framework.By("Creating RemoteKubernetesCluster %q with credentials to cluster #%d", rkcName, idx)
+		originalRKC, err := utils.GetRemoteKubernetesClusterWithOperatorClusterRole(ctx, cluster.KubeAdminClient(), cluster.AdminClientConfig(), rkcName, userNs.Name)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		rc := framework.NewRestoringCleaner(
+			ctx,
+			f.KubeAdminClient(),
+			f.DynamicAdminClient(),
+			remoteKubernetesClusterResourceInfo,
+			originalRKC.Namespace,
+			originalRKC.Name,
+			framework.RestoreStrategyRecreate,
+		)
+		f.AddCleaners(rc)
+
+		rkc, err := cluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters().Create(ctx, originalRKC, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the RemoteKubernetesCluster %q to roll out (RV=%s)", rkc.Name, rkc.ResourceVersion)
+		waitCtx1, waitCtx1Cancel := utils.ContextForRemoteKubernetesClusterRollout(ctx, rkc)
+		defer waitCtx1Cancel()
+
+		const expectedFinalizer = "scylla-operator.scylladb.com/remotekubernetescluster-protection"
+		hasRKCFinalizer := func(rkc *scyllav1alpha1.RemoteKubernetesCluster) (bool, error) {
+			return slices.ContainsItem(rkc.Finalizers, expectedFinalizer), nil
+		}
+
+		rkc, err = controllerhelpers.WaitForRemoteKubernetesClusterState(waitCtx1, cluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters(), rkc.Name, controllerhelpers.WaitForStateOptions{},
+			utils.IsRemoteKubernetesClusterRolledOut,
+			hasRKCFinalizer,
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Deleting RemoteKubernetesCluster %q", rkc.Name)
+		err = cluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters().Delete(ctx, rkcName, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Awaiting RemoteKubernetesCluster %q deletion", rkc.Name)
+		err = framework.WaitForObjectDeletion(ctx, f.DynamicAdminClient(), scyllav1alpha1.GroupVersion.WithResource("remotekubernetesclusters"), rkc.Namespace, rkc.Name, nil)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Recreating RemoteKubernetesCluster %q", rkcName)
+		rkc = originalRKC.DeepCopy()
+		rkc, err = cluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters().Create(ctx, rkc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the RemoteKubernetesCluster %q to roll out (RV=%s)", rkc.Name, rkc.ResourceVersion)
+		waitCtx2, waitCtx2Cancel := utils.ContextForRemoteKubernetesClusterRollout(ctx, rkc)
+		defer waitCtx2Cancel()
+
+		rkc, err = controllerhelpers.WaitForRemoteKubernetesClusterState(waitCtx2, cluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters(), rkc.Name, controllerhelpers.WaitForStateOptions{},
+			utils.IsRemoteKubernetesClusterRolledOut,
+			hasRKCFinalizer,
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Creating ScyllaDBCluster using RemoteKubernetesCluster %q", rkcName)
+		sc1 := f.GetDefaultScyllaDBCluster([]*scyllav1alpha1.RemoteKubernetesCluster{rkc})
+
+		sc1, err = cluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()).Create(ctx, sc1, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaDBCluster %q to roll out (RV=%s)", sc1.Name, sc1.ResourceVersion)
+		waitCtx3, waitCtx3Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc1)
+		defer waitCtx3Cancel()
+		sc1, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx3, cluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()), sc1.Name, controllerhelpers.WaitForStateOptions{},
+			utils.IsScyllaDBClusterRolledOut,
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Deleting RemoteKubernetesCluster %q", rkc.Name)
+		err = cluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters().Delete(ctx, rkcName, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		rkc, err = cluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters().Get(ctx, rkcName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(rkc.DeletionTimestamp).NotTo(o.BeNil())
+
+		hasIsBeingUsedCondition := func(rkc *scyllav1alpha1.RemoteKubernetesCluster) (bool, error) {
+			cond := meta.FindStatusCondition(rkc.Status.Conditions, "RemoteKubernetesClusterFinalizerProgressing")
+			return cond != nil &&
+				cond.Reason == "RemoteKubernetesClusterFinalizerProgressing_IsBeingUsed" &&
+				cond.Status == metav1.ConditionTrue &&
+				cond.ObservedGeneration == rkc.Generation, nil
+		}
+		framework.By("Awaiting IsBeingUsed condition on RemoteKubernetesCluster %q", rkc.Name)
+		waitCtx4, waitCtx4Cancel := utils.ContextForRemoteKubernetesClusterRollout(ctx, rkc)
+		defer waitCtx4Cancel()
+		rkc, err = controllerhelpers.WaitForRemoteKubernetesClusterState(waitCtx4, cluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters(), rkc.Name, controllerhelpers.WaitForStateOptions{},
+			hasRKCFinalizer,
+			hasIsBeingUsedCondition,
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Deleting ScyllaDBCluster %q", sc1.Name)
+		err = cluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc1.Namespace).Delete(ctx, sc1.Name, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Awaiting ScyllaDBCluster %q deletion", sc1.Name)
+		err = framework.WaitForObjectDeletion(ctx, f.DynamicAdminClient(), scyllav1alpha1.GroupVersion.WithResource("scylladbclusters"), sc1.Namespace, sc1.Name, nil)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Awaiting RemoteKubernetesCluster %q deletion", rkc.Name)
+		err = framework.WaitForObjectDeletion(ctx, f.DynamicAdminClient(), scyllav1alpha1.GroupVersion.WithResource("remotekubernetesclusters"), rkc.Namespace, rkc.Name, nil)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})


### PR DESCRIPTION
**Description of your changes:**

Controller reconciles finalizer on RemoteKubernetesCluster, preventing from premature deletion. It waits until all ScyllaDBClusters using particular RemoteKubernetesCluster are deleted.

**Which issue is resolved by this Pull Request:**
Resolves #2277
