### PR TITLE
Support configuring ScyllaDB and Scylla Manager versions for e2e tests with flags

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -207,6 +207,13 @@ function run-e2e {
   SO_BUCKET_NAME="${SO_BUCKET_NAME:-}"
   SO_E2E_PARALLELISM="${SO_E2E_PARALLELISM:-0}"
 
+  config_file="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../../../assets/config/config.yaml")"
+  SCYLLADB_VERSION="${SCYLLADB_VERSION:-$(yq '.operator.scyllaDBVersion' "$config_file")}"
+  SCYLLADB_MANAGER_VERSION="${SCYLLADB_MANAGER_VERSION:-$(yq '.operator.scyllaDBManagerVersion' "$config_file")}"
+  SCYLLADB_MANAGER_AGENT_VERSION="${SCYLLADB_MANAGER_AGENT_VERSION:-$(yq '.operator.scyllaDBManagerAgentVersion' "$config_file")}"
+  SCYLLADB_UPDATE_FROM_VERSION="${SCYLLADB_UPDATE_FROM_VERSION:-$(yq '.operatorTests.scyllaDBVersions.updateFrom' "$config_file")}"
+  SCYLLADB_UPGRADE_FROM_VERSION="${SCYLLADB_UPGRADE_FROM_VERSION:-$(yq '.operatorTests.scyllaDBVersions.upgradeFrom' "$config_file")}"
+
   kubectl create namespace e2e --dry-run=client -o=yaml | kubectl_create -f=-
   kubectl create clusterrolebinding e2e --clusterrole=cluster-admin --serviceaccount=e2e:default --dry-run=client -o=yaml | kubectl_create -f=-
   kubectl create -n=e2e pdb my-pdb --selector='app=e2e' --min-available=1 --dry-run=client -o=yaml | kubectl_create -f=-
@@ -274,6 +281,11 @@ spec:
     - "--object-storage-bucket=${SO_BUCKET_NAME}"
     - "--gcs-service-account-key-path=${gcs_sa_in_container_path}"
     - "--s3-credentials-file-path=${s3_credentials_in_container_path}"
+    - "--scylladb-version=${SCYLLADB_VERSION}"
+    - "--scylladb-manager-version=${SCYLLADB_MANAGER_VERSION}"
+    - "--scylladb-manager-agent-version=${SCYLLADB_MANAGER_AGENT_VERSION}"
+    - "--scylladb-update-from-version=${SCYLLADB_UPDATE_FROM_VERSION}"
+    - "--scylladb-upgrade-from-version=${SCYLLADB_UPGRADE_FROM_VERSION}"
     image: "${SO_IMAGE}"
     imagePullPolicy: Always
     volumeMounts:

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -113,6 +113,19 @@ if [[ -n "${SO_SCYLLACLUSTER_STORAGECLASS_NAME:-}" ]]; then
 elif [[ -n "${SO_SCYLLACLUSTER_STORAGECLASS_NAME+x}" ]]; then
   yq e --inplace 'del(.spec.datacenter.racks[0].storage.storageClassName)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"
 fi
