### PR TITLE
Make RSA key size configurable in CI scripts and use 2048 bits in E2E CI jobs by default

### DIFF
--- a/hack/.ci/run-e2e-shared.env.sh
+++ b/hack/.ci/run-e2e-shared.env.sh
@@ -22,6 +22,8 @@ if [[ -n "${SO_E2E_PARALLELISM:-}" && "${SO_E2E_PARALLELISM}" -ne 0 ]]; then
   crypto_key_buffer_size_multiplier="${SO_E2E_PARALLELISM}"
 fi
 
+SO_CRYPTO_KEY_SIZE="${SO_CRYPTO_KEY_SIZE:-2048}"
+export SO_CRYPTO_KEY_SIZE
 SO_CRYPTO_KEY_BUFFER_SIZE_MIN="${SO_CRYPTO_KEY_BUFFER_SIZE_MIN:-$(( 6 * "${crypto_key_buffer_size_multiplier}" ))}"
 export SO_CRYPTO_KEY_BUFFER_SIZE_MIN
 SO_CRYPTO_KEY_BUFFER_SIZE_MAX="${SO_CRYPTO_KEY_BUFFER_SIZE_MAX:-$(( 10 * "${crypto_key_buffer_size_multiplier}" ))}"

--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -58,6 +58,8 @@ wait-for-object-creation cert-manager secret/cert-manager-webhook-ca
 SO_SCYLLA_OPERATOR_LOGLEVEL="${SO_SCYLLA_OPERATOR_LOGLEVEL:-4}"
 export SO_SCYLLA_OPERATOR_LOGLEVEL
 
+SO_CRYPTO_KEY_SIZE="${SO_CRYPTO_KEY_SIZE:-4096}"
+export SO_CRYPTO_KEY_SIZE
 SO_CRYPTO_KEY_BUFFER_SIZE_MIN="${SO_CRYPTO_KEY_BUFFER_SIZE_MIN:-6}"
 export SO_CRYPTO_KEY_BUFFER_SIZE_MIN
 SO_CRYPTO_KEY_BUFFER_SIZE_MAX="${SO_CRYPTO_KEY_BUFFER_SIZE_MAX:-10}"
@@ -92,6 +94,9 @@ patches:
     kind: Deployment
     name: scylla-operator
 - patch: |
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--crypto-key-size=${SO_CRYPTO_KEY_SIZE}"
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: "--crypto-key-buffer-size-min=${SO_CRYPTO_KEY_BUFFER_SIZE_MIN}"

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -66,11 +66,13 @@ fi
 
 yq e --inplace '.spec.template.spec.containers[0].args += ["--qps=200", "--burst=400"]' "${DEPLOY_DIR}/operator/50_operator.deployment.yaml"
 
+SO_CRYPTO_KEY_SIZE="${SO_CRYPTO_KEY_SIZE:-4096}"
+export SO_CRYPTO_KEY_SIZE
 SO_CRYPTO_KEY_BUFFER_SIZE_MIN="${SO_CRYPTO_KEY_BUFFER_SIZE_MIN:-6}"
 export SO_CRYPTO_KEY_BUFFER_SIZE_MIN
 SO_CRYPTO_KEY_BUFFER_SIZE_MAX="${SO_CRYPTO_KEY_BUFFER_SIZE_MAX:-10}"
 export SO_CRYPTO_KEY_BUFFER_SIZE_MAX
-yq e --inplace '.spec.template.spec.containers[0].args += ["--crypto-key-buffer-size-min="+env(SO_CRYPTO_KEY_BUFFER_SIZE_MIN), "--crypto-key-buffer-size-max="+env(SO_CRYPTO_KEY_BUFFER_SIZE_MAX), "--crypto-key-buffer-delay=2s"]' "${DEPLOY_DIR}/operator/50_operator.deployment.yaml"
+yq e --inplace '.spec.template.spec.containers[0].args += ["--crypto-key-size="+env(SO_CRYPTO_KEY_SIZE), "--crypto-key-buffer-size-min="+env(SO_CRYPTO_KEY_BUFFER_SIZE_MIN), "--crypto-key-buffer-size-max="+env(SO_CRYPTO_KEY_BUFFER_SIZE_MAX), "--crypto-key-buffer-delay=2s"]' "${DEPLOY_DIR}/operator/50_operator.deployment.yaml"
 
 if [[ -n ${SCYLLA_OPERATOR_FEATURE_GATES+x} ]]; then
     yq e --inplace '.spec.template.spec.containers[0].args += "--feature-gates="+ env(SCYLLA_OPERATOR_FEATURE_GATES)' "${DEPLOY_DIR}/operator/50_operator.deployment.yaml"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR enables RSA key size configuration in CI scripts and sets the default to 2048.

See the comparison between the e2e parallel suite configured with 2048 bits vs 4096 bits below.

### 4096 bits

https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2360/pull-scylla-operator-master-e2e-gke-parallel/1899068125266055168
Scylla Operator logs (first 10 minutes): [scylla-operator-4096.txt](https://github.com/user-attachments/files/19162461/scylla-operator-4096.txt)

```
$ cat scylla-operator-4096.txt | grep -Pe "Generating item finished" | grep -Pe "I0310 12:(1[0-9]|20):\d+.?\d* " | awk 'match($0, /Duration="([0-9.]+)(ms|s)"/, a) { d = a[1]; if (a[2] == "ms") { d = d / 1000; }; s += d; c++; } END { print s / c, "s" ; }'
2.58872 s
```

```
$ cat scylla-operator-4096.txt | grep -Pe "Certificate created" | grep -Pe "I0310 12:(1[0-9]|20):\d+.?\d* " | awk 'match($0, /ElapsedTime="([0-9.]+)(ms|s)"/, a) { d = a[1]; if (a[2] == "ms") { d = d / 1000; }; s += d; c++; } END { print s / c, "s" ; }'
8.48106 s
```
![operator-4096](https://github.com/user-attachments/assets/6f0e35df-d196-4048-9d81-61b18ba57f06)


### 2048 bits

Prow job: https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2474/pull-scylla-operator-master-e2e-gke-parallel/1899058495462838272
Scylla Operator logs (first 10 minutes): [scylla-operator-2048.txt](https://github.com/user-attachments/files/19162378/scylla-operator-2048.txt)

```
$ cat scylla-operator-2048.txt | grep -Pe "Generating item finished" | grep -Pe "I0310 11:(4[2-9]|5[0-2]):\d+.?\d* " | awk 'match($0, /Duration="([0-9.]+)(ms|s)"/, a) { d = a[1]; if (a[2] == "ms") { d = d / 1000; }; s += d; c++; } END { print s / c, "s" ; }'
0.242117 s
```

```
$ cat scylla-operator-2048.txt | grep -Pe "Certificate created" | grep -Pe "I0310 11:(4[2-9]|5[0-2]):\d+.?\d* " | awk 'match($0, /ElapsedTime="([0-9.]+)(ms|s)"/, a) { d = a[1]; if (a[2] == "ms") { d = d / 1000; }; s += d; c++; } END { print s / c, "s" ; }'
0.00291128 s
```
![operator-2048](https://github.com/user-attachments/assets/c35f42a4-1f8f-4770-aae9-5da901ee5e9b)





**Which issue is resolved by this Pull Request:**
Resolves #2303 

/kind machinery
/priority important-soon
/cc
