### PR TITLE
Use alphanum characters in hashed name suffix

### DIFF
--- a/pkg/controller/scylladbcluster/resource_test.go
+++ b/pkg/controller/scylladbcluster/resource_test.go
@@ -75,7 +75,7 @@ func TestMakeRemoteOwners(t *testing.T) {
 					&scyllav1alpha1.RemoteOwner{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "scylla-abc",
-							Name:      "cluster-vg5nl",
+							Name:      "cluster-28t03",
 							Labels: map[string]string{
 								"internal.scylla-operator.scylladb.com/remote-owner-cluster":   "dc1-rkc",
 								"internal.scylla-operator.scylladb.com/remote-owner-namespace": "scylla",
@@ -90,7 +90,7 @@ func TestMakeRemoteOwners(t *testing.T) {
 					&scyllav1alpha1.RemoteOwner{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "scylla-def",
-							Name:      "cluster-wwkor",
+							Name:      "cluster-1513j",
 							Labels: map[string]string{
 								"internal.scylla-operator.scylladb.com/remote-owner-cluster":   "dc2-rkc",
 								"internal.scylla-operator.scylladb.com/remote-owner-namespace": "scylla",
@@ -105,7 +105,7 @@ func TestMakeRemoteOwners(t *testing.T) {
 					&scyllav1alpha1.RemoteOwner{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "scylla-ghj",
-							Name:      "cluster-fkvjv",
+							Name:      "cluster-2p77z",
 							Labels: map[string]string{
 								"internal.scylla-operator.scylladb.com/remote-owner-cluster":   "dc3-rkc",
 								"internal.scylla-operator.scylladb.com/remote-owner-namespace": "scylla",
@@ -204,7 +204,7 @@ func TestMakeNamespaces(t *testing.T) {
 			expectedNamespaces: map[string][]*corev1.Namespace{
 				"dc1-rkc": {{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "scylla-vg5nl",
+						Name: "scylla-28t03",
 						Labels: map[string]string{
 							"scylla-operator.scylladb.com/parent-scylladbcluster-name":            "cluster",
 							"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
@@ -215,7 +215,7 @@ func TestMakeNamespaces(t *testing.T) {
 				}},
 				"dc2-rkc": {{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "scylla-wwkor",
+						Name: "scylla-1513j",
 						Labels: map[string]string{
 							"scylla-operator.scylladb.com/parent-scylladbcluster-name":            "cluster",
 							"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
@@ -226,7 +226,7 @@ func TestMakeNamespaces(t *testing.T) {
 				}},
 				"dc3-rkc": {{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "scylla-fkvjv",
+						Name: "scylla-2p77z",
 						Labels: map[string]string{
 							"scylla-operator.scylladb.com/parent-scylladbcluster-name":            "cluster",
 							"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -275,10 +275,9 @@ func ScyllaDBDatacenterName(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alph
 }
 
 func GenerateNameHash(parts ...string) (string, error) {
-	h, err := hash.HashObjects(parts)
+	h, err := hash.HashObjectFNV64a(parts)
 	if err != nil {
 		return "", fmt.Errorf("can't hash name parts: %w", err)
 	}
-
-	return strings.ToLower(h[:lengthOfNameSuffixHash]), nil
+	return strconv.FormatUint(h, 36)[:lengthOfNameSuffixHash], nil
 }

--- a/pkg/util/hash/hash.go
+++ b/pkg/util/hash/hash.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 )
 
 func HashObjects(objs ...interface{}) (string, error) {
@@ -29,4 +30,16 @@ func HashBytes(buf []byte) (string, error) {
 		return "", fmt.Errorf("can't write bytes to hasher: %w", err)
 	}
 	return string(hasher.Sum(nil)), nil
+}
+
+func HashObjectFNV64a(objs ...interface{}) (uint64, error) {
+	hasher := fnv.New64a()
+	encoder := json.NewEncoder(hasher)
+	for _, obj := range objs {
+		if err := encoder.Encode(obj); err != nil {
+			return 0, err
+		}
+	}
+
+	return hasher.Sum64(), nil
 }


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/docs/contributing.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Funcion used for generating a stable hash suffix used in resource names used base64 std encoding charset which contains characters which cannot be used at the end of resource names. It could lead to Operator generating name which cannot be created due to validation.

**Which issue is resolved by this Pull Request:**
Resolves #2504

/cc mflendrich
