### PR TITLE
Disabled XFS rmapbt and reflink flags for reducing overhead

### DIFF
--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_nodeconfigs.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_nodeconfigs.yaml
@@ -70,6 +70,11 @@ spec:
                           type:
                             description: type is a desired filesystem type.
                             type: string
+                          xfsFlags:
+                            description: xfsFlags contains XFS-specific flags to be used during filesystem creation
+                            items:
+                              type: string
+                            type: array
                         type: object
                       type: array
                     loopDevices:

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_nodeconfigs.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_nodeconfigs.yaml
@@ -70,11 +70,6 @@ spec:
                           type:
                             description: type is a desired filesystem type.
                             type: string
-                          xfsFlags:
-                            description: xfsFlags contains XFS-specific flags to be used during filesystem creation
-                            items:
-                              type: string
-                            type: array
                         type: object
                       type: array
                     loopDevices:

--- a/pkg/api/scylla/v1alpha1/types_nodeconfig.go
+++ b/pkg/api/scylla/v1alpha1/types_nodeconfig.go
@@ -177,6 +177,10 @@ type FilesystemConfiguration struct {
 
 	// type is a desired filesystem type.
 	Type FilesystemType `json:"type"`
+
+	// xfsFlags contains XFS-specific flags to be used during filesystem creation
+	// +optional
+	XFSFlags []string `json:"xfsFlags,omitempty"`
 }
 
 // MountConfiguration specifies mount configuration options.

--- a/pkg/api/scylla/v1alpha1/types_nodeconfig.go
+++ b/pkg/api/scylla/v1alpha1/types_nodeconfig.go
@@ -178,9 +178,9 @@ type FilesystemConfiguration struct {
 	// type is a desired filesystem type.
 	Type FilesystemType `json:"type"`
 
-	// xfsFlags contains XFS-specific flags to be used during filesystem creation
+	// flags contains filesystem-specific flags to be used during filesystem creation
 	// +optional
-	XFSFlags []string `json:"xfsFlags,omitempty"`
+	Flags []string `json:"flags,omitempty"`
 }
 
 // MountConfiguration specifies mount configuration options.

--- a/pkg/controller/nodesetup/sync_filesystems.go
+++ b/pkg/controller/nodesetup/sync_filesystems.go
@@ -35,7 +35,7 @@ func (nsc *Controller) syncFilesystems(ctx context.Context, nc *scyllav1alpha1.N
 			continue
 		}
 
-		changed, err := disks.MakeFS(ctx, nsc.executor, device, blockSize, string(fs.Type))
+		changed, err := disks.MakeFS(ctx, nsc.executor, device, blockSize, string(fs.Type), fs.XFSFlags)
 		if err != nil {
 			nsc.eventRecorder.Eventf(
 				nc,

--- a/pkg/controller/nodesetup/sync_filesystems.go
+++ b/pkg/controller/nodesetup/sync_filesystems.go
@@ -35,7 +35,13 @@ func (nsc *Controller) syncFilesystems(ctx context.Context, nc *scyllav1alpha1.N
 			continue
 		}
 
-		changed, err := disks.MakeFS(ctx, nsc.executor, device, blockSize, string(fs.Type), fs.XFSFlags)
+		// Add default flags for XFS filesystem
+		flags := fs.Flags
+		if fs.Type == scyllav1alpha1.XFSFilesystem {
+			flags = append(flags, "rmapbt=0", "reflink=0")
+		}
+
+		changed, err := disks.MakeFS(ctx, nsc.executor, device, blockSize, string(fs.Type), flags)
 		if err != nil {
 			nsc.eventRecorder.Eventf(
 				nc,

--- a/pkg/disks/fs_test.go
+++ b/pkg/disks/fs_test.go
@@ -92,7 +92,7 @@ func TestMakeFS(t *testing.T) {
 
 			executor := exectest.NewFakeExec(tc.expectedCommands...)
 
-			finished, err := MakeFS(ctx, executor, tc.device, tc.blockSize, tc.fsType)
+			finished, err := MakeFS(ctx, executor, tc.device, tc.blockSize, tc.fsType, nil)
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Fatalf("expected %v error, got %v", tc.expectedErr, err)
 			}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Added changes to support disabling XFS flags rmapbt=0 reflink=0 to reduce the metadata overhead as mentioned in ScyllaDB AMI

**Which issue is resolved by this Pull Request:**
Resolves #2353 
