### PR TITLE
Reimplement `wait-for-object-creation` with `kubectl wait`

### DIFF
--- a/hack/lib/kube.sh
+++ b/hack/lib/kube.sh
@@ -23,9 +23,7 @@ function kubectl_create {
 }
 
 function wait-for-object-creation {
-    for i in {1..30}; do
-        { kubectl -n "${1}" get "${2}" && break; } || sleep 1
-    done
+  kubectl wait --timeout=60s --for=create -n "${1}" "${2}"
 }
 
 # $1 - namespace


### PR DESCRIPTION
As of kubectl 1.31, there's a `kubectl wait --for=create`.

This should make the below excerpt of the E2E test logs less chatty and not unnecessarily highlighted as a test error.

```
 + wait-for-object-creation ci-clusters configmap/13ede74d-0b97-4590-b6d0-264cda6ca74d-openshift-install-config
+ for i in {1..30}
+ kubectl -n ci-clusters get configmap/13ede74d-0b97-4590-b6d0-264cda6ca74d-openshift-install-config
Error from server (NotFound): configmaps "13ede74d-0b97-4590-b6d0-264cda6ca74d-openshift-install-config" not found
+ sleep 1
+ for i in {1..30}
+ kubectl -n ci-clusters get configmap/13ede74d-0b97-4590-b6d0-264cda6ca74d-openshift-install-config
Error from server (NotFound): configmaps "13ede74d-0b97-4590-b6d0-264cda6ca74d-openshift-install-config" not found
+ sleep 1
+ for i in {1..30}
+ kubectl -n ci-clusters get configmap/13ede74d-0b97-4590-b6d0-264cda6ca74d-openshift-install-config
NAME                                                            DATA   AGE
13ede74d-0b97-4590-b6d0-264cda6ca74d-openshift-install-config   1      1s
+ break 
```

I picked the 60s timeout value because the existing implementation does 30 retries with `sleep 1`. The extra 30s is to approximate the total current `kubectl get` latency.