### PR TITLE
Clean up `ScyllaCluster` GET `ClusterRole`

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -27980,15 +27980,6 @@ rules:
   - list
   - patch
   - watch
-# Sidecar no longer fetches ScyllaClusters. Necessary information is provided by the Operator to sidecar via ScyllaDB config or arguments.
-# However, to ensure smooth Operator updates, this cannot be removed earlier than in 1.16.
-# TODO: remove this permission in Operator >=1.16 (https://github.com/scylladb/scylla-operator/issues/2141)
-- apiGroups:
-  - scylla.scylladb.com
-  resources:
-  - scyllaclusters
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:

--- a/deploy/operator/00_scyllacluster_member_clusterrole_def.yaml
+++ b/deploy/operator/00_scyllacluster_member_clusterrole_def.yaml
@@ -47,15 +47,6 @@ rules:
   - list
   - patch
   - watch
-# Sidecar no longer fetches ScyllaClusters. Necessary information is provided by the Operator to sidecar via ScyllaDB config or arguments.
-# However, to ensure smooth Operator updates, this cannot be removed earlier than in 1.16.
-# TODO: remove this permission in Operator >=1.16 (https://github.com/scylladb/scylla-operator/issues/2141)
-- apiGroups:
-  - scylla.scylladb.com
-  resources:
-  - scyllaclusters
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:

--- a/helm/scylla-operator/templates/scyllacluster_member_clusterrole_def.yaml
+++ b/helm/scylla-operator/templates/scyllacluster_member_clusterrole_def.yaml
@@ -47,15 +47,6 @@ rules:
   - list
   - patch
   - watch
-# Sidecar no longer fetches ScyllaClusters. Necessary information is provided by the Operator to sidecar via ScyllaDB config or arguments.
-# However, to ensure smooth Operator updates, this cannot be removed earlier than in 1.16.
-# TODO: remove this permission in Operator >=1.16 (https://github.com/scylladb/scylla-operator/issues/2141)
-- apiGroups:
-  - scylla.scylladb.com
-  resources:
-  - scyllaclusters
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**Description of your changes:**
Deletes the `GET` verb permission from the member `ClusterRole` because Operator >=1.16 no longer needs it.

**Which issue is resolved by this Pull Request:**
Resolves #2141 
