### PR TITLE
Mirror ConfigMaps and Secrets referenced in ScyllaDBCluster into remote datacenters

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -443,6 +443,8 @@ rules:
   - endpoints
   - namespaces
   - services
+  - secrets
+  - configmaps
   verbs:
   - create
   - delete

--- a/deploy/operator/00_operator_remote.clusterrole_def.yaml
+++ b/deploy/operator/00_operator_remote.clusterrole_def.yaml
@@ -47,6 +47,8 @@ rules:
   - endpoints
   - namespaces
   - services
+  - secrets
+  - configmaps
   verbs:
   - create
   - delete

--- a/helm/scylla-operator/templates/operator_remote.clusterrole_def.yaml
+++ b/helm/scylla-operator/templates/operator_remote.clusterrole_def.yaml
@@ -47,6 +47,8 @@ rules:
   - endpoints
   - namespaces
   - services
+  - secrets
+  - configmaps
   verbs:
   - create
   - delete

--- a/pkg/controller/scylladbcluster/conditions.go
+++ b/pkg/controller/scylladbcluster/conditions.go
@@ -15,4 +15,8 @@ const (
 	remoteEndpointsControllerDegradedCondition             = "RemoteEndpointsControllerDegraded"
 	scyllaDBClusterFinalizerProgressingCondition           = "ScyllaDBClusterFinalizerProgressing"
 	scyllaDBClusterFinalizerDegradedCondition              = "ScyllaDBClusterFinalizerDegraded"
+	remoteConfigMapControllerProgressingCondition          = "RemoteConfigMapControllerProgressing"
+	remoteConfigMapControllerDegradedCondition             = "RemoteConfigMapControllerDegraded"
+	remoteSecretControllerProgressingCondition             = "RemoteSecretControllerProgressing"
+	remoteSecretControllerDegradedCondition                = "RemoteSecretControllerDegraded"
 )

--- a/pkg/controller/scylladbcluster/resource_test.go
+++ b/pkg/controller/scylladbcluster/resource_test.go
@@ -82,6 +82,7 @@ func TestMakeRemoteOwners(t *testing.T) {
 								"internal.scylla-operator.scylladb.com/remote-owner-name":      "cluster",
 								"internal.scylla-operator.scylladb.com/remote-owner-gvr":       "scylla.scylladb.com-v1alpha1-scylladbclusters",
 								"scylla-operator.scylladb.com/managed-by-cluster":              "test-cluster.local",
+								"app.kubernetes.io/managed-by":                                 "remote.scylla-operator.scylladb.com",
 							},
 						},
 					},
@@ -97,6 +98,7 @@ func TestMakeRemoteOwners(t *testing.T) {
 								"internal.scylla-operator.scylladb.com/remote-owner-name":      "cluster",
 								"internal.scylla-operator.scylladb.com/remote-owner-gvr":       "scylla.scylladb.com-v1alpha1-scylladbclusters",
 								"scylla-operator.scylladb.com/managed-by-cluster":              "test-cluster.local",
+								"app.kubernetes.io/managed-by":                                 "remote.scylla-operator.scylladb.com",
 							},
 						},
 					},
@@ -112,6 +114,7 @@ func TestMakeRemoteOwners(t *testing.T) {
 								"internal.scylla-operator.scylladb.com/remote-owner-name":      "cluster",
 								"internal.scylla-operator.scylladb.com/remote-owner-gvr":       "scylla.scylladb.com-v1alpha1-scylladbclusters",
 								"scylla-operator.scylladb.com/managed-by-cluster":              "test-cluster.local",
+								"app.kubernetes.io/managed-by":                                 "remote.scylla-operator.scylladb.com",
 							},
 						},
 					},
@@ -210,6 +213,7 @@ func TestMakeNamespaces(t *testing.T) {
 							"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 							"scylla-operator.scylladb.com/parent-scylladbcluster-datacenter-name": "dc1",
 							"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+							"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 						},
 					},
 				}},
@@ -221,6 +225,7 @@ func TestMakeNamespaces(t *testing.T) {
 							"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 							"scylla-operator.scylladb.com/parent-scylladbcluster-datacenter-name": "dc2",
 							"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+							"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 						},
 					},
 				}},
@@ -232,6 +237,7 @@ func TestMakeNamespaces(t *testing.T) {
 							"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 							"scylla-operator.scylladb.com/parent-scylladbcluster-datacenter-name": "dc3",
 							"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+							"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 						},
 					},
 				}},
@@ -475,6 +481,7 @@ func TestMakeServices(t *testing.T) {
 								"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 								"scylla-operator.scylladb.com/parent-scylladbcluster-datacenter-name": "dc1",
 								"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+								"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 							},
 							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&scyllav1alpha1.RemoteOwner{
 								ObjectMeta: metav1.ObjectMeta{
@@ -497,6 +504,7 @@ func TestMakeServices(t *testing.T) {
 								"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 								"scylla-operator.scylladb.com/parent-scylladbcluster-datacenter-name": "dc1",
 								"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+								"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 							},
 							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&scyllav1alpha1.RemoteOwner{
 								ObjectMeta: metav1.ObjectMeta{
@@ -521,6 +529,7 @@ func TestMakeServices(t *testing.T) {
 								"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 								"scylla-operator.scylladb.com/parent-scylladbcluster-datacenter-name": "dc2",
 								"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+								"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 							},
 							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&scyllav1alpha1.RemoteOwner{
 								ObjectMeta: metav1.ObjectMeta{
@@ -543,6 +552,7 @@ func TestMakeServices(t *testing.T) {
 								"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 								"scylla-operator.scylladb.com/parent-scylladbcluster-datacenter-name": "dc2",
 								"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+								"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 							},
 							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&scyllav1alpha1.RemoteOwner{
 								ObjectMeta: metav1.ObjectMeta{
@@ -567,6 +577,7 @@ func TestMakeServices(t *testing.T) {
 								"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 								"scylla-operator.scylladb.com/parent-scylladbcluster-datacenter-name": "dc3",
 								"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+								"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 							},
 							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&scyllav1alpha1.RemoteOwner{
 								ObjectMeta: metav1.ObjectMeta{
@@ -589,6 +600,7 @@ func TestMakeServices(t *testing.T) {
 								"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 								"scylla-operator.scylladb.com/parent-scylladbcluster-datacenter-name": "dc3",
 								"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+								"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 							},
 							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&scyllav1alpha1.RemoteOwner{
 								ObjectMeta: metav1.ObjectMeta{
@@ -838,6 +850,7 @@ func TestMakeScyllaDBDatacenters(t *testing.T) {
 					"scylla-operator.scylladb.com/parent-scylladbcluster-name":            "cluster",
 					"scylla-operator.scylladb.com/parent-scylladbcluster-namespace":       "scylla",
 					"scylla-operator.scylladb.com/managed-by-cluster":                     "test-cluster.local",
+					"app.kubernetes.io/managed-by":                                        "remote.scylla-operator.scylladb.com",
 				},
 				Annotations:     map[string]string{},
 				OwnerReferences: newBasicOwnerReference(namespace),

--- a/pkg/controller/scylladbcluster/sync_configmap.go
+++ b/pkg/controller/scylladbcluster/sync_configmap.go
@@ -1,0 +1,88 @@
+package scylladbcluster
+
+import (
+	"context"
+	"fmt"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/resourceapply"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func (scc *Controller) syncConfigMaps(
+	ctx context.Context,
+	sc *scyllav1alpha1.ScyllaDBCluster,
+	remoteNamespaces map[string]*corev1.Namespace,
+	remoteControllers map[string]metav1.Object,
+	remoteConfigMaps map[string]map[string]*corev1.ConfigMap,
+	managingClusterDomain string,
+) ([]metav1.Condition, error) {
+	progressingConditions, requiredConfigMaps, err := MakeRemoteConfigMaps(sc, remoteNamespaces, remoteControllers, scc.configMapLister, managingClusterDomain)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't make required configmaps: %w", err)
+	}
+
+	if len(progressingConditions) > 0 {
+		return progressingConditions, nil
+	}
+
+	// Delete has to be the first action to avoid getting stuck on quota.
+	var deletionErrors []error
+	for _, dc := range sc.Spec.Datacenters {
+		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
+		if !ok {
+			continue
+		}
+
+		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+		if err != nil {
+			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
+		}
+
+		err = controllerhelpers.Prune(ctx,
+			requiredConfigMaps[dc.RemoteKubernetesClusterName],
+			remoteConfigMaps[dc.RemoteKubernetesClusterName],
+			&controllerhelpers.PruneControlFuncs{
+				DeleteFunc: clusterClient.CoreV1().ConfigMaps(ns.Name).Delete,
+			},
+			scc.eventRecorder,
+		)
+		if err != nil {
+			return progressingConditions, fmt.Errorf("can't prune configmap(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
+		}
+	}
+
+	if err := utilerrors.NewAggregate(deletionErrors); err != nil {
+		return nil, fmt.Errorf("can't prune remote configmap(s): %w", err)
+	}
+
+	var errs []error
+	for _, dc := range sc.Spec.Datacenters {
+		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't get client to %q cluster: %w", dc.Name, err))
+			continue
+		}
+
+		for _, cm := range requiredConfigMaps[dc.RemoteKubernetesClusterName] {
+			_, changed, err := resourceapply.ApplyConfigMap(ctx, clusterClient.CoreV1(), scc.remoteConfigMapLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, cm, resourceapply.ApplyOptions{})
+			if changed {
+				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteConfigMapControllerProgressingCondition, cm, "apply", sc.Generation)
+			}
+			if err != nil {
+				errs = append(errs, fmt.Errorf("can't apply configmap: %w", err))
+				continue
+			}
+		}
+	}
+
+	err = utilerrors.NewAggregate(errs)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't apply configmap(s): %w", err)
+	}
+
+	return progressingConditions, nil
+}

--- a/pkg/controller/scylladbcluster/sync_secrets.go
+++ b/pkg/controller/scylladbcluster/sync_secrets.go
@@ -1,0 +1,88 @@
+package scylladbcluster
+
+import (
+	"context"
+	"fmt"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/resourceapply"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func (scc *Controller) syncSecrets(
+	ctx context.Context,
+	sc *scyllav1alpha1.ScyllaDBCluster,
+	remoteNamespaces map[string]*corev1.Namespace,
+	remoteControllers map[string]metav1.Object,
+	remoteSecrets map[string]map[string]*corev1.Secret,
+	managingClusterDomain string,
+) ([]metav1.Condition, error) {
+	progressingConditions, requiredRemoteSecrets, err := MakeRemoteSecrets(sc, remoteNamespaces, remoteControllers, scc.secretLister, managingClusterDomain)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't make remote secrets: %w", err)
+	}
+
+	if len(progressingConditions) > 0 {
+		return progressingConditions, nil
+	}
+
+	// Delete has to be the first action to avoid getting stuck on quota.
+	var deletionErrors []error
+	for _, dc := range sc.Spec.Datacenters {
+		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
+		if !ok {
+			continue
+		}
+
+		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+		if err != nil {
+			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
+		}
+
+		err = controllerhelpers.Prune(ctx,
+			requiredRemoteSecrets[dc.RemoteKubernetesClusterName],
+			remoteSecrets[dc.RemoteKubernetesClusterName],
+			&controllerhelpers.PruneControlFuncs{
+				DeleteFunc: clusterClient.CoreV1().Secrets(ns.Name).Delete,
+			},
+			scc.eventRecorder,
+		)
+		if err != nil {
+			return progressingConditions, fmt.Errorf("can't prune secret(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
+		}
+	}
+
+	if err := utilerrors.NewAggregate(deletionErrors); err != nil {
+		return nil, fmt.Errorf("can't prune remote secret(s): %w", err)
+	}
+
+	var errs []error
+	for _, dc := range sc.Spec.Datacenters {
+		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't get client to %q cluster: %w", dc.Name, err))
+			continue
+		}
+
+		for _, rs := range requiredRemoteSecrets[dc.RemoteKubernetesClusterName] {
+			_, changed, err := resourceapply.ApplySecret(ctx, clusterClient.CoreV1(), scc.remoteSecretLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, rs, resourceapply.ApplyOptions{})
+			if changed {
+				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteSecretControllerProgressingCondition, rs, "apply", sc.Generation)
+			}
+			if err != nil {
+				errs = append(errs, fmt.Errorf("can't apply secret: %w", err))
+				continue
+			}
+		}
+	}
+
+	err = utilerrors.NewAggregate(errs)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't apply secret(s): %w", err)
+	}
+
+	return progressingConditions, nil
+}

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -231,10 +231,15 @@ const (
 )
 
 const (
-	OperatorAppNameWithDomain = "scylla-operator.scylladb.com"
+	OperatorAppNameWithDomain       = "scylla-operator.scylladb.com"
+	RemoteOperatorAppNameWithDomain = "remote.scylla-operator.scylladb.com"
 )
 
 const (
 	RemoteKubernetesClusterFinalizer = "scylla-operator.scylladb.com/remotekubernetescluster-protection"
 	ScyllaDBClusterFinalizer         = "scylla-operator.scylladb.com/scylladbcluster-protection"
+)
+
+const (
+	KubernetesManagedByLabel = "app.kubernetes.io/managed-by"
 )

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -91,9 +91,10 @@ func mergeLabels(l1, l2 map[string]string) map[string]string {
 	return res
 }
 
-func ManagedResourcesLabels(managingClusterDomain string) map[string]string {
+func RemoteManagedResourcesLabels(managingClusterDomain string) map[string]string {
 	return map[string]string{
-		ManagedByClusterLabel: managingClusterDomain,
+		KubernetesManagedByLabel: RemoteOperatorAppNameWithDomain,
+		ManagedByClusterLabel:    managingClusterDomain,
 	}
 }
 
@@ -113,7 +114,7 @@ func ScyllaDBClusterDatacenterLabels(sc *scyllav1alpha1.ScyllaDBCluster, dc *scy
 	if dc.Metadata != nil {
 		maps.Copy(dcLabels, dc.Metadata.Labels)
 	}
-	maps.Copy(dcLabels, ManagedResourcesLabels(managingClusterDomain))
+	maps.Copy(dcLabels, RemoteManagedResourcesLabels(managingClusterDomain))
 	maps.Copy(dcLabels, ScyllaDBClusterSelectorLabels(sc))
 	dcLabels[ParentClusterDatacenterNameLabel] = dc.Name
 	return dcLabels
@@ -155,7 +156,7 @@ func ScyllaDBClusterDatacenterEndpointsLabels(sc *scyllav1alpha1.ScyllaDBCluster
 	if dc.Metadata != nil {
 		maps.Copy(dcLabels, dc.Metadata.Labels)
 	}
-	maps.Copy(dcLabels, ManagedResourcesLabels(managingClusterDomain))
+	maps.Copy(dcLabels, RemoteManagedResourcesLabels(managingClusterDomain))
 	maps.Copy(dcLabels, ScyllaDBClusterEndpointsSelectorLabels(sc))
 	dcLabels[ParentClusterDatacenterNameLabel] = dc.Name
 	return dcLabels
@@ -200,7 +201,7 @@ func RemoteOwnerSelectorLabels(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1a
 func RemoteOwnerLabels(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, managingClusterDomain string) map[string]string {
 	remoteOwnerLabels := make(map[string]string)
 
-	maps.Copy(remoteOwnerLabels, ManagedResourcesLabels(managingClusterDomain))
+	maps.Copy(remoteOwnerLabels, RemoteManagedResourcesLabels(managingClusterDomain))
 	maps.Copy(remoteOwnerLabels, RemoteOwnerSelectorLabels(sc, dc))
 
 	return remoteOwnerLabels

--- a/pkg/scyllaclient/config_client.go
+++ b/pkg/scyllaclient/config_client.go
@@ -79,3 +79,12 @@ func (c *ConfigClient) ReplaceNodeFirstBoot(ctx context.Context) (string, error)
 	}
 	return resp.Payload, nil
 }
+
+// ReadRequestTimeoutInMs returns value of "read_request_timeout_in_ms" config parameter.
+func (c *ConfigClient) ReadRequestTimeoutInMs(ctx context.Context) (int64, error) {
+	resp, err := c.client.Config.FindConfigReadRequestTimeoutInMs(config.NewFindConfigReadRequestTimeoutInMsParamsWithContext(ctx))
+	if err != nil {
+		return 0, fmt.Errorf("can't get read_request_timeout_in_ms: %w", err)
+	}
+	return resp.Payload, nil
+}

--- a/test/e2e/set/scylladbcluster/multidatacenter/multidatacenter_scylladbcluster_config.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/multidatacenter_scylladbcluster_config.go
@@ -1,0 +1,212 @@
+package multidatacenter
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
+	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	scylladbclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scylladbcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter, func() {
+	f := framework.NewFramework("scylladbcluster")
+
+	g.It("should mirror ConfigMaps and Secrets referenced by ScyllaDBCluster into remote datacenters", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		rkcs, rkcClusterMap, err := utils.SetUpRemoteKubernetesClustersFromRestConfigs(ctx, framework.TestContext.RestConfigs, f)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Creating configs for ScyllaDB and ScyllaDB Manager Agent")
+
+		metaCluster := f.Cluster(0)
+		userNS, userClient, ok := metaCluster.DefaultNamespaceIfAny()
+		o.Expect(ok).To(o.BeTrue())
+
+		makeScyllaDBConfigMap := func(name, configValue string) *corev1.ConfigMap {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: userNS.Name,
+				},
+				Data: map[string]string{
+					"scylla.yaml": fmt.Sprintf(`read_request_timeout_in_ms: %s`, configValue),
+				},
+			}
+		}
+
+		makeScyllaDBManagerAgentSecret := func(name, configValue string) *corev1.Secret {
+			return &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: userNS.Name,
+				},
+				StringData: map[string]string{
+					"scylla-manager-agent.yaml": fmt.Sprintf(`auth_token: %s`, configValue),
+				},
+			}
+		}
+
+		scyllaDBDatacenterTemplateConfigMap := makeScyllaDBConfigMap("datacenter-template", "1111")
+		scyllaDBDatacenterTemplateRackTemplateConfigMap := makeScyllaDBConfigMap("datacenter-template-rack-template", "2222")
+		scyllaDBDatacenterRackTemplateConfigMap := makeScyllaDBConfigMap("datacenter-rack-template", "3333")
+		scyllaDBDatacenterDatacenterConfigMap := makeScyllaDBConfigMap("datacenter", "4444")
+		const scyllaDBRackReadRequestTimeoutInMs = 5555
+		scyllaDBDatacenterRackConfigMap := makeScyllaDBConfigMap("rack", fmt.Sprintf("%d", scyllaDBRackReadRequestTimeoutInMs))
+
+		scyllaDBConfigMaps := []*corev1.ConfigMap{
+			scyllaDBDatacenterTemplateConfigMap,
+			scyllaDBDatacenterTemplateRackTemplateConfigMap,
+			scyllaDBDatacenterRackTemplateConfigMap,
+			scyllaDBDatacenterDatacenterConfigMap,
+			scyllaDBDatacenterRackConfigMap,
+		}
+
+		scyllaDBManagerAgentDatacenterTemplateSecret := makeScyllaDBManagerAgentSecret("datacenter-template", "aaaa")
+		scyllaDBManagerAgentDatacenterTemplateRackTemplateSecret := makeScyllaDBManagerAgentSecret("datacenter-template-rack-template", "bbbb")
+		scyllaDBManagerAgentDatacenterRackTemplateSecret := makeScyllaDBManagerAgentSecret("datacenter-rack-template", "cccc")
+		scyllaDBManagerAgentDatacenterSecret := makeScyllaDBManagerAgentSecret("datacenter", "dddd")
+		const scyllaDBManagerAgentRackAuthToken = "eeee"
+		scyllaDBManagerAgentDatacenterRackSecret := makeScyllaDBManagerAgentSecret("rack", scyllaDBManagerAgentRackAuthToken)
+
+		scyllaDBManagerAgentSecrets := []*corev1.Secret{
+			scyllaDBManagerAgentDatacenterTemplateSecret,
+			scyllaDBManagerAgentDatacenterTemplateRackTemplateSecret,
+			scyllaDBManagerAgentDatacenterRackTemplateSecret,
+			scyllaDBManagerAgentDatacenterSecret,
+			scyllaDBManagerAgentDatacenterRackSecret,
+		}
+
+		for _, cm := range scyllaDBConfigMaps {
+			_, err := userClient.KubeClient().CoreV1().ConfigMaps(cm.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		for _, secret := range scyllaDBManagerAgentSecrets {
+			_, err := userClient.KubeClient().CoreV1().Secrets(secret.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		framework.By("Creating ScyllaDBCluster")
+		sc := f.GetDefaultScyllaDBCluster(rkcs)
+
+		sc.Spec.DatacenterTemplate.ScyllaDB.CustomConfigMapRef = pointer.Ptr(scyllaDBDatacenterTemplateConfigMap.Name)
+		sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent = &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+			CustomConfigSecretRef: pointer.Ptr(scyllaDBManagerAgentDatacenterTemplateSecret.Name),
+		}
+		sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDB = &scyllav1alpha1.ScyllaDBTemplate{
+			CustomConfigMapRef: pointer.Ptr(scyllaDBDatacenterTemplateRackTemplateConfigMap.Name),
+		}
+		sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent = &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+			CustomConfigSecretRef: pointer.Ptr(scyllaDBManagerAgentDatacenterTemplateRackTemplateSecret.Name),
+		}
+		o.Expect(len(sc.Spec.Datacenters)).To(o.BeNumerically(">", 0))
+		for idx := range sc.Spec.Datacenters {
+			sc.Spec.Datacenters[idx].ScyllaDB = &scyllav1alpha1.ScyllaDBTemplate{
+				CustomConfigMapRef: pointer.Ptr(scyllaDBDatacenterDatacenterConfigMap.Name),
+			}
+			sc.Spec.Datacenters[idx].ScyllaDBManagerAgent = &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+				CustomConfigSecretRef: pointer.Ptr(scyllaDBManagerAgentDatacenterSecret.Name),
+			}
+			sc.Spec.Datacenters[idx].RackTemplate = &scyllav1alpha1.RackTemplate{
+				ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+					CustomConfigMapRef: pointer.Ptr(scyllaDBDatacenterRackTemplateConfigMap.Name),
+				},
+				ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+					CustomConfigSecretRef: pointer.Ptr(scyllaDBManagerAgentDatacenterRackTemplateSecret.Name),
+				},
+			}
+			sc.Spec.Datacenters[idx].Racks = []scyllav1alpha1.RackSpec{
+				{
+					Name: "a",
+					RackTemplate: scyllav1alpha1.RackTemplate{
+						ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+							CustomConfigMapRef: pointer.Ptr(scyllaDBDatacenterRackConfigMap.Name),
+						},
+						ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+							CustomConfigSecretRef: pointer.Ptr(scyllaDBManagerAgentDatacenterRackSecret.Name),
+						},
+					},
+				},
+			}
+		}
+
+		sc, err = metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(userNS.Name).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaDBCluster %q roll out (RV=%s)", sc.Name, sc.ResourceVersion)
+		waitCtx2, waitCtx2Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
+		defer waitCtx2Cancel()
+		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx2, metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaDBClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		scylladbclusterverification.Verify(ctx, sc, rkcClusterMap)
+		err = scylladbclusterverification.WaitForFullQuorum(ctx, rkcClusterMap, sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		for _, dc := range sc.Spec.Datacenters {
+			framework.By("Verifying if ConfigMaps and Secrets referenced by ScyllaDBCluster %q are mirrored in %q Datacenter", sc.Name, dc.Name)
+
+			clusterClient := rkcClusterMap[dc.RemoteKubernetesClusterName]
+
+			dcStatus, _, ok := slices.Find(sc.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
+				return dc.Name == dcStatus.Name
+			})
+			o.Expect(ok).To(o.BeTrue())
+			o.Expect(dcStatus.RemoteNamespaceName).ToNot(o.BeNil())
+
+			for _, cm := range scyllaDBConfigMaps {
+				mirroredCM, err := clusterClient.KubeAdminClient().CoreV1().ConfigMaps(*dcStatus.RemoteNamespaceName).Get(ctx, cm.Name, metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(mirroredCM.Data).To(o.Equal(cm.Data))
+			}
+
+			for _, secret := range scyllaDBManagerAgentSecrets {
+				mirroredSecret, err := clusterClient.KubeAdminClient().CoreV1().Secrets(*dcStatus.RemoteNamespaceName).Get(ctx, secret.Name, metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				for k, v := range secret.Data {
+					decodedValue, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, bytes.NewReader(mirroredSecret.Data[k])))
+					o.Expect(err).NotTo(o.HaveOccurred())
+					o.Expect(mirroredSecret.Data).To(o.HaveKey(k))
+					o.Expect(decodedValue).To(o.Equal(v))
+				}
+			}
+
+			framework.By("Verifying if custom auth token set via configuration of ScyllaDB Manager Agent is being used by %q datacenter", dc.Name)
+			sdc, err := clusterClient.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBDatacenters(*dcStatus.RemoteNamespaceName).Get(ctx, naming.ScyllaDBDatacenterName(sc, &dc), metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			svc, err := clusterClient.KubeAdminClient().CoreV1().Services(*dcStatus.RemoteNamespaceName).Get(ctx, naming.MemberServiceName(sdc.Spec.Racks[0], sdc, 0), metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			pod, err := clusterClient.KubeAdminClient().CoreV1().Pods(*dcStatus.RemoteNamespaceName).Get(ctx, naming.PodNameFromService(svc), metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			host, err := controllerhelpers.GetScyllaHost(sdc, svc, pod)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			scyllaConfigClient := scyllaclient.NewConfigClient(host, scyllaDBManagerAgentRackAuthToken)
+
+			framework.By("Verifying if configuration of ScyllaDB is being used by %q datacenter", dc.Name)
+			gotReadRequestTimeoutInMs, err := scyllaConfigClient.ReadRequestTimeoutInMs(ctx)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(gotReadRequestTimeoutInMs).To(o.Equal(int64(scyllaDBRackReadRequestTimeoutInMs)))
+		}
+	})
+})

--- a/test/e2e/utils/verification/scylladbcluster/verify.go
+++ b/test/e2e/utils/verification/scylladbcluster/verify.go
@@ -104,6 +104,22 @@ func Verify(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, rkcClusterM
 				condType: "RemoteRemoteOwnerControllerDegraded",
 				status:   metav1.ConditionFalse,
 			},
+			{
+				condType: "RemoteConfigMapControllerProgressing",
+				status:   metav1.ConditionFalse,
+			},
+			{
+				condType: "RemoteConfigMapControllerDegraded",
+				status:   metav1.ConditionFalse,
+			},
+			{
+				condType: "RemoteSecretControllerProgressing",
+				status:   metav1.ConditionFalse,
+			},
+			{
+				condType: "RemoteSecretControllerDegraded",
+				status:   metav1.ConditionFalse,
+			},
 		}
 
 		expectedConditions := make([]interface{}, 0, len(condList))


### PR DESCRIPTION
The ScyllaDBCluster controller has been extended with a new capability of mirroring the ConfigMaps and Secrets referenced by the ScyllaDBCluster, into remote datacenters.
This improvement provides users with the convenience of managing the configuration of an entire cluster from a single centralized location.

Note: any modifications made to the ConfigMaps or Secrets do not automatically initiate a rollout to apply those changes.
A manual trigger is required to implement the updates - for example using `forceRedeploymentReason`.

Requires:
- [x] https://github.com/scylladb/scylla-operator/pull/2523

Fixes #2255

/cc 