### PR TITLE
Reconcile remote datacenters independently

### DIFF
--- a/pkg/controller/scylladbcluster/conditions.go
+++ b/pkg/controller/scylladbcluster/conditions.go
@@ -1,22 +1,37 @@
 package scylladbcluster
 
-const (
-	remoteRemoteOwnerControllerProgressingCondition        = "RemoteRemoteOwnerControllerProgressing"
-	remoteRemoteOwnerControllerDegradedCondition           = "RemoteRemoteOwnerControllerDegraded"
-	remoteScyllaDBDatacenterControllerProgressingCondition = "RemoteScyllaDBDatacenterControllerProgressing"
-	remoteScyllaDBDatacenterControllerDegradedCondition    = "RemoteScyllaDBDatacenterControllerDegraded"
-	remoteNamespaceControllerProgressingCondition          = "RemoteNamespaceControllerProgressing"
-	remoteNamespaceControllerDegradedCondition             = "RemoteNamespaceControllerDegraded"
-	remoteServiceControllerProgressingCondition            = "RemoteServiceControllerProgressing"
-	remoteServiceControllerDegradedCondition               = "RemoteServiceControllerDegraded"
-	remoteEndpointSliceControllerProgressingCondition      = "RemoteEndpointSliceControllerProgressing"
-	remoteEndpointSliceControllerDegradedCondition         = "RemoteEndpointSliceControllerDegraded"
-	remoteEndpointsControllerProgressingCondition          = "RemoteEndpointsControllerProgressing"
-	remoteEndpointsControllerDegradedCondition             = "RemoteEndpointsControllerDegraded"
-	scyllaDBClusterFinalizerProgressingCondition           = "ScyllaDBClusterFinalizerProgressing"
-	scyllaDBClusterFinalizerDegradedCondition              = "ScyllaDBClusterFinalizerDegraded"
-	remoteConfigMapControllerProgressingCondition          = "RemoteConfigMapControllerProgressing"
-	remoteConfigMapControllerDegradedCondition             = "RemoteConfigMapControllerDegraded"
-	remoteSecretControllerProgressingCondition             = "RemoteSecretControllerProgressing"
-	remoteSecretControllerDegradedCondition                = "RemoteSecretControllerDegraded"
+import (
+	"fmt"
+
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
 )
+
+var (
+	makeRemoteRemoteOwnerControllerDatacenterProgressingCondition        = MakeRemoteKindControllerDatacenterConditionFunc("RemoteOwner", scyllav1alpha1.ProgressingCondition)
+	makeRemoteRemoteOwnerControllerDatacenterDegradedCondition           = MakeRemoteKindControllerDatacenterConditionFunc("RemoteOwner", scyllav1alpha1.DegradedCondition)
+	makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition = MakeRemoteKindControllerDatacenterConditionFunc("ScyllaDBDatacenter", scyllav1alpha1.ProgressingCondition)
+	makeRemoteScyllaDBDatacenterControllerDatacenterDegradedCondition    = MakeRemoteKindControllerDatacenterConditionFunc("ScyllaDBDatacenter", scyllav1alpha1.DegradedCondition)
+	makeRemoteNamespaceControllerDatacenterProgressingCondition          = MakeRemoteKindControllerDatacenterConditionFunc("Namespace", scyllav1alpha1.ProgressingCondition)
+	makeRemoteNamespaceControllerDatacenterDegradedCondition             = MakeRemoteKindControllerDatacenterConditionFunc("Namespace", scyllav1alpha1.DegradedCondition)
+	makeRemoteServiceControllerDatacenterProgressingCondition            = MakeRemoteKindControllerDatacenterConditionFunc("Service", scyllav1alpha1.ProgressingCondition)
+	makeRemoteServiceControllerDatacenterDegradedCondition               = MakeRemoteKindControllerDatacenterConditionFunc("Service", scyllav1alpha1.DegradedCondition)
+	makeRemoteEndpointSliceControllerDatacenterProgressingCondition      = MakeRemoteKindControllerDatacenterConditionFunc("EndpointSlice", scyllav1alpha1.ProgressingCondition)
+	makeRemoteEndpointSliceControllerDatacenterDegradedCondition         = MakeRemoteKindControllerDatacenterConditionFunc("EndpointSlice", scyllav1alpha1.DegradedCondition)
+	makeRemoteEndpointsControllerDatacenterProgressingCondition          = MakeRemoteKindControllerDatacenterConditionFunc("Endpoints", scyllav1alpha1.ProgressingCondition)
+	makeRemoteEndpointsControllerDatacenterDegradedCondition             = MakeRemoteKindControllerDatacenterConditionFunc("Endpoints", scyllav1alpha1.DegradedCondition)
+	makeRemoteConfigMapControllerDatacenterProgressingCondition          = MakeRemoteKindControllerDatacenterConditionFunc("ConfigMap", scyllav1alpha1.ProgressingCondition)
+	makeRemoteConfigMapControllerDatacenterDegradedCondition             = MakeRemoteKindControllerDatacenterConditionFunc("ConfigMap", scyllav1alpha1.DegradedCondition)
+	makeRemoteSecretControllerDatacenterProgressingCondition             = MakeRemoteKindControllerDatacenterConditionFunc("Secret", scyllav1alpha1.ProgressingCondition)
+	makeRemoteSecretControllerDatacenterDegradedCondition                = MakeRemoteKindControllerDatacenterConditionFunc("Secret", scyllav1alpha1.DegradedCondition)
+
+	scyllaDBClusterFinalizerProgressingCondition = internalapi.MakeKindFinalizerCondition("ScyllaDBCluster", scyllav1alpha1.ProgressingCondition)
+	scyllaDBClusterFinalizerDegradedCondition    = internalapi.MakeKindFinalizerCondition("ScyllaDBCluster", scyllav1alpha1.DegradedCondition)
+)
+
+// MakeRemoteKindControllerDatacenterConditionFunc returns a format string for a remote kind controller datacenter condition.
+func MakeRemoteKindControllerDatacenterConditionFunc(kind, conditionType string) func(dcName string) string {
+	return func(dcName string) string {
+		return fmt.Sprintf("Remote%s", internalapi.MakeKindControllerCondition(kind, internalapi.MakeDatacenterConditionFunc(conditionType)(dcName)))
+	}
+}

--- a/pkg/controller/scylladbcluster/conditions_test.go
+++ b/pkg/controller/scylladbcluster/conditions_test.go
@@ -1,0 +1,38 @@
+package scylladbcluster_test
+
+import (
+	"testing"
+
+	"github.com/scylladb/scylla-operator/pkg/controller/scylladbcluster"
+)
+
+func TestMakeRemoteKindControllerDatacenterConditionFunc(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name              string
+		kind              string
+		conditionType     string
+		dcName            string
+		expectedCondition string
+	}{
+		{
+			name:              "condition having provided kind and condition type and dc name",
+			kind:              "ConfigMap",
+			conditionType:     "Progressing",
+			dcName:            "dc1",
+			expectedCondition: "RemoteConfigMapControllerDatacenterdc1Progressing",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotCondition := scylladbcluster.MakeRemoteKindControllerDatacenterConditionFunc(tc.kind, tc.conditionType)(tc.dcName)
+			if gotCondition != tc.expectedCondition {
+				t.Errorf("expected condition %q, got %q", tc.expectedCondition, gotCondition)
+			}
+		})
+	}
+}

--- a/pkg/controller/scylladbcluster/resource.go
+++ b/pkg/controller/scylladbcluster/resource.go
@@ -22,492 +22,421 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func MakeRemoteRemoteOwners(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace, existingRemoteOwners map[string]map[string]*scyllav1alpha1.RemoteOwner, managingClusterDomain string) ([]metav1.Condition, map[string][]*scyllav1alpha1.RemoteOwner, error) {
-	var progressingConditions []metav1.Condition
-	requiredRemoteOwners := make(map[string][]*scyllav1alpha1.RemoteOwner, len(sc.Spec.Datacenters))
-
-	for _, dc := range sc.Spec.Datacenters {
-		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
-		if !ok {
-			progressingConditions = append(progressingConditions, metav1.Condition{
-				Type:               remoteRemoteOwnerControllerProgressingCondition,
-				Status:             metav1.ConditionTrue,
-				Reason:             "WaitingForRemoteNamespace",
-				Message:            fmt.Sprintf("Waiting for Namespace to be created in %q Cluster", dc.RemoteKubernetesClusterName),
-				ObservedGeneration: sc.Generation,
-			})
-			return progressingConditions, nil, nil
-		}
-
-		nameSuffix, err := naming.GenerateNameHash(sc.Namespace, dc.Name)
-		if err != nil {
-			return nil, nil, fmt.Errorf("can't generate remoteowner name suffix: %w", err)
-		}
-
-		ro := &scyllav1alpha1.RemoteOwner{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.Name,
-				Name:      fmt.Sprintf("%s-%s", sc.Name, nameSuffix),
-				Labels:    naming.RemoteOwnerLabels(sc, &dc, managingClusterDomain),
-			},
-		}
-
-		requiredRemoteOwners[dc.RemoteKubernetesClusterName] = append(requiredRemoteOwners[dc.RemoteKubernetesClusterName], ro)
+func MakeRemoteRemoteOwners(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, remoteNamespace *corev1.Namespace, managingClusterDomain string) ([]*scyllav1alpha1.RemoteOwner, error) {
+	nameSuffix, err := naming.GenerateNameHash(sc.Namespace, dc.Name)
+	if err != nil {
+		return nil, fmt.Errorf("can't generate remoteowner name suffix: %w", err)
 	}
 
-	return progressingConditions, requiredRemoteOwners, nil
+	requiredRemoteOwners := []*scyllav1alpha1.RemoteOwner{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: remoteNamespace.Name,
+				Name:      fmt.Sprintf("%s-%s", sc.Name, nameSuffix),
+				Labels:    naming.RemoteOwnerLabels(sc, dc, managingClusterDomain),
+			},
+		},
+	}
+
+	return requiredRemoteOwners, nil
 }
 
-func MakeRemoteNamespaces(sc *scyllav1alpha1.ScyllaDBCluster, existingNamespaces map[string]map[string]*corev1.Namespace, managingClusterDomain string) (map[string][]*corev1.Namespace, error) {
-	requiredNamespaces := make(map[string][]*corev1.Namespace)
+func MakeRemoteNamespaces(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, managingClusterDomain string) ([]*corev1.Namespace, error) {
+	suffix, err := naming.GenerateNameHash(sc.Namespace, dc.Name)
+	if err != nil {
+		return nil, fmt.Errorf("can't generate namespace name suffix: %w", err)
+	}
 
-	for _, dc := range sc.Spec.Datacenters {
-		suffix, err := naming.GenerateNameHash(sc.Namespace, dc.Name)
-		if err != nil {
-			return nil, fmt.Errorf("can't generate namespace name suffix: %w", err)
-		}
-
-		ns := &corev1.Namespace{
+	return []*corev1.Namespace{
+		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   fmt.Sprintf("%s-%s", sc.Namespace, suffix),
-				Labels: naming.ScyllaDBClusterDatacenterLabels(sc, &dc, managingClusterDomain),
+				Labels: naming.ScyllaDBClusterDatacenterLabels(sc, dc, managingClusterDomain),
 			},
-		}
-
-		requiredNamespaces[dc.RemoteKubernetesClusterName] = append(requiredNamespaces[dc.RemoteKubernetesClusterName], ns)
-	}
-
-	return requiredNamespaces, nil
+		},
+	}, nil
 }
 
-func MakeRemoteServices(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace, remoteControllers map[string]metav1.Object, managingClusterDomain string) ([]metav1.Condition, map[string][]*corev1.Service) {
-	var progressingConditions []metav1.Condition
-	remoteServices := make(map[string][]*corev1.Service, len(sc.Spec.Datacenters))
+func MakeRemoteServices(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, remoteNamespace *corev1.Namespace, remoteController metav1.Object, managingClusterDomain string) []*corev1.Service {
+	var remoteServices []*corev1.Service
 
-	for _, dc := range sc.Spec.Datacenters {
-		dcProgressingConditions, remoteNamespace, remoteController := getRemoteNamespaceAndController(
-			remoteServiceControllerProgressingCondition,
-			sc,
-			dc.RemoteKubernetesClusterName,
-			remoteNamespaces,
-			remoteControllers,
-		)
-		if len(dcProgressingConditions) > 0 {
-			progressingConditions = append(progressingConditions, dcProgressingConditions...)
+	for _, otherDC := range sc.Spec.Datacenters {
+		if dc.Name == otherDC.Name {
 			continue
 		}
 
-		for _, otherDC := range sc.Spec.Datacenters {
-			if dc.Name == otherDC.Name {
-				continue
-			}
-
-			remoteServices[dc.RemoteKubernetesClusterName] = append(remoteServices[dc.RemoteKubernetesClusterName], &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            naming.SeedService(sc, &otherDC),
-					Namespace:       remoteNamespace.Name,
-					Labels:          naming.ScyllaDBClusterDatacenterLabels(sc, &dc, managingClusterDomain),
-					Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, &dc),
-					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{
-						{
-							Name:     "inter-node",
-							Protocol: corev1.ProtocolTCP,
-							Port:     7000,
-						},
-						{
-							Name:     "inter-node-ssl",
-							Protocol: corev1.ProtocolTCP,
-							Port:     7001,
-						},
-						{
-							Name:     "cql",
-							Protocol: corev1.ProtocolTCP,
-							Port:     9042,
-						},
-						{
-							Name:     "cql-ssl",
-							Protocol: corev1.ProtocolTCP,
-							Port:     9142,
-						},
+		remoteServices = append(remoteServices, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            naming.SeedService(sc, &otherDC),
+				Namespace:       remoteNamespace.Name,
+				Labels:          naming.ScyllaDBClusterDatacenterLabels(sc, dc, managingClusterDomain),
+				Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, dc),
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "inter-node",
+						Protocol: corev1.ProtocolTCP,
+						Port:     7000,
 					},
-					Selector:  nil,
-					ClusterIP: corev1.ClusterIPNone,
-					Type:      corev1.ServiceTypeClusterIP,
+					{
+						Name:     "inter-node-ssl",
+						Protocol: corev1.ProtocolTCP,
+						Port:     7001,
+					},
+					{
+						Name:     "cql",
+						Protocol: corev1.ProtocolTCP,
+						Port:     9042,
+					},
+					{
+						Name:     "cql-ssl",
+						Protocol: corev1.ProtocolTCP,
+						Port:     9142,
+					},
 				},
-			})
-		}
+				Selector:  nil,
+				ClusterIP: corev1.ClusterIPNone,
+				Type:      corev1.ServiceTypeClusterIP,
+			},
+		})
 	}
 
-	return progressingConditions, remoteServices
+	return remoteServices
 }
 
