### PR TITLE
Fix Available Condition of RemoteKubernetesCluster after recovery

### DIFF
--- a/pkg/controller/remotekubernetescluster/sync_healthchecks.go
+++ b/pkg/controller/remotekubernetescluster/sync_healthchecks.go
@@ -84,6 +84,14 @@ func (rkcc *Controller) syncClientHealthchecks(ctx context.Context, key string, 
 			Message:            strings.Join(messages, "\n"),
 			ObservedGeneration: rkc.Generation,
 		})
+	} else {
+		apimeta.SetStatusCondition(&status.Conditions, metav1.Condition{
+			Type:               clientHealthcheckControllerAvailableCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "ClientProbeSucceded",
+			Message:            strings.Join(messages, "\n"),
+			ObservedGeneration: rkc.Generation,
+		})
 	}
 
 	err := errors.NewAggregate(errs)


### PR DESCRIPTION
**Description of your changes:**

Sets ClientHealthcheckControllerAvailable condition status when RemoteKubernetesCluster healthcheck probes succeeds.

Previously aggregated Available condition was set to True when there was no ClientHealthcheckControllerAvailable having False status. When access to Kubernetes is broken and then restored, nothing removed this failed condition, hence RemoteKubernetesCluster was constantly not Available. To fix that, healthcheck controller sets this condition according to state of given healthcheck iteration.
