### PR TITLE
Extend ScyllaDBCluster controller with finalizer

### DIFF
--- a/pkg/controller/scylladbcluster/conditions.go
+++ b/pkg/controller/scylladbcluster/conditions.go
@@ -13,4 +13,6 @@ const (
 	remoteEndpointSliceControllerDegradedCondition         = "RemoteEndpointSliceControllerDegraded"
 	remoteEndpointsControllerProgressingCondition          = "RemoteEndpointsControllerProgressing"
 	remoteEndpointsControllerDegradedCondition             = "RemoteEndpointsControllerDegraded"
+	scyllaDBClusterFinalizerProgressingCondition           = "ScyllaDBClusterFinalizerProgressing"
+	scyllaDBClusterFinalizerDegradedCondition              = "ScyllaDBClusterFinalizerDegraded"
 )

--- a/pkg/controller/scylladbcluster/sync_finalizer.go
+++ b/pkg/controller/scylladbcluster/sync_finalizer.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package scylladbcluster
+
+import (
+	"context"
+	"fmt"
+
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+)
+
+func (scc *Controller) syncFinalizer(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace) ([]metav1.Condition, error) {
+	var progressingConditions []metav1.Condition
+	var err error
+
+	if !scc.hasFinalizer(sc.GetFinalizers()) {
+		klog.V(4).InfoS("Object is already finalized", "ScyllaDBCluster", klog.KObj(sc), "UID", sc.UID)
+		return progressingConditions, nil
+	}
+
+	// Delete remote Namespace for every ScyllaDBCluster's datacenter.
+	// As all remotely reconciled objects are namespaced, except Namespace,
+	// it's enough to remove the Namespace and rely on remote GC to clear the rest.
+	// This may need to be adjusted when the Operator will reconcile other cluster-wide resources.
+	klog.V(4).InfoS("Finalizing object", "ScyllaDBCluster", klog.KObj(sc), "UID", sc.UID)
+
+	informerRemoteNamespaces := map[string][]*corev1.Namespace{}
+	for _, dc := range sc.Spec.Datacenters {
+		remoteNamespace, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
+		if ok {
+			informerRemoteNamespaces[dc.RemoteKubernetesClusterName] = append(informerRemoteNamespaces[dc.RemoteKubernetesClusterName], remoteNamespace)
+		}
+	}
+
+	deletionProgressingCondition, err := scc.deleteRemoteNamespaces(ctx, sc, informerRemoteNamespaces)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't finalize remote Namespaces: %w", err)
+	}
+
+	progressingConditions = append(progressingConditions, deletionProgressingCondition...)
+
+	// Wait until all Namespaces from Informers are gone.
+	if len(informerRemoteNamespaces) != 0 {
+		return progressingConditions, nil
+	}
+
+	// Live list remote Namespaces to be 100% sure before we delete. Informer cache might not be updated yet.
+	var errs []error
+	clientRemoteNamespaces := map[string][]*corev1.Namespace{}
+
+	for _, dc := range sc.Spec.Datacenters {
+		remoteClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't get remote kube client for %q cluster: %w", dc.RemoteKubernetesClusterName, err))
+			continue
+		}
+
+		rnss, err := remoteClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+			LabelSelector: labels.SelectorFromSet(naming.ScyllaDBClusterDatacenterSelectorLabels(sc, &dc)).String(),
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't list remote Namespaces via %q cluster client: %w", dc.RemoteKubernetesClusterName, err))
+			continue
+		}
+
+		if len(rnss.Items) == 0 {
+			continue
+		}
+
+		clientRemoteNamespaces[dc.RemoteKubernetesClusterName] = slices.ConvertSlice(rnss.Items, pointer.Ptr[corev1.Namespace])
+	}
+
+	deletionProgressingCondition, err = scc.deleteRemoteNamespaces(ctx, sc, clientRemoteNamespaces)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't finalize remote Namespaces: %w", err)
+	}
+
+	progressingConditions = append(progressingConditions, deletionProgressingCondition...)
+
+	// Wait until all Namespaces from clients are gone.
+	if len(clientRemoteNamespaces) != 0 {
+		return progressingConditions, nil
+	}
+
+	klog.V(2).InfoS("ScyllaDBCluster no longer has dependant objects, removing finalizer")
+	err = scc.removeFinalizer(ctx, sc)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't remove finalizer from ScyllaDBCluster %q: %w", naming.ObjRef(sc), err)
+	}
+
+	return progressingConditions, nil
+}
+
+func (scc *Controller) deleteRemoteNamespaces(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, namespacesToDelete map[string][]*corev1.Namespace) ([]metav1.Condition, error) {
+	var progressingConditions []metav1.Condition
+	var errs []error
+
+	for remoteCluster, remoteNamespaces := range namespacesToDelete {
+		remoteClient, err := scc.kubeRemoteClient.Cluster(remoteCluster)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't get remote kube client for %q cluster: %w", remoteCluster, err))
+			continue
+		}
+
+		for _, remoteNamespace := range remoteNamespaces {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, scyllaDBClusterFinalizerProgressingCondition, remoteNamespace, "delete", sc.Generation)
+			err = remoteClient.CoreV1().Namespaces().Delete(ctx, remoteNamespace.Name, metav1.DeleteOptions{
+				Preconditions:     metav1.NewUIDPreconditions(string(remoteNamespace.UID)),
+				PropagationPolicy: pointer.Ptr(metav1.DeletePropagationForeground),
+			})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("can't delete remote Namespace %q from %q cluster: %w", naming.ObjRef(remoteNamespace), remoteCluster, err))
+				continue
+			}
+		}
+	}
+
+	err := errors.NewAggregate(errs)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't delete remote namespaces: %w", err)
+	}
+
+	return progressingConditions, nil
+}
+
+func (scc *Controller) hasFinalizer(finalizers []string) bool {
+	return slices.ContainsItem(finalizers, naming.ScyllaDBClusterFinalizer)
+}
+
+func (scc *Controller) addFinalizer(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster) error {
+	if scc.hasFinalizer(sc.GetFinalizers()) {
+		return nil
+	}
+
+	patch, err := controllerhelpers.AddFinalizerPatch(sc, naming.ScyllaDBClusterFinalizer)
+	if err != nil {
+		return fmt.Errorf("can't create add finalizer patch: %w", err)
+	}
+
+	_, err = scc.scyllaClient.ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace).Patch(ctx, sc.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("can't patch ScyllaDBCluster %q: %w", naming.ObjRef(sc), err)
+	}
+
+	klog.V(2).InfoS("Added finalizer to ScyllaDBCluster", "ScyllaDBCluster", klog.KObj(sc))
+	return nil
+}
+
+func (scc *Controller) removeFinalizer(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster) error {
+	patch, err := controllerhelpers.RemoveFinalizerPatch(sc, naming.ScyllaDBClusterFinalizer)
+	if err != nil {
+		return fmt.Errorf("can't create remove finalizer patch: %w", err)
+	}
+
+	_, err = scc.scyllaClient.ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace).Patch(ctx, sc.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("can't patch ScyllaDBCluster %q: %w", naming.ObjRef(sc), err)
+	}
+
+	klog.V(2).InfoS("Removed finalizer from ScyllaDBCluster", "ScyllaDBCluster", klog.KObj(sc))
+	return nil
+}

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -236,4 +236,5 @@ const (
 
 const (
 	RemoteKubernetesClusterFinalizer = "scylla-operator.scylladb.com/remotekubernetescluster-protection"
+	ScyllaDBClusterFinalizer         = "scylla-operator.scylladb.com/scylladbcluster-protection"
 )

--- a/test/e2e/set/scylladbcluster/multidatacenter_scylladbcluster_finalizer.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter_scylladbcluster_finalizer.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2024 ScyllaDB.
+
+package scylladbcluster
+
+import (
+	"context"
+	"fmt"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	v1alpha1utils "github.com/scylladb/scylla-operator/test/e2e/utils/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var _ = g.Describe("ScyllaDBCluster finalizer", framework.MultiDatacenter, func() {
+	f := framework.NewFramework("scylladbcluster")
+
+	g.It("should delete remote Namespaces when ScyllaDBCluster is deleted", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		availableClusters := len(framework.TestContext.RestConfigs)
+
+		framework.By("Creating RemoteKubernetesClusters")
+		rkcs := make([]*scyllav1alpha1.RemoteKubernetesCluster, 0, availableClusters)
+		rkcClusterMap := make(map[string]framework.ClusterInterface, availableClusters)
+
+		metaCluster := f.Cluster(0)
+		for idx := range availableClusters {
+			cluster := f.Cluster(idx)
+			userNs, _ := cluster.CreateUserNamespace(ctx)
+
+			clusterName := fmt.Sprintf("%s-%d", f.Namespace(), idx)
+
+			framework.By("Creating SA having Operator ClusterRole in #%d cluster", idx)
+			adminKubeconfig, err := utils.GetKubeConfigHavingOperatorRemoteClusterRole(ctx, cluster.KubeAdminClient(), cluster.AdminClientConfig(), clusterName, userNs.Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			kubeconfig, err := clientcmd.Write(adminKubeconfig)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			rkc, err := utils.GetRemoteKubernetesClusterWithKubeconfig(ctx, metaCluster.KubeAdminClient(), kubeconfig, clusterName, f.Namespace())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			rc := framework.NewRestoringCleaner(
+				ctx,
+				f.KubeAdminClient(),
+				f.DynamicAdminClient(),
+				remoteKubernetesClusterResourceInfo,
+				rkc.Namespace,
+				rkc.Name,
+				framework.RestoreStrategyRecreate,
+			)
+			f.AddCleaners(rc)
+			rc.DeleteObject(ctx, true)
+
+			framework.By("Creating RemoteKubernetesCluster %q with credentials to cluster #%d", clusterName, idx)
+			rkc, err = metaCluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters().Create(ctx, rkc, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			rkcs = append(rkcs, rkc)
+			rkcClusterMap[rkc.Name] = cluster
+		}
+
+		for _, rkc := range rkcs {
+			func() {
+				framework.By("Waiting for the RemoteKubernetesCluster %q to roll out (RV=%s)", rkc.Name, rkc.ResourceVersion)
+				waitCtx1, waitCtx1Cancel := utils.ContextForRemoteKubernetesClusterRollout(ctx, rkc)
+				defer waitCtx1Cancel()
+
+				_, err := controllerhelpers.WaitForRemoteKubernetesClusterState(waitCtx1, metaCluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters(), rkc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsRemoteKubernetesClusterRolledOut)
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}()
+		}
+
+		framework.By("Creating ScyllaDBCluster")
+		var err error
+		sc := f.GetDefaultScyllaDBCluster(rkcs)
+		sc, err = metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaDBCluster %q roll out (RV=%s)", sc.Name, sc.ResourceVersion)
+		waitCtx2, waitCtx2Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
+		defer waitCtx2Cancel()
+		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx2, metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaDBClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyScyllaDBCluster(ctx, sc, rkcClusterMap)
+		err = v1alpha1utils.WaitForFullScyllaDBClusterQuorum(ctx, rkcClusterMap, sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		const expectedFinalizer = "scylla-operator.scylladb.com/scylladbcluster-protection"
+		o.Expect(sc.Finalizers).To(o.ContainElement(expectedFinalizer))
+
+		framework.By("Validating there are remote Namespaces matching ScyllaDBCluster selector")
+		o.Expect(rkcs).NotTo(o.BeEmpty())
+		for i := range rkcs {
+			namespaces, err := f.Cluster(i).KubeAdminClient().CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+				LabelSelector: naming.ScyllaDBClusterSelector(sc).String(),
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(namespaces.Items).NotTo(o.BeEmpty())
+		}
+
+		framework.By("Deleting ScyllaDBCluster")
+		err = metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()).Delete(ctx, sc.Name, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for ScyllaDBCluster %q to be removed.", sc.Name)
+		err = framework.WaitForObjectDeletion(ctx, f.DynamicClient(), scyllav1alpha1.SchemeGroupVersion.WithResource("scylladbclusters"), sc.Namespace, sc.Name, &sc.UID)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Verifying if all remote Namespaces having ScyllaDBCluster %q selector are gone.", sc.Name)
+		o.Expect(sc.Spec.Datacenters).ToNot(o.BeEmpty())
+		for i := range rkcs {
+			namespaces, err := f.Cluster(i).KubeAdminClient().CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+				LabelSelector: naming.ScyllaDBClusterSelector(sc).String(),
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(namespaces.Items).To(o.BeEmpty())
+		}
+	})
+})


### PR DESCRIPTION
Finalizer makes sure that before ScyllaDBCluster deletion, all dependant remote Namespaces (and other resources dependant on Namespace) are removed before ScyllaDBCluster is removed.

/cc 

Resolves #2481 