### PR TITLE
Add a NodeConfig manifest for CI jobs on GKE on arm64

### DIFF
--- a/hack/.ci/manifests/cluster/nodeconfig-gke-arm64.yaml
+++ b/hack/.ci/manifests/cluster/nodeconfig-gke-arm64.yaml
@@ -1,0 +1,26 @@
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: NodeConfig
+metadata:
+  name: cluster
+spec:
+  localDiskSetup:
+    loopDevices:
+    - name: persistent-volumes
+      imagePath: /var/lib/persistent-volumes.img
+      size: 80Gi
+    filesystems:
+    - device: /dev/loops/persistent-volumes
+      type: xfs
+    mounts:
+    - device: /dev/loops/persistent-volumes
+      mountPoint: /var/lib/persistent-volumes
+      unsupportedOptions:
+      - prjquota
+  placement:
+    nodeSelector:
+      scylla.scylladb.com/node-type: scylla
+    tolerations:
+    - effect: NoSchedule
+      key: scylla-operator.scylladb.com/dedicated
+      operator: Equal
+      value: scyllaclusters


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR adds a dedicated NodeConfig manifest for CI jobs on GKE on arm64, required to address https://github.com/scylladb/scylla-operator-release/issues/383.

**Which issue is resolved by this Pull Request:**
Resolves #

Prerequisite for https://github.com/scylladb/scylla-operator-release/pull/385.

/kind failing-test
/priority important-soon