### PR TITLE
Refactor ErrorLists into nil slices

### DIFF
--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -45,7 +45,7 @@ func ValidateScyllaCluster(c *scyllav1.ScyllaCluster) field.ErrorList {
 }
 
 func ValidateUserManagedTLSCertificateOptions(opts *scyllav1.UserManagedTLSCertificateOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(opts.SecretName) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("secretName"), ""))
@@ -59,7 +59,7 @@ func ValidateUserManagedTLSCertificateOptions(opts *scyllav1.UserManagedTLSCerti
 }
 
 func ValidateOperatorManagedTLSCertificateOptions(opts *scyllav1.OperatorManagedTLSCertificateOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	for _, dnsName := range opts.AdditionalDNSNames {
 		for _, msg := range apimachineryutilvalidation.IsDNS1123Subdomain(dnsName) {
@@ -77,7 +77,7 @@ func ValidateOperatorManagedTLSCertificateOptions(opts *scyllav1.OperatorManaged
 }
 
 func ValidateTLSCertificate(cert *scyllav1.TLSCertificate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	switch cert.Type {
 	case scyllav1.TLSCertificateTypeOperatorManaged:
@@ -120,7 +120,7 @@ func ValidateTLSCertificate(cert *scyllav1.TLSCertificate, fldPath *field.Path) 
 }
 
 func ValidateAlternatorSpec(alternator *scyllav1.AlternatorSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if alternator.WriteIsolation != "" {
 		found := slices.ContainsItem(AlternatorSupportedWriteIsolation, alternator.WriteIsolation)
@@ -150,7 +150,7 @@ func ValidateAlternatorSpec(alternator *scyllav1.AlternatorSpec, fldPath *field.
 }
 
 func ValidateScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	rackNames := sets.NewString()
 
@@ -214,7 +214,7 @@ func ValidateScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *field.
 }
 
 func ValidateRepairTaskSpec(repairTaskSpec *scyllav1.RepairTaskSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	_, err := strconv.ParseFloat(repairTaskSpec.Intensity, 64)
 	if err != nil {
@@ -227,7 +227,7 @@ func ValidateRepairTaskSpec(repairTaskSpec *scyllav1.RepairTaskSpec, fldPath *fi
 }
 
 func ValidateBackupTaskSpec(backupTaskSpec *scyllav1.BackupTaskSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, ValidateTaskSpec(&backupTaskSpec.TaskSpec, fldPath)...)
 
@@ -235,7 +235,7 @@ func ValidateBackupTaskSpec(backupTaskSpec *scyllav1.BackupTaskSpec, fldPath *fi
 }
 
 func ValidateTaskSpec(taskSpec *scyllav1.TaskSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, ValidateSchedulerTaskSpec(&taskSpec.SchedulerTaskSpec, fldPath)...)
 
@@ -243,7 +243,7 @@ func ValidateTaskSpec(taskSpec *scyllav1.TaskSpec, fldPath *field.Path) field.Er
 }
 
 func ValidateSchedulerTaskSpec(schedulerTaskSpec *scyllav1.SchedulerTaskSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if schedulerTaskSpec.Cron != nil {
 		_, err := cron.NewParser(schedulerTaskSpecCronParseOptions).Parse(*schedulerTaskSpec.Cron)
@@ -281,7 +281,7 @@ func ValidateSchedulerTaskSpec(schedulerTaskSpec *scyllav1.SchedulerTaskSpec, fl
 }
 
 func ValidateExposeOptions(options *scyllav1.ExposeOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if options.CQL != nil && options.CQL.Ingress != nil {
 		allErrs = append(allErrs, ValidateIngressOptions(options.CQL.Ingress, fldPath.Child("cql", "ingress"))...)
@@ -299,7 +299,7 @@ func ValidateExposeOptions(options *scyllav1.ExposeOptions, fldPath *field.Path)
 }
 
 func ValidateNodeBroadcastOptions(options *scyllav1.NodeBroadcastOptions, nodeService *scyllav1.NodeServiceTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, ValidateBroadcastOptions(options.Clients, nodeService, fldPath.Child("clients"))...)
 	allErrs = append(allErrs, ValidateBroadcastOptions(options.Nodes, nodeService, fldPath.Child("nodes"))...)
@@ -308,7 +308,7 @@ func ValidateNodeBroadcastOptions(options *scyllav1.NodeBroadcastOptions, nodeSe
 }
 
 func ValidateBroadcastOptions(options scyllav1.BroadcastOptions, nodeService *scyllav1.NodeServiceTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if !slices.ContainsItem(SupportedScyllaV1BroadcastAddressTypes, options.Type) {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), options.Type, slices.ConvertSlice(SupportedScyllaV1BroadcastAddressTypes, slices.ToString[scyllav1.BroadcastAddressType])))
@@ -344,7 +344,7 @@ func ValidateBroadcastOptions(options scyllav1.BroadcastOptions, nodeService *sc
 }
 
 func ValidateNodeService(nodeService *scyllav1.NodeServiceTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	var supportedServiceTypes = []scyllav1.NodeServiceType{
 		scyllav1.NodeServiceTypeHeadless,
@@ -370,7 +370,7 @@ func ValidateNodeService(nodeService *scyllav1.NodeServiceTemplate, fldPath *fie
 }
 
 func ValidateIngressOptions(options *scyllav1.IngressOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(options.IngressClassName) != 0 {
 		for _, msg := range apimachineryvalidation.NameIsDNSSubdomain(options.IngressClassName, false) {
@@ -386,7 +386,7 @@ func ValidateIngressOptions(options *scyllav1.IngressOptions, fldPath *field.Pat
 }
 
 func ValidateScyllaClusterRackSpec(rack scyllav1.RackSpec, rackNames sets.String, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	// Check that no two racks have the same name
 	if rackNames.Has(rack.Name) {
@@ -410,7 +410,7 @@ func ValidateScyllaClusterUpdate(new, old *scyllav1.ScyllaCluster) field.ErrorLi
 }
 
 func ValidateScyllaClusterSpecUpdate(new, old *scyllav1.ScyllaCluster, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	// Check that the datacenter name didn't change
 	if old.Spec.Datacenter.Name != new.Spec.Datacenter.Name {

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -34,7 +34,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 		{
 			name:                "valid",
 			cluster:             validCluster.DeepCopy(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -85,7 +85,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				}
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -334,7 +334,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				})
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -352,7 +352,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				})
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -371,7 +371,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				})
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -389,7 +389,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				})
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -408,7 +408,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				})
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -426,7 +426,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				})
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -508,7 +508,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				}...)
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -537,7 +537,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				}...)
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -721,7 +721,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -884,7 +884,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				cluster.Spec.Alternator = &scyllav1.AlternatorSpec{}
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -901,7 +901,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				}
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -934,7 +934,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				}
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -970,7 +970,7 @@ func TestValidateScyllaCluster(t *testing.T) {
 				}
 				return cluster
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -1026,35 +1026,35 @@ func TestValidateScyllaClusterUpdate(t *testing.T) {
 			name:                "same as old",
 			old:                 unit.NewSingleRackCluster(3),
 			new:                 unit.NewSingleRackCluster(3),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
 			name:                "major version changed",
 			old:                 unit.NewSingleRackCluster(3),
 			new:                 unit.NewDetailedSingleRackCluster("test-cluster", "test-ns", "repo", "3.3.1", "test-dc", "test-rack", 3),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
 			name:                "minor version changed",
 			old:                 unit.NewSingleRackCluster(3),
 			new:                 unit.NewDetailedSingleRackCluster("test-cluster", "test-ns", "repo", "2.4.2", "test-dc", "test-rack", 3),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
 			name:                "patch version changed",
 			old:                 unit.NewSingleRackCluster(3),
 			new:                 unit.NewDetailedSingleRackCluster("test-cluster", "test-ns", "repo", "2.3.2", "test-dc", "test-rack", 3),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
 			name:                "repo changed",
 			old:                 unit.NewSingleRackCluster(3),
 			new:                 unit.NewDetailedSingleRackCluster("test-cluster", "test-ns", "new-repo", "2.3.2", "test-dc", "test-rack", 3),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -1070,7 +1070,7 @@ func TestValidateScyllaClusterUpdate(t *testing.T) {
 			name:                "rackPlacement changed",
 			old:                 unit.NewSingleRackCluster(3),
 			new:                 placementChanged(unit.NewSingleRackCluster(3)),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -1086,14 +1086,14 @@ func TestValidateScyllaClusterUpdate(t *testing.T) {
 			name:                "rackResources changed",
 			old:                 unit.NewSingleRackCluster(3),
 			new:                 resourceChanged(unit.NewSingleRackCluster(3)),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
 			name:                "empty rack removed",
 			old:                 unit.NewSingleRackCluster(0),
 			new:                 racksDeleted(unit.NewSingleRackCluster(0)),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{

--- a/pkg/api/scylla/validation/nodeconfig_validation.go
+++ b/pkg/api/scylla/validation/nodeconfig_validation.go
@@ -14,7 +14,7 @@ func ValidateNodeConfig(nc *scyllav1alpha1.NodeConfig) field.ErrorList {
 }
 
 func ValidateNodeConfigSpec(spec *scyllav1alpha1.NodeConfigSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if spec.LocalDiskSetup != nil {
 		allErrs = append(allErrs, ValidateLocalDiskSetup(spec.LocalDiskSetup, fldPath.Child("localDiskSetup"))...)
@@ -24,7 +24,7 @@ func ValidateNodeConfigSpec(spec *scyllav1alpha1.NodeConfigSpec, fldPath *field.
 }
 
 func ValidateLocalDiskSetup(lds *scyllav1alpha1.LocalDiskSetup, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, ValidateLocalDiskSetupFilesystems(lds.Filesystems, fldPath.Child("filesystems"))...)
 
@@ -36,13 +36,13 @@ func ValidateLocalDiskSetup(lds *scyllav1alpha1.LocalDiskSetup, fldPath *field.P
 }
 
 func ValidateLocalDiskSetupFilesystems(fcs []scyllav1alpha1.FilesystemConfiguration, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	return allErrs
 }
 
 func ValidateLocalDiskSetupMounts(mcs []scyllav1alpha1.MountConfiguration, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	mountPoints := map[string]struct{}{}
 
@@ -58,7 +58,7 @@ func ValidateLocalDiskSetupMounts(mcs []scyllav1alpha1.MountConfiguration, fldPa
 }
 
 func ValidateLocalDiskSetupRAIDs(rcs []scyllav1alpha1.RAIDConfiguration, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	names := map[string]struct{}{}
 
@@ -90,7 +90,7 @@ func ValidateNodeConfigUpdate(new, old *scyllav1alpha1.NodeConfig) field.ErrorLi
 }
 
 func ValidateNodeConfigSpecUpdate(new, old *scyllav1alpha1.NodeConfig, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	oldLoopDevicesSizes := make(map[string]resource.Quantity)
 	if old.Spec.LocalDiskSetup != nil {

--- a/pkg/api/scylla/validation/nodeconfig_validation_test.go
+++ b/pkg/api/scylla/validation/nodeconfig_validation_test.go
@@ -29,7 +29,7 @@ func TestValidateNodeConfig(t *testing.T) {
 		{
 			name:                "valid",
 			nodeConfig:          validNodeConfig,
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -100,7 +100,7 @@ func TestValidateNodeConfig(t *testing.T) {
 				}
 				return nc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -116,7 +116,7 @@ func TestValidateNodeConfig(t *testing.T) {
 				}
 				return nc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 	}
@@ -158,7 +158,7 @@ func TestValidateNodeConfigUpdate(t *testing.T) {
 			name:                "identity",
 			old:                 validNodeConfig,
 			new:                 validNodeConfig,
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{

--- a/pkg/api/scylla/validation/scylladbcluster_validation.go
+++ b/pkg/api/scylla/validation/scylladbcluster_validation.go
@@ -18,7 +18,7 @@ import (
 )
 
 func ValidateScyllaDBCluster(sc *scyllav1alpha1.ScyllaDBCluster) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, ValidateScyllaDBClusterSpec(&sc.Spec, field.NewPath("spec"))...)
 
@@ -26,7 +26,7 @@ func ValidateScyllaDBCluster(sc *scyllav1alpha1.ScyllaDBCluster) field.ErrorList
 }
 
 func ValidateScyllaDBClusterSpec(spec *scyllav1alpha1.ScyllaDBClusterSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if spec.Metadata != nil {
 		allErrs = append(allErrs, apimachinerymetav1validation.ValidateLabels(spec.Metadata.Labels, fldPath.Child("metadata", "labels"))...)
@@ -70,7 +70,7 @@ func ValidateScyllaDBClusterSpec(spec *scyllav1alpha1.ScyllaDBClusterSpec, fldPa
 }
 
 func ValidateScyllaDBClusterDatacenter(dc scyllav1alpha1.ScyllaDBClusterDatacenter, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(dc.Name) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "datacenter name must not be empty"))
@@ -86,7 +86,7 @@ func ValidateScyllaDBClusterDatacenter(dc scyllav1alpha1.ScyllaDBClusterDatacent
 }
 
 func ValidateScyllaDBClusterDatacenterTemplate(dcTemplate *scyllav1alpha1.ScyllaDBClusterDatacenterTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if dcTemplate.Metadata != nil {
 		allErrs = append(allErrs, apimachinerymetav1validation.ValidateLabels(dcTemplate.Metadata.Labels, fldPath.Child("metadata", "labels"))...)
@@ -136,7 +136,7 @@ func ValidateScyllaDBClusterDatacenterTemplate(dcTemplate *scyllav1alpha1.Scylla
 }
 
 func ValidateScyllaDBClusterSpecExposeOptions(options *scyllav1alpha1.ScyllaDBClusterExposeOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if options.NodeService != nil {
 		allErrs = append(allErrs, ValidateScyllaDBClusterNodeService(options.NodeService, fldPath.Child("nodeService"))...)
@@ -150,7 +150,7 @@ func ValidateScyllaDBClusterSpecExposeOptions(options *scyllav1alpha1.ScyllaDBCl
 }
 
 func ValidateScyllaDBClusterNodeService(nodeService *scyllav1alpha1.NodeServiceTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(nodeService.Type) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("type"), fmt.Sprintf("supported values: %s", strings.Join(slices.ConvertSlice(supportedNodeServiceTypes, slices.ToString[scyllav1alpha1.NodeServiceType]), ", "))))
@@ -171,7 +171,7 @@ func ValidateScyllaDBClusterNodeService(nodeService *scyllav1alpha1.NodeServiceT
 }
 
 func ValidateScyllaDBClusterNodeBroadcastOptions(options *scyllav1alpha1.ScyllaDBClusterNodeBroadcastOptions, nodeService *scyllav1alpha1.NodeServiceTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	var nodeServiceType *scyllav1alpha1.NodeServiceType
 	if nodeService != nil {
@@ -204,7 +204,7 @@ func ValidateScyllaDBClusterNodeBroadcastOptions(options *scyllav1alpha1.ScyllaD
 }
 
 func ValidateScyllaDBClusterUpdate(new, old *scyllav1alpha1.ScyllaDBCluster) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, ValidateScyllaDBCluster(new)...)
 	allErrs = append(allErrs, ValidateScyllaDBClusterSpecUpdate(new, old, field.NewPath("spec"))...)
@@ -213,7 +213,7 @@ func ValidateScyllaDBClusterUpdate(new, old *scyllav1alpha1.ScyllaDBCluster) fie
 }
 
 func ValidateScyllaDBClusterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBCluster, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec.ClusterName, old.Spec.ClusterName, fldPath.Child("clusterName"))...)
 

--- a/pkg/api/scylla/validation/scylladbcluster_validation_test.go
+++ b/pkg/api/scylla/validation/scylladbcluster_validation_test.go
@@ -85,7 +85,7 @@ func TestValidateScyllaDBCluster(t *testing.T) {
 		{
 			name:                "valid",
 			cluster:             newValidScyllaDBCluster(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -262,7 +262,7 @@ func TestValidateScyllaDBCluster(t *testing.T) {
 
 				return sc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -385,7 +385,7 @@ func TestValidateScyllaDBCluster(t *testing.T) {
 				sc.Spec.ScyllaDB.AlternatorOptions = &scyllav1alpha1.AlternatorOptions{}
 				return sc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -402,7 +402,7 @@ func TestValidateScyllaDBCluster(t *testing.T) {
 				}
 				return sc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -435,7 +435,7 @@ func TestValidateScyllaDBCluster(t *testing.T) {
 				}
 				return sc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -471,7 +471,7 @@ func TestValidateScyllaDBCluster(t *testing.T) {
 				}
 				return sc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -2586,7 +2586,7 @@ func TestValidateScyllaDBClusterUpdate(t *testing.T) {
 			name:                "same as old",
 			old:                 newValidScyllaDBCluster(),
 			new:                 newValidScyllaDBCluster(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -2616,7 +2616,7 @@ func TestValidateScyllaDBClusterUpdate(t *testing.T) {
 				sc.Spec.Datacenters[0].Racks = nil
 				return sc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation.go
@@ -51,7 +51,7 @@ var (
 )
 
 func ValidateScyllaDBDatacenter(sdc *scyllav1alpha1.ScyllaDBDatacenter) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, ValidateScyllaDBDatacenterSpec(&sdc.Spec, field.NewPath("spec"))...)
 
@@ -59,7 +59,7 @@ func ValidateScyllaDBDatacenter(sdc *scyllav1alpha1.ScyllaDBDatacenter) field.Er
 }
 
 func ValidateScyllaDBDatacenterSpec(spec *scyllav1alpha1.ScyllaDBDatacenterSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, ValidateScyllaDBDatacenterScyllaDB(&spec.ScyllaDB, fldPath.Child("scyllaDB"))...)
 	allErrs = append(allErrs, ValidateScyllaDBDatacenterScyllaDBManagerAgent(spec.ScyllaDBManagerAgent, fldPath.Child("scyllaDBManagerAgent"))...)
@@ -98,7 +98,7 @@ func ValidateScyllaDBDatacenterSpec(spec *scyllav1alpha1.ScyllaDBDatacenterSpec,
 }
 
 func ValidateScyllaDBDatacenterRackTemplate(rackTemplate *scyllav1alpha1.RackTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if rackTemplate.Nodes != nil && *rackTemplate.Nodes < 0 {
 		allErrs = append(allErrs, apimachineryvalidation.ValidateNonnegativeField(int64(*rackTemplate.Nodes), fldPath.Child("nodes"))...)
@@ -122,7 +122,7 @@ func ValidateScyllaDBDatacenterRackTemplate(rackTemplate *scyllav1alpha1.RackTem
 }
 
 func ValidateScyllaDBDatacenterScyllaDBManagerAgentTemplate(scyllaDBManagerAgentTemplate *scyllav1alpha1.ScyllaDBManagerAgentTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if scyllaDBManagerAgentTemplate.CustomConfigSecretRef != nil {
 		for _, msg := range apimachineryvalidation.NameIsDNSSubdomain(*scyllaDBManagerAgentTemplate.CustomConfigSecretRef, false) {
@@ -134,7 +134,7 @@ func ValidateScyllaDBDatacenterScyllaDBManagerAgentTemplate(scyllaDBManagerAgent
 }
 
 func ValidateScyllaDBDatacenterScyllaDBTemplate(scyllaDBTemplate *scyllav1alpha1.ScyllaDBTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if scyllaDBTemplate.Storage != nil {
 		if scyllaDBTemplate.Storage.Metadata != nil {
@@ -166,7 +166,7 @@ func ValidateScyllaDBDatacenterScyllaDBTemplate(scyllaDBTemplate *scyllav1alpha1
 }
 
 func ValidateScyllaDBDatacenterScyllaDB(scyllaDB *scyllav1alpha1.ScyllaDB, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(scyllaDB.Image) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("image"), "must not be empty"))
@@ -185,7 +185,7 @@ func ValidateScyllaDBDatacenterScyllaDB(scyllaDB *scyllav1alpha1.ScyllaDB, fldPa
 }
 
 func ValidateScyllaDBDatacenterScyllaDBManagerAgent(scyllaDBManagerAgent *scyllav1alpha1.ScyllaDBManagerAgent, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if scyllaDBManagerAgent == nil || scyllaDBManagerAgent.Image == nil || len(*scyllaDBManagerAgent.Image) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("image"), "must not be empty"))
@@ -200,7 +200,7 @@ func ValidateScyllaDBDatacenterScyllaDBManagerAgent(scyllaDBManagerAgent *scylla
 }
 
 func ValidateScyllaDBDatacenterSpecExposeOptions(options *scyllav1alpha1.ExposeOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if options.CQL != nil && options.CQL.Ingress != nil {
 		allErrs = append(allErrs, ValidateScyllaDBDatacenterIngressOptions(options, fldPath)...)
@@ -218,7 +218,7 @@ func ValidateScyllaDBDatacenterSpecExposeOptions(options *scyllav1alpha1.ExposeO
 }
 
 func ValidateScyllaDBDatacenterIngressOptions(options *scyllav1alpha1.ExposeOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(options.CQL.Ingress.IngressClassName) != 0 {
 		for _, msg := range apimachineryvalidation.NameIsDNSSubdomain(options.CQL.Ingress.IngressClassName, false) {
@@ -233,7 +233,7 @@ func ValidateScyllaDBDatacenterIngressOptions(options *scyllav1alpha1.ExposeOpti
 }
 
 func ValidateScyllaDBDatacenterNodeService(options *scyllav1alpha1.ExposeOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(options.NodeService.Type) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("nodeService", "type"), fmt.Sprintf("supported values: %s", strings.Join(slices.ConvertSlice(supportedNodeServiceTypes, slices.ToString[scyllav1alpha1.NodeServiceType]), ", "))))
@@ -254,7 +254,7 @@ func ValidateScyllaDBDatacenterNodeService(options *scyllav1alpha1.ExposeOptions
 }
 
 func ValidateScyllaDBDatacenterSpecExposeOptionsNodeBroadcastOptions(options *scyllav1alpha1.NodeBroadcastOptions, nodeService *scyllav1alpha1.NodeServiceTemplate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	var nodeServiceType *scyllav1alpha1.NodeServiceType
 	if nodeService != nil {
@@ -302,7 +302,7 @@ func ValidateScyllaDBDatacenterSpecExposeOptionsNodeBroadcastOptions(options *sc
 }
 
 func ValidateScyllaDBDatacenterBroadcastOptions[BT ~string, ST ~string](broadcastAddressType BT, supportedBroadcastedTypes []BT, defaultNodeServiceType ST, nodeServiceType *ST, allowedNodeServiceTypesByBroadcastAddressType map[BT][]ST, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, validateEnum(broadcastAddressType, supportedBroadcastedTypes, fldPath.Child("type"))...)
 
@@ -321,7 +321,7 @@ func ValidateScyllaDBDatacenterBroadcastOptions[BT ~string, ST ~string](broadcas
 }
 
 func ValidateScyllaDBDatacenterAlternatorOptions(alternator *scyllav1alpha1.AlternatorOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if alternator.WriteIsolation != "" {
 		found := slices.ContainsItem(AlternatorSupportedWriteIsolation, alternator.WriteIsolation)
@@ -338,7 +338,7 @@ func ValidateScyllaDBDatacenterAlternatorOptions(alternator *scyllav1alpha1.Alte
 }
 
 func ValidateScyllaDBDatacenterTLSCertificate(servingCertificate *scyllav1alpha1.TLSCertificate, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	switch servingCertificate.Type {
 	case scyllav1alpha1.TLSCertificateTypeOperatorManaged:
@@ -376,7 +376,7 @@ func ValidateScyllaDBDatacenterTLSCertificate(servingCertificate *scyllav1alpha1
 }
 
 func ValidateScyllaDBDatacenterUserManagedTLSCertificateOptions(options *scyllav1alpha1.UserManagedTLSCertificateOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(options.SecretName) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("secretName"), ""))
@@ -389,7 +389,7 @@ func ValidateScyllaDBDatacenterUserManagedTLSCertificateOptions(options *scyllav
 }
 
 func ValidateScyllaDBDatacenterOperatorManagedTLSCertificateOptions(options *scyllav1alpha1.OperatorManagedTLSCertificateOptions, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	for _, dnsName := range options.AdditionalDNSNames {
 		for _, msg := range apimachineryutilvalidation.IsDNS1123Subdomain(dnsName) {
@@ -406,7 +406,7 @@ func ValidateScyllaDBDatacenterOperatorManagedTLSCertificateOptions(options *scy
 }
 
 func ValidateScyllaDBDatacenterPlacement(placement *scyllav1alpha1.Placement, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if placement.NodeAffinity != nil {
 		allErrs = append(allErrs, corevalidation.ValidateNodeAffinity(placement.NodeAffinity, fldPath.Child("nodeAffinity"))...)
@@ -428,7 +428,7 @@ func ValidateScyllaDBDatacenterPlacement(placement *scyllav1alpha1.Placement, fl
 }
 
 func ValidateScyllaDBDatacenterUpdate(new, old *scyllav1alpha1.ScyllaDBDatacenter) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, ValidateScyllaDBDatacenter(new)...)
 	allErrs = append(allErrs, ValidateScyllaDBDatacenterSpecUpdate(new, old, field.NewPath("spec"))...)
@@ -437,7 +437,7 @@ func ValidateScyllaDBDatacenterUpdate(new, old *scyllav1alpha1.ScyllaDBDatacente
 }
 
 func ValidateScyllaDBDatacenterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBDatacenter, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec.ClusterName, old.Spec.ClusterName, fldPath.Child("clusterName"))...)
 
@@ -552,7 +552,7 @@ func ValidateScyllaDBDatacenterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBDatac
 }
 
 func validateStructSliceFieldUniqueness[E any, F comparable](s []E, mapFunc func(E) F, fieldSubPath string, structPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	set := sets.New[F]()
 	for i, e := range s {
@@ -568,7 +568,7 @@ func validateStructSliceFieldUniqueness[E any, F comparable](s []E, mapFunc func
 }
 
 func validateEnum[E ~string](value E, supported []E, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if !slices.ContainsItem(supported, value) {
 		allErrs = append(allErrs, field.NotSupported(fldPath, value, slices.ConvertSlice(supported, slices.ToString[E])))

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
@@ -66,7 +66,7 @@ func TestValidateScyllaDBDatacenter(t *testing.T) {
 		{
 			name:                "valid",
 			datacenter:          newValidScyllaDBDatacenter(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -224,7 +224,7 @@ func TestValidateScyllaDBDatacenter(t *testing.T) {
 
 				return sdc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -382,7 +382,7 @@ func TestValidateScyllaDBDatacenter(t *testing.T) {
 				sdc.Spec.ScyllaDB.AlternatorOptions = &scyllav1alpha1.AlternatorOptions{}
 				return sdc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -399,7 +399,7 @@ func TestValidateScyllaDBDatacenter(t *testing.T) {
 				}
 				return sdc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -432,7 +432,7 @@ func TestValidateScyllaDBDatacenter(t *testing.T) {
 				}
 				return sdc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -468,7 +468,7 @@ func TestValidateScyllaDBDatacenter(t *testing.T) {
 				}
 				return sdc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -740,7 +740,7 @@ func TestValidateScyllaDBDatacenterUpdate(t *testing.T) {
 			name:                "same as old",
 			old:                 newValidScyllaDBDatacenter(),
 			new:                 newValidScyllaDBDatacenter(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
@@ -781,7 +781,7 @@ func TestValidateScyllaDBDatacenterUpdate(t *testing.T) {
 				sdc.Spec.Racks = []scyllav1alpha1.RackSpec{}
 				return sdc
 			}(),
-			expectedErrorList:   field.ErrorList{},
+			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{

--- a/pkg/api/scylla/validation/scyllaoperatorconfig.go
+++ b/pkg/api/scylla/validation/scyllaoperatorconfig.go
@@ -14,7 +14,7 @@ import (
 )
 
 func ValidateImageRef(imageRef string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(imageRef) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath, "image reference can't be empty"))
@@ -29,7 +29,7 @@ func ValidateImageRef(imageRef string, fldPath *field.Path) field.ErrorList {
 }
 
 func ValidateSemanticVersion(v string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if len(v) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath, "version can't be empty"))
@@ -50,7 +50,7 @@ func ValidateScyllaOperatorConfig(nc *scyllav1alpha1.ScyllaOperatorConfig) field
 }
 
 func ValidateScyllaOperatorConfigSpec(spec *scyllav1alpha1.ScyllaOperatorConfigSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var allErrs field.ErrorList
 
 	if spec.UnsupportedBashToolsImageOverride != nil {
 		allErrs = append(allErrs, ValidateImageRef(*spec.UnsupportedBashToolsImageOverride, fldPath.Child("unsupportedBashToolsImageOverride"))...)

--- a/pkg/api/scylla/validation/scyllaoperatorconfig_test.go
+++ b/pkg/api/scylla/validation/scyllaoperatorconfig_test.go
@@ -25,7 +25,7 @@ func TestValidateScyllaOperatorConfig(t *testing.T) {
 		{
 			name:                 "empty config is valid",
 			ScyllaOperatorConfig: &scyllav1alpha1.ScyllaOperatorConfig{},
-			expectedErrorList:    field.ErrorList{},
+			expectedErrorList:    nil,
 			expectedErrorString:  "",
 		},
 		{


### PR DESCRIPTION
Tiny drive-by refactor to use nil slices where they're perfectly legal, and marginally better memory allocation-wise.
I've grepped `k8s.io/apimachinery` and they're somewhat 50-50 divided on "nil slice" and `allErrs := field.ErrorList{}`.

I was somewhat on the edge of "if it ain't broken, don't fix it" but uncontroversial little code smells might be a good way to get the code health in a better shape.

Feel free to close if you see a good reason to leave it as it was.

/cc rzetelskik
/kind cleanup
/priority backlog