### PR TITLE
Move overriding Scylla Operator's log level to CI scripts and make it configurable

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -211,15 +211,6 @@ function run-e2e {
   kubectl create clusterrolebinding e2e --clusterrole=cluster-admin --serviceaccount=e2e:default --dry-run=client -o=yaml | kubectl_create -f=-
   kubectl create -n=e2e pdb my-pdb --selector='app=e2e' --min-available=1 --dry-run=client -o=yaml | kubectl_create -f=-
 
-
-  # Raise loglevel in CI.
-  # TODO: Replace it with ScyllaOperatorConfig field when available.
-  kubectl -n=scylla-operator patch --field-manager="${FIELD_MANAGER}" deployment/scylla-operator --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--loglevel=4"}]'
-  kubectl -n=scylla-operator rollout status deployment/scylla-operator
-
-  kubectl -n=scylla-manager patch --field-manager="${FIELD_MANAGER}" deployment/scylla-manager-controller --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--loglevel=4"}]'
-  kubectl -n=scylla-manager rollout status deployment/scylla-manager-controller
-
   kubectl create -n=e2e secret generic kubeconfigs ${KUBECONFIGS[@]/#/--from-file=} --dry-run=client -o=yaml | kubectl_create -f=-
   kubeconfigs_in_container_path=$( IFS=','; basenames=( "${KUBECONFIGS[@]##*/}" ) && in_container_paths="${basenames[@]/#//var/run/secrets/kubeconfigs/}" && echo "${in_container_paths[*]}" )
 

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -37,6 +37,13 @@ for f in $( find "${DEPLOY_DIR}"/ -type f -name '*.yaml' ); do
     sed -i -E -e "s~docker\.io/scylladb/scylla-operator:[^ @]+$~${OPERATOR_IMAGE_REF}~" "${f}"
 done
 
+# TODO: Replace it with ScyllaOperatorConfig field when available.
+# Ref: https://github.com/scylladb/scylla-operator/issues/2314.
+SO_SCYLLA_OPERATOR_LOGLEVEL="${SO_SCYLLA_OPERATOR_LOGLEVEL:-4}"
+export SO_SCYLLA_OPERATOR_LOGLEVEL
+yq e --inplace '.spec.template.spec.containers[0].args += "--loglevel=" + env(SO_SCYLLA_OPERATOR_LOGLEVEL)' "${DEPLOY_DIR}/operator/50_operator.deployment.yaml"
+yq e --inplace '.spec.template.spec.containers[0].args += "--loglevel=" + env(SO_SCYLLA_OPERATOR_LOGLEVEL)' "${DEPLOY_DIR}/manager/50_controller_deployment.yaml"
+
 yq e --inplace '.spec.template.spec.containers[0].args += ["--qps=200", "--burst=400"]' "${DEPLOY_DIR}/operator/50_operator.deployment.yaml"
 yq e --inplace '.spec.template.spec.containers[0].args += ["--crypto-key-buffer-size-min=3", "--crypto-key-buffer-size-max=6", "--crypto-key-buffer-delay=2s"]' "${DEPLOY_DIR}/operator/50_operator.deployment.yaml"
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Currently, the Operator's and manager controller's loglevels are patched after they have already been deployed, which causes a rolling restart. It prevents us from giving operator guaranteed QoS in CI with resources >= half of what's available because PDB blocks the restart and everything gets stuck.

This PR moves the adjustment to CI scripts and makes the value configurable through e2e scripts.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2296

/cc