+
+if [[ -n "${SCYLLADB_VERSION:-}" ]]; then
+  yq e --inplace '.spec.version = env(SCYLLADB_VERSION)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"
+fi
+
+if [[ -n "${SCYLLA_MANAGER_VERSION:-}" ]]; then
+  yq e --inplace '.spec.template.spec.containers[0].image |= "docker.io/scylladb/scylla-manager:" + env(SCYLLA_MANAGER_VERSION)' "${DEPLOY_DIR}/manager/50_manager_deployment.yaml"
+fi
+
+if [[ -n "${SCYLLA_MANAGER_AGENT_VERSION:-}" ]]; then
+  yq e --inplace '.spec.agentVersion = env(SCYLLA_MANAGER_AGENT_VERSION)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"
+fi
+
 kubectl_create -f "${DEPLOY_DIR}"/manager
 
 kubectl -n=scylla-manager wait --timeout=10m --for='condition=Progressing=False' scyllaclusters.scylla.scylladb.com/scylla-manager-cluster

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -12,7 +12,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	configassets "github.com/scylladb/scylla-operator/assets/config"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
@@ -135,8 +134,8 @@ func (f *Framework) CommonLabels() map[string]string {
 
 func (f *Framework) GetDefaultScyllaCluster() *scyllav1.ScyllaCluster {
 	renderArgs := map[string]any{
-		"scyllaDBVersion":             configassets.Project.Operator.ScyllaDBVersion,
-		"scyllaDBManagerVersion":      configassets.Project.Operator.ScyllaDBManagerAgentVersion,
+		"scyllaDBVersion":             TestContext.ScyllaDBVersion,
+		"scyllaDBManagerVersion":      TestContext.ScyllaDBManagerAgentVersion,
 		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
 		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
@@ -151,8 +150,8 @@ func (f *Framework) GetDefaultScyllaCluster() *scyllav1.ScyllaCluster {
 
 func (f *Framework) GetDefaultZonalScyllaClusterWithThreeRacks() *scyllav1.ScyllaCluster {
 	renderArgs := map[string]any{
-		"scyllaDBVersion":             configassets.Project.Operator.ScyllaDBVersion,
-		"scyllaDBManagerVersion":      configassets.Project.Operator.ScyllaDBManagerAgentVersion,
+		"scyllaDBVersion":             TestContext.ScyllaDBVersion,
+		"scyllaDBManagerVersion":      TestContext.ScyllaDBManagerAgentVersion,
 		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
 		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
@@ -168,8 +167,8 @@ func (f *Framework) GetDefaultZonalScyllaClusterWithThreeRacks() *scyllav1.Scyll
 
 func (f *Framework) GetDefaultScyllaDBDatacenter() *scyllav1alpha1.ScyllaDBDatacenter {
 	renderArgs := map[string]any{
-		"scyllaDBVersion":             configassets.Project.Operator.ScyllaDBVersion,
-		"scyllaDBManagerVersion":      configassets.Project.Operator.ScyllaDBManagerVersion,
+		"scyllaDBVersion":             TestContext.ScyllaDBVersion,
+		"scyllaDBManagerVersion":      TestContext.ScyllaDBManagerAgentVersion,
 		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
 		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
@@ -184,8 +183,8 @@ func (f *Framework) GetDefaultScyllaDBDatacenter() *scyllav1alpha1.ScyllaDBDatac
 
 func (f *Framework) GetDefaultScyllaDBCluster(rkcs []*scyllav1alpha1.RemoteKubernetesCluster) *scyllav1alpha1.ScyllaDBCluster {
 	renderArgs := map[string]any{
-		"scyllaDBVersion":             configassets.Project.Operator.ScyllaDBVersion,
-		"scyllaDBManagerVersion":      configassets.Project.Operator.ScyllaDBManagerAgentVersion,
+		"scyllaDBVersion":             TestContext.ScyllaDBVersion,
+		"scyllaDBManagerVersion":      TestContext.ScyllaDBManagerAgentVersion,
 		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
 		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -43,13 +43,18 @@ const (
 )
 
 type TestContextType struct {
-	RestConfigs          []*restclient.Config
-	ArtifactsDir         string
-	CleanupPolicy        CleanupPolicyType
-	IngressController    *IngressController
-	ScyllaClusterOptions *ScyllaClusterOptions
-	ObjectStorageType    ObjectStorageType
-	ObjectStorageBucket  string
-	GCSServiceAccountKey []byte
-	S3CredentialsFile    []byte
+	RestConfigs                 []*restclient.Config
+	ArtifactsDir                string
+	CleanupPolicy               CleanupPolicyType
+	IngressController           *IngressController
+	ScyllaClusterOptions        *ScyllaClusterOptions
+	ObjectStorageType           ObjectStorageType
+	ObjectStorageBucket         string
+	GCSServiceAccountKey        []byte
+	S3CredentialsFile           []byte
+	ScyllaDBVersion             string
+	ScyllaDBManagerVersion      string
+	ScyllaDBManagerAgentVersion string
+	ScyllaDBUpdateFrom          string
+	ScyllaDBUpgradeFrom         string
 }

--- a/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
@@ -8,7 +8,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	configassets "github.com/scylladb/scylla-operator/assets/config"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
@@ -115,32 +114,32 @@ var _ = g.Describe("ScyllaCluster upgrades", func() {
 		g.Entry(describeEntry, &entry{
 			rackCount:      1,
 			rackSize:       1,
-			initialVersion: configassets.Project.OperatorTests.ScyllaDBVersions.UpdateFrom,
-			updatedVersion: configassets.Project.Operator.ScyllaDBVersion,
+			initialVersion: framework.TestContext.ScyllaDBUpdateFrom,
+			updatedVersion: framework.TestContext.ScyllaDBVersion,
 		}),
 		g.Entry(describeEntry, &entry{
 			rackCount:      1,
 			rackSize:       3,
-			initialVersion: configassets.Project.OperatorTests.ScyllaDBVersions.UpdateFrom,
-			updatedVersion: configassets.Project.Operator.ScyllaDBVersion,
+			initialVersion: framework.TestContext.ScyllaDBUpdateFrom,
+			updatedVersion: framework.TestContext.ScyllaDBVersion,
 		}),
 		g.Entry(describeEntry, &entry{
 			rackCount:      1,
 			rackSize:       1,
-			initialVersion: configassets.Project.OperatorTests.ScyllaDBVersions.UpgradeFrom,
-			updatedVersion: configassets.Project.Operator.ScyllaDBVersion,
+			initialVersion: framework.TestContext.ScyllaDBUpgradeFrom,
+			updatedVersion: framework.TestContext.ScyllaDBVersion,
 		}),
 		g.Entry(describeEntry, &entry{
 			rackCount:      1,
 			rackSize:       3,
-			initialVersion: configassets.Project.OperatorTests.ScyllaDBVersions.UpgradeFrom,
-			updatedVersion: configassets.Project.Operator.ScyllaDBVersion,
+			initialVersion: framework.TestContext.ScyllaDBUpgradeFrom,
+			updatedVersion: framework.TestContext.ScyllaDBVersion,
 		}),
 		g.Entry(describeEntry, &entry{
 			rackCount:      2,
 			rackSize:       3,
-			initialVersion: configassets.Project.OperatorTests.ScyllaDBVersions.UpgradeFrom,
-			updatedVersion: configassets.Project.Operator.ScyllaDBVersion,
+			initialVersion: framework.TestContext.ScyllaDBUpgradeFrom,
+			updatedVersion: framework.TestContext.ScyllaDBVersion,
 		}),
 	)
 })


### PR DESCRIPTION
**Description of your changes:**
This PR makes the flags for ScyllaDB and Scylla Manager versions configurable. Hardcoded values (versions) in config.yaml will be overwritten by the ones passed as arguments.

**Which issue is resolved by this Pull Request:**
Resolves #2320
