### PR TITLE
Fix flaky e2e test by zeroing XFS log before checking filesystem integrity

### DIFF
--- a/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
@@ -639,6 +639,10 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mkfs", "-t", string(scyllav1alpha1.XFSFilesystem), "-b", fmt.Sprintf("size=%s", blockSize), "-K", "-f", hostDevicePath)
 		o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
+		framework.By("Zeroing XFS log")
+		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-L", "-f", hostDevicePath)
+		o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
+
 		framework.By("Verifying the filesystem's integrity")
 		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-o", "force_geometry", "-f", "-n", hostDevicePath)
 		o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)


### PR DESCRIPTION
**Description of your changes:**

Test flaked because when it validated filesystem integrity the tool complained about dirty log containing metadata. Zero it after recreating the filesystem.

**Which issue is resolved by this Pull Request:**
Resolves #2542
