### PR TITLE
Remove `:link:` option from sphinx-design cards

### DIFF
--- a/docs/source/_static/fix-cards.js
+++ b/docs/source/_static/fix-cards.js
@@ -1,0 +1,27 @@
+// Fix for sphinx-design cards :link: option not working on multiversion
+document.addEventListener('DOMContentLoaded', function() {
+    const cards = document.querySelectorAll('.sd-card');
+    
+    cards.forEach(card => {
+        const link = card.querySelector('a');
+        
+        if (link) {
+            card.style.cursor = 'pointer';
+            
+            card.addEventListener('click', function(e) {
+                if (!e.target.closest('a')) {
+                    link.click();
+                }
+            });
+            
+            card.addEventListener('mouseenter', function() {
+                card.style.transform = 'translateY(-2px)';
+                card.style.transition = 'transform 0.2s ease';
+            });
+            
+            card.addEventListener('mouseleave', function() {
+                card.style.transform = 'translateY(0)';
+            });
+        }
+    });
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,7 +133,13 @@ htmlhelp_basename = 'ScyllaDocumentationdoc'
 # URL which points to the root of the HTML documentation.
 html_baseurl = 'https://operator.docs.scylladb.com'
 
-# Dictionary of values to pass into the template engine’s context for all pages
+# Dictionary of values to pass into the template engine's context for all pages
 html_context = {'html_baseurl': html_baseurl}
+
+# Add the _static directory to the static path
+html_static_path = ['_static']
+
+# Add custom JavaScript files
+html_js_files = ['fix-cards.js']
 
 sitemap_url_scheme = "/stable/{link}"

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -54,7 +54,6 @@ You can also navigate through the documentation using the menu.
 :gutter: 4
 
 :::{grid-item-card} {material-regular}`architecture;2em` Architecture
-:link: architecture/overview
 
 Learn about the components of Scylla Operator and how they fit together.
 +++
@@ -62,7 +61,6 @@ Learn about the components of Scylla Operator and how they fit together.
 :::
 
 :::{grid-item-card} {material-regular}`electric_bolt;2em` Installation
-:link: installation/overview
 
 Configure your Kubernetes platform, install prerequisites and all components of {{productName}}.
 +++
@@ -70,14 +68,13 @@ Configure your Kubernetes platform, install prerequisites and all components of 
 :::
 
 :::{grid-item-card} {material-regular}`storage;2em` Working with Resources
-:link: resources/overview
+
 Learn about the APIs that {{productName}} provides. ScyllaClusters, ScyllaDBMonitorings and more.  
 +++
 [Learn more »](resources/overview)
 :::
 
 :::{grid-item-card} {material-regular}`explore;2em` Quickstarts
-:link: quickstarts/index
 
 Get it running right now. Simple GKE and EKS setups.
 
@@ -86,21 +83,21 @@ Get it running right now. Simple GKE and EKS setups.
 :::
 
 :::{grid-item-card} {material-regular}`fitness_center;2em` Performance Tuning
-:link: architecture/tuning
+
 Tune your infra and ScyllaDB cluster for the best performance and low latency. 
 +++
 [Learn more »](architecture/tuning)
 :::
 
 :::{grid-item-card} {material-regular}`build;2em` Support
-:link: support/overview
+
 FAQs, support matrix, must-gather and more. 
 +++
 [Learn more »](support/overview)
 :::
 
 :::{grid-item-card} {material-regular}`menu_book;2em` API Rererence
-:link: api-reference/index
+
 Visit the automatically generated API reference for all our APIs.
 +++
 [Learn more »](api-reference/index)

--- a/docs/source/resources/overview.md
+++ b/docs/source/resources/overview.md
@@ -19,7 +19,6 @@ kubectl explain --api-version='scylla.scylladb.com/v1alpha1' NodeConfig.spec
 :gutter: 4
 
 :::{grid-item-card} {material-regular}`storage;2em` ScyllaClusters
-:link: /resources/scyllaclusters/basics
 
 ScyllaCluster defines a ScyllaDB datacenter and manages the racks within.
 +++
@@ -27,7 +26,6 @@ ScyllaCluster defines a ScyllaDB datacenter and manages the racks within.
 :::
 
 :::{grid-item-card} {material-round}`insights;2em` ScyllaDBMonitorings
-:link: /resources/scylladbmonitorings
 
 ScyllaDBMonitoring defines and manages a ScyllaDB monitoring stack.
 +++
@@ -47,7 +45,6 @@ Generally, there can be multiple instances of these resources but for some of th
 :gutter: 4
 
 :::{grid-item-card} {material-regular}`bolt;2em` NodeConfigs
-:link: /resources/nodeconfigs
 
 NodeConfig manages setup and tuning for a set of Kubernetes nodes.
 +++
@@ -55,7 +52,6 @@ NodeConfig manages setup and tuning for a set of Kubernetes nodes.
 :::
 
 :::{grid-item-card} {material-regular}`settings;2em` ScyllaOperatorConfigs
-:link: /resources/scyllaoperatorconfigs
 
 ScyllaOperatorConfig configures the {{productName}} deployment and reports the status.
 +++


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-operator/issues/2502

This PR removes the `:link:` option from `sphinx-cards` to ensure compatibility with the `sphinx-multiversion` extension.

As a workaround, we've added a custom script to make the entire card clickable.

## How to test

1. Clone the PR.
2. Update the `conf.py` multiversion options as follows:

   ```python
   # -- Options for multiversion extension
   # Whitelist pattern for tags (set to None to ignore all tags)
   TAGS = []
   smv_tag_whitelist = multiversion_regex_builder(TAGS)

   # Whitelist pattern for branches (set to None to ignore all branches)
   BRANCHES = ['fix-links']
   smv_branch_whitelist = multiversion_regex_builder(BRANCHES)

   # Set which versions are not released yet.
   UNSTABLE_VERSIONS = ["master"]

   # Defines which version is considered to be the latest stable version.
   # Must be listed in smv_tag_whitelist or smv_branch_whitelist.
   smv_latest_version = 'fix-links'
   smv_rename_latest_version = 'stable'

   # Whitelist pattern for remotes (set to None to use local branches only)
   smv_remote_whitelist = ""

   # Pattern for released versions
   smv_released_pattern = r'^tags/.*$'

   # Format for versioned output directories inside the build directory
   smv_outputdir_format = '{ref.name}'
   ```

3. Run:

   ```bash
   make multiversion
   ```

4. Then run:

   ```bash
   make multiversionpreview
   ```

5. Open http://0.0.0.0:5500/. Verify that the card links are working as expected.