### PR TITLE
Update local-csi-driver to 0.5.0

### DIFF
--- a/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
+++ b/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/local-csi-driver:0.4.1@sha256:4da6cc8fc65f8983c3ff0d3f0f831c59ef013a04f9b2021615316aca7a790f16
+        image: docker.io/scylladb/local-csi-driver:0.5.0@sha256:46c1d2e9be8edf076d8dea7e82a3bb763d4bdda5adf43c794f617e9c94251079
         imagePullPolicy: IfNotPresent
         args:
         - --listen=/csi/csi.sock

--- a/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/local-csi-driver:0.4.1@sha256:4da6cc8fc65f8983c3ff0d3f0f831c59ef013a04f9b2021615316aca7a790f16
+        image: docker.io/scylladb/local-csi-driver:0.5.0@sha256:46c1d2e9be8edf076d8dea7e82a3bb763d4bdda5adf43c794f617e9c94251079
         imagePullPolicy: IfNotPresent
         args:
         - --listen=/csi/csi.sock


### PR DESCRIPTION
Use the [v0.5.0 version](https://github.com/scylladb/local-csi-driver/releases/tag/v0.5.0) of the local-csi-driver.

Questions to reviewer: (I intend to put those in a codified release procedure)
- Did I find all places where the version needs to be updated?
- Any code generation necessary here?

/kind cleanup
/priority important-longterm
/cc zimnx rzetelskik