-func MakeRemoteScyllaDBDatacenters(sc *scyllav1alpha1.ScyllaDBCluster, remoteScyllaDBDatacenters map[string]map[string]*scyllav1alpha1.ScyllaDBDatacenter, remoteNamespaces map[string]*corev1.Namespace, remoteControllers map[string]metav1.Object, managingClusterDomain string) ([]metav1.Condition, map[string][]*scyllav1alpha1.ScyllaDBDatacenter, error) {
-	var progressingConditions []metav1.Condition
-	requiredRemoteScyllaDBDatacenters := make(map[string][]*scyllav1alpha1.ScyllaDBDatacenter, len(sc.Spec.Datacenters))
-
+func MakeRemoteScyllaDBDatacenters(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, remoteScyllaDBDatacenters map[string]map[string]*scyllav1alpha1.ScyllaDBDatacenter, remoteNamespace *corev1.Namespace, remoteController metav1.Object, managingClusterDomain string) (*scyllav1alpha1.ScyllaDBDatacenter, error) {
 	// Given DC is part of seed list if it's fully reconciled, or is part of another DC seeds list,
 	// meaning it was fully reconciled in the past, so DC is part of the cluster.
 	seedDCNamesSet := sets.New[string]()
-	for _, dc := range sc.Spec.Datacenters {
-		sdc, ok := remoteScyllaDBDatacenters[dc.RemoteKubernetesClusterName][naming.ScyllaDBDatacenterName(sc, &dc)]
+	for _, dcSpec := range sc.Spec.Datacenters {
+		sdc, ok := remoteScyllaDBDatacenters[dcSpec.RemoteKubernetesClusterName][naming.ScyllaDBDatacenterName(sc, &dcSpec)]
 		if !ok {
 			continue
 
 		}
 		dcIsRolledOut, err := controllerhelpers.IsScyllaDBDatacenterRolledOut(sdc)
 		if err != nil {
-			return progressingConditions, nil, fmt.Errorf("can't check if %q ScyllaDBDatacenter is rolled out: %w", naming.ObjRef(sdc), err)
+			return nil, fmt.Errorf("can't check if %q ScyllaDBDatacenter is rolled out: %w", naming.ObjRef(sdc), err)
 		}
 		if dcIsRolledOut {
-			seedDCNamesSet.Insert(dc.Name)
+			seedDCNamesSet.Insert(dcSpec.Name)
 			continue
 		}
 
 		for _, remoteSDCs := range remoteScyllaDBDatacenters {
 			for _, remoteSDC := range remoteSDCs {
 				isReferencedByOtherDCAsSeed := slices.Contains(remoteSDC.Spec.ScyllaDB.ExternalSeeds, func(remoteSDCSeed string) bool {
-					return naming.DCNameFromSeedServiceAddress(sc, remoteSDCSeed, remoteSDC.Namespace) == dc.Name
+					return naming.DCNameFromSeedServiceAddress(sc, remoteSDCSeed, remoteSDC.Namespace) == dcSpec.Name
 				})
 
 				if isReferencedByOtherDCAsSeed {
-					seedDCNamesSet.Insert(dc.Name)
+					seedDCNamesSet.Insert(dcSpec.Name)
 				}
 			}
 		}
 	}
 
-	for _, dcSpec := range sc.Spec.Datacenters {
-		dcProgressingConditions, remoteNamespace, remoteController := getRemoteNamespaceAndController(
-			remoteScyllaDBDatacenterControllerProgressingCondition,
-			sc,
-			dcSpec.RemoteKubernetesClusterName,
-			remoteNamespaces,
-			remoteControllers,
-		)
-		if len(dcProgressingConditions) > 0 {
-			progressingConditions = append(progressingConditions, dcProgressingConditions...)
+	dcSpec := applyDatacenterTemplateOnDatacenter(sc.Spec.DatacenterTemplate, dc)
+
+	seeds := make([]string, 0, len(sc.Spec.ScyllaDB.ExternalSeeds)+seedDCNamesSet.Len())
+	seeds = append(seeds, sc.Spec.ScyllaDB.ExternalSeeds...)
+
+	for _, otherDC := range sc.Spec.Datacenters {
+		if otherDC.Name == dcSpec.Name {
 			continue
 		}
 
-		dc := applyDatacenterTemplateOnDatacenter(sc.Spec.DatacenterTemplate, &dcSpec)
-
-		seeds := make([]string, 0, len(sc.Spec.ScyllaDB.ExternalSeeds)+seedDCNamesSet.Len())
-		seeds = append(seeds, sc.Spec.ScyllaDB.ExternalSeeds...)
-
-		for _, otherDC := range sc.Spec.Datacenters {
-			if otherDC.Name == dcSpec.Name {
-				continue
-			}
-
-			if seedDCNamesSet.Has(otherDC.Name) {
-				seeds = append(seeds, fmt.Sprintf("%s.%s.svc", naming.SeedService(sc, &otherDC), remoteNamespace.Name))
-			}
+		if seedDCNamesSet.Has(otherDC.Name) {
+			seeds = append(seeds, fmt.Sprintf("%s.%s.svc", naming.SeedService(sc, &otherDC), remoteNamespace.Name))
 		}
+	}
 
-		requiredRemoteScyllaDBDatacenters[dc.RemoteKubernetesClusterName] = append(requiredRemoteScyllaDBDatacenters[dc.RemoteKubernetesClusterName], &scyllav1alpha1.ScyllaDBDatacenter{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            naming.ScyllaDBDatacenterName(sc, dc),
-				Namespace:       remoteNamespace.Name,
-				Labels:          naming.ScyllaDBClusterDatacenterLabels(sc, dc, managingClusterDomain),
-				Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, dc),
-				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
-			},
-			Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
-				Metadata: func() *scyllav1alpha1.ObjectTemplateMetadata {
-					var metadata *scyllav1alpha1.ObjectTemplateMetadata
-					if sc.Spec.Metadata != nil {
-						metadata = &scyllav1alpha1.ObjectTemplateMetadata{
-							Labels:      map[string]string{},
-							Annotations: map[string]string{},
-						}
-						maps.Copy(metadata.Labels, sc.Spec.Metadata.Labels)
-						maps.Copy(metadata.Annotations, sc.Spec.Metadata.Annotations)
+	return &scyllav1alpha1.ScyllaDBDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            naming.ScyllaDBDatacenterName(sc, dcSpec),
+			Namespace:       remoteNamespace.Name,
+			Labels:          naming.ScyllaDBClusterDatacenterLabels(sc, dcSpec, managingClusterDomain),
+			Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, dcSpec),
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
+		},
+		Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
+			Metadata: func() *scyllav1alpha1.ObjectTemplateMetadata {
+				var metadata *scyllav1alpha1.ObjectTemplateMetadata
+				if sc.Spec.Metadata != nil {
+					metadata = &scyllav1alpha1.ObjectTemplateMetadata{
+						Labels:      map[string]string{},
+						Annotations: map[string]string{},
 					}
+					maps.Copy(metadata.Labels, sc.Spec.Metadata.Labels)
+					maps.Copy(metadata.Annotations, sc.Spec.Metadata.Annotations)
+				}
 
-					if dc.Metadata != nil {
-						if metadata == nil {
-							metadata = &scyllav1alpha1.ObjectTemplateMetadata{
-								Labels:      map[string]string{},
-								Annotations: map[string]string{},
-							}
-						}
-						maps.Copy(metadata.Labels, dc.Metadata.Labels)
-						maps.Copy(metadata.Annotations, dc.Metadata.Annotations)
-					}
-
+				if dcSpec.Metadata != nil {
 					if metadata == nil {
 						metadata = &scyllav1alpha1.ObjectTemplateMetadata{
 							Labels:      map[string]string{},
 							Annotations: map[string]string{},
 						}
 					}
+					maps.Copy(metadata.Labels, dcSpec.Metadata.Labels)
+					maps.Copy(metadata.Annotations, dcSpec.Metadata.Annotations)
+				}
 
-					metadata.Labels[naming.ParentClusterNameLabel] = sc.Name
-					metadata.Labels[naming.ParentClusterNamespaceLabel] = sc.Namespace
-
-					return metadata
-				}(),
-				ClusterName:    sc.Name,
-				DatacenterName: pointer.Ptr(dc.Name),
-				ScyllaDB: scyllav1alpha1.ScyllaDB{
-					Image:                       sc.Spec.ScyllaDB.Image,
-					ExternalSeeds:               seeds,
-					AlternatorOptions:           sc.Spec.ScyllaDB.AlternatorOptions,
-					AdditionalScyllaDBArguments: sc.Spec.ScyllaDB.AdditionalScyllaDBArguments,
-					EnableDeveloperMode:         sc.Spec.ScyllaDB.EnableDeveloperMode,
-				},
-				ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgent{
-					Image: func() *string {
-						var image *string
-						if sc.Spec.ScyllaDBManagerAgent != nil {
-							image = sc.Spec.ScyllaDBManagerAgent.Image
-						}
-						return image
-					}(),
-				},
-				ForceRedeploymentReason: func() *string {
-					sb := strings.Builder{}
-					if sc.Spec.ForceRedeploymentReason != nil {
-						sb.WriteString(*sc.Spec.ForceRedeploymentReason)
+				if metadata == nil {
+					metadata = &scyllav1alpha1.ObjectTemplateMetadata{
+						Labels:      map[string]string{},
+						Annotations: map[string]string{},
 					}
+				}
 
-					if sc.Spec.ForceRedeploymentReason != nil && dc.ForceRedeploymentReason != nil {
-						sb.WriteByte(',')
-					}
+				metadata.Labels[naming.ParentClusterNameLabel] = sc.Name
+				metadata.Labels[naming.ParentClusterNamespaceLabel] = sc.Namespace
 
-					if dc.ForceRedeploymentReason != nil {
-						sb.WriteString(*dc.ForceRedeploymentReason)
-					}
-					if sb.Len() == 0 {
-						return nil
-					}
-					return pointer.Ptr(sb.String())
-				}(),
-				ExposeOptions: func() *scyllav1alpha1.ExposeOptions {
-					exposeOptions := &scyllav1alpha1.ExposeOptions{
-						// TODO: not supported yet
-						// Ref: https://github.com/scylladb/scylla-operator/issues/2602
-						CQL: nil,
-						NodeService: &scyllav1alpha1.NodeServiceTemplate{
-							Type: scyllav1alpha1.NodeServiceTypeHeadless,
-						},
-						BroadcastOptions: &scyllav1alpha1.NodeBroadcastOptions{
-							Nodes: scyllav1alpha1.BroadcastOptions{
-								Type: scyllav1alpha1.BroadcastAddressTypePodIP,
-							},
-							Clients: scyllav1alpha1.BroadcastOptions{
-								Type: scyllav1alpha1.BroadcastAddressTypePodIP,
-							},
-						},
-					}
-
-					if sc.Spec.ExposeOptions != nil {
-						if sc.Spec.ExposeOptions.NodeService != nil {
-							exposeOptions.NodeService = sc.Spec.ExposeOptions.NodeService
-						}
-
-						if sc.Spec.ExposeOptions.BroadcastOptions != nil {
-							exposeOptions.BroadcastOptions.Nodes = scyllav1alpha1.BroadcastOptions{
-								Type:  sc.Spec.ExposeOptions.BroadcastOptions.Nodes.Type,
-								PodIP: sc.Spec.ExposeOptions.BroadcastOptions.Nodes.PodIP,
-							}
-							exposeOptions.BroadcastOptions.Clients = scyllav1alpha1.BroadcastOptions{
-								Type:  sc.Spec.ExposeOptions.BroadcastOptions.Clients.Type,
-								PodIP: sc.Spec.ExposeOptions.BroadcastOptions.Clients.PodIP,
-							}
-						}
-						return exposeOptions
-					}
-
-					return exposeOptions
-				}(),
-				RackTemplate:                            dc.RackTemplate,
-				Racks:                                   dc.Racks,
-				DisableAutomaticOrphanedNodeReplacement: pointer.Ptr(sc.Spec.DisableAutomaticOrphanedNodeReplacement),
-				MinTerminationGracePeriodSeconds:        sc.Spec.MinTerminationGracePeriodSeconds,
-				MinReadySeconds:                         sc.Spec.MinReadySeconds,
-				ReadinessGates:                          sc.Spec.ReadinessGates,
-				// TODO: not supported yet
-				// Ref: https://github.com/scylladb/scylla-operator/issues/2262
-				ImagePullSecrets: nil,
-				// TODO not supported yet:
-				// Ref: https://github.com/scylladb/scylla-operator/issues/2603
-				DNSPolicy: nil,
-				// TODO not supported yet:
-				// Ref: https://github.com/scylladb/scylla-operator/issues/2602
-				DNSDomains: nil,
+				return metadata
+			}(),
+			ClusterName:    sc.Name,
+			DatacenterName: pointer.Ptr(dcSpec.Name),
+			ScyllaDB: scyllav1alpha1.ScyllaDB{
+				Image:                       sc.Spec.ScyllaDB.Image,
+				ExternalSeeds:               seeds,
+				AlternatorOptions:           sc.Spec.ScyllaDB.AlternatorOptions,
+				AdditionalScyllaDBArguments: sc.Spec.ScyllaDB.AdditionalScyllaDBArguments,
+				EnableDeveloperMode:         sc.Spec.ScyllaDB.EnableDeveloperMode,
 			},
-		})
-	}
+			ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgent{
+				Image: func() *string {
+					var image *string
+					if sc.Spec.ScyllaDBManagerAgent != nil {
+						image = sc.Spec.ScyllaDBManagerAgent.Image
+					}
+					return image
+				}(),
+			},
+			ForceRedeploymentReason: func() *string {
+				sb := strings.Builder{}
+				if sc.Spec.ForceRedeploymentReason != nil {
+					sb.WriteString(*sc.Spec.ForceRedeploymentReason)
+				}
 
-	return progressingConditions, requiredRemoteScyllaDBDatacenters, nil
+				if sc.Spec.ForceRedeploymentReason != nil && dcSpec.ForceRedeploymentReason != nil {
+					sb.WriteByte(',')
+				}
+
+				if dcSpec.ForceRedeploymentReason != nil {
+					sb.WriteString(*dcSpec.ForceRedeploymentReason)
+				}
+				if sb.Len() == 0 {
+					return nil
+				}
+				return pointer.Ptr(sb.String())
+			}(),
+			ExposeOptions: func() *scyllav1alpha1.ExposeOptions {
+				exposeOptions := &scyllav1alpha1.ExposeOptions{
+					// TODO: not supported yet
+					// Ref: https://github.com/scylladb/scylla-operator-enterprise/issues/55
+					CQL: nil,
+					NodeService: &scyllav1alpha1.NodeServiceTemplate{
+						Type: scyllav1alpha1.NodeServiceTypeHeadless,
+					},
+					BroadcastOptions: &scyllav1alpha1.NodeBroadcastOptions{
+						Nodes: scyllav1alpha1.BroadcastOptions{
+							Type: scyllav1alpha1.BroadcastAddressTypePodIP,
+						},
+						Clients: scyllav1alpha1.BroadcastOptions{
+							Type: scyllav1alpha1.BroadcastAddressTypePodIP,
+						},
+					},
+				}
+
+				if sc.Spec.ExposeOptions != nil {
+					if sc.Spec.ExposeOptions.NodeService != nil {
+						exposeOptions.NodeService = sc.Spec.ExposeOptions.NodeService
+					}
+
+					if sc.Spec.ExposeOptions.BroadcastOptions != nil {
+						exposeOptions.BroadcastOptions.Nodes = scyllav1alpha1.BroadcastOptions{
+							Type:  sc.Spec.ExposeOptions.BroadcastOptions.Nodes.Type,
+							PodIP: sc.Spec.ExposeOptions.BroadcastOptions.Nodes.PodIP,
+						}
+						exposeOptions.BroadcastOptions.Clients = scyllav1alpha1.BroadcastOptions{
+							Type:  sc.Spec.ExposeOptions.BroadcastOptions.Clients.Type,
+							PodIP: sc.Spec.ExposeOptions.BroadcastOptions.Clients.PodIP,
+						}
+					}
+					return exposeOptions
+				}
+
+				return exposeOptions
+			}(),
+			RackTemplate:                            dcSpec.RackTemplate,
+			Racks:                                   dcSpec.Racks,
+			DisableAutomaticOrphanedNodeReplacement: pointer.Ptr(sc.Spec.DisableAutomaticOrphanedNodeReplacement),
+			MinTerminationGracePeriodSeconds:        sc.Spec.MinTerminationGracePeriodSeconds,
+			MinReadySeconds:                         sc.Spec.MinReadySeconds,
+			ReadinessGates:                          sc.Spec.ReadinessGates,
+			// TODO: not supported yet
+			// Ref: https://github.com/scylladb/scylla-operator/issues/2262
+			ImagePullSecrets: nil,
+			// TODO not supported yet:
+			// Ref: https://github.com/scylladb/scylla-operator/issues/2603
+			DNSPolicy: nil,
+			// TODO not supported yet:
+			// Ref: https://github.com/scylladb/scylla-operator/issues/2602
+			DNSDomains: nil,
+		},
+	}, nil
 }
 
