### PR TITLE
Mark v1.15 as latest stable in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,13 +81,13 @@ redirects_file = "./redirections.yaml"
 TAGS = []
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
-BRANCHES = ['master', 'v1.12', 'v1.13', 'v1.14', 'v1.15']
+BRANCHES = ['master', 'v1.13', 'v1.14', 'v1.15']
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", "v1.15"]
+UNSTABLE_VERSIONS = ["master"]
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.
-smv_latest_version = 'v1.14'
+smv_latest_version = 'v1.15'
 smv_rename_latest_version = 'stable'
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"


### PR DESCRIPTION
**Description of your changes:**

Marks v1.15 as latest stable and removes it from unstable list.

