### PR TITLE
[1.16] Bump upload-artifact to v4 in GH Actions

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -118,7 +118,7 @@ runs:
   
   - name: Upload artifact
     if: ${{ always() }}
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: release_notes.md
       path: ~/release_notes.md


### PR DESCRIPTION
Backport of #2514 to 1.16.