-func MakeRemoteEndpointSlices(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace, remoteControllers map[string]metav1.Object, remoteServiceLister remotelister.GenericClusterLister[corev1listers.ServiceLister], remotePodLister remotelister.GenericClusterLister[corev1listers.PodLister], managingClusterDomain string) ([]metav1.Condition, map[string][]*discoveryv1.EndpointSlice, error) {
+func MakeRemoteEndpointSlices(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, remoteNamespace *corev1.Namespace, remoteController metav1.Object, remoteNamespaces map[string]*corev1.Namespace, remoteServiceLister remotelister.GenericClusterLister[corev1listers.ServiceLister], remotePodLister remotelister.GenericClusterLister[corev1listers.PodLister], managingClusterDomain string) ([]metav1.Condition, []*discoveryv1.EndpointSlice, error) {
 	var progressingConditions []metav1.Condition
-	remoteEndpointSlices := make(map[string][]*discoveryv1.EndpointSlice, len(sc.Spec.Datacenters))
+	var remoteEndpointSlices []*discoveryv1.EndpointSlice
 
 	nodeBroadcastType := scyllav1alpha1.BroadcastAddressTypePodIP
 	if sc.Spec.ExposeOptions != nil && sc.Spec.ExposeOptions.BroadcastOptions != nil {
 		nodeBroadcastType = sc.Spec.ExposeOptions.BroadcastOptions.Nodes.Type
 	}
 
-	for _, dc := range sc.Spec.Datacenters {
-		dcProgressingConditions, remoteNamespace, remoteController := getRemoteNamespaceAndController(
-			remoteEndpointSliceControllerProgressingCondition,
-			sc,
-			dc.RemoteKubernetesClusterName,
-			remoteNamespaces,
-			remoteControllers,
-		)
-		if len(dcProgressingConditions) > 0 {
-			progressingConditions = append(progressingConditions, dcProgressingConditions...)
+	for _, otherDC := range sc.Spec.Datacenters {
+		if dc.Name == otherDC.Name {
 			continue
 		}
 
-		for _, otherDC := range sc.Spec.Datacenters {
-			if dc.Name == otherDC.Name {
-				continue
-			}
+		dcLabels := naming.ScyllaDBClusterDatacenterEndpointsLabels(sc, dc, managingClusterDomain)
+		dcLabels[discoveryv1.LabelServiceName] = naming.SeedService(sc, &otherDC)
+		dcLabels[discoveryv1.LabelManagedBy] = naming.OperatorAppNameWithDomain
 
-			dcLabels := naming.ScyllaDBClusterDatacenterEndpointsLabels(sc, dc, managingClusterDomain)
-			dcLabels[discoveryv1.LabelServiceName] = naming.SeedService(sc, &otherDC)
-			dcLabels[discoveryv1.LabelManagedBy] = naming.OperatorAppNameWithDomain
-
-			dcEs := &discoveryv1.EndpointSlice{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace:       remoteNamespace.Name,
-					Name:            naming.SeedService(sc, &otherDC),
-					Labels:          dcLabels,
-					Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, &dc),
-					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
+		dcEs := &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       remoteNamespace.Name,
+				Name:            naming.SeedService(sc, &otherDC),
+				Labels:          dcLabels,
+				Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, dc),
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Ports: []discoveryv1.EndpointPort{
+				{
+					Name:     pointer.Ptr("inter-node"),
+					Protocol: pointer.Ptr(corev1.ProtocolTCP),
+					Port:     pointer.Ptr(int32(7000)),
 				},
-				AddressType: discoveryv1.AddressTypeIPv4,
-				Ports: []discoveryv1.EndpointPort{
-					{
-						Name:     pointer.Ptr("inter-node"),
-						Protocol: pointer.Ptr(corev1.ProtocolTCP),
-						Port:     pointer.Ptr(int32(7000)),
-					},
-					{
-						Name:     pointer.Ptr("inter-node-ssl"),
-						Protocol: pointer.Ptr(corev1.ProtocolTCP),
-						Port:     pointer.Ptr(int32(7001)),
-					},
-					{
-						Name:     pointer.Ptr("cql"),
-						Protocol: pointer.Ptr(corev1.ProtocolTCP),
-						Port:     pointer.Ptr(int32(9042)),
-					},
-					{
-						Name:     pointer.Ptr("cql-ssl"),
-						Protocol: pointer.Ptr(corev1.ProtocolTCP),
-						Port:     pointer.Ptr(int32(9142)),
-					},
+				{
+					Name:     pointer.Ptr("inter-node-ssl"),
+					Protocol: pointer.Ptr(corev1.ProtocolTCP),
+					Port:     pointer.Ptr(int32(7001)),
 				},
-			}
-
-			otherDCPodSelector := naming.DatacenterPodsSelector(sc, &otherDC)
-			otherDCNamespace, ok := remoteNamespaces[otherDC.RemoteKubernetesClusterName]
-			if !ok {
-				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               remoteEndpointSliceControllerProgressingCondition,
-					Status:             metav1.ConditionTrue,
-					Reason:             "WaitingForRemoteNamespace",
-					Message:            fmt.Sprintf("Waiting for Namespace to be created in %q Cluster", otherDC.RemoteKubernetesClusterName),
-					ObservedGeneration: sc.Generation,
-				})
-				continue
-			}
-
-			switch nodeBroadcastType {
-			case scyllav1alpha1.BroadcastAddressTypePodIP:
-				dcPods, err := remotePodLister.Cluster(otherDC.RemoteKubernetesClusterName).Pods(otherDCNamespace.Name).List(otherDCPodSelector)
-				if err != nil {
-					return progressingConditions, nil, fmt.Errorf("can't list pods in %q ScyllaCluster %q Datacenter: %w", naming.ObjRef(sc), otherDC.Name, err)
-				}
-
-				klog.V(4).InfoS("Found remote Scylla Pods", "Cluster", klog.KObj(sc), "Datacenter", otherDC.Name, "Pods", len(dcPods))
-
-				// Sort pods to have stable list of endpoints
-				sort.Slice(dcPods, func(i, j int) bool {
-					return dcPods[i].Name < dcPods[j].Name
-				})
-				for _, dcPod := range dcPods {
-					if len(dcPod.Status.PodIP) == 0 {
-						continue
-					}
-
-					ready := controllerhelpers.IsPodReady(dcPod)
-					terminating := dcPod.DeletionTimestamp != nil
-					serving := ready && !terminating
-
-					dcEs.Endpoints = append(dcEs.Endpoints, discoveryv1.Endpoint{
-						Addresses: []string{dcPod.Status.PodIP},
-						Conditions: discoveryv1.EndpointConditions{
-							Ready:       pointer.Ptr(ready),
-							Serving:     pointer.Ptr(serving),
-							Terminating: pointer.Ptr(terminating),
-						},
-					})
-				}
-
-			case scyllav1alpha1.BroadcastAddressTypeServiceLoadBalancerIngress:
-				dcServices, err := remoteServiceLister.Cluster(otherDC.RemoteKubernetesClusterName).Services(otherDCNamespace.Name).List(otherDCPodSelector)
-				if err != nil {
-					return progressingConditions, nil, fmt.Errorf("can't list services in %q ScyllaDBCluster %q Datacenter: %w", naming.ObjRef(sc), otherDC.Name, err)
-				}
-
-				klog.V(4).InfoS("Found remote ScyllaDB Services", "ScyllaDBCluster", klog.KObj(sc), "Datacenter", otherDC.Name, "Services", len(dcServices))
-
-				// Sort objects to have stable list of endpoints
-				sort.Slice(dcServices, func(i, j int) bool {
-					return dcServices[i].Name < dcServices[j].Name
-				})
-
-				for _, dcService := range dcServices {
-					if dcService.Labels[naming.ScyllaServiceTypeLabel] != string(naming.ScyllaServiceTypeMember) {
-						continue
-					}
-
-					if len(dcService.Status.LoadBalancer.Ingress) < 1 {
-						continue
-					}
-
-					for _, ingress := range dcService.Status.LoadBalancer.Ingress {
-						ep := discoveryv1.Endpoint{
-							Conditions: discoveryv1.EndpointConditions{
-								Terminating: pointer.Ptr(dcService.DeletionTimestamp != nil),
-							},
-						}
-						if len(ingress.IP) != 0 {
-							ep.Addresses = append(ep.Addresses, ingress.IP)
-						}
-
-						if len(ingress.Hostname) != 0 {
-							ep.Addresses = append(ep.Addresses, ingress.Hostname)
-						}
-
-						if len(ep.Addresses) > 0 {
-							// LoadBalancer services are external to Kubernetes, and they don't report their readiness.
-							// Assume that if the address is there, it's ready and serving.
-							ep.Conditions.Ready = pointer.Ptr(true)
-							ep.Conditions.Serving = pointer.Ptr(true)
-						}
-
-						dcEs.Endpoints = append(dcEs.Endpoints, ep)
-					}
-				}
-
-			default:
-				return progressingConditions, nil, fmt.Errorf("unsupported node broadcast address type %v specified in %q ScyllaDBCluster", nodeBroadcastType, naming.ObjRef(sc))
-			}
-
-			remoteEndpointSlices[dc.RemoteKubernetesClusterName] = append(remoteEndpointSlices[dc.RemoteKubernetesClusterName], dcEs)
+				{
+					Name:     pointer.Ptr("cql"),
+					Protocol: pointer.Ptr(corev1.ProtocolTCP),
+					Port:     pointer.Ptr(int32(9042)),
+				},
+				{
+					Name:     pointer.Ptr("cql-ssl"),
+					Protocol: pointer.Ptr(corev1.ProtocolTCP),
+					Port:     pointer.Ptr(int32(9142)),
+				},
+			},
 		}
+
+		otherDCPodSelector := naming.DatacenterPodsSelector(sc, &otherDC)
+		otherDCNamespace, ok := remoteNamespaces[otherDC.RemoteKubernetesClusterName]
+		if !ok {
+			progressingConditions = append(progressingConditions, metav1.Condition{
+				Type:               remoteEndpointSliceControllerProgressingCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             "WaitingForRemoteNamespace",
+				Message:            fmt.Sprintf("Waiting for Namespace to be created in %q Cluster", otherDC.RemoteKubernetesClusterName),
+				ObservedGeneration: sc.Generation,
+			})
+			continue
+		}
+
+		switch nodeBroadcastType {
+		case scyllav1alpha1.BroadcastAddressTypePodIP:
+			dcPods, err := remotePodLister.Cluster(otherDC.RemoteKubernetesClusterName).Pods(otherDCNamespace.Name).List(otherDCPodSelector)
+			if err != nil {
+				return progressingConditions, nil, fmt.Errorf("can't list pods in %q ScyllaCluster %q Datacenter: %w", naming.ObjRef(sc), otherDC.Name, err)
+			}
+
+			klog.V(4).InfoS("Found remote Scylla Pods", "Cluster", klog.KObj(sc), "Datacenter", otherDC.Name, "Pods", len(dcPods))
+
+			// Sort pods to have stable list of endpoints
+			sort.Slice(dcPods, func(i, j int) bool {
+				return dcPods[i].Name < dcPods[j].Name
+			})
+			for _, dcPod := range dcPods {
+				if len(dcPod.Status.PodIP) == 0 {
+					continue
+				}
+
+				ready := controllerhelpers.IsPodReady(dcPod)
+				terminating := dcPod.DeletionTimestamp != nil
+				serving := ready && !terminating
+
+				dcEs.Endpoints = append(dcEs.Endpoints, discoveryv1.Endpoint{
+					Addresses: []string{dcPod.Status.PodIP},
+					Conditions: discoveryv1.EndpointConditions{
+						Ready:       pointer.Ptr(ready),
+						Serving:     pointer.Ptr(serving),
+						Terminating: pointer.Ptr(terminating),
+					},
+				})
+			}
+
+		case scyllav1alpha1.BroadcastAddressTypeServiceLoadBalancerIngress:
+			dcServices, err := remoteServiceLister.Cluster(otherDC.RemoteKubernetesClusterName).Services(otherDCNamespace.Name).List(otherDCPodSelector)
+			if err != nil {
+				return progressingConditions, nil, fmt.Errorf("can't list services in %q ScyllaDBCluster %q Datacenter: %w", naming.ObjRef(sc), otherDC.Name, err)
+			}
+
+			klog.V(4).InfoS("Found remote ScyllaDB Services", "ScyllaDBCluster", klog.KObj(sc), "Datacenter", otherDC.Name, "Services", len(dcServices))
+
+			// Sort objects to have stable list of endpoints
+			sort.Slice(dcServices, func(i, j int) bool {
+				return dcServices[i].Name < dcServices[j].Name
+			})
+
+			for _, dcService := range dcServices {
+				if dcService.Labels[naming.ScyllaServiceTypeLabel] != string(naming.ScyllaServiceTypeMember) {
+					continue
+				}
+
+				if len(dcService.Status.LoadBalancer.Ingress) < 1 {
+					continue
+				}
+
+				for _, ingress := range dcService.Status.LoadBalancer.Ingress {
+					ep := discoveryv1.Endpoint{
+						Conditions: discoveryv1.EndpointConditions{
+							Terminating: pointer.Ptr(dcService.DeletionTimestamp != nil),
+						},
+					}
+					if len(ingress.IP) != 0 {
+						ep.Addresses = append(ep.Addresses, ingress.IP)
+					}
+
+					if len(ingress.Hostname) != 0 {
+						ep.Addresses = append(ep.Addresses, ingress.Hostname)
+					}
+
+					if len(ep.Addresses) > 0 {
+						// LoadBalancer services are external to Kubernetes, and they don't report their readiness.
+						// Assume that if the address is there, it's ready and serving.
+						ep.Conditions.Ready = pointer.Ptr(true)
+						ep.Conditions.Serving = pointer.Ptr(true)
+					}
+
+					dcEs.Endpoints = append(dcEs.Endpoints, ep)
+				}
+			}
+
+		default:
+			return progressingConditions, nil, fmt.Errorf("unsupported node broadcast address type %v specified in %q ScyllaDBCluster", nodeBroadcastType, naming.ObjRef(sc))
+		}
+
+		remoteEndpointSlices = append(remoteEndpointSlices, dcEs)
 	}
 
 	return progressingConditions, remoteEndpointSlices, nil
@@ -885,122 +814,77 @@ func applyDatacenterTemplateOnDatacenter(dcTemplate *scyllav1alpha1.ScyllaDBClus
 	}
 }
 
-func getRemoteNamespaceAndController(controllerProgressingType string, sc *scyllav1alpha1.ScyllaDBCluster, clusterName string, remoteNamespaces map[string]*corev1.Namespace, remoteControllers map[string]metav1.Object) ([]metav1.Condition, *corev1.Namespace, metav1.Object) {
-	var progressingConditions []metav1.Condition
-	remoteNamespace, ok := remoteNamespaces[clusterName]
-	if !ok {
-		progressingConditions = append(progressingConditions, metav1.Condition{
-			Type:               controllerProgressingType,
-			Status:             metav1.ConditionTrue,
-			Reason:             "WaitingForRemoteNamespace",
-			Message:            fmt.Sprintf("Waiting for Namespace to be created in %q Cluster", clusterName),
-			ObservedGeneration: sc.Generation,
-		})
-		return progressingConditions, nil, nil
-	}
+func MakeRemoteConfigMaps(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, remoteNamespace *corev1.Namespace, remoteController metav1.Object, localConfigMapLister corev1listers.ConfigMapLister, managingClusterDomain string) ([]metav1.Condition, []*corev1.ConfigMap, error) {
+	var requiredRemoteConfigMaps []*corev1.ConfigMap
 
-	remoteController, ok := remoteControllers[clusterName]
-	if !ok {
-		progressingConditions = append(progressingConditions, metav1.Condition{
-			Type:               controllerProgressingType,
-			Status:             metav1.ConditionTrue,
-			Reason:             "WaitingForRemoteController",
-			Message:            fmt.Sprintf("Waiting for controller object to be created in %q Cluster", clusterName),
-			ObservedGeneration: sc.Generation,
-		})
-		return progressingConditions, nil, nil
-	}
-
-	return progressingConditions, remoteNamespace, remoteController
-}
-
-func MakeRemoteConfigMaps(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace, remoteControllers map[string]metav1.Object, localConfigMapLister corev1listers.ConfigMapLister, managingClusterDomain string) ([]metav1.Condition, map[string][]*corev1.ConfigMap, error) {
-	requiredRemoteConfigMaps := make(map[string][]*corev1.ConfigMap)
-
-	progressingConditions, mirroredConfigMaps, err := makeMirroredRemoteConfigMaps(sc, remoteNamespaces, remoteControllers, localConfigMapLister, managingClusterDomain)
+	progressingConditions, mirroredConfigMaps, err := makeMirroredRemoteConfigMaps(sc, dc, remoteNamespace, remoteController, localConfigMapLister, managingClusterDomain)
 	if err != nil {
 		return progressingConditions, nil, fmt.Errorf("can't make mirrored configmaps: %w", err)
 	}
 
-	for k, v := range mirroredConfigMaps {
-		requiredRemoteConfigMaps[k] = append(requiredRemoteConfigMaps[k], v...)
-	}
+	requiredRemoteConfigMaps = append(requiredRemoteConfigMaps, mirroredConfigMaps...)
 
 	return progressingConditions, requiredRemoteConfigMaps, nil
 }
 
-func makeMirroredRemoteConfigMaps(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace, remoteControllers map[string]metav1.Object, localConfigMapLister corev1listers.ConfigMapLister, managingClusterDomain string) ([]metav1.Condition, map[string][]*corev1.ConfigMap, error) {
+func makeMirroredRemoteConfigMaps(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, remoteNamespace *corev1.Namespace, remoteController metav1.Object, localConfigMapLister corev1listers.ConfigMapLister, managingClusterDomain string) ([]metav1.Condition, []*corev1.ConfigMap, error) {
 	var errs []error
 	var progressingConditions []metav1.Condition
-	requiredRemoteConfigMaps := make(map[string][]*corev1.ConfigMap, len(sc.Spec.Datacenters))
+	var requiredRemoteConfigMaps []*corev1.ConfigMap
 
-	for _, dc := range sc.Spec.Datacenters {
-		dcProgressingConditions, remoteNamespace, remoteController := getRemoteNamespaceAndController(
-			remoteConfigMapControllerProgressingCondition,
-			sc,
-			dc.RemoteKubernetesClusterName,
-			remoteNamespaces,
-			remoteControllers,
-		)
-		if len(dcProgressingConditions) > 0 {
-			progressingConditions = append(progressingConditions, dcProgressingConditions...)
+	var configMapsToMirror []string
+
+	if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.ScyllaDB != nil && sc.Spec.DatacenterTemplate.ScyllaDB.CustomConfigMapRef != nil {
+		configMapsToMirror = append(configMapsToMirror, *sc.Spec.DatacenterTemplate.ScyllaDB.CustomConfigMapRef)
+	}
+
+	if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDB != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDB.CustomConfigMapRef != nil {
+		configMapsToMirror = append(configMapsToMirror, *sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDB.CustomConfigMapRef)
+	}
+
+	if dc.ScyllaDB != nil && dc.ScyllaDB.CustomConfigMapRef != nil {
+		configMapsToMirror = append(configMapsToMirror, *dc.ScyllaDB.CustomConfigMapRef)
+	}
+
+	if dc.RackTemplate != nil && dc.RackTemplate.ScyllaDB != nil && dc.RackTemplate.ScyllaDB.CustomConfigMapRef != nil {
+		configMapsToMirror = append(configMapsToMirror, *dc.RackTemplate.ScyllaDB.CustomConfigMapRef)
+	}
+
+	for _, rack := range dc.Racks {
+		if rack.ScyllaDB != nil && rack.ScyllaDB.CustomConfigMapRef != nil {
+			configMapsToMirror = append(configMapsToMirror, *rack.ScyllaDB.CustomConfigMapRef)
+		}
+	}
+
+	for _, cmName := range configMapsToMirror {
+		localConfigMap, err := localConfigMapLister.ConfigMaps(sc.Namespace).Get(cmName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				progressingConditions = append(progressingConditions, metav1.Condition{
+					Type:               remoteConfigMapControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "WaitingForConfigMap",
+					Message:            fmt.Sprintf("Waiting for ConfigMap %q to exist.", naming.ManualRef(sc.Namespace, cmName)),
+					ObservedGeneration: sc.Generation,
+				})
+				continue
+			}
+			errs = append(errs, fmt.Errorf("can't get %q ConfigMap: %w", naming.ManualRef(sc.Namespace, cmName), err))
 			continue
 		}
 
-		var configMapsToMirror []string
-
-		if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.ScyllaDB != nil && sc.Spec.DatacenterTemplate.ScyllaDB.CustomConfigMapRef != nil {
-			configMapsToMirror = append(configMapsToMirror, *sc.Spec.DatacenterTemplate.ScyllaDB.CustomConfigMapRef)
-		}
-
-		if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDB != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDB.CustomConfigMapRef != nil {
-			configMapsToMirror = append(configMapsToMirror, *sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDB.CustomConfigMapRef)
-		}
-
-		if dc.ScyllaDB != nil && dc.ScyllaDB.CustomConfigMapRef != nil {
-			configMapsToMirror = append(configMapsToMirror, *dc.ScyllaDB.CustomConfigMapRef)
-		}
-
-		if dc.RackTemplate != nil && dc.RackTemplate.ScyllaDB != nil && dc.RackTemplate.ScyllaDB.CustomConfigMapRef != nil {
-			configMapsToMirror = append(configMapsToMirror, *dc.RackTemplate.ScyllaDB.CustomConfigMapRef)
-		}
-
-		for _, rack := range dc.Racks {
-			if rack.ScyllaDB != nil && rack.ScyllaDB.CustomConfigMapRef != nil {
-				configMapsToMirror = append(configMapsToMirror, *rack.ScyllaDB.CustomConfigMapRef)
-			}
-		}
-
-		for _, cmName := range configMapsToMirror {
-			localConfigMap, err := localConfigMapLister.ConfigMaps(sc.Namespace).Get(cmName)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					progressingConditions = append(progressingConditions, metav1.Condition{
-						Type:               remoteConfigMapControllerProgressingCondition,
-						Status:             metav1.ConditionTrue,
-						Reason:             "WaitingForConfigMap",
-						Message:            fmt.Sprintf("Waiting for ConfigMap %q to exist.", naming.ManualRef(sc.Namespace, cmName)),
-						ObservedGeneration: sc.Generation,
-					})
-					continue
-				}
-				errs = append(errs, fmt.Errorf("can't get %q ConfigMap: %w", naming.ManualRef(sc.Namespace, cmName), err))
-				continue
-			}
-
-			requiredRemoteConfigMaps[dc.RemoteKubernetesClusterName] = append(requiredRemoteConfigMaps[dc.RemoteKubernetesClusterName], &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            cmName,
-					Namespace:       remoteNamespace.Name,
-					Labels:          naming.ScyllaDBClusterDatacenterLabels(sc, &dc, managingClusterDomain),
-					Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, &dc),
-					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
-				},
-				Immutable:  localConfigMap.Immutable,
-				Data:       maps.Clone(localConfigMap.Data),
-				BinaryData: maps.Clone(localConfigMap.BinaryData),
-			})
-		}
+		requiredRemoteConfigMaps = append(requiredRemoteConfigMaps, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            cmName,
+				Namespace:       remoteNamespace.Name,
+				Labels:          naming.ScyllaDBClusterDatacenterLabels(sc, dc, managingClusterDomain),
+				Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, dc),
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
+			},
+			Immutable:  localConfigMap.Immutable,
+			Data:       maps.Clone(localConfigMap.Data),
+			BinaryData: maps.Clone(localConfigMap.BinaryData),
+		})
 	}
 
 	err := errors.NewAggregate(errs)
@@ -1011,93 +895,82 @@ func makeMirroredRemoteConfigMaps(sc *scyllav1alpha1.ScyllaDBCluster, remoteName
 	return progressingConditions, requiredRemoteConfigMaps, nil
 }
 
