### PR TITLE
Remove Type prefix for aggregated Condition Reasons

### DIFF
--- a/pkg/controllerhelpers/core.go
+++ b/pkg/controllerhelpers/core.go
@@ -61,7 +61,7 @@ func aggregateStatusConditionInfo(conditions []metav1.Condition) (string, string
 	messages := make([]string, 0, len(conditions))
 
 	for _, c := range conditions {
-		reasons = append(reasons, fmt.Sprintf("%s_%s", c.Type, c.Reason))
+		reasons = append(reasons, c.Reason)
 
 		for _, line := range strings.Split(c.Message, "\n") {
 			messages = append(messages, fmt.Sprintf("%s: %s", c.Type, line))

--- a/pkg/controllerhelpers/core_test.go
+++ b/pkg/controllerhelpers/core_test.go
@@ -173,7 +173,7 @@ func TestAggregateStatusConditions(t *testing.T) {
 			expectedCondition: metav1.Condition{
 				Type:               "Available",
 				Status:             metav1.ConditionUnknown,
-				Reason:             "UnknownAvailableFoo_UnknownAvailableFooReason,UnknownAvailableBar_UnknownAvailableBarReason",
+				Reason:             "UnknownAvailableFooReason,UnknownAvailableBarReason",
 				Message:            "UnknownAvailableFoo: UnknownAvailableFoo message\nUnknownAvailableBar: UnknownAvailableBar message",
 				ObservedGeneration: 42,
 			},
@@ -217,7 +217,7 @@ func TestAggregateStatusConditions(t *testing.T) {
 			expectedCondition: metav1.Condition{
 				Type:               "Available",
 				Status:             metav1.ConditionFalse,
-				Reason:             "FooAvailable_FooAvailableReason,BarAvailable_BarAvailableReason",
+				Reason:             "FooAvailableReason,BarAvailableReason",
 				Message:            "FooAvailable: FooAvailable error\nBarAvailable: BarAvailable error",
 				ObservedGeneration: 42,
 			},
@@ -293,7 +293,7 @@ func TestAggregateStatusConditions(t *testing.T) {
 			expectedCondition: metav1.Condition{
 				Type:               "Degraded",
 				Status:             metav1.ConditionUnknown,
-				Reason:             "UnknownDegradedFoo_UnknownDegradedFooReason,UnknownDegradedBar_UnknownDegradedBar reason",
+				Reason:             "UnknownDegradedFooReason,UnknownDegradedBar reason",
 				Message:            "UnknownDegradedFoo: UnknownDegradedFoo message\nUnknownDegradedBar: UnknownDegradedBar message",
 				ObservedGeneration: 42,
 			},
@@ -337,7 +337,7 @@ func TestAggregateStatusConditions(t *testing.T) {
 			expectedCondition: metav1.Condition{
 				Type:               "Degraded",
 				Status:             metav1.ConditionTrue,
-				Reason:             "FooDegraded_FooDegradedReason,BarDegraded_BarDegradedReason",
+				Reason:             "FooDegradedReason,BarDegradedReason",
 				Message:            "FooDegraded: FooDegraded error\nBarDegraded: BarDegraded error",
 				ObservedGeneration: 42,
 			},

--- a/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
+++ b/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
@@ -111,7 +111,7 @@ var _ = g.Describe("RemoteKubernetesCluster finalizer", func() {
 		hasIsBeingUsedCondition := func(rkc *scyllav1alpha1.RemoteKubernetesCluster) (bool, error) {
 			cond := meta.FindStatusCondition(rkc.Status.Conditions, "RemoteKubernetesClusterFinalizerProgressing")
 			return cond != nil &&
-				cond.Reason == "RemoteKubernetesClusterFinalizerProgressing_IsBeingUsed" &&
+				cond.Reason == "IsBeingUsed" &&
 				cond.Status == metav1.ConditionTrue &&
 				cond.ObservedGeneration == rkc.Generation, nil
 		}


### PR DESCRIPTION
**Description of your changes:**

metav1.Condition.Type accepts much wider regexp compared to Reason. Some of accepted values may not pass validation when it's merged into Reason.
This caused that Operator wasn't able to update the status of resources, usually during transitive failure.