### PR TITLE
Graceful e2e shutdown on timeout

### DIFF
--- a/hack/.ci/run-e2e-gke-release.sh
+++ b/hack/.ci/run-e2e-gke-release.sh
@@ -18,6 +18,7 @@ source "$( dirname "${BASH_SOURCE[0]}" )/run-e2e-shared.env.sh"
 parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
 
 trap gather-artifacts-on-exit EXIT
+trap gracefully-shutdown-e2es INT
 
 SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=${parent_dir}/manifests/cluster/nodeconfig.yaml}"
 export SO_NODECONFIG_PATH

--- a/hack/.ci/run-e2e-gke.sh
+++ b/hack/.ci/run-e2e-gke.sh
@@ -17,6 +17,7 @@ source "$( dirname "${BASH_SOURCE[0]}" )/run-e2e-shared.env.sh"
 parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
 
 trap gather-artifacts-on-exit EXIT
+trap gracefully-shutdown-e2es INT
 
 SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=./hack/.ci/manifests/cluster/nodeconfig.yaml}"
 export SO_NODECONFIG_PATH

--- a/hack/.ci/run-e2e-openshift-aws-release.sh
+++ b/hack/.ci/run-e2e-openshift-aws-release.sh
@@ -19,6 +19,7 @@ source "$( dirname "${BASH_SOURCE[0]}" )/run-e2e-shared.env.sh"
 parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
 
 trap gather-artifacts-on-exit EXIT
+trap gracefully-shutdown-e2es INT
 
 REENTRANT="${REENTRANT=false}"
 export REENTRANT

--- a/hack/.ci/run-e2e-openshift-aws.sh
+++ b/hack/.ci/run-e2e-openshift-aws.sh
@@ -19,6 +19,7 @@ source "$( dirname "${BASH_SOURCE[0]}" )/run-e2e-shared.env.sh"
 parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
 
 trap gather-artifacts-on-exit EXIT
+trap gracefully-shutdown-e2es INT
 
 REENTRANT="${REENTRANT=false}"
 export REENTRANT

--- a/hack/lib/kube.sh
+++ b/hack/lib/kube.sh
@@ -22,6 +22,12 @@ function kubectl_create {
     fi
 }
 
+function kubectl_cp {
+  for i in {1..60}; do
+    kubectl cp "$@" && break || echo "Attempt $i to kubectl copy failed, retrying"
+  done
+}
+
 function wait-for-object-creation {
   kubectl wait --timeout=60s --for=create -n "${1}" "${2}"
 }


### PR DESCRIPTION
With scylladb/scylla-operator-release#406 e2e script receives SIGINT when timeout happens. It's not propagated to actual e2e binary because it's being run as Pod in spawned e2e Kubernetes cluster. This registers INT signal handler which will gracefully delete e2e Pod giving it a chance to print out where it's being stuck and collect e2e artifacts.

/cc mflendrich