### PR TITLE
Render `.spec.datacenter.racks` directly in Helm template

### DIFF
--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -310,18 +310,8 @@ spec:
   datacenter:
     name: manager-dc
     racks:
-      - name: manager-rack
-        members: 1
-        storage:
-          capacity: 5Gi
-          storageClassName: scylladb-local-xfs
-        resources:
-          limits:
-            cpu: 200m
-            memory: 200Mi
-          requests:
-            cpu: 10m
-            memory: 100Mi
+      - members: 1
+        name: manager-rack
         placement:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -336,5 +326,15 @@ spec:
               key: scylla-operator.scylladb.com/dedicated
               operator: Equal
               value: scyllaclusters
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        storage:
+          capacity: 5Gi
+          storageClassName: scylladb-local-xfs
 
 ---

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -310,18 +310,8 @@ spec:
   datacenter:
     name: manager-dc
     racks:
-    - name: manager-rack
-      members: 1
-      storage:
-        capacity: 5Gi
-        storageClassName: scylladb-local-xfs
-      resources:
-        limits:
-          cpu: 1
-          memory: 200Mi
-        requests:
-          cpu: 1
-          memory: 200Mi
+    - members: 1
+      name: manager-rack
       placement:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -332,9 +322,19 @@ spec:
                 values:
                 - scylla
         tolerations:
-          - effect: NoSchedule
-            key: scylla-operator.scylladb.com/dedicated
-            operator: Equal
-            value: scyllaclusters
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
+      resources:
+        limits:
+          cpu: 1
+          memory: 200Mi
+        requests:
+          cpu: 1
+          memory: 200Mi
+      storage:
+        capacity: 5Gi
+        storageClassName: scylladb-local-xfs
 
 ---

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -13,18 +13,8 @@ spec:
   datacenter:
     name: manager-dc
     racks:
-      - name: manager-rack
-        members: 1
-        storage:
-          capacity: 5Gi
-          storageClassName: scylladb-local-xfs
-        resources:
-          limits:
-            cpu: 200m
-            memory: 200Mi
-          requests:
-            cpu: 10m
-            memory: 100Mi
+      - members: 1
+        name: manager-rack
         placement:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -39,3 +29,13 @@ spec:
               key: scylla-operator.scylladb.com/dedicated
               operator: Equal
               value: scyllaclusters
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        storage:
+          capacity: 5Gi
+          storageClassName: scylladb-local-xfs

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -13,18 +13,8 @@ spec:
   datacenter:
     name: manager-dc
     racks:
-    - name: manager-rack
-      members: 1
-      storage:
-        capacity: 5Gi
-        storageClassName: scylladb-local-xfs
-      resources:
-        limits:
-          cpu: 1
-          memory: 200Mi
-        requests:
-          cpu: 1
-          memory: 200Mi
+    - members: 1
+      name: manager-rack
       placement:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -35,7 +25,17 @@ spec:
                 values:
                 - scylla
         tolerations:
-          - effect: NoSchedule
-            key: scylla-operator.scylladb.com/dedicated
-            operator: Equal
-            value: scyllaclusters
+        - effect: NoSchedule
+          key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
+      resources:
+        limits:
+          cpu: 1
+          memory: 200Mi
+        requests:
+          cpu: 1
+          memory: 200Mi
+      storage:
+        capacity: 5Gi
+        storageClassName: scylladb-local-xfs

--- a/helm/scylla/templates/scyllacluster.yaml
+++ b/helm/scylla/templates/scyllacluster.yaml
@@ -69,53 +69,7 @@ spec:
   {{- end }}
   datacenter:
     name: {{ .Values.datacenter }}
+    {{- with .Values.racks }}
     racks:
-    {{- range .Values.racks }}
-    - name: {{ .name }}
-      {{- with .scyllaConfig }}
-      scyllaConfig: {{ . }}
-      {{- end }}
-      {{- with .scyllaAgentConfig }}
-      scyllaAgentConfig: {{ . }}
-      {{- end }}
-      members: {{ .members }}
-      storage:
-        {{- .storage | toYaml | nindent 8 }}
-      resources:
-        {{- toYaml .resources | nindent 8 }}
-      {{- if .agentResources }}
-      agentResources:
-        {{- toYaml .agentResources | nindent 8 }}
-      {{- end }}
-      {{- if .volumes }}
-      volumes:
-        {{- toYaml .volumes | nindent 8 }}
-      {{- end }}
-      {{- if .volumeMounts }}
-      volumeMounts:
-        {{- toYaml .volumeMounts | nindent 8 }}
-      {{- end }}
-      {{- if .agentVolumeMounts }}
-      agentVolumeMounts:
-        {{- toYaml .agentVolumeMounts | nindent 8 }}
-      {{- end }}
-      {{- if .placement }}
-      placement:
-        {{- if .placement.podAffinity }}
-        podAffinity:
-          {{- toYaml .placement.podAffinity | nindent 10 }}
-        {{- end }}
-        {{- if .placement.podAntiAffinity }}
-        podAntiAffinity:
-          {{- toYaml .placement.podAntiAffinity | nindent 10 }}
-        {{- end }}
-        {{- if .placement.nodeAffinity }}
-        nodeAffinity:
-          {{- toYaml .placement.nodeAffinity | nindent 10 }}
-        {{- end }}
-        {{- if .placement.tolerations }}
-        tolerations:
-          {{- toYaml .placement.tolerations | nindent 10 }}
-        {{- end }}
-      {{- end }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Replacing field-wise rendering of `.spec.datacenter.racks` with a direct render to make maintenance simpler (not need to copy fields over to the helm template when adding them in the CRD).

Part of #2554 
Follow-up to https://github.com/scylladb/scylla-operator/pull/2484 (https://github.com/scylladb/scylla-operator/issues/2479)

An equivalent but more conservative change is landing in 1.16: https://github.com/scylladb/scylla-operator/pull/2555.
This PR is a solution to #2554 for `master`. #2555 (and not a backport of this PR) fixes #2554 for 1.16.

This should produce an exactly identical render as before, with the below differences:
- the fields in an object will be in a different order
- the `.racks[].exposeOptions` field that didn't exist in the preexisting template is now rendered correctly
- semantically equivalent indentation changes (at least in `.racks[].placement.tolerations`, maybe elsewhere as well)

/cc zimnx
/kind bug
/priority important-soon