### PR TITLE
Docs: remove irrelevant step from Prometheus Operator installation

### DIFF
--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -55,11 +55,6 @@ kubectl wait --for='condition=established' crd/prometheuses.monitoring.coreos.co
 
 # Wait for prometheus operator deployment.
 kubectl -n=prometheus-operator rollout status --timeout=10m deployment.apps/prometheus-operator
-
-# Wait for webhook CA secret to be created.
-for i in {1..30}; do
-    { kubectl -n=cert-manager get secret/cert-manager-webhook-ca && break; } || sleep 1
-done
 :::
 
 ### {{productName}}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
The `# Wait for webhook CA secret to be created.` steps doesn't make sense for Prometheus Operator, thus I'm proposing it's removal.

**Which issue is resolved by this Pull Request:**
N/A
