### PR TITLE
Make RSA key size configurable in operator command

### DIFF
--- a/pkg/crypto/certcreators_test.go
+++ b/pkg/crypto/certcreators_test.go
@@ -79,7 +79,7 @@ func TestX509CertCreator_MakeCertificate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			keygen, err := NewRSAKeyGenerator(1, 1, 42*time.Hour)
+			keygen, err := NewRSAKeyGenerator(1, 1, 4096, 42*time.Hour)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/crypto/config.go
+++ b/pkg/crypto/config.go
@@ -5,6 +5,5 @@ import (
 )
 
 var (
-	keySize            = 4096
 	signatureAlgorithm = x509.SHA512WithRSA
 )

--- a/pkg/crypto/keygenerator.go
+++ b/pkg/crypto/keygenerator.go
@@ -22,7 +22,7 @@ type RSAKeyGenerator struct {
 
 var _ RSAKeyGetter = &RSAKeyGenerator{}
 
-func NewRSAKeyGenerator(min, max int, delay time.Duration) (*RSAKeyGenerator, error) {
+func NewRSAKeyGenerator(min, max, keySize int, delay time.Duration) (*RSAKeyGenerator, error) {
 	g, err := itemgenerator.NewGenerator[rsa.PrivateKey]("RSAKeyGenerator", min, max, delay, func() (*rsa.PrivateKey, error) {
 		privateKey, err := rsa.GenerateKey(rand.Reader, keySize)
 		if err != nil {

--- a/pkg/kubecrypto/certs_test.go
+++ b/pkg/kubecrypto/certs_test.go
@@ -726,7 +726,7 @@ func Test_makeCertificate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			keygen, err := ocrypto.NewRSAKeyGenerator(1, 1, 42*time.Hour)
+			keygen, err := ocrypto.NewRSAKeyGenerator(1, 1, 4096, 42*time.Hour)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR makes RSA key size configurable in the operator command. Changes in CI scripts have to go separately: https://github.com/scylladb/scylla-operator/pull/2360#issuecomment-2636456633.

Prerequisite for https://github.com/scylladb/scylla-operator/pull/2474.

**Which issue is resolved by this Pull Request:**
Resolves #


/kind machinery
/priority important-soon
/cc
