### PR TITLE
Fix default Local CSI Driver manifest paths in CI deploy release script

### DIFF
--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -87,7 +87,7 @@ else
 fi
 
 if [[ -z "${SO_CSI_DRIVER_PATH+x}" ]]; then
-  kubectl_create -n=local-csi-driver -f="${source_url}/${revision}/examples/common/local-volume-provisioner/local-csi-driver/"{00_namespace.yaml,00_scylladb-local-xfs.storageclass.yaml,10_csidriver.yaml,10_driver.serviceaccount.yaml,10_provisioner_clusterrole.yaml,20_provisioner_clusterrolebinding.yaml,50_daemonset.yaml}
+  kubectl_create -n=local-csi-driver -f="${source_url}/${revision}/examples/common/local-volume-provisioner/local-csi-driver/"{00_clusterrole.yaml,00_clusterrole_def.yaml,00_clusterrole_def_openshift.yaml,00_namespace.yaml,00_scylladb-local-xfs.storageclass.yaml,10_csidriver.yaml,10_serviceaccount.yaml,20_clusterrolebinding.yaml,50_daemonset.yaml}
   kubectl -n=local-csi-driver rollout status --timeout=5m daemonset.apps/local-csi-driver
 elif [[ -n "${SO_CSI_DRIVER_PATH}" ]]; then
   kubectl_create -n=local-csi-driver -f="${SO_CSI_DRIVER_PATH}"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** https://github.com/scylladb/scylla-operator/pull/1955 broke ci-deploy-release script becaused it changed local-csi-driver manifests and the test verifying the script's correctness was overridden.
This PR fixes the paths.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2300

/kind bug
/priority critical-urgent
/cc