### PR TITLE
Sync CI Openshift NodeConfig NVMe disks discovery with AWS

### DIFF
--- a/hack/.ci/manifests/cluster/nodeconfig-openshift-aws.yaml
+++ b/hack/.ci/manifests/cluster/nodeconfig-openshift-aws.yaml
@@ -17,7 +17,8 @@ spec:
       type: RAID0
       RAID0:
         devices:
-          nameRegex: ^/dev/nvme[1-9]\d*n\d+$
+          modelRegex: Amazon EC2 NVMe Instance Storage
+          nameRegex: ^/dev/nvme\d+n\d+$
   placement:
     nodeSelector:
       scylla.scylladb.com/node-type: scylla


### PR DESCRIPTION
Openshift is being run on AWS where pattern for Local NVMes is different and requires an additional model filter. Currently there's a chance that on two different workers local disk would be called differently, one not matching existing regex.

Example from one of CI cluster:
worker-0:
```
[root@ip-10-0-49-204 /]# fdisk -l
Disk /dev/nvme0n1: 120 GiB, 128849018880 bytes, 251658240 sectors
Disk model: Amazon Elastic Block Store              
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 4096 bytes / 4096 bytes
Disklabel type: gpt
Disk identifier: 518D7F6F-1D64-406E-AC7F-2B9FC8D72F4F

Device           Start       End   Sectors   Size Type
/dev/nvme0n1p1    2048      4095      2048     1M BIOS boot
/dev/nvme0n1p2    4096    264191    260096   127M EFI System
/dev/nvme0n1p3  264192   1050623    786432   384M Linux filesystem
/dev/nvme0n1p4 1050624 251658206 250607583 119.5G Linux filesystem


Disk /dev/nvme1n1: 279.4 GiB, 300000000000 bytes, 585937500 sectors
Disk model: Amazon EC2 NVMe Instance Storage        
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes


Disk /dev/md127: 279.27 GiB, 299864424448 bytes, 585672704 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 1048576 bytes / 1048576 bytes
[root@ip-10-0-49-204 /]# 

```

worker-1:
```
[root@ip-10-0-56-235 /]# fdisk -l
Disk /dev/nvme0n1: 279.4 GiB, 300000000000 bytes, 585937500 sectors
Disk model: Amazon EC2 NVMe Instance Storage        
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes


Disk /dev/nvme1n1: 120 GiB, 128849018880 bytes, 251658240 sectors
Disk model: Amazon Elastic Block Store              
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 4096 bytes / 4096 bytes
Disklabel type: gpt
Disk identifier: 914B69F4-DD9B-4453-8353-08DA721C0252

Device           Start       End   Sectors   Size Type
/dev/nvme1n1p1    2048      4095      2048     1M BIOS boot
/dev/nvme1n1p2    4096    264191    260096   127M EFI System
/dev/nvme1n1p3  264192   1050623    786432   384M Linux filesystem
/dev/nvme1n1p4 1050624 251658206 250607583 119.5G Linux filesystem
```