### PR TITLE
Fix `vendor` syntax in the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,11 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: /
+  vendor: true
   schedule:
     interval: weekly
     day: wednesday
-    time: '08:00' # UTC
+    time: '10:00' # UTC
   labels:
   - priority/important-longterm
   - kind/dependency-bump
@@ -26,4 +27,3 @@ updates:
   labels:
   - priority/important-longterm
   - kind/dependency-bump
-vendor: true


### PR DESCRIPTION
Fixes the below issue.

> Your .github/dependabot.yml contained invalid details
> 
> Dependabot encountered the following error when parsing your .github/dependabot.yml:
> 
>     The property '#/' contains additional properties ["vendor"] outside of the schema when none are allowed

Also bumps the cron trigger a bit so that we can get dependabot to kick in today with the corrected configuration.

follow-up to #2592 