### PR TITLE
Bump upload-artifact to v4 in GH Actions

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -118,7 +118,7 @@ runs:
   
   - name: Upload artifact
     if: ${{ always() }}
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: release_notes.md
       path: ~/release_notes.md


### PR DESCRIPTION
v3 is deprecated and [no longer working](https://github.com/scylladb/scylla-operator/actions/runs/13561442565/job/37905171053). This is blocking the v1.16.0-beta.0 release now.

[Deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)[
Migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)

/priority important-soon
/kind cleanup
/cc zimnx