### PR TITLE
Introduce Dependabot to bump go.mod & vendored packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+    day: wednesday
+    time: '08:00' # UTC
+  labels:
+  - priority/important-longterm
+  - kind/dependency-bump
+  groups:
+    k8s.io:
+        applies-to: version-updates
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+    gomod:
+        applies-to: version-updates
+        patterns:
+          - "*"
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  labels:
+  - priority/important-longterm
+  - kind/dependency-bump
+vendor: true


### PR DESCRIPTION
Now that Dependabot supports gomod vendoring and PR grouping, all technical blockers preventing us from productive automated dependency management seem to be off the table.

Therefore, this PR adds a Dependabot config that will result in weekly grouped PRs with version bumps.
There are 2 PRs with weekly cadence expected: one bumping Kubernetes dependencies and one for the rest.
Vendoring is enabled and I'd expect it to run fine with our CI - we shall see with the first run.

This only manages the dependencies on the main branch; we'd still need to backport manually.

Also includes a weekly auto-bumper for GH Actions.

/cc zimnx rzetelskik