### PR TITLE
Update default storage capacity to 120Gi and set sysctls' fs.aio-max-nr value to 30000000 in Scylla helm chart

### DIFF
--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -307,6 +307,8 @@ spec:
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true
   cpuset: false
+  sysctls:
+    - fs.aio-max-nr=30000000
   datacenter:
     name: manager-dc
     racks:

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -307,6 +307,8 @@ spec:
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true
   cpuset: true
+  sysctls:
+    - fs.aio-max-nr=30000000
   datacenter:
     name: manager-dc
     racks:

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -10,6 +10,8 @@ spec:
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true
   cpuset: false
+  sysctls:
+    - fs.aio-max-nr=30000000
   datacenter:
     name: manager-dc
     racks:

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -10,6 +10,8 @@ spec:
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true
   cpuset: true
+  sysctls:
+    - fs.aio-max-nr=30000000
   datacenter:
     name: manager-dc
     racks:

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -34,7 +34,8 @@ hostNetworking: false
 # Whether Scylla Operator should perform automatic cleanup of orphaned Pods
 automaticOrphanedNodeCleanup: false
 # Sysctl properties to be applied during initialization given as a list of key=value pairs
-sysctls: []
+sysctls:
+  - fs.aio-max-nr=30000000
 # Scylla Manager Backups task definition
 backups: []
 # Scylla Manager Repair task definition
@@ -57,7 +58,7 @@ racks:
     # Storage definition
     storage:
       storageClassName: scylladb-local-xfs
-      capacity: 10Gi
+      capacity: 120Gi
     # Scylla container resource definition
     resources:
       limits:


### PR DESCRIPTION
Scylla fails to start with the current default storage capacity set to 10Gi in the Helm chart and when developerMode is disabled. This commit is bumping it to 120Gi.

Fixes https://github.com/scylladb/scylla-operator/issues/906