-func MakeRemoteSecrets(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace, remoteControllers map[string]metav1.Object, localSecretLister corev1listers.SecretLister, managingClusterDomain string) ([]metav1.Condition, map[string][]*corev1.Secret, error) {
-	requiredRemoteSecrets := make(map[string][]*corev1.Secret)
+func MakeRemoteSecrets(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, remoteNamespace *corev1.Namespace, remoteController metav1.Object, localSecretLister corev1listers.SecretLister, managingClusterDomain string) ([]metav1.Condition, []*corev1.Secret, error) {
+	var requiredRemoteSecrets []*corev1.Secret
 
-	progressingConditions, mirroredSecrets, err := makeMirroredRemoteSecrets(sc, remoteNamespaces, remoteControllers, localSecretLister, managingClusterDomain)
+	progressingConditions, mirroredSecrets, err := makeMirroredRemoteSecrets(sc, dc, remoteNamespace, remoteController, localSecretLister, managingClusterDomain)
 	if err != nil {
 		return progressingConditions, nil, fmt.Errorf("can't make mirrored secrets: %w", err)
 	}
 
-	for k, v := range mirroredSecrets {
-		requiredRemoteSecrets[k] = append(requiredRemoteSecrets[k], v...)
-	}
+	requiredRemoteSecrets = append(requiredRemoteSecrets, mirroredSecrets...)
 
 	return progressingConditions, requiredRemoteSecrets, nil
 }
 
-func makeMirroredRemoteSecrets(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace, remoteControllers map[string]metav1.Object, localSecretLister corev1listers.SecretLister, managingClusterDomain string) ([]metav1.Condition, map[string][]*corev1.Secret, error) {
+func makeMirroredRemoteSecrets(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, remoteNamespace *corev1.Namespace, remoteController metav1.Object, localSecretLister corev1listers.SecretLister, managingClusterDomain string) ([]metav1.Condition, []*corev1.Secret, error) {
 	var progressingConditions []metav1.Condition
-	requiredRemoteSecrets := make(map[string][]*corev1.Secret, len(sc.Spec.Datacenters))
+	var requiredRemoteSecrets []*corev1.Secret
+
+	var secretsToMirror []string
+
+	if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent != nil && sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
+		secretsToMirror = append(secretsToMirror, *sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
+	}
+
+	if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
+		secretsToMirror = append(secretsToMirror, *sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
+	}
+
+	if dc.ScyllaDBManagerAgent != nil && dc.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
+		secretsToMirror = append(secretsToMirror, *dc.ScyllaDBManagerAgent.CustomConfigSecretRef)
+	}
+
+	if dc.RackTemplate != nil && dc.RackTemplate.ScyllaDBManagerAgent != nil && dc.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
+		secretsToMirror = append(secretsToMirror, *dc.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
+	}
+
+	for _, rack := range dc.Racks {
+		if rack.ScyllaDBManagerAgent != nil && rack.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
+			secretsToMirror = append(secretsToMirror, *rack.ScyllaDBManagerAgent.CustomConfigSecretRef)
+		}
+	}
 
 	var errs []error
-	for _, dc := range sc.Spec.Datacenters {
-		dcProgressingConditions, remoteNamespace, remoteController := getRemoteNamespaceAndController(
-			remoteConfigMapControllerProgressingCondition,
-			sc,
-			dc.RemoteKubernetesClusterName,
-			remoteNamespaces,
-			remoteControllers,
-		)
-		if len(dcProgressingConditions) > 0 {
-			progressingConditions = append(progressingConditions, dcProgressingConditions...)
+	for _, secretName := range secretsToMirror {
+		localSecret, err := localSecretLister.Secrets(sc.Namespace).Get(secretName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				progressingConditions = append(progressingConditions, metav1.Condition{
+					Type:               remoteSecretControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "WaitingForSecret",
+					Message:            fmt.Sprintf("Waiting for Secret %q to exist.", naming.ManualRef(sc.Namespace, secretName)),
+					ObservedGeneration: sc.Generation,
+				})
+				continue
+			}
+			errs = append(errs, fmt.Errorf("can't get %q Secret: %w", naming.ManualRef(sc.Namespace, secretName), err))
 			continue
 		}
 
-		var secretsToMirror []string
+		requiredRemoteSecrets = append(requiredRemoteSecrets, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            secretName,
+				Namespace:       remoteNamespace.Name,
+				Labels:          naming.ScyllaDBClusterDatacenterLabels(sc, dc, managingClusterDomain),
+				Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, dc),
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
+			},
+			Immutable: localSecret.Immutable,
+			Data:      maps.Clone(localSecret.Data),
+			Type:      localSecret.Type,
+		})
+	}
 
-		if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent != nil && sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-			secretsToMirror = append(secretsToMirror, *sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
-		}
-
-		if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-			secretsToMirror = append(secretsToMirror, *sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
-		}
-
-		if dc.ScyllaDBManagerAgent != nil && dc.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-			secretsToMirror = append(secretsToMirror, *dc.ScyllaDBManagerAgent.CustomConfigSecretRef)
-		}
-
-		if dc.RackTemplate != nil && dc.RackTemplate.ScyllaDBManagerAgent != nil && dc.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-			secretsToMirror = append(secretsToMirror, *dc.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
-		}
-
-		for _, rack := range dc.Racks {
-			if rack.ScyllaDBManagerAgent != nil && rack.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-				secretsToMirror = append(secretsToMirror, *rack.ScyllaDBManagerAgent.CustomConfigSecretRef)
-			}
-		}
-
-		for _, secretName := range secretsToMirror {
-			localSecret, err := localSecretLister.Secrets(sc.Namespace).Get(secretName)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					progressingConditions = append(progressingConditions, metav1.Condition{
-						Type:               remoteSecretControllerProgressingCondition,
-						Status:             metav1.ConditionTrue,
-						Reason:             "WaitingForSecret",
-						Message:            fmt.Sprintf("Waiting for Secret %q to exist.", naming.ManualRef(sc.Namespace, secretName)),
-						ObservedGeneration: sc.Generation,
-					})
-					continue
-				}
-				errs = append(errs, fmt.Errorf("can't get %q Secret: %w", naming.ManualRef(sc.Namespace, secretName), err))
-				continue
-			}
-
-			requiredRemoteSecrets[dc.RemoteKubernetesClusterName] = append(requiredRemoteSecrets[dc.RemoteKubernetesClusterName], &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            secretName,
-					Namespace:       remoteNamespace.Name,
-					Labels:          naming.ScyllaDBClusterDatacenterLabels(sc, &dc, managingClusterDomain),
-					Annotations:     naming.ScyllaDBClusterDatacenterAnnotations(sc, &dc),
-					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(remoteController, remoteControllerGVK)},
-				},
-				Immutable: localSecret.Immutable,
-				Data:      maps.Clone(localSecret.Data),
-				Type:      localSecret.Type,
-			})
-		}
+	err := errors.NewAggregate(errs)
+	if err != nil {
+		return progressingConditions, requiredRemoteSecrets, fmt.Errorf("can't make mirrored Secrets: %w", err)
 	}
 
 	return progressingConditions, requiredRemoteSecrets, nil

--- a/pkg/controller/scylladbcluster/resource.go
+++ b/pkg/controller/scylladbcluster/resource.go
@@ -344,7 +344,7 @@ func MakeRemoteEndpointSlices(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1al
 		otherDCNamespace, ok := remoteNamespaces[otherDC.RemoteKubernetesClusterName]
 		if !ok {
 			progressingConditions = append(progressingConditions, metav1.Condition{
-				Type:               remoteEndpointSliceControllerProgressingCondition,
+				Type:               makeRemoteEndpointSliceControllerDatacenterProgressingCondition(dc.Name),
 				Status:             metav1.ConditionTrue,
 				Reason:             "WaitingForRemoteNamespace",
 				Message:            fmt.Sprintf("Waiting for Namespace to be created in %q Cluster", otherDC.RemoteKubernetesClusterName),
@@ -861,7 +861,7 @@ func makeMirroredRemoteConfigMaps(sc *scyllav1alpha1.ScyllaDBCluster, dc *scylla
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               remoteConfigMapControllerProgressingCondition,
+					Type:               makeRemoteConfigMapControllerDatacenterProgressingCondition(dc.Name),
 					Status:             metav1.ConditionTrue,
 					Reason:             "WaitingForConfigMap",
 					Message:            fmt.Sprintf("Waiting for ConfigMap %q to exist.", naming.ManualRef(sc.Namespace, cmName)),
@@ -942,7 +942,7 @@ func makeMirroredRemoteSecrets(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1a
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               remoteSecretControllerProgressingCondition,
+					Type:               makeRemoteSecretControllerDatacenterProgressingCondition(dc.Name),
 					Status:             metav1.ConditionTrue,
 					Reason:             "WaitingForSecret",
 					Message:            fmt.Sprintf("Waiting for Secret %q to exist.", naming.ManualRef(sc.Namespace, secretName)),

--- a/pkg/controller/scylladbcluster/sync.go
+++ b/pkg/controller/scylladbcluster/sync.go
@@ -61,33 +61,27 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 	// Operator reconciles objects in remote Kubernetes clusters, hence we can't set up a OwnerReference to ScyllaDBCluster
 	// because it's not there. Instead, we will manage dependent object ownership via a RemoteOwner.
 	type remoteCT = *scyllav1alpha1.RemoteOwner
-	var objectErrs []error
+	var objectErrMaps map[string][]error
 
 	remoteClusterNames := slices.ConvertSlice(sc.Spec.Datacenters, func(dc scyllav1alpha1.ScyllaDBClusterDatacenter) string {
 		return dc.RemoteKubernetesClusterName
 	})
 
-	remoteNamespaceMap, err := scc.getRemoteNamespacesMap(sc)
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't get remote namespaces: %w", err))
+	remoteNamespaceMap, errMap := scc.getRemoteNamespacesMap(sc)
+	for remoteClusterName, err := range errMap {
+		objectErrMaps[remoteClusterName] = append(objectErrMaps[remoteClusterName], fmt.Errorf("cant get remote namespaces for %q remote cluster: %w", remoteClusterName, err))
 	}
 
-	remoteNamespaces, err := scc.chooseRemoteNamespaces(sc, remoteNamespaceMap)
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't choose remote namespaces: %w", err))
+	remoteNamespaces := scc.chooseRemoteNamespaces(sc, remoteNamespaceMap)
+
+	remoteRemoteOwnerMap, errMap := scc.getRemoteRemoteOwners(sc, remoteNamespaces)
+	for remoteClusterName, err := range errMap {
+		objectErrMaps[remoteClusterName] = append(objectErrMaps[remoteClusterName], fmt.Errorf("can't get remote remoteowners for %q remote cluster: %w", remoteClusterName, err))
 	}
 
-	remoteRemoteOwnerMap, err := scc.getRemoteRemoteOwners(sc, remoteNamespaces)
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't get remote remoteowners: %w", err))
-	}
+	remoteControllers := scc.chooseRemoteControllers(sc, remoteRemoteOwnerMap)
 
-	remoteControllers, err := scc.chooseRemoteControllers(sc, remoteRemoteOwnerMap)
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't choose remote controllers: %w", err))
-	}
-
-	remoteServiceMap, err := controllerhelpers.GetRemoteObjects[remoteCT, *corev1.Service](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *corev1.Service]{
+	remoteServiceMap, errMap := controllerhelpers.GetRemoteObjects[remoteCT, *corev1.Service](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *corev1.Service]{
 		ClusterFunc: func(clusterName string) (controllerhelpers.ControlleeManagerGetObjectsInterface[remoteCT, *corev1.Service], error) {
 			ns, ok := remoteNamespaces[clusterName]
 			if !ok {
@@ -106,11 +100,11 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 			}, nil
 		},
 	})
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't get remote services: %w", err))
+	for remoteClusterName, err := range errMap {
+		objectErrMaps[remoteClusterName] = append(objectErrMaps[remoteClusterName], fmt.Errorf("can't get remote services for %q remote cluster: %w", remoteClusterName, err))
 	}
 
-	remoteEndpointSlicesMap, err := controllerhelpers.GetRemoteObjects[remoteCT, *discoveryv1.EndpointSlice](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *discoveryv1.EndpointSlice]{
+	remoteEndpointSlicesMap, errMap := controllerhelpers.GetRemoteObjects[remoteCT, *discoveryv1.EndpointSlice](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *discoveryv1.EndpointSlice]{
 		ClusterFunc: func(clusterName string) (controllerhelpers.ControlleeManagerGetObjectsInterface[remoteCT, *discoveryv1.EndpointSlice], error) {
 			ns, ok := remoteNamespaces[clusterName]
 			if !ok {
@@ -129,13 +123,13 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 			}, nil
 		},
 	})
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't get remote endpointslices: %w", err))
+	for remoteClusterName, err := range errMap {
+		objectErrMaps[remoteClusterName] = append(objectErrMaps[remoteClusterName], fmt.Errorf("can't get remote endpointslices for %q remote cluster: %w", remoteClusterName, err))
 	}
 
 	// GKE DNS doesn't understand EndpointSlices hence we have to reconcile both Endpoints and EndpointSlices.
 	// https://github.com/kubernetes/kubernetes/issues/107742
-	remoteEndpointsMap, err := controllerhelpers.GetRemoteObjects[remoteCT, *corev1.Endpoints](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteEndpointsSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *corev1.Endpoints]{
+	remoteEndpointsMap, errMap := controllerhelpers.GetRemoteObjects[remoteCT, *corev1.Endpoints](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteEndpointsSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *corev1.Endpoints]{
 		ClusterFunc: func(clusterName string) (controllerhelpers.ControlleeManagerGetObjectsInterface[remoteCT, *corev1.Endpoints], error) {
 			ns, ok := remoteNamespaces[clusterName]
 			if !ok {
@@ -154,11 +148,11 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 			}, nil
 		},
 	})
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't get remote endpoints: %w", err))
+	for remoteClusterName, err := range errMap {
+		objectErrMaps[remoteClusterName] = append(objectErrMaps[remoteClusterName], fmt.Errorf("can't get remote endpoints for %q remote cluster: %w", remoteClusterName, err))
 	}
 
-	remoteConfigMapMap, err := controllerhelpers.GetRemoteObjects[remoteCT, *corev1.ConfigMap](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *corev1.ConfigMap]{
+	remoteConfigMapMap, errMap := controllerhelpers.GetRemoteObjects[remoteCT, *corev1.ConfigMap](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *corev1.ConfigMap]{
 		ClusterFunc: func(clusterName string) (controllerhelpers.ControlleeManagerGetObjectsInterface[remoteCT, *corev1.ConfigMap], error) {
 			ns, ok := remoteNamespaces[clusterName]
 			if !ok {
@@ -177,11 +171,11 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 			}, nil
 		},
 	})
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't get remote configmaps: %w", err))
+	for remoteClusterName, err := range errMap {
+		objectErrMaps[remoteClusterName] = append(objectErrMaps[remoteClusterName], fmt.Errorf("can't get remote configmaps for %q remote cluster: %w", remoteClusterName, err))
 	}
 
-	remoteSecretMap, err := controllerhelpers.GetRemoteObjects[remoteCT, *corev1.Secret](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *corev1.Secret]{
+	remoteSecretMap, errMap := controllerhelpers.GetRemoteObjects[remoteCT, *corev1.Secret](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *corev1.Secret]{
 		ClusterFunc: func(clusterName string) (controllerhelpers.ControlleeManagerGetObjectsInterface[remoteCT, *corev1.Secret], error) {
 			ns, ok := remoteNamespaces[clusterName]
 			if !ok {
@@ -200,11 +194,11 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 			}, nil
 		},
 	})
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't get remote configmaps: %w", err))
+	for remoteClusterName, err := range errMap {
+		objectErrMaps[remoteClusterName] = append(objectErrMaps[remoteClusterName], fmt.Errorf("can't get remote secrets for %q remote cluster: %w", remoteClusterName, err))
 	}
 
-	remoteScyllaDBDatacenterMap, err := controllerhelpers.GetRemoteObjects[remoteCT, *scyllav1alpha1.ScyllaDBDatacenter](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *scyllav1alpha1.ScyllaDBDatacenter]{
+	remoteScyllaDBDatacenterMap, errMap := controllerhelpers.GetRemoteObjects[remoteCT, *scyllav1alpha1.ScyllaDBDatacenter](ctx, remoteClusterNames, remoteControllers, remoteControllerGVK, scRemoteSelector, &controllerhelpers.ClusterControlleeManagerGetObjectsFuncs[remoteCT, *scyllav1alpha1.ScyllaDBDatacenter]{
 		ClusterFunc: func(clusterName string) (controllerhelpers.ControlleeManagerGetObjectsInterface[remoteCT, *scyllav1alpha1.ScyllaDBDatacenter], error) {
 			ns, ok := remoteNamespaces[clusterName]
 			if !ok {
@@ -223,13 +217,8 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 			}, nil
 		},
 	})
-	if err != nil {
-		objectErrs = append(objectErrs, fmt.Errorf("can't get remote scyllaclusters: %w", err))
-	}
-
-	objectErr := utilerrors.NewAggregate(objectErrs)
-	if objectErr != nil {
-		return objectErr
+	for remoteClusterName, err := range errMap {
+		objectErrMaps[remoteClusterName] = append(objectErrMaps[remoteClusterName], fmt.Errorf("can't get remote scylladbdatacenters for %q remote cluster: %w", remoteClusterName, err))
 	}
 
 	status := scc.calculateStatus(sc, remoteScyllaDBDatacenterMap)
@@ -266,108 +255,151 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 
 	var errs []error
 
-	err = controllerhelpers.RunSync(
-		&status.Conditions,
-		remoteNamespaceControllerProgressingCondition,
-		remoteNamespaceControllerDegradedCondition,
-		sc.Generation,
-		func() ([]metav1.Condition, error) {
-			return scc.syncNamespaces(ctx, sc, remoteNamespaceMap, managingClusterDomain)
-		},
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("can't sync remote namespaces: %w", err))
-	}
+	for _, dc := range sc.Spec.Datacenters {
+		objectErrs := objectErrMaps[dc.RemoteKubernetesClusterName]
 
-	err = controllerhelpers.RunSync(
-		&status.Conditions,
-		remoteRemoteOwnerControllerProgressingCondition,
-		remoteRemoteOwnerControllerDegradedCondition,
-		sc.Generation,
-		func() ([]metav1.Condition, error) {
-			return scc.syncRemoteOwners(ctx, sc, remoteNamespaces, remoteRemoteOwnerMap, managingClusterDomain)
-		},
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("can't sync remote remoteowners: %w", err))
-	}
+		var err error
+		err = utilerrors.NewAggregate(objectErrs)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't sync remote datacenter %q: %w", dc.RemoteKubernetesClusterName, err))
+			continue
+		}
 
-	err = controllerhelpers.RunSync(
-		&status.Conditions,
-		remoteServiceControllerProgressingCondition,
-		remoteServiceControllerDegradedCondition,
-		sc.Generation,
-		func() ([]metav1.Condition, error) {
-			return scc.syncServices(ctx, sc, remoteNamespaces, remoteControllers, remoteServiceMap, managingClusterDomain)
-		},
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("can't sync remote services: %w", err))
-	}
+		err = controllerhelpers.RunSync(
+			&status.Conditions,
+			remoteNamespaceControllerProgressingCondition,
+			remoteNamespaceControllerDegradedCondition,
+			sc.Generation,
+			func() ([]metav1.Condition, error) {
+				return scc.syncRemoteNamespaces(ctx, sc, &dc, remoteNamespaceMap[dc.RemoteKubernetesClusterName], managingClusterDomain)
+			},
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't sync remote namespaces: %w", err))
+		}
 
-	err = controllerhelpers.RunSync(
-		&status.Conditions,
-		remoteEndpointSliceControllerProgressingCondition,
-		remoteEndpointSliceControllerDegradedCondition,
-		sc.Generation,
-		func() ([]metav1.Condition, error) {
-			return scc.syncEndpointSlices(ctx, sc, remoteNamespaces, remoteControllers, remoteEndpointSlicesMap, managingClusterDomain)
-		},
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("can't sync remote endpointslices: %w", err))
-	}
+		err = controllerhelpers.RunSync(
+			&status.Conditions,
+			remoteRemoteOwnerControllerProgressingCondition,
+			remoteRemoteOwnerControllerDegradedCondition,
+			sc.Generation,
+			func() ([]metav1.Condition, error) {
+				var progressingConditions []metav1.Condition
 
-	err = controllerhelpers.RunSync(
-		&status.Conditions,
-		remoteEndpointsControllerProgressingCondition,
-		remoteEndpointsControllerDegradedCondition,
-		sc.Generation,
-		func() ([]metav1.Condition, error) {
-			return scc.syncEndpoints(ctx, sc, remoteNamespaces, remoteControllers, remoteEndpointsMap, managingClusterDomain)
-		},
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("can't sync remote endpoints: %w", err))
-	}
+				remoteNamespace := remoteNamespaces[dc.RemoteKubernetesClusterName]
+				if remoteNamespace == nil {
+					progressingConditions = append(progressingConditions, metav1.Condition{
+						Type:               fmt.Sprintf(remoteRemoteOwnerControllerDatacenterProgressingConditionFormat, dc.Name),
+						Status:             metav1.ConditionTrue,
+						Reason:             "WaitingForRemoteNamespace",
+						Message:            fmt.Sprintf("Waiting for Namespace to be created in %q Cluster", dc.RemoteKubernetesClusterName),
+						ObservedGeneration: sc.Generation,
+					})
+					return progressingConditions, nil
+				}
 
-	err = controllerhelpers.RunSync(
-		&status.Conditions,
-		remoteConfigMapControllerProgressingCondition,
-		remoteConfigMapControllerDegradedCondition,
-		sc.Generation,
-		func() ([]metav1.Condition, error) {
-			return scc.syncConfigMaps(ctx, sc, remoteNamespaces, remoteControllers, remoteConfigMapMap, managingClusterDomain)
-		},
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("can't sync remote configmaps: %w", err))
-	}
+				return scc.syncRemoteRemoteOwners(ctx, sc, &dc, remoteNamespace, remoteRemoteOwnerMap[dc.RemoteKubernetesClusterName], managingClusterDomain)
+			},
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't sync remote remoteowners: %w", err))
+		}
 
