### PR TITLE
Propagate Options in DataInserter constructor in E2E utils

### DIFF
--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -43,7 +43,7 @@ func WithSession(session *gocqlx.Session) func(*DataInserter) {
 
 func NewDataInserter(hosts []string, options ...DataInserterOption) (*DataInserter, error) {
 	// Instead of specifying hosts for the provided datacenter, use 'replication_factor' as a single key to specify a default RF.
-	return NewMultiDCDataInserter(map[string][]string{"replication_factor": hosts})
+	return NewMultiDCDataInserter(map[string][]string{"replication_factor": hosts}, options...)
 }
 
 func NewMultiDCDataInserter(dcHosts map[string][]string, options ...DataInserterOption) (*DataInserter, error) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** `Options` parameter of e2e utils' DataInserter constructor are not propagated to further constructor. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-longterm
/cc