### PR TITLE
Change the source of the ScyllaDBVersion parameter value in replace e2e

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -9,7 +9,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	configassests "github.com/scylladb/scylla-operator/assets/config"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
@@ -172,7 +171,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 	},
 		g.Entry(describeEntry, &entry{
 			scyllaImageRepository: scyllaOSImageRepository,
-			scyllaVersion:         configassests.Project.Operator.ScyllaDBVersion,
+			scyllaVersion:         framework.TestContext.ScyllaDBVersion,
 			validateScyllaConfig:  validateReplaceViaHostID,
 		}),
 		g.Entry(describeEntry, &entry{


### PR DESCRIPTION
**Description of your changes:** 
Fixes a missing update to ScyllaDBVersion after commit b2d7fb1, which made ScyllaDB and Scylla Manager flags configurable.