-	err = controllerhelpers.RunSync(
-		&status.Conditions,
-		remoteSecretControllerProgressingCondition,
-		remoteSecretControllerDegradedCondition,
-		sc.Generation,
-		func() ([]metav1.Condition, error) {
-			return scc.syncSecrets(ctx, sc, remoteNamespaces, remoteControllers, remoteSecretMap, managingClusterDomain)
-		},
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("can't sync remote secrets: %w", err))
-	}
+		err = controllerhelpers.SyncRemoteNamespacedObject(
+			&status.Conditions,
+			remoteServiceControllerProgressingCondition,
+			remoteServiceControllerDegradedCondition,
+			sc.Generation,
+			dc.RemoteKubernetesClusterName,
+			remoteNamespaces[dc.RemoteKubernetesClusterName],
+			remoteControllers[dc.RemoteKubernetesClusterName],
+			func(remoteNamespace *corev1.Namespace, remoteController metav1.Object) ([]metav1.Condition, error) {
+				return scc.syncRemoteServices(ctx, sc, &dc, remoteNamespace, remoteController, remoteServiceMap[dc.RemoteKubernetesClusterName], managingClusterDomain)
+			},
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't sync remote services: %w", err))
+		}
 
-	err = controllerhelpers.RunSync(
-		&status.Conditions,
-		remoteScyllaDBDatacenterControllerProgressingCondition,
-		remoteScyllaDBDatacenterControllerDegradedCondition,
-		sc.Generation,
-		func() ([]metav1.Condition, error) {
-			return scc.syncScyllaDBDatacenters(ctx, sc, remoteNamespaces, remoteControllers, remoteScyllaDBDatacenterMap, managingClusterDomain)
-		},
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("can't sync remote scylladbdatacenters: %w", err))
+		err = controllerhelpers.SyncRemoteNamespacedObject(
+			&status.Conditions,
+			remoteEndpointSliceControllerProgressingCondition,
+			remoteEndpointSliceControllerDegradedCondition,
+			sc.Generation,
+			dc.RemoteKubernetesClusterName,
+			remoteNamespaces[dc.RemoteKubernetesClusterName],
+			remoteControllers[dc.RemoteKubernetesClusterName],
+			func(remoteNamespace *corev1.Namespace, remoteController metav1.Object) ([]metav1.Condition, error) {
+				return scc.syncRemoteEndpointSlices(ctx, sc, &dc, remoteNamespace, remoteController, remoteEndpointSlicesMap[dc.RemoteKubernetesClusterName], remoteNamespaces, managingClusterDomain)
+			},
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't sync remote endpointslices: %w", err))
+		}
+
+		err = controllerhelpers.SyncRemoteNamespacedObject(
+			&status.Conditions,
+			remoteEndpointsControllerProgressingCondition,
+			remoteEndpointsControllerDegradedCondition,
+			sc.Generation,
+			dc.RemoteKubernetesClusterName,
+			remoteNamespaces[dc.RemoteKubernetesClusterName],
+			remoteControllers[dc.RemoteKubernetesClusterName],
+			func(remoteNamespace *corev1.Namespace, remoteController metav1.Object) ([]metav1.Condition, error) {
+				return scc.syncRemoteEndpoints(ctx, sc, &dc, remoteNamespace, remoteController, remoteEndpointsMap[dc.RemoteKubernetesClusterName], remoteNamespaces, managingClusterDomain)
+			},
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't sync remote endpoints: %w", err))
+		}
+
+		err = controllerhelpers.SyncRemoteNamespacedObject(
+			&status.Conditions,
+			remoteConfigMapControllerProgressingCondition,
+			remoteConfigMapControllerDegradedCondition,
+			sc.Generation,
+			dc.RemoteKubernetesClusterName,
+			remoteNamespaces[dc.RemoteKubernetesClusterName],
+			remoteControllers[dc.RemoteKubernetesClusterName],
+			func(remoteNamespace *corev1.Namespace, remoteController metav1.Object) ([]metav1.Condition, error) {
+				return scc.syncRemoteConfigMaps(ctx, sc, &dc, remoteNamespace, remoteController, remoteConfigMapMap[dc.RemoteKubernetesClusterName], managingClusterDomain)
+			},
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't sync remote configmaps: %w", err))
+		}
+
+		err = controllerhelpers.SyncRemoteNamespacedObject(
+			&status.Conditions,
+			remoteSecretControllerProgressingCondition,
+			remoteSecretControllerDegradedCondition,
+			sc.Generation,
+			dc.RemoteKubernetesClusterName,
+			remoteNamespaces[dc.RemoteKubernetesClusterName],
+			remoteControllers[dc.RemoteKubernetesClusterName],
+			func(remoteNamespace *corev1.Namespace, remoteController metav1.Object) ([]metav1.Condition, error) {
+				return scc.syncRemoteSecrets(ctx, sc, &dc, remoteNamespace, remoteController, remoteSecretMap[dc.RemoteKubernetesClusterName], managingClusterDomain)
+			},
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't sync remote secrets: %w", err))
+		}
+
+		err = controllerhelpers.SyncRemoteNamespacedObject(
+			&status.Conditions,
+			remoteScyllaDBDatacenterControllerProgressingCondition,
+			remoteScyllaDBDatacenterControllerDegradedCondition,
+			sc.Generation,
+			dc.RemoteKubernetesClusterName,
+			remoteNamespaces[dc.RemoteKubernetesClusterName],
+			remoteControllers[dc.RemoteKubernetesClusterName],
+			func(remoteNamespace *corev1.Namespace, remoteController metav1.Object) ([]metav1.Condition, error) {
+				return scc.syncRemoteScyllaDBDatacenters(ctx, sc, &dc, remoteNamespace, remoteController, remoteScyllaDBDatacenterMap, managingClusterDomain)
+			},
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't sync remote scylladbdatacenters: %w", err))
+		}
 	}
 
 	// Aggregate conditions.
@@ -382,7 +414,7 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 	return utilerrors.NewAggregate(errs)
 }
 
-func (scc *Controller) chooseRemoteControllers(sc *scyllav1alpha1.ScyllaDBCluster, remoteRemoteOwnersMap map[string]map[string]*scyllav1alpha1.RemoteOwner) (map[string]metav1.Object, error) {
+func (scc *Controller) chooseRemoteControllers(sc *scyllav1alpha1.ScyllaDBCluster, remoteRemoteOwnersMap map[string]map[string]*scyllav1alpha1.RemoteOwner) map[string]metav1.Object {
 	remoteControllers := make(map[string]metav1.Object)
 
 	for _, dc := range sc.Spec.Datacenters {
@@ -401,11 +433,12 @@ func (scc *Controller) chooseRemoteControllers(sc *scyllav1alpha1.ScyllaDBCluste
 		remoteControllers[dc.RemoteKubernetesClusterName] = remoteOwners[0]
 	}
 
-	return remoteControllers, nil
+	return remoteControllers
 }
 
-func (scc *Controller) getRemoteRemoteOwners(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace) (map[string]map[string]*scyllav1alpha1.RemoteOwner, error) {
+func (scc *Controller) getRemoteRemoteOwners(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespaces map[string]*corev1.Namespace) (map[string]map[string]*scyllav1alpha1.RemoteOwner, map[string]error) {
 	remoteOwnerMap := make(map[string]map[string]*scyllav1alpha1.RemoteOwner, len(sc.Spec.Datacenters))
+	errMap := make(map[string]error, len(sc.Spec.Datacenters))
 	for _, dc := range sc.Spec.Datacenters {
 		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
 		if !ok {
@@ -416,14 +449,16 @@ func (scc *Controller) getRemoteRemoteOwners(sc *scyllav1alpha1.ScyllaDBCluster,
 		selector := labels.SelectorFromSet(naming.RemoteOwnerSelectorLabels(sc, &dc))
 		remoteOwners, err := scc.remoteRemoteOwnerLister.Cluster(dc.RemoteKubernetesClusterName).RemoteOwners(ns.Name).List(selector)
 		if err != nil {
-			return nil, fmt.Errorf("can't list remote remoteowners in %q cluster: %w", dc.RemoteKubernetesClusterName, err)
+			errMap[dc.RemoteKubernetesClusterName] = fmt.Errorf("can't list remote remoteowners in %q cluster: %w", dc.RemoteKubernetesClusterName, err)
+			continue
 		}
 
 		roMap := make(map[string]*scyllav1alpha1.RemoteOwner, len(remoteOwners))
 
 		for _, ro := range remoteOwners {
 			if len(ro.OwnerReferences) > 0 {
-				return nil, fmt.Errorf("unexpected RemoteOwner %q matching our selector and having an OwnerReference in %q cluster", naming.ObjRef(ro), dc.RemoteKubernetesClusterName)
+				errMap[dc.RemoteKubernetesClusterName] = fmt.Errorf("unexpected RemoteOwner %q matching our selector and having an OwnerReference in %q cluster", naming.ObjRef(ro), dc.RemoteKubernetesClusterName)
+				continue
 			}
 
 			roMap[ro.Name] = ro
@@ -432,11 +467,11 @@ func (scc *Controller) getRemoteRemoteOwners(sc *scyllav1alpha1.ScyllaDBCluster,
 		remoteOwnerMap[dc.RemoteKubernetesClusterName] = roMap
 	}
 
-	return remoteOwnerMap, nil
+	return remoteOwnerMap, errMap
 }
 
 // chooseRemoteNamespaces returns a map of namespaces used for reconciled objects per each remote.
-func (scc *Controller) chooseRemoteNamespaces(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespacesMap map[string]map[string]*corev1.Namespace) (map[string]*corev1.Namespace, error) {
+func (scc *Controller) chooseRemoteNamespaces(sc *scyllav1alpha1.ScyllaDBCluster, remoteNamespacesMap map[string]map[string]*corev1.Namespace) map[string]*corev1.Namespace {
 	remoteNamespaces := make(map[string]*corev1.Namespace)
 
 	for _, dc := range sc.Spec.Datacenters {
@@ -455,24 +490,26 @@ func (scc *Controller) chooseRemoteNamespaces(sc *scyllav1alpha1.ScyllaDBCluster
 		remoteNamespaces[dc.RemoteKubernetesClusterName] = remoteNss[0]
 	}
 
-	return remoteNamespaces, nil
+	return remoteNamespaces
 }
 
 // getRemoteNamespacesMap returns a map of remote namespaces matching provided selector.
-func (scc *Controller) getRemoteNamespacesMap(sc *scyllav1alpha1.ScyllaDBCluster) (map[string]map[string]*corev1.Namespace, error) {
+func (scc *Controller) getRemoteNamespacesMap(sc *scyllav1alpha1.ScyllaDBCluster) (map[string]map[string]*corev1.Namespace, map[string]error) {
 	namespacesMap := make(map[string]map[string]*corev1.Namespace, len(sc.Spec.Datacenters))
-
+	errMap := make(map[string]error, len(sc.Spec.Datacenters))
 	for _, dc := range sc.Spec.Datacenters {
 		selector := labels.SelectorFromSet(naming.ScyllaDBClusterDatacenterSelectorLabels(sc, &dc))
 		remoteNamespaces, err := scc.remoteNamespaceLister.Cluster(dc.RemoteKubernetesClusterName).List(selector)
 		if err != nil {
-			return nil, fmt.Errorf("can't list remote namespaces in %q cluster: %w", dc.RemoteKubernetesClusterName, err)
+			errMap[dc.RemoteKubernetesClusterName] = fmt.Errorf("can't list remote namespaces in %q cluster: %w", dc.RemoteKubernetesClusterName, err)
+			continue
 		}
 
 		nsMap := make(map[string]*corev1.Namespace, len(remoteNamespaces))
 		for _, rns := range remoteNamespaces {
 			if len(rns.OwnerReferences) != 0 {
-				return nil, fmt.Errorf("unexpected Namespace %q matching our selector and having an OwnerReference in %q cluster", rns.Name, dc.RemoteKubernetesClusterName)
+				errMap[dc.RemoteKubernetesClusterName] = fmt.Errorf("unexpected Namespace %q matching our selector and having an OwnerReference in %q cluster", rns.Name, dc.RemoteKubernetesClusterName)
+				continue
 			}
 
 			nsMap[rns.Name] = rns
@@ -481,7 +518,7 @@ func (scc *Controller) getRemoteNamespacesMap(sc *scyllav1alpha1.ScyllaDBCluster
 		namespacesMap[dc.RemoteKubernetesClusterName] = nsMap
 	}
 
-	return namespacesMap, nil
+	return namespacesMap, errMap
 }
 
 func (scc *Controller) getClusterClients(clusterName string) (kubernetes.Interface, scyllaclient.Interface, error) {

--- a/pkg/controller/scylladbcluster/sync_configmap.go
+++ b/pkg/controller/scylladbcluster/sync_configmap.go
@@ -53,7 +53,7 @@ func (scc *Controller) syncRemoteConfigMaps(
 	for _, cm := range requiredConfigMaps {
 		_, changed, err := resourceapply.ApplyConfigMap(ctx, clusterClient.CoreV1(), scc.remoteConfigMapLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, cm, resourceapply.ApplyOptions{})
 		if changed {
-			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteConfigMapControllerProgressingCondition, cm, "apply", sc.Generation)
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, makeRemoteConfigMapControllerDatacenterProgressingCondition(dc.Name), cm, "apply", sc.Generation)
 		}
 		if err != nil {
 			errs = append(errs, fmt.Errorf("can't apply configmap: %w", err))

--- a/pkg/controller/scylladbcluster/sync_endpoints.go
+++ b/pkg/controller/scylladbcluster/sync_endpoints.go
@@ -60,7 +60,7 @@ func (scc *Controller) syncRemoteEndpoints(
 	for _, e := range requiredEndpoints {
 		_, changed, err := resourceapply.ApplyEndpoints(ctx, clusterClient.CoreV1(), scc.remoteEndpointsLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, e, resourceapply.ApplyOptions{})
 		if changed {
-			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteEndpointsControllerProgressingCondition, e, "apply", sc.Generation)
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, makeRemoteEndpointsControllerDatacenterProgressingCondition(dc.Name), e, "apply", sc.Generation)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("can't apply endpoints: %w", err)

--- a/pkg/controller/scylladbcluster/sync_endpoints.go
+++ b/pkg/controller/scylladbcluster/sync_endpoints.go
@@ -12,78 +12,58 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-func (scc *Controller) syncEndpoints(
+func (scc *Controller) syncRemoteEndpoints(
 	ctx context.Context,
 	sc *scyllav1alpha1.ScyllaDBCluster,
+	dc *scyllav1alpha1.ScyllaDBClusterDatacenter,
+	remoteNamespace *corev1.Namespace,
+	remoteController metav1.Object,
+	remoteEndpoints map[string]*corev1.Endpoints,
 	remoteNamespaces map[string]*corev1.Namespace,
-	remoteControllers map[string]metav1.Object,
-	remoteEndpoints map[string]map[string]*corev1.Endpoints,
 	managingClusterDomain string,
 ) ([]metav1.Condition, error) {
-	progressingConditions, requiredEndpointSlices, err := MakeRemoteEndpointSlices(sc, remoteNamespaces, remoteControllers, scc.remoteServiceLister, scc.remotePodLister, managingClusterDomain)
+	progressingConditions, requiredEndpointSlices, err := MakeRemoteEndpointSlices(sc, dc, remoteNamespace, remoteController, remoteNamespaces, scc.remoteServiceLister, scc.remotePodLister, managingClusterDomain)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't make endpointslices: %w", err)
 	}
 
-	requiredEndpoints := make(map[string][]*corev1.Endpoints, len(requiredEndpointSlices))
+	requiredEndpoints := make([]*corev1.Endpoints, 0, len(requiredEndpointSlices))
 
-	for _, dc := range sc.Spec.Datacenters {
-		re, err := controllerhelpers.ConvertEndpointSlicesToEndpoints(requiredEndpointSlices[dc.RemoteKubernetesClusterName])
-		if err != nil {
-			return progressingConditions, fmt.Errorf("can't convert endpointslices to endpoints: %w", err)
-		}
+	re, err := controllerhelpers.ConvertEndpointSlicesToEndpoints(requiredEndpointSlices)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't convert endpointslices to endpoints: %w", err)
+	}
 
-		requiredEndpoints[dc.RemoteKubernetesClusterName] = re
+	requiredEndpoints = append(requiredEndpoints, re...)
+
+	clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
 	}
 
 	// Delete any excessive Endpoints.
 	// Delete has to be the first action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, dc := range sc.Spec.Datacenters {
-		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
-		if !ok {
-			continue
-		}
-
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
-		}
-
-		err = controllerhelpers.Prune(ctx,
-			requiredEndpoints[dc.RemoteKubernetesClusterName],
-			remoteEndpoints[dc.RemoteKubernetesClusterName],
-			&controllerhelpers.PruneControlFuncs{
-				DeleteFunc: clusterClient.CoreV1().Endpoints(ns.Name).Delete,
-			},
-			scc.eventRecorder,
-		)
-		if err != nil {
-			return progressingConditions, fmt.Errorf("can't prune endpoints in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
-		}
+	err = controllerhelpers.Prune(ctx,
+		requiredEndpoints,
+		remoteEndpoints,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: clusterClient.CoreV1().Endpoints(remoteNamespace.Name).Delete,
+		},
+		scc.eventRecorder,
+	)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't prune endpoints in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
 	}
 
-	if err := utilerrors.NewAggregate(deletionErrors); err != nil {
-		return nil, fmt.Errorf("can't prune remote endpoints: %w", err)
-	}
-
-	for _, dc := range sc.Spec.Datacenters {
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.Name, err)
+	for _, e := range requiredEndpoints {
+		_, changed, err := resourceapply.ApplyEndpoints(ctx, clusterClient.CoreV1(), scc.remoteEndpointsLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, e, resourceapply.ApplyOptions{})
+		if changed {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteEndpointsControllerProgressingCondition, e, "apply", sc.Generation)
 		}
-
-		for _, e := range requiredEndpoints[dc.RemoteKubernetesClusterName] {
-			_, changed, err := resourceapply.ApplyEndpoints(ctx, clusterClient.CoreV1(), scc.remoteEndpointsLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, e, resourceapply.ApplyOptions{})
-			if changed {
-				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteEndpointsControllerProgressingCondition, e, "apply", sc.Generation)
-			}
-			if err != nil {
-				return nil, fmt.Errorf("can't apply endpoints: %w", err)
-			}
+		if err != nil {
+			return nil, fmt.Errorf("can't apply endpoints: %w", err)
 		}
 	}
 

--- a/pkg/controller/scylladbcluster/sync_endpointslices.go
+++ b/pkg/controller/scylladbcluster/sync_endpointslices.go
@@ -55,7 +55,7 @@ func (scc *Controller) syncRemoteEndpointSlices(
 	for _, es := range requiredEndpointSlices {
 		_, changed, err := resourceapply.ApplyEndpointSlice(ctx, clusterClient.DiscoveryV1(), scc.remoteEndpointSliceLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, es, resourceapply.ApplyOptions{})
 		if changed {
-			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteEndpointSliceControllerProgressingCondition, es, "apply", sc.Generation)
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, makeRemoteEndpointSliceControllerDatacenterProgressingCondition(dc.Name), es, "apply", sc.Generation)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("can't apply endpointslice: %w", err)

--- a/pkg/controller/scylladbcluster/sync_endpointslices.go
+++ b/pkg/controller/scylladbcluster/sync_endpointslices.go
@@ -13,18 +13,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-func (scc *Controller) syncEndpointSlices(
+func (scc *Controller) syncRemoteEndpointSlices(
 	ctx context.Context,
 	sc *scyllav1alpha1.ScyllaDBCluster,
+	dc *scyllav1alpha1.ScyllaDBClusterDatacenter,
+	remoteNamespace *corev1.Namespace,
+	remoteController metav1.Object,
+	remoteEndpointSlices map[string]*discoveryv1.EndpointSlice,
 	remoteNamespaces map[string]*corev1.Namespace,
-	remoteControllers map[string]metav1.Object,
-	remoteEndpointSlices map[string]map[string]*discoveryv1.EndpointSlice,
 	managingClusterDomain string,
 ) ([]metav1.Condition, error) {
-	progressingConditions, requiredEndpointSlices, err := MakeRemoteEndpointSlices(sc, remoteNamespaces, remoteControllers, scc.remoteServiceLister, scc.remotePodLister, managingClusterDomain)
+	progressingConditions, requiredEndpointSlices, err := MakeRemoteEndpointSlices(sc, dc, remoteNamespace, remoteController, remoteNamespaces, scc.remoteServiceLister, scc.remotePodLister, managingClusterDomain)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't make endpointslices: %w", err)
 	}
@@ -32,51 +33,32 @@ func (scc *Controller) syncEndpointSlices(
 		return progressingConditions, nil
 	}
 
+	clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
+	}
+
 	// Delete any excessive EndpointSlices.
 	// Delete has to be the first action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, dc := range sc.Spec.Datacenters {
-		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
-		if !ok {
-			continue
-		}
-
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
-		}
-
-		err = controllerhelpers.Prune(ctx,
-			requiredEndpointSlices[dc.RemoteKubernetesClusterName],
-			remoteEndpointSlices[dc.RemoteKubernetesClusterName],
-			&controllerhelpers.PruneControlFuncs{
-				DeleteFunc: clusterClient.DiscoveryV1().EndpointSlices(ns.Name).Delete,
-			},
-			scc.eventRecorder,
-		)
-		if err != nil {
-			return progressingConditions, fmt.Errorf("can't prune endpointslices in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
-		}
+	err = controllerhelpers.Prune(ctx,
+		requiredEndpointSlices,
+		remoteEndpointSlices,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: clusterClient.DiscoveryV1().EndpointSlices(remoteNamespace.Name).Delete,
+		},
+		scc.eventRecorder,
+	)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't prune endpointslices in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
 	}
 
-	if err := utilerrors.NewAggregate(deletionErrors); err != nil {
-		return nil, fmt.Errorf("can't prune remote endpointslice(s): %w", err)
-	}
-
-	for _, dc := range sc.Spec.Datacenters {
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q region: %w", dc.Name, err)
+	for _, es := range requiredEndpointSlices {
+		_, changed, err := resourceapply.ApplyEndpointSlice(ctx, clusterClient.DiscoveryV1(), scc.remoteEndpointSliceLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, es, resourceapply.ApplyOptions{})
+		if changed {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteEndpointSliceControllerProgressingCondition, es, "apply", sc.Generation)
 		}
-
-		for _, es := range requiredEndpointSlices[dc.RemoteKubernetesClusterName] {
-			_, changed, err := resourceapply.ApplyEndpointSlice(ctx, clusterClient.DiscoveryV1(), scc.remoteEndpointSliceLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, es, resourceapply.ApplyOptions{})
-			if changed {
-				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteEndpointSliceControllerProgressingCondition, es, "apply", sc.Generation)
-			}
-			if err != nil {
-				return nil, fmt.Errorf("can't apply endpointslice: %w", err)
-			}
+		if err != nil {
+			return nil, fmt.Errorf("can't apply endpointslice: %w", err)
 		}
 	}
 

--- a/pkg/controller/scylladbcluster/sync_namespace.go
+++ b/pkg/controller/scylladbcluster/sync_namespace.go
@@ -12,71 +12,53 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-func (scc *Controller) syncNamespaces(
+func (scc *Controller) syncRemoteNamespaces(
 	ctx context.Context,
 	sc *scyllav1alpha1.ScyllaDBCluster,
-	remoteNamespaces map[string]map[string]*corev1.Namespace,
+	dc *scyllav1alpha1.ScyllaDBClusterDatacenter,
+	remoteNamespaces map[string]*corev1.Namespace,
 	managingClusterDomain string,
 ) ([]metav1.Condition, error) {
 	var progressingConditions []metav1.Condition
 
-	requiredNamespaces, err := MakeRemoteNamespaces(sc, remoteNamespaces, managingClusterDomain)
+	requiredNamespaces, err := MakeRemoteNamespaces(sc, dc, managingClusterDomain)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't make required namespaces: %w", err)
 	}
 
+	clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
+	}
+
 	// Delete any excessive Namespaces.
 	// Delete has to be the first action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, dc := range sc.Spec.Datacenters {
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
-		}
-
-		err = controllerhelpers.Prune(ctx,
-			requiredNamespaces[dc.RemoteKubernetesClusterName],
-			remoteNamespaces[dc.RemoteKubernetesClusterName],
-			&controllerhelpers.PruneControlFuncs{
-				DeleteFunc: func(ctx context.Context, name string, opts metav1.DeleteOptions) error {
-					return clusterClient.CoreV1().Namespaces().Delete(ctx, name, opts)
-				},
+	err = controllerhelpers.Prune(ctx,
+		requiredNamespaces,
+		remoteNamespaces,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: func(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+				return clusterClient.CoreV1().Namespaces().Delete(ctx, name, opts)
 			},
-			scc.eventRecorder,
-		)
-		if err != nil {
-			return progressingConditions, fmt.Errorf("can't prune namespace(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
-		}
+		},
+		scc.eventRecorder,
+	)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't prune namespace(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
 	}
 
-	if err := utilerrors.NewAggregate(deletionErrors); err != nil {
-		return nil, fmt.Errorf("can't delete namespace(s): %w", err)
-	}
-
-	for _, dc := range sc.Spec.Datacenters {
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+	lister := scc.remoteNamespaceLister.Cluster(dc.RemoteKubernetesClusterName)
+	for _, rns := range requiredNamespaces {
+		_, changed, err := resourceapply.ApplyNamespace(ctx, clusterClient.CoreV1(), lister, scc.eventRecorder, rns, resourceapply.ApplyOptions{
+			AllowMissingControllerRef: true,
+		})
+		if changed {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteNamespaceControllerProgressingCondition, rns, "apply", sc.Generation)
+		}
 		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.Name, err)
-		}
-		lister := scc.remoteNamespaceLister.Cluster(dc.RemoteKubernetesClusterName)
-
-		rnss, ok := requiredNamespaces[dc.RemoteKubernetesClusterName]
-		if !ok {
-			continue
-		}
-		for _, rns := range rnss {
-			_, changed, err := resourceapply.ApplyNamespace(ctx, clusterClient.CoreV1(), lister, scc.eventRecorder, rns, resourceapply.ApplyOptions{
-				AllowMissingControllerRef: true,
-			})
-			if changed {
-				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteNamespaceControllerProgressingCondition, rns, "apply", sc.Generation)
-			}
-			if err != nil {
-				return nil, fmt.Errorf("can't apply namespace %q: %w", rns.Name, err)
-			}
+			return nil, fmt.Errorf("can't apply namespace %q: %w", rns.Name, err)
 		}
 	}
 

--- a/pkg/controller/scylladbcluster/sync_namespace.go
+++ b/pkg/controller/scylladbcluster/sync_namespace.go
@@ -55,7 +55,7 @@ func (scc *Controller) syncRemoteNamespaces(
 			AllowMissingControllerRef: true,
 		})
 		if changed {
-			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteNamespaceControllerProgressingCondition, rns, "apply", sc.Generation)
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, makeRemoteNamespaceControllerDatacenterProgressingCondition(dc.Name), rns, "apply", sc.Generation)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("can't apply namespace %q: %w", rns.Name, err)

--- a/pkg/controller/scylladbcluster/sync_remoteowner.go
+++ b/pkg/controller/scylladbcluster/sync_remoteowner.go
@@ -52,7 +52,7 @@ func (scc *Controller) syncRemoteRemoteOwners(
 			AllowMissingControllerRef: true,
 		})
 		if changed {
-			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteRemoteOwnerControllerProgressingCondition, ro, "apply", sc.Generation)
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, makeRemoteRemoteOwnerControllerDatacenterProgressingCondition(dc.Name), ro, "apply", sc.Generation)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("can't apply remoteowner: %w", err)

--- a/pkg/controller/scylladbcluster/sync_remoteowner.go
+++ b/pkg/controller/scylladbcluster/sync_remoteowner.go
@@ -12,71 +12,50 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-func (scc *Controller) syncRemoteOwners(
+func (scc *Controller) syncRemoteRemoteOwners(
 	ctx context.Context,
 	sc *scyllav1alpha1.ScyllaDBCluster,
-	remoteNamespaces map[string]*corev1.Namespace,
-	remoteRemoteOwners map[string]map[string]*scyllav1alpha1.RemoteOwner,
+	dc *scyllav1alpha1.ScyllaDBClusterDatacenter,
+	remoteNamespace *corev1.Namespace,
+	remoteRemoteOwners map[string]*scyllav1alpha1.RemoteOwner,
 	managingClusterDomain string,
 ) ([]metav1.Condition, error) {
-	progressingConditions, requiredRemoteOwners, err := MakeRemoteRemoteOwners(sc, remoteNamespaces, remoteRemoteOwners, managingClusterDomain)
+	var progressingConditions []metav1.Condition
+	requiredRemoteOwners, err := MakeRemoteRemoteOwners(sc, dc, remoteNamespace, managingClusterDomain)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't make remote owners: %w", err)
 	}
-	if len(progressingConditions) > 0 {
-		return progressingConditions, nil
+
+	clusterClient, err := scc.scyllaRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
 	}
 
 	// Delete any excessive RemoteOwners.
 	// Delete has to be the first action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, dc := range sc.Spec.Datacenters {
-		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
-		if !ok {
-			continue
-		}
-
-		clusterClient, err := scc.scyllaRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
-		}
-
-		err = controllerhelpers.Prune(ctx,
-			requiredRemoteOwners[dc.RemoteKubernetesClusterName],
-			remoteRemoteOwners[dc.RemoteKubernetesClusterName],
-			&controllerhelpers.PruneControlFuncs{
-				DeleteFunc: clusterClient.ScyllaV1alpha1().RemoteOwners(ns.Name).Delete,
-			},
-			scc.eventRecorder,
-		)
-		if err != nil {
-			return progressingConditions, fmt.Errorf("can't prune remoteowner(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
-		}
+	err = controllerhelpers.Prune(ctx,
+		requiredRemoteOwners,
+		remoteRemoteOwners,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: clusterClient.ScyllaV1alpha1().RemoteOwners(remoteNamespace.Name).Delete,
+		},
+		scc.eventRecorder,
+	)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't prune remoteowner(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
 	}
 
-	if err := utilerrors.NewAggregate(deletionErrors); err != nil {
-		return nil, fmt.Errorf("can't prune remote remoteowner(s): %w", err)
-	}
-
-	for _, dc := range sc.Spec.Datacenters {
-		clusterClient, err := scc.scyllaRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.Name, err)
+	for _, ro := range requiredRemoteOwners {
+		_, changed, err := resourceapply.ApplyRemoteOwner(ctx, clusterClient.ScyllaV1alpha1(), scc.remoteRemoteOwnerLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, ro, resourceapply.ApplyOptions{
+			AllowMissingControllerRef: true,
+		})
+		if changed {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteRemoteOwnerControllerProgressingCondition, ro, "apply", sc.Generation)
 		}
-
-		for _, ro := range requiredRemoteOwners[dc.RemoteKubernetesClusterName] {
-			_, changed, err := resourceapply.ApplyRemoteOwner(ctx, clusterClient.ScyllaV1alpha1(), scc.remoteRemoteOwnerLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, ro, resourceapply.ApplyOptions{
-				AllowMissingControllerRef: true,
-			})
-			if changed {
-				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteRemoteOwnerControllerProgressingCondition, ro, "apply", sc.Generation)
-			}
-			if err != nil {
-				return nil, fmt.Errorf("can't apply remoteowner: %w", err)
-			}
+		if err != nil {
+			return nil, fmt.Errorf("can't apply remoteowner: %w", err)
 		}
 	}
 

--- a/pkg/controller/scylladbcluster/sync_scylladbdatacenter.go
+++ b/pkg/controller/scylladbcluster/sync_scylladbdatacenter.go
@@ -12,95 +12,115 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
-func (scc *Controller) syncScyllaDBDatacenters(
+func (scc *Controller) syncRemoteScyllaDBDatacenters(
 	ctx context.Context,
 	sc *scyllav1alpha1.ScyllaDBCluster,
-	remoteNamespaces map[string]*corev1.Namespace,
-	remoteControllers map[string]metav1.Object,
+	dc *scyllav1alpha1.ScyllaDBClusterDatacenter,
+	remoteNamespace *corev1.Namespace,
+	remoteController metav1.Object,
 	remoteScyllaDBDatacenters map[string]map[string]*scyllav1alpha1.ScyllaDBDatacenter,
 	managingClusterDomain string,
 ) ([]metav1.Condition, error) {
-	progressingConditions, requiredScyllaDBDatacenters, err := MakeRemoteScyllaDBDatacenters(sc, remoteScyllaDBDatacenters, remoteNamespaces, remoteControllers, managingClusterDomain)
+	var progressingConditions []metav1.Condition
+	requiredScyllaDBDatacenter, err := MakeRemoteScyllaDBDatacenters(sc, dc, remoteScyllaDBDatacenters, remoteNamespace, remoteController, managingClusterDomain)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't make remote ScyllaDBDatacenters: %w", err)
 	}
-	if len(progressingConditions) > 0 {
-		return progressingConditions, nil
+
+	clusterClient, err := scc.scyllaRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
 	}
 
 	// Delete any excessive ScyllaDBDatacenters.
 	// Delete has to be the first action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, dc := range sc.Spec.Datacenters {
-		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
-		if !ok {
-			continue
-		}
-
-		clusterClient, err := scc.scyllaRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
-		}
-
-		// FIXME: This should first scale all racks to 0, only then remove.
-		//  	 Without graceful removal, state of other DC might be skewed.
-		// Ref: https://github.com/scylladb/scylla-operator/issues/2604
-		err = controllerhelpers.Prune(ctx,
-			requiredScyllaDBDatacenters[dc.RemoteKubernetesClusterName],
-			remoteScyllaDBDatacenters[dc.RemoteKubernetesClusterName],
-			&controllerhelpers.PruneControlFuncs{
-				DeleteFunc: clusterClient.ScyllaV1alpha1().ScyllaDBDatacenters(ns.Name).Delete,
-			},
-			scc.eventRecorder,
-		)
-		if err != nil {
-			return progressingConditions, fmt.Errorf("can't prune scylladbdatacenter(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
-		}
-	}
-
-	err = utilerrors.NewAggregate(deletionErrors)
+	// FIXME: This should first scale all racks to 0, only then remove.
+	//  	 Without graceful removal, state of other DC might be skewed.
+	// Ref: https://github.com/scylladb/scylla-operator/issues/2604
+	err = controllerhelpers.Prune(ctx,
+		[]*scyllav1alpha1.ScyllaDBDatacenter{requiredScyllaDBDatacenter},
+		remoteScyllaDBDatacenters[dc.RemoteKubernetesClusterName],
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: clusterClient.ScyllaV1alpha1().ScyllaDBDatacenters(remoteNamespace.Name).Delete,
+		},
+		scc.eventRecorder,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("can't prune scylladbdatacenter(s): %w", err)
+		return progressingConditions, fmt.Errorf("can't prune scylladbdatacenter(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
 	}
 
-	for _, dc := range sc.Spec.Datacenters {
-		clusterClient, err := scc.scyllaRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return progressingConditions, fmt.Errorf("can't get remote client: %w", err)
-		}
-
-		for _, sdc := range requiredScyllaDBDatacenters[dc.RemoteKubernetesClusterName] {
-			sdc, changed, err := resourceapply.ApplyScyllaDBDatacenter(ctx, clusterClient.ScyllaV1alpha1(), scc.remoteScyllaDBDatacenterLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, sdc, resourceapply.ApplyOptions{})
-			if err != nil {
-				return progressingConditions, fmt.Errorf("can't apply scylladbdatacenter: %w", err)
+	_, sdcExists := remoteScyllaDBDatacenters[dc.RemoteKubernetesClusterName][requiredScyllaDBDatacenter.Name]
+	if !sdcExists {
+		klog.V(4).InfoS("Required ScyllaDBDatacenter doesn't exists, awaiting all previous DC to finish bootstrapping", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(requiredScyllaDBDatacenter))
+		for i := range sc.Spec.Datacenters {
+			if sc.Spec.Datacenters[i].Name == dc.Name {
+				break
 			}
-
-			if changed {
-				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteScyllaDBDatacenterControllerProgressingCondition, sdc, "apply", sc.Generation)
-			}
-
-			rolledOut, err := controllerhelpers.IsScyllaDBDatacenterRolledOut(sdc)
-			if err != nil {
-				return progressingConditions, fmt.Errorf("can't check if scylladbdatacenter is rolled out: %w", err)
-			}
-
-			if !rolledOut {
-				klog.V(4).InfoS("Waiting for ScyllaDBDatacenter to roll out", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(sdc))
+			previousDCSpec := sc.Spec.Datacenters[i]
+			previousDCSDCName := naming.ScyllaDBDatacenterName(sc, &previousDCSpec)
+			previousDCSDC, ok := remoteScyllaDBDatacenters[previousDCSpec.RemoteKubernetesClusterName][previousDCSDCName]
+			if !ok {
+				klog.V(4).InfoS("Waiting for datacenter to be created", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(requiredScyllaDBDatacenter), "Datacenter", previousDCSpec.Name)
 				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               remoteScyllaDBDatacenterControllerProgressingCondition,
+					Type:               fmt.Sprintf(remoteScyllaDBDatacenterControllerDatacenterProgressingConditionFormat, dc.Name),
 					Status:             metav1.ConditionTrue,
-					Reason:             "WaitingForScyllaDBDatacenterRollout",
-					Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to roll out.", naming.ObjRef(sdc)),
+					Reason:             "WaitingForScyllaDBDatacenterCreation",
+					Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to be created.", previousDCSDCName),
 					ObservedGeneration: sc.Generation,
 				})
 
 				return progressingConditions, nil
 			}
+
+			rolledOut, err := controllerhelpers.IsScyllaDBDatacenterRolledOut(previousDCSDC)
+			if err != nil {
+				return progressingConditions, fmt.Errorf("can't check if scylladbdatacenter %q is rolled out: %w", naming.ObjRef(previousDCSDC), err)
+			}
+			if !rolledOut {
+				klog.V(4).InfoS("Waiting for datacenter to roll out", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(requiredScyllaDBDatacenter), "Datacenter", previousDCSpec.Name)
+				progressingConditions = append(progressingConditions, metav1.Condition{
+					Type:               fmt.Sprintf(remoteScyllaDBDatacenterControllerDatacenterProgressingConditionFormat, dc.Name),
+					Status:             metav1.ConditionTrue,
+					Reason:             "WaitingForScyllaDBDatacenterRollout",
+					Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to roll out.", naming.ObjRef(previousDCSDC)),
+					ObservedGeneration: sc.Generation,
+				})
+			}
 		}
+	}
+
+	if len(progressingConditions) > 0 {
+		return progressingConditions, nil
+	}
+
+	sdc, changed, err := resourceapply.ApplyScyllaDBDatacenter(ctx, clusterClient.ScyllaV1alpha1(), scc.remoteScyllaDBDatacenterLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, requiredScyllaDBDatacenter, resourceapply.ApplyOptions{})
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't apply scylladbdatacenter: %w", err)
+	}
+
+	if changed {
+		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, fmt.Sprintf(remoteScyllaDBDatacenterControllerDatacenterProgressingConditionFormat, dc.Name), sdc, "apply", sc.Generation)
+	}
+
+	rolledOut, err := controllerhelpers.IsScyllaDBDatacenterRolledOut(sdc)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't check if scylladbdatacenter is rolled out: %w", err)
+	}
+
+	if !rolledOut {
+		klog.V(4).InfoS("Waiting for ScyllaDBDatacenter to roll out", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(sdc))
+		progressingConditions = append(progressingConditions, metav1.Condition{
+			Type:               fmt.Sprintf(remoteScyllaDBDatacenterControllerDatacenterProgressingConditionFormat, dc.Name),
+			Status:             metav1.ConditionTrue,
+			Reason:             "WaitingForScyllaDBDatacenterRollout",
+			Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to roll out.", naming.ObjRef(sdc)),
+			ObservedGeneration: sc.Generation,
+		})
+
+		return progressingConditions, nil
 	}
 
 	return progressingConditions, nil

