### PR TITLE
[v1.15] Clear data keyspace snapshots for first node in rack during ScyllaDB version upgrade

### DIFF
--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -832,14 +832,6 @@ func (sdcc *Controller) syncStatefulSets(
 					}
 				}
 
-				if partition <= 0 {
-					continue
-				}
-
-				nextPartition := partition - 1
-
-				klog.V(4).InfoS("Upgrade is running a rollout", "Partition", partition, "NextPartition", nextPartition)
-
 				if partition < *sts.Spec.Replicas {
 					// TODO: Move the post-node-upgrade hook into a Job.
 					err = sdcc.afterNodeUpgrade(ctx, sdc, sts, partition, services, currentUpgradeContext)
@@ -848,6 +840,14 @@ func (sdcc *Controller) syncStatefulSets(
 					}
 					klog.V(2).InfoS("AfterNodeUpgrade hook finished", "ScyllaDBDatacenter", klog.KObj(sdc), "StatefulSet", klog.KObj(sts))
 				}
+
+				if partition <= 0 {
+					continue
+				}
+
+				nextPartition := partition - 1
+
+				klog.V(4).InfoS("Upgrade is running a rollout", "Partition", partition, "NextPartition", nextPartition)
 
 				// TODO: Move the pre-node-upgrade hook into a Job.
 				done, err := sdcc.beforeNodeUpgrade(ctx, sdc, sts, nextPartition, services, currentUpgradeContext)

--- a/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
@@ -110,6 +110,17 @@ var _ = g.Describe("ScyllaCluster upgrades", func() {
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 			scyllaclusterverification.VerifyCQLData(ctx, di)
+
+			framework.By("Validating if all snapshots created by upgrade hooks are cleared for every node")
+			scyllaClient, hosts, err := utils.GetScyllaClient(ctx, f.KubeClient().CoreV1(), sc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			for _, host := range hosts {
+				snapshots, err := scyllaClient.ListSnapshots(ctx, host)
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				o.Expect(snapshots).To(o.BeEmpty())
+			}
 		},
 		// Test 1 and 3 member rack to cover e.g. handling PDBs correctly.
 		g.Entry(describeEntry, &entry{


### PR DESCRIPTION
Backport of https://github.com/scylladb/scylla-operator/pull/2528

/hold for https://github.com/scylladb/scylla-operator/pull/2528

/cc mflendrich