### PR TITLE
Use strict decoding in e2e tests' fixture registry

### DIFF
--- a/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
@@ -11,25 +11,9 @@ spec:
   datacenterName: us-east-1
   scyllaDB:
     image: "docker.io/scylladb/scylla:{{ .scyllaDBVersion }}"
-    developerMode: true
-    resources:
-      requests:
-        cpu: 10m
-        memory: 100Mi
-      limits:
-        cpu: 1
-        memory: 1Gi
-    storage:
-      capacity: 1Gi
-      {{- if .storageClassName }}
-      storageClassName: {{ .storageClassName }}
-      {{- end }}
+    enableDeveloperMode: true
   scyllaDBManagerAgent:
     image: "docker.io/scylladb/scylla-manager-agent:{{ .scyllaDBManagerVersion }}"
-    resources:
-      requests:
-        cpu: 10m
-        memory: 100Mi
   exposeOptions:
     nodeService:
       type: {{ .nodeServiceType }}
@@ -40,6 +24,24 @@ spec:
         type: {{ .clientsBroadcastAddressType }}
   rackTemplate:
     nodes: 1
+    scyllaDB:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          cpu: 1
+          memory: 1Gi
+      storage:
+        capacity: 1Gi
+        {{- if .storageClassName }}
+        storageClassName: {{ .storageClassName }}
+        {{- end }}
+    scyllaDBManagerAgent:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
     placement:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/test/e2e/scheme/scheme.go
+++ b/test/e2e/scheme/scheme.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	Scheme = runtime.NewScheme()
-	Codecs = serializer.NewCodecFactory(Scheme)
+	Codecs = serializer.NewCodecFactory(Scheme, serializer.EnableStrict)
 )
 
 func DefaultJSONEncoder() runtime.Encoder {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR enables strict mode deserialization in codecs factory used in e2e tests' fixture registry. It also fixes a fixture that got out of sync with the scheme and would start causing the tests to fail otherwise.

**Which issue is resolved by this Pull Request:**
Resolves #2289 

/cc