--- a/pkg/controller/scylladbcluster/sync_scylladbdatacenter.go
+++ b/pkg/controller/scylladbcluster/sync_scylladbdatacenter.go
@@ -65,7 +65,7 @@ func (scc *Controller) syncRemoteScyllaDBDatacenters(
 			if !ok {
 				klog.V(4).InfoS("Waiting for datacenter to be created", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(requiredScyllaDBDatacenter), "Datacenter", previousDCSpec.Name)
 				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               fmt.Sprintf(remoteScyllaDBDatacenterControllerDatacenterProgressingConditionFormat, dc.Name),
+					Type:               makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(dc.Name),
 					Status:             metav1.ConditionTrue,
 					Reason:             "WaitingForScyllaDBDatacenterCreation",
 					Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to be created.", previousDCSDCName),
@@ -82,7 +82,7 @@ func (scc *Controller) syncRemoteScyllaDBDatacenters(
 			if !rolledOut {
 				klog.V(4).InfoS("Waiting for datacenter to roll out", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(requiredScyllaDBDatacenter), "Datacenter", previousDCSpec.Name)
 				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               fmt.Sprintf(remoteScyllaDBDatacenterControllerDatacenterProgressingConditionFormat, dc.Name),
+					Type:               makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(dc.Name),
 					Status:             metav1.ConditionTrue,
 					Reason:             "WaitingForScyllaDBDatacenterRollout",
 					Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to roll out.", naming.ObjRef(previousDCSDC)),
@@ -102,7 +102,7 @@ func (scc *Controller) syncRemoteScyllaDBDatacenters(
 	}
 
 	if changed {
-		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, fmt.Sprintf(remoteScyllaDBDatacenterControllerDatacenterProgressingConditionFormat, dc.Name), sdc, "apply", sc.Generation)
+		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(dc.Name), sdc, "apply", sc.Generation)
 	}
 
 	rolledOut, err := controllerhelpers.IsScyllaDBDatacenterRolledOut(sdc)
@@ -113,7 +113,7 @@ func (scc *Controller) syncRemoteScyllaDBDatacenters(
 	if !rolledOut {
 		klog.V(4).InfoS("Waiting for ScyllaDBDatacenter to roll out", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(sdc))
 		progressingConditions = append(progressingConditions, metav1.Condition{
-			Type:               fmt.Sprintf(remoteScyllaDBDatacenterControllerDatacenterProgressingConditionFormat, dc.Name),
+			Type:               makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(dc.Name),
 			Status:             metav1.ConditionTrue,
 			Reason:             "WaitingForScyllaDBDatacenterRollout",
 			Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to roll out.", naming.ObjRef(sdc)),

--- a/pkg/controller/scylladbcluster/sync_secrets.go
+++ b/pkg/controller/scylladbcluster/sync_secrets.go
@@ -53,7 +53,7 @@ func (scc *Controller) syncRemoteSecrets(
 	for _, rs := range requiredRemoteSecrets {
 		_, changed, err := resourceapply.ApplySecret(ctx, clusterClient.CoreV1(), scc.remoteSecretLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, rs, resourceapply.ApplyOptions{})
 		if changed {
-			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteSecretControllerProgressingCondition, rs, "apply", sc.Generation)
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, makeRemoteSecretControllerDatacenterProgressingCondition(dc.Name), rs, "apply", sc.Generation)
 		}
 		if err != nil {
 			errs = append(errs, fmt.Errorf("can't apply secret: %w", err))

--- a/pkg/controller/scylladbcluster/sync_secrets.go
+++ b/pkg/controller/scylladbcluster/sync_secrets.go
@@ -3,6 +3,7 @@ package scylladbcluster
 import (
 	"context"
 	"fmt"
+
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
@@ -12,15 +13,16 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-func (scc *Controller) syncSecrets(
+func (scc *Controller) syncRemoteSecrets(
 	ctx context.Context,
 	sc *scyllav1alpha1.ScyllaDBCluster,
-	remoteNamespaces map[string]*corev1.Namespace,
-	remoteControllers map[string]metav1.Object,
-	remoteSecrets map[string]map[string]*corev1.Secret,
+	dc *scyllav1alpha1.ScyllaDBClusterDatacenter,
+	remoteNamespace *corev1.Namespace,
+	remoteController metav1.Object,
+	remoteSecrets map[string]*corev1.Secret,
 	managingClusterDomain string,
 ) ([]metav1.Condition, error) {
-	progressingConditions, requiredRemoteSecrets, err := MakeRemoteSecrets(sc, remoteNamespaces, remoteControllers, scc.secretLister, managingClusterDomain)
+	progressingConditions, requiredRemoteSecrets, err := MakeRemoteSecrets(sc, dc, remoteNamespace, remoteController, scc.secretLister, managingClusterDomain)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't make remote secrets: %w", err)
 	}
@@ -29,53 +31,33 @@ func (scc *Controller) syncSecrets(
 		return progressingConditions, nil
 	}
 
-	// Delete has to be the first action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, dc := range sc.Spec.Datacenters {
-		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
-		if !ok {
-			continue
-		}
-
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
-		}
-
-		err = controllerhelpers.Prune(ctx,
-			requiredRemoteSecrets[dc.RemoteKubernetesClusterName],
-			remoteSecrets[dc.RemoteKubernetesClusterName],
-			&controllerhelpers.PruneControlFuncs{
-				DeleteFunc: clusterClient.CoreV1().Secrets(ns.Name).Delete,
-			},
-			scc.eventRecorder,
-		)
-		if err != nil {
-			return progressingConditions, fmt.Errorf("can't prune secret(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
-		}
+	clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get client to %q cluster: %w", dc.RemoteKubernetesClusterName, err)
 	}
 
-	if err := utilerrors.NewAggregate(deletionErrors); err != nil {
-		return nil, fmt.Errorf("can't prune remote secret(s): %w", err)
+	// Delete has to be the first action to avoid getting stuck on quota.
+	err = controllerhelpers.Prune(ctx,
+		requiredRemoteSecrets,
+		remoteSecrets,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: clusterClient.CoreV1().Secrets(remoteNamespace.Name).Delete,
+		},
+		scc.eventRecorder,
+	)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't prune secret(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
 	}
 
 	var errs []error
-	for _, dc := range sc.Spec.Datacenters {
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("can't get client to %q cluster: %w", dc.Name, err))
-			continue
+	for _, rs := range requiredRemoteSecrets {
+		_, changed, err := resourceapply.ApplySecret(ctx, clusterClient.CoreV1(), scc.remoteSecretLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, rs, resourceapply.ApplyOptions{})
+		if changed {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteSecretControllerProgressingCondition, rs, "apply", sc.Generation)
 		}
-
-		for _, rs := range requiredRemoteSecrets[dc.RemoteKubernetesClusterName] {
-			_, changed, err := resourceapply.ApplySecret(ctx, clusterClient.CoreV1(), scc.remoteSecretLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, rs, resourceapply.ApplyOptions{})
-			if changed {
-				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteSecretControllerProgressingCondition, rs, "apply", sc.Generation)
-			}
-			if err != nil {
-				errs = append(errs, fmt.Errorf("can't apply secret: %w", err))
-				continue
-			}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't apply secret: %w", err))
+			continue
 		}
 	}
 

--- a/pkg/controller/scylladbcluster/sync_service.go
+++ b/pkg/controller/scylladbcluster/sync_service.go
@@ -49,7 +49,7 @@ func (scc *Controller) syncRemoteServices(
 	for _, svc := range requiredServices {
 		_, changed, err := resourceapply.ApplyService(ctx, clusterClient.CoreV1(), scc.remoteServiceLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, svc, resourceapply.ApplyOptions{})
 		if changed {
-			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteServiceControllerProgressingCondition, svc, "apply", sc.Generation)
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, makeRemoteServiceControllerDatacenterProgressingCondition(dc.Name), svc, "apply", sc.Generation)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("can't apply service: %w", err)

--- a/pkg/controller/scylladbcluster/sync_service.go
+++ b/pkg/controller/scylladbcluster/sync_service.go
@@ -12,67 +12,47 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-func (scc *Controller) syncServices(
+func (scc *Controller) syncRemoteServices(
 	ctx context.Context,
 	sc *scyllav1alpha1.ScyllaDBCluster,
-	remoteNamespaces map[string]*corev1.Namespace,
-	remoteControllers map[string]metav1.Object,
-	remoteServices map[string]map[string]*corev1.Service,
+	dc *scyllav1alpha1.ScyllaDBClusterDatacenter,
+	remoteNamespace *corev1.Namespace,
+	remoteController metav1.Object,
+	remoteServices map[string]*corev1.Service,
 	managingClusterDomain string,
 ) ([]metav1.Condition, error) {
-	progressingConditions, requiredServices := MakeRemoteServices(sc, remoteNamespaces, remoteControllers, managingClusterDomain)
-	if len(progressingConditions) > 0 {
-		return progressingConditions, nil
+	var progressingConditions []metav1.Condition
+
+	requiredServices := MakeRemoteServices(sc, dc, remoteNamespace, remoteController, managingClusterDomain)
+
+	clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get client to %q region: %w", dc.RemoteKubernetesClusterName, err)
 	}
 
 	// Delete any excessive Services.
 	// Delete has to be the first action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, dc := range sc.Spec.Datacenters {
-		ns, ok := remoteNamespaces[dc.RemoteKubernetesClusterName]
-		if !ok {
-			continue
-		}
-
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q region: %w", dc.RemoteKubernetesClusterName, err)
-		}
-
-		err = controllerhelpers.Prune(ctx,
-			requiredServices[dc.RemoteKubernetesClusterName],
-			remoteServices[dc.RemoteKubernetesClusterName],
-			&controllerhelpers.PruneControlFuncs{
-				DeleteFunc: clusterClient.CoreV1().Services(ns.Name).Delete,
-			},
-			scc.eventRecorder,
-		)
-		if err != nil {
-			return progressingConditions, fmt.Errorf("can't prune service(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
-		}
+	err = controllerhelpers.Prune(ctx,
+		requiredServices,
+		remoteServices,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: clusterClient.CoreV1().Services(remoteNamespace.Name).Delete,
+		},
+		scc.eventRecorder,
+	)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't prune service(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
 	}
 
-	if err := utilerrors.NewAggregate(deletionErrors); err != nil {
-		return nil, fmt.Errorf("can't prune remote services(s): %w", err)
-	}
-
-	for _, dc := range sc.Spec.Datacenters {
-		clusterClient, err := scc.kubeRemoteClient.Cluster(dc.RemoteKubernetesClusterName)
-		if err != nil {
-			return nil, fmt.Errorf("can't get client to %q region: %w", dc.Name, err)
+	for _, svc := range requiredServices {
+		_, changed, err := resourceapply.ApplyService(ctx, clusterClient.CoreV1(), scc.remoteServiceLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, svc, resourceapply.ApplyOptions{})
+		if changed {
+			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteServiceControllerProgressingCondition, svc, "apply", sc.Generation)
 		}
-
-		for _, svc := range requiredServices[dc.RemoteKubernetesClusterName] {
-			_, changed, err := resourceapply.ApplyService(ctx, clusterClient.CoreV1(), scc.remoteServiceLister.Cluster(dc.RemoteKubernetesClusterName), scc.eventRecorder, svc, resourceapply.ApplyOptions{})
-			if changed {
-				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, remoteServiceControllerProgressingCondition, svc, "apply", sc.Generation)
-			}
-			if err != nil {
-				return nil, fmt.Errorf("can't apply service: %w", err)
-			}
+		if err != nil {
+			return nil, fmt.Errorf("can't apply service: %w", err)
 		}
 	}
 

--- a/pkg/controllerhelpers/sync.go
+++ b/pkg/controllerhelpers/sync.go
@@ -200,10 +200,20 @@ func SyncRemoteNamespacedObject(conditions *[]metav1.Condition, progressingCondi
 }
 
 func SetAggregatedWorkloadConditions(conditions *[]metav1.Condition, generation int64) error {
+	return SetAggregatedWorkloadConditionsBySuffixes(
+		scyllav1.AvailableCondition,
+		scyllav1.ProgressingCondition,
+		scyllav1.DegradedCondition,
+		conditions,
+		generation,
+	)
+}
+
+func SetAggregatedWorkloadConditionsBySuffixes(availableConditionType, progressingConditionType, degradedConditionType string, conditions *[]metav1.Condition, generation int64) error {
 	availableCondition, err := AggregateStatusConditions(
-		FindStatusConditionsWithSuffix(*conditions, scyllav1.AvailableCondition),
+		FindStatusConditionsWithSuffix(*conditions, availableConditionType),
 		metav1.Condition{
-			Type:               scyllav1.AvailableCondition,
+			Type:               availableConditionType,
 			Status:             metav1.ConditionTrue,
 			Reason:             internalapi.AsExpectedReason,
 			Message:            "",
@@ -216,9 +226,9 @@ func SetAggregatedWorkloadConditions(conditions *[]metav1.Condition, generation 
 	apimeta.SetStatusCondition(conditions, availableCondition)
 
 	progressingCondition, err := AggregateStatusConditions(
-		FindStatusConditionsWithSuffix(*conditions, scyllav1.ProgressingCondition),
+		FindStatusConditionsWithSuffix(*conditions, progressingConditionType),
 		metav1.Condition{
-			Type:               scyllav1.ProgressingCondition,
+			Type:               progressingConditionType,
 			Status:             metav1.ConditionFalse,
 			Reason:             internalapi.AsExpectedReason,
 			Message:            "",
@@ -231,9 +241,9 @@ func SetAggregatedWorkloadConditions(conditions *[]metav1.Condition, generation 
 	apimeta.SetStatusCondition(conditions, progressingCondition)
 
 	degradedCondition, err := AggregateStatusConditions(
-		FindStatusConditionsWithSuffix(*conditions, scyllav1.DegradedCondition),
+		FindStatusConditionsWithSuffix(*conditions, degradedConditionType),
 		metav1.Condition{
-			Type:               scyllav1.DegradedCondition,
+			Type:               degradedConditionType,
 			Status:             metav1.ConditionFalse,
 			Reason:             internalapi.AsExpectedReason,
 			Message:            "",

--- a/pkg/internalapi/conditions.go
+++ b/pkg/internalapi/conditions.go
@@ -1,5 +1,11 @@
 package internalapi
 
+import (
+	"fmt"
+
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+)
+
 const (
 	NodeAvailableConditionFormat   = "Node%sAvailable"
 	NodeProgressingConditionFormat = "Node%sProgressing"
@@ -18,3 +24,24 @@ const (
 	ProgressingReason       = "Progressing"
 	AwaitingConditionReason = "AwaitingCondition"
 )
+
+var (
+	MakeDatacenterAvailableCondition   = MakeDatacenterConditionFunc(scyllav1alpha1.AvailableCondition)
+	MakeDatacenterProgressingCondition = MakeDatacenterConditionFunc(scyllav1alpha1.ProgressingCondition)
+	MakeDatacenterDegradedCondition    = MakeDatacenterConditionFunc(scyllav1alpha1.DegradedCondition)
+)
+
+// MakeDatacenterConditionFunc returns a function that creates a datacenter condition using the provided condition type.
+func MakeDatacenterConditionFunc(conditionType string) func(dcName string) string {
+	return func(dcName string) string {
+		return fmt.Sprintf("Datacenter%s%s", dcName, conditionType)
+	}
+}
+
+func MakeKindControllerCondition(kind, conditionType string) string {
+	return fmt.Sprintf("%sController%s", kind, conditionType)
+}
+
+func MakeKindFinalizerCondition(kind, conditionType string) string {
+	return fmt.Sprintf("%sFinalizer%s", kind, conditionType)
+}

--- a/pkg/internalapi/conditions_test.go
+++ b/pkg/internalapi/conditions_test.go
@@ -1,0 +1,94 @@
+package internalapi_test
+
+import (
+	"testing"
+
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
+)
+
+func TestMakeDatacenterConditionFunc(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name              string
+		conditionType     string
+		dcName            string
+		expectedCondition string
+	}{
+		{
+			name:              "datacenter condition having provided condition type and dc name",
+			conditionType:     "Progressing",
+			dcName:            "dc1",
+			expectedCondition: "Datacenterdc1Progressing",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotCondition := internalapi.MakeDatacenterConditionFunc(tc.conditionType)(tc.dcName)
+			if gotCondition != tc.expectedCondition {
+				t.Errorf("expected condition %q, got %q", tc.expectedCondition, gotCondition)
+			}
+		})
+	}
+}
+
+func TestMakeKindControllerCondition(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name              string
+		kind              string
+		conditionType     string
+		expectedCondition string
+	}{
+		{
+			name:              "returns condition for kind controller having provided condition type and kind",
+			kind:              "ConfigMap",
+			conditionType:     "Progressing",
+			expectedCondition: "ConfigMapControllerProgressing",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotCondition := internalapi.MakeKindControllerCondition(tc.kind, tc.conditionType)
+			if gotCondition != tc.expectedCondition {
+				t.Errorf("expected condition %q, got %q", tc.expectedCondition, gotCondition)
+			}
+		})
+	}
+}
+
+func TestMakeKindFinalizerCondition(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name              string
+		kind              string
+		conditionType     string
+		expectedCondition string
+	}{
+		{
+			name:              "returns condition for kind finalizer having provided condition type and kind",
+			kind:              "ConfigMap",
+			conditionType:     "Progressing",
+			expectedCondition: "ConfigMapFinalizerProgressing",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotCondition := internalapi.MakeKindFinalizerCondition(tc.kind, tc.conditionType)
+			if gotCondition != tc.expectedCondition {
+				t.Errorf("expected condition %q, got %q", tc.expectedCondition, gotCondition)
+			}
+		})
+	}
+}

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -147,7 +147,7 @@ func ScyllaDBClusterSelector(sc *scyllav1alpha1.ScyllaDBCluster) labels.Selector
 	return labels.SelectorFromSet(ScyllaDBClusterSelectorLabels(sc))
 }
 
-func ScyllaDBClusterDatacenterEndpointsLabels(sc *scyllav1alpha1.ScyllaDBCluster, dc scyllav1alpha1.ScyllaDBClusterDatacenter, managingClusterDomain string) map[string]string {
+func ScyllaDBClusterDatacenterEndpointsLabels(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, managingClusterDomain string) map[string]string {
 	dcLabels := make(map[string]string)
 	if sc.Spec.Metadata != nil {
 		maps.Copy(dcLabels, sc.Spec.Metadata.Labels)

--- a/test/e2e/fixture/scylla/registry.go
+++ b/test/e2e/fixture/scylla/registry.go
@@ -46,6 +46,9 @@ var (
 	//go:embed "scylladbcluster.yaml.tmpl"
 	ScyllaDBClusterTemplateString string
 	ScyllaDBClusterTemplate       = ParseObjectTemplateOrDie[*scyllav1alpha1.ScyllaDBCluster]("scylladbcluster", ScyllaDBClusterTemplateString)
+
+	//go:embed "unauthorized.kubeconfig.yaml"
+	UnauthorizedKubeconfigBytes []byte
 )
 
 type NodeConfigBytes []byte

--- a/test/e2e/fixture/scylla/unauthorized.kubeconfig.yaml
+++ b/test/e2e/fixture/scylla/unauthorized.kubeconfig.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+current-context: kubernetes
+clusters:
+- name: kubernetes
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: kubernetes
+  context:
+    cluster: kubernetes
+    user: admin
+users:
+- name: admin
+  user:
+    token: token-having-no-access-anywhere
+

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_fault_tolerance.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_fault_tolerance.go
@@ -1,0 +1,184 @@
+package multidatacenter
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
+	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	v1alpha1utils "github.com/scylladb/scylla-operator/test/e2e/utils/v1alpha1"
+	scylladbclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scylladbcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter, func() {
+	f := framework.NewFramework("scylladbcluster")
+
+	g.It("should reconcile healthy datacenters when any of DCs are down", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		rkcs, rkcClusterMap, err := utils.SetUpRemoteKubernetesClustersFromRestConfigs(ctx, framework.TestContext.RestConfigs, f)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(len(rkcs)).To(o.BeNumerically(">=", 2))
+
+		framework.By("Creating ScyllaDBCluster")
+		scyllaConfigCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "scylla-config",
+			},
+			Data: map[string]string{
+				"scylla.yaml": `read_request_timeout_in_ms: 1234`,
+			},
+		}
+
+		const agentAuthToken = "foobar"
+		scyllaManagerAgentConfigSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "scylla-manager-agent-config",
+			},
+			StringData: map[string]string{
+				"scylla-manager-agent.yaml": fmt.Sprintf(`auth_token: %s`, agentAuthToken),
+			},
+		}
+
+		scyllaConfigCM, err = f.KubeClient().CoreV1().ConfigMaps(f.Namespace()).Create(ctx, scyllaConfigCM, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		scyllaManagerAgentConfigSecret, err = f.KubeClient().CoreV1().Secrets(f.Namespace()).Create(ctx, scyllaManagerAgentConfigSecret, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		sc := f.GetDefaultScyllaDBCluster(rkcs)
+		sc.Spec.DatacenterTemplate.ScyllaDB.CustomConfigMapRef = pointer.Ptr(scyllaConfigCM.Name)
+		sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent = &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+			CustomConfigSecretRef: pointer.Ptr(scyllaManagerAgentConfigSecret.Name),
+		}
+
+		metaCluster := f.Cluster(0)
+		sc, err = metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaDBCluster %q roll out (RV=%s)", sc.Name, sc.ResourceVersion)
+		waitCtx2, waitCtx2Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
+		defer waitCtx2Cancel()
+		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx2, metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaDBClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
+
+		scylladbclusterverification.Verify(ctx, sc, rkcClusterMap)
+		err = scylladbclusterverification.WaitForFullQuorum(ctx, rkcClusterMap, sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Removing Operator access to remote Kubernetes cluster associated with last DC")
+		lastDCRKC := rkcs[len(rkcs)-1]
+
+		lastDCRKCKubeconfigSecret, err := metaCluster.KubeAdminClient().CoreV1().Secrets(lastDCRKC.Spec.KubeconfigSecretRef.Namespace).Get(ctx, lastDCRKC.Spec.KubeconfigSecretRef.Name, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		const kubeconfigKey = "kubeconfig"
+
+		o.Expect(lastDCRKCKubeconfigSecret.Data).To(o.HaveKey(kubeconfigKey))
+		o.Expect(lastDCRKCKubeconfigSecret.Data[kubeconfigKey]).ToNot(o.BeEmpty())
+		lastDCRKCWorkingKubeconfigBytes := lastDCRKCKubeconfigSecret.Data[kubeconfigKey]
+
+		_, err = metaCluster.KubeAdminClient().CoreV1().Secrets(lastDCRKCKubeconfigSecret.Namespace).Patch(
+			ctx,
+			lastDCRKCKubeconfigSecret.Name,
+			types.JSONPatchType,
+			[]byte(fmt.Sprintf(
+				`[{"op": "replace", "path": "/data/%s", "value": "%s"}]`, kubeconfigKey, base64.StdEncoding.EncodeToString(scyllafixture.UnauthorizedKubeconfigBytes),
+			)),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Changing ScyllaDB configuration")
+		const scyllaDBRackReadRequestTimeoutInMs = 4321
+		_, err = f.KubeClient().CoreV1().ConfigMaps(scyllaConfigCM.Namespace).Patch(
+			ctx,
+			scyllaConfigCM.Name,
+			types.JSONPatchType,
+			[]byte(fmt.Sprintf(
+				`[{"op": "replace", "path": "/data/scylla.yaml", "value": "read_request_timeout_in_ms: %d"}]`, scyllaDBRackReadRequestTimeoutInMs,
+			)),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Forcing a ScyllaDBCluster rollout")
+		sc, err = f.ScyllaClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace).Patch(
+			ctx,
+			sc.Name,
+			types.JSONPatchType,
+			[]byte(`[{"op": "replace", "path": "/spec/forceRedeploymentReason", "value": "scylla config changed"}]`),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Awaiting until ScyllaDBCluster is degraded")
+		waitCtx3, waitCtx3Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
+		defer waitCtx3Cancel()
+		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx3, metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{},
+			utils.IsScyllaDBClusterDegraded,
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Verifying if configuration change of ScyllaDB has been applied on healthy datacenters")
+		o.Eventually(func(eo o.Gomega) {
+			for _, dc := range sc.Spec.Datacenters[:len(sc.Spec.Datacenters)-1] {
+				clusterClient := rkcClusterMap[dc.RemoteKubernetesClusterName]
+
+				scyllaConfigClient, err := v1alpha1utils.GetRemoteDatacenterScyllaConfigClient(ctx, sc, &dc, clusterClient.ScyllaAdminClient(), clusterClient.KubeAdminClient(), agentAuthToken)
+				eo.Expect(err).NotTo(o.HaveOccurred())
+
+				framework.By("Verifying if configuration of ScyllaDB is being used by %q datacenter", dc.Name)
+				gotReadRequestTimeoutInMs, err := scyllaConfigClient.ReadRequestTimeoutInMs(ctx)
+				eo.Expect(err).NotTo(o.HaveOccurred())
+				eo.Expect(gotReadRequestTimeoutInMs).To(o.Equal(int64(scyllaDBRackReadRequestTimeoutInMs)))
+			}
+		}).WithContext(waitCtx3).WithPolling(time.Second).Should(o.Succeed())
+
+		framework.By("Fixing Operator access to remote Kubernetes cluster associated with last DC")
+		_, err = metaCluster.KubeAdminClient().CoreV1().Secrets(lastDCRKCKubeconfigSecret.Namespace).Patch(
+			ctx,
+			lastDCRKCKubeconfigSecret.Name,
+			types.JSONPatchType,
+			[]byte(fmt.Sprintf(
+				`[{"op": "replace", "path": "/data/%s", "value": "%s"}]`, kubeconfigKey, base64.StdEncoding.EncodeToString(lastDCRKCWorkingKubeconfigBytes),
+			)),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaDBCluster %q roll out (RV=%s)", sc.Name, sc.ResourceVersion)
+		waitCtx4, waitCtx4Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
+		defer waitCtx4Cancel()
+		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx4, metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaDBClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Verifying if configuration change of ScyllaDB has been applied on all datacenters")
+		for _, dc := range sc.Spec.Datacenters {
+			clusterClient := rkcClusterMap[dc.RemoteKubernetesClusterName]
+
+			scyllaConfigClient, err := v1alpha1utils.GetRemoteDatacenterScyllaConfigClient(ctx, sc, &dc, clusterClient.ScyllaAdminClient(), clusterClient.KubeAdminClient(), agentAuthToken)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			framework.By("Verifying if configuration of ScyllaDB is being used by %q datacenter", dc.Name)
+			gotReadRequestTimeoutInMs, err := scyllaConfigClient.ReadRequestTimeoutInMs(ctx)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(gotReadRequestTimeoutInMs).To(o.Equal(int64(scyllaDBRackReadRequestTimeoutInMs)))
+		}
+	})
+})

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -211,6 +211,10 @@ func IsScyllaDBClusterRolledOut(sc *scyllav1alpha1.ScyllaDBCluster) (bool, error
 	return true, nil
 }
 
+func IsScyllaDBClusterDegraded(sc *scyllav1alpha1.ScyllaDBCluster) (bool, error) {
+	return helpers.IsStatusConditionPresentAndTrue(sc.Status.Conditions, scyllav1alpha1.DegradedCondition, sc.Generation), nil
+}
+
 func RunEphemeralContainerAndWaitForCompletion(ctx context.Context, client corev1client.PodInterface, podName string, ec *corev1.EphemeralContainer) (*corev1.Pod, error) {
 	ephemeralPod := &corev1.Pod{
 		Spec: corev1.PodSpec{

--- a/test/e2e/utils/verification/scylladbcluster/verify.go
+++ b/test/e2e/utils/verification/scylladbcluster/verify.go
@@ -5,8 +5,10 @@ import (
 
 	o "github.com/onsi/gomega"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	scylladbclustercontroller "github.com/scylladb/scylla-operator/pkg/controller/scylladbcluster"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
@@ -43,83 +45,103 @@ func Verify(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, rkcClusterM
 		condList := []condValue{
 			// Aggregated conditions
 			{
-				condType: "Available",
+				condType: scyllav1alpha1.AvailableCondition,
 				status:   metav1.ConditionTrue,
 			},
 			{
-				condType: "Progressing",
+				condType: scyllav1alpha1.ProgressingCondition,
 				status:   metav1.ConditionFalse,
 			},
 			{
-				condType: "Degraded",
+				condType: scyllav1alpha1.DegradedCondition,
 				status:   metav1.ConditionFalse,
 			},
+		}
 
-			// Controller conditions
-			{
-				condType: "RemoteScyllaDBDatacenterControllerProgressing",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteScyllaDBDatacenterControllerDegraded",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteNamespaceControllerProgressing",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteNamespaceControllerDegraded",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteServiceControllerProgressing",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteServiceControllerDegraded",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteEndpointSliceControllerProgressing",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteEndpointSliceControllerDegraded",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteEndpointsControllerProgressing",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteEndpointsControllerDegraded",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteRemoteOwnerControllerProgressing",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteRemoteOwnerControllerDegraded",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteConfigMapControllerProgressing",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteConfigMapControllerDegraded",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteSecretControllerProgressing",
-				status:   metav1.ConditionFalse,
-			},
-			{
-				condType: "RemoteSecretControllerDegraded",
-				status:   metav1.ConditionFalse,
-			},
+		for _, dc := range sc.Spec.Datacenters {
+			dcCondList := []condValue{
+				// Datacenter aggregated conditions
+				{
+					condType: internalapi.MakeDatacenterConditionFunc(scyllav1alpha1.AvailableCondition)(dc.Name),
+					status:   metav1.ConditionTrue,
+				},
+				{
+					condType: internalapi.MakeDatacenterConditionFunc(scyllav1alpha1.ProgressingCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: internalapi.MakeDatacenterConditionFunc(scyllav1alpha1.DegradedCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+
+				// Datacenter controller conditions
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("ScyllaDBDatacenter", scyllav1alpha1.ProgressingCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("ScyllaDBDatacenter", scyllav1alpha1.DegradedCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("Namespace", scyllav1alpha1.ProgressingCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("Namespace", scyllav1alpha1.DegradedCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("Service", scyllav1alpha1.ProgressingCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("Service", scyllav1alpha1.DegradedCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("EndpointSlice", scyllav1alpha1.ProgressingCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("EndpointSlice", scyllav1alpha1.DegradedCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("Endpoints", scyllav1alpha1.ProgressingCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("Endpoints", scyllav1alpha1.DegradedCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("RemoteOwner", scyllav1alpha1.ProgressingCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("RemoteOwner", scyllav1alpha1.DegradedCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("ConfigMap", scyllav1alpha1.ProgressingCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("ConfigMap", scyllav1alpha1.DegradedCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("Secret", scyllav1alpha1.ProgressingCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+				{
+					condType: scylladbclustercontroller.MakeRemoteKindControllerDatacenterConditionFunc("Secret", scyllav1alpha1.DegradedCondition)(dc.Name),
+					status:   metav1.ConditionFalse,
+				},
+			}
+
+			condList = append(condList, dcCondList...)
 		}
 
 		expectedConditions := make([]interface{}, 0, len(condList))


### PR DESCRIPTION
Refactors ScyllaDBCluster controller to reconcile each datacenter independenly.
Errors or connection issues of down datacenter no longer affects reconcilation of other datacenter.

Requires:

- [x] https://github.com/scylladb/scylla-operator/pull/2581
- [x] https://github.com/scylladb/scylla-operator/pull/2599
- [x] https://github.com/scylladb/scylla-operator/pull/2600

Fixes #2494