### PR TITLE
Always terminate leftover jobs in scripts

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -6,6 +6,7 @@
 set -euExo pipefail
 shopt -s inherit_errexit
 
+source "$( dirname "${BASH_SOURCE[0]}" )/../../lib/bash.sh"
 source "$( dirname "${BASH_SOURCE[0]}" )/../../lib/kube.sh"
 
 if [ -z "${KUBECONFIG_DIR+x}" ]; then
@@ -84,6 +85,8 @@ EOF
 }
 
 function gather-artifacts-on-exit {
+  ec=$?
+
   for i in "${!KUBECONFIGS[@]}"; do
     KUBECONFIG="${KUBECONFIGS[$i]}" gather-artifacts "${ARTIFACTS}/must-gather/${i}" &
     gather_artifacts_bg_pids["${i}"]=$!
@@ -92,6 +95,8 @@ function gather-artifacts-on-exit {
   for pid in "${gather_artifacts_bg_pids[@]}"; do
     wait "${pid}"
   done
+
+  cleanup-bg-jobs "${ec}"
 }
 
 function apply-e2e-workarounds {

--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -9,6 +9,7 @@
 set -euxEo pipefail
 shopt -s inherit_errexit
 
+source "$( dirname "${BASH_SOURCE[0]}" )/lib/bash.sh"
 source "$( dirname "${BASH_SOURCE[0]}" )/lib/kube.sh"
 
 if [[ -n "${1+x}" ]]; then
@@ -17,6 +18,8 @@ else
     echo "Missing operator image ref.\nUsage: ${0} <operator_image_ref>" >&2 >/dev/null
     exit 1
 fi
+
+trap cleanup-bg-jobs-on-exit EXIT
 
 source_raw="$( skopeo inspect --format='{{ index .Labels "org.opencontainers.image.source" }}' "docker://${operator_image_ref}" )"
 if [[ -z "${source_raw}" ]]; then

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -8,12 +8,15 @@
 set -euxEo pipefail
 shopt -s inherit_errexit
 
+source "$( dirname "${BASH_SOURCE[0]}" )/lib/bash.sh"
 source "$( dirname "${BASH_SOURCE[0]}" )/lib/kube.sh"
 
 if [[ -z ${1+x} ]]; then
     echo "Missing operator image ref.\nUsage: ${0} <operator_image_ref>" >&2 >/dev/null
     exit 1
 fi
+
+trap cleanup-bg-jobs-on-exit EXIT
 
 ARTIFACTS=${ARTIFACTS:-$( mktemp -d )}
 OPERATOR_IMAGE_REF=${1}

--- a/hack/lib/bash.sh
+++ b/hack/lib/bash.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright (C) 2024 ScyllaDB
+#
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+function cleanup-bg-jobs() {
+  ec=$1
+  mapfile -t bg_jobs < <( jobs -p )
+  if [[ ${#bg_jobs[@]} -ne 0 ]]; then
+    printf "Found %d leftover jobs" "${#bg_jobs[@]}" >> /dev/stderr
+    jobs
+    printf "Killing %d leftover jobs" "${#bg_jobs[@]}" >> /dev/stderr
+    kill "${bg_jobs[@]}"
+    echo "Waiting for terminating jobs to finish" >> /dev/stderr
+    wait
+    exit $(( 127 + ec ))
+  fi
+}
+
+function cleanup-bg-jobs-on-exit() {
+  ec=$?
+  cleanup-bg-jobs "${ec}"
+}


### PR DESCRIPTION
**Description of your changes:**
When a script is terminated we should make sure there are no leftover jobs running on the background. This is especially important in CI where such processes will block container exit and the job will timeout, without logs.

**Which issue is resolved by this Pull Request:**
Resolves #2282
