### PR TITLE
Forget keys on nonretriable errors in observer

### DIFF
--- a/pkg/controllertools/observer.go
+++ b/pkg/controllertools/observer.go
@@ -110,6 +110,8 @@ func (o *Observer) processNextItem(ctx context.Context) bool {
 	default:
 		if IsNonRetriable(err) {
 			klog.InfoS("Hit non-retriable error. Dropping the item from the queue.", "Error", err)
+			o.queue.Forget(key)
+			return true
 		}
 		utilruntime.HandleError(fmt.Errorf("sync loop has failed: %w", err))
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Observer workers should forget the key and return on nonretriable errors, otherwise nonretriable errors are no different than regular errors. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-longterm
/cc
