### PR TITLE
Add a dedicated CI script to run E2Es with published releases on OpenShift on AWS

### DIFF
--- a/hack/.ci/run-e2e-openshift-aws-release.sh
+++ b/hack/.ci/run-e2e-openshift-aws-release.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2025 ScyllaDB
+#
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+trap 'kill $( jobs -p ); exit 0' EXIT
+
+if [ -z "${ARTIFACTS+x}" ]; then
+  echo "ARTIFACTS can't be empty" > /dev/stderr
+  exit 2
+fi
+
+source "$( dirname "${BASH_SOURCE[0]}" )/../lib/kube.sh"
+source "$( dirname "${BASH_SOURCE[0]}" )/lib/e2e.sh"
+parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
+
+trap gather-artifacts-on-exit EXIT
+
+REENTRANT="${REENTRANT=false}"
+export REENTRANT
+
+SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=${parent_dir}/manifests/cluster/nodeconfig-openshift-aws.yaml}"
+export SO_NODECONFIG_PATH
+
+SO_SCYLLACLUSTER_STORAGECLASS_NAME="${SO_SCYLLACLUSTER_STORAGECLASS_NAME=scylladb-local-xfs}"
+export SO_SCYLLACLUSTER_STORAGECLASS_NAME
+
+SCYLLA_OPERATOR_FEATURE_GATES="${SCYLLA_OPERATOR_FEATURE_GATES:-AllAlpha=true,AllBeta=true}"
+export SCYLLA_OPERATOR_FEATURE_GATES
+
+for i in "${!KUBECONFIGS[@]}"; do
+  KUBECONFIG="${KUBECONFIGS[$i]}" DEPLOY_DIR="${ARTIFACTS}/deploy/${i}" timeout --foreground -v 10m "${parent_dir}/../ci-deploy-release.sh" "${SO_IMAGE}" &
+  ci_deploy_bg_pids["${i}"]=$!
+done
+
+for pid in "${ci_deploy_bg_pids[@]}"; do
+  wait "${pid}"
+done
+
+KUBECONFIG="${KUBECONFIGS[0]}" apply-e2e-workarounds
+KUBECONFIG="${KUBECONFIGS[0]}" run-e2e


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR adds a dedicated script running `/hack/ci-deploy-release.sh` for OpenShift on AWS periodics/postsubmits, similar to what we currently do with GKE.

**Which issue is resolved by this Pull Request:**
Partially addresses https://github.com/scylladb/scylla-operator-release/issues/371

/kind machinery
/priority important-soon
/cc