### PR TITLE
[1.16] Propagate racks.exposeOptions in Helm

### DIFF
--- a/helm/scylla/templates/scyllacluster.yaml
+++ b/helm/scylla/templates/scyllacluster.yaml
@@ -87,6 +87,10 @@ spec:
       agentResources:
         {{- toYaml .agentResources | nindent 8 }}
       {{- end }}
+      {{- with .exposeOptions }}
+      exposeOptions:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .volumes }}
       volumes:
         {{- toYaml .volumes | nindent 8 }}


### PR DESCRIPTION
Follow-up to https://github.com/scylladb/scylla-operator/pull/2484/ (#2479)

Part of #2554

Ensures that the Helm template for ScyllaCluster propagates the rack-specific `exposeOptions`.