### PR TITLE
Fix the reference to contributing guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ If you find a bug please file an [issue](https://github.com/scylladb/scylla-oper
 We are also available on `#scylla-operator` channel on [Slack](https://scylladb-users.slack.com) if you have questions.
 
 ## Contributing
-We would **love** you to contribute to Scylla Operator, help make it even better and learn together! Have a look at the [Contributing Guide](docs/source/contributing.md) or reach out to us on `#scylla-operator` channel on [Slack](https://scylladb-users.slack.com/) if you have questions.
+We would **love** you to contribute to Scylla Operator, help make it even better and learn together! Have a look at the [Contributing Guide](CONTRIBUTING.md) or reach out to us on `#scylla-operator` channel on [Slack](https://scylladb-users.slack.com/) if you have questions.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** After the recent changes to the readme and contributing guide, the readme still uses a wrong path for the contributing guide. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind cleanup
/priority important-soon