### PR TITLE
Remove the explicit `vendor` setting from the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,10 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: /
-  vendor: true
   schedule:
     interval: weekly
     day: wednesday
-    time: '10:00' # UTC
+    time: '11:00' # UTC
   labels:
   - priority/important-longterm
   - kind/dependency-bump


### PR DESCRIPTION
This fixes a failing validation

    The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed

There is inconsistency in the Dependabot docs - on one hand the [example](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#updating-vendored-dependencies) allows a `vendor` value to be set, and the [options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#vendor--) expects it,

on the other hand there's a failing validation and a lot of public repos that happily use Dependabot without explicitly setting `vendor: true`.

I've looked at a number of public repos that have vendoring enabled, and dependabot works just fine. This is against documentation, but it appears to work.
This commit aims to make the validator happy while keeping the vendoring behavior enabled by implicit autodetection by dependabot - that is empirically verified to work, as described above.

Also bumps the cron time a bit to get it triggered soon.

Follow-up to #2593 

/cc rzetelskik
/kind machinery
/priority important-soon