### PR TITLE
Fix 'OS Metrics' dashboards in ScyllaDBMonitoring

### DIFF
--- a/assets/monitoring/prometheus/v1/scylladb.servicemonitor.yaml
+++ b/assets/monitoring/prometheus/v1/scylladb.servicemonitor.yaml
@@ -30,6 +30,11 @@ spec:
       regex:  '(.+)'
       targetLabel: dc
       replacement: '${1}'
+    # Scylla Monitoring OS Metrics dashboard expect node exporter metrics to have 'job=node_exporter'
+    - sourceLabels: [__meta_kubernetes_endpoint_port_name]
+      regex: '(.+)'
+      replacement: 'node_exporter'
+      targetLabel: job
   - port: prometheus
     honorLabels: false
     metricRelabelings:

--- a/pkg/controller/scylladbmonitoring/sync_prometheus_test.go
+++ b/pkg/controller/scylladbmonitoring/sync_prometheus_test.go
@@ -63,6 +63,11 @@ spec:
       regex:  '(.+)'
       targetLabel: dc
       replacement: '${1}'
+    # Scylla Monitoring OS Metrics dashboard expect node exporter metrics to have 'job=node_exporter'
+    - sourceLabels: [__meta_kubernetes_endpoint_port_name]
+      regex: '(.+)'
+      replacement: 'node_exporter'
+      targetLabel: job
   - port: prometheus
     honorLabels: false
     metricRelabelings:
@@ -168,6 +173,11 @@ spec:
       regex:  '(.+)'
       targetLabel: dc
       replacement: '${1}'
+    # Scylla Monitoring OS Metrics dashboard expect node exporter metrics to have 'job=node_exporter'
+    - sourceLabels: [__meta_kubernetes_endpoint_port_name]
+      regex: '(.+)'
+      replacement: 'node_exporter'
+      targetLabel: job
   - port: prometheus
     honorLabels: false
     metricRelabelings:


### PR DESCRIPTION
`OS Metrics` dashboard panels require `job="node_exporter.*"` label for metrics coming from node-exporter. Our endpoint for node-exporter had `job="scylla"` which didn't match and as a result dashboard was completely empty. Additional relabelling makes sure that job label has correct value.

After this change, `OS Metrics` dashboards starts showing the data.
![Selection_103](https://github.com/user-attachments/assets/b9c6c9df-35e3-49cf-9ce1-cc87f7904273)


**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #2278
