### PR TITLE
Disable ScyllaDBMonitoring tests in OpenShift E2E

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -203,6 +203,7 @@ function run-e2e {
     exit 2
   fi
 
+  SO_SKIPPED_TESTS="${SO_SKIPPED_TESTS:-}"
   FIELD_MANAGER="${FIELD_MANAGER:-run-e2e-script}"
   SO_BUCKET_NAME="${SO_BUCKET_NAME:-}"
   SO_E2E_PARALLELISM="${SO_E2E_PARALLELISM:-0}"
@@ -265,6 +266,7 @@ spec:
     - scylla-operator-tests
     - run
     - "${SO_SUITE}"
+    - "--skip=${SO_SKIPPED_TESTS}"
     - "--kubeconfig=${kubeconfigs_in_container_path}"
     - --loglevel=2
     - --color=false

--- a/hack/.ci/run-e2e-openshift-aws-release.sh
+++ b/hack/.ci/run-e2e-openshift-aws-release.sh
@@ -23,6 +23,13 @@ trap gather-artifacts-on-exit EXIT
 REENTRANT="${REENTRANT=false}"
 export REENTRANT
 
+# Test cases including $test_disable_tag in their name will be skipped.
+# TODO: Get rid of this tagging method in favor of defined test suites, and mapping
+# specific test suites to specific runtime configurations.
+test_disable_tag="TESTCASE_DISABLED_ON_OPENSHIFT"
+SO_SKIPPED_TESTS="${SO_SKIPPED_TESTS:-$test_disable_tag}"
+export SO_SKIPPED_TESTS
+
 SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=${parent_dir}/manifests/cluster/nodeconfig-openshift-aws.yaml}"
 export SO_NODECONFIG_PATH
 

--- a/hack/.ci/run-e2e-openshift-aws.sh
+++ b/hack/.ci/run-e2e-openshift-aws.sh
@@ -23,10 +23,19 @@ trap gather-artifacts-on-exit EXIT
 REENTRANT="${REENTRANT=false}"
 export REENTRANT
 
+# Test cases including $test_disable_tag in their name will be skipped.
+# TODO: Get rid of this tagging method in favor of defined test suites, and mapping
+# specific test suites to specific runtime configurations.
+test_disable_tag="TESTCASE_DISABLED_ON_OPENSHIFT"
+SO_SKIPPED_TESTS="${SO_SKIPPED_TESTS:-$test_disable_tag}"
+export SO_SKIPPED_TESTS
+
 SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=${parent_dir}/manifests/cluster/nodeconfig-openshift-aws.yaml}"
 export SO_NODECONFIG_PATH
+
 SO_CSI_DRIVER_PATH="${SO_CSI_DRIVER_PATH=${parent_dir}/manifests/namespaces/local-csi-driver/}"
 export SO_CSI_DRIVER_PATH
+
 SO_SCYLLACLUSTER_STORAGECLASS_NAME="${SO_SCYLLACLUSTER_STORAGECLASS_NAME=scylladb-local-xfs}"
 export SO_SCYLLACLUSTER_STORAGECLASS_NAME
 

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
@@ -132,7 +132,8 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 		return fmt.Sprintf("with %q monitoring type", e.Type)
 	}
 
-	g.DescribeTable("should setup monitoring stack", func(e *entry) {
+	// Disabled on OpenShift because of https://github.com/scylladb/scylla-operator/issues/2319#issuecomment-2643287819
+	g.DescribeTable("should setup monitoring stack TESTCASE_DISABLED_ON_OPENSHIFT", func(e *entry) {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 		defer cancel()
 


### PR DESCRIPTION
Disables the ScyllaDBMonitoring test on OpenShift. We have decided ([here](https://github.com/scylladb/scylla-operator/issues/2319#issuecomment-2643287819)) that we won't support ScyllaDBMonitoring in its current form (spinning up a Prometheus) on OpenShift and will instead implement #2490.

Resolves #2318
Resolves #2319

I wanted to avoid calling out test cases by name in the CI machinery and therefore introduced a "tag" concept as a simplistic approach at https://github.com/scylladb/scylla-operator/issues/2448.
I think that the right long-term solution will be to define a number of test "suites" https://github.com/scylladb/scylla-operator/issues/2448 and have a proper grid for test configurations.

One failure is expected in the parallel suite and will be handled separately: https://github.com/scylladb/scylla-operator/issues/2489