### PR TITLE
Register collection of remote Namespaces originating from ScyllaDBCluster during E2E tests

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -198,8 +198,12 @@ func (f *Framework) GetDefaultScyllaDBCluster(rkcs []*scyllav1alpha1.RemoteKuber
 	return sc
 }
 
-func (f *Framework) AddCleaners(cleaners ...CleanupInterface) {
+func (f *Framework) AddCleaners(cleaners ...Cleaner) {
 	f.defaultCluster().AddCleaners(cleaners...)
+}
+
+func (f *Framework) AddCollectors(collectors ...Collector) {
+	f.defaultCluster().AddCollectors(collectors...)
 }
 
 func (f *Framework) CreateUserNamespace(ctx context.Context) (*corev1.Namespace, Client) {

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
@@ -2,6 +2,7 @@ package multidatacenter
 
 import (
 	"context"
+
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
@@ -31,6 +32,9 @@ var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter
 		waitCtx2, waitCtx2Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
 		defer waitCtx2Cancel()
 		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx2, metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaDBClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		scylladbclusterverification.Verify(ctx, sc, rkcClusterMap)

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
@@ -155,6 +155,9 @@ var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter
 		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx2, metaCluster.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaDBClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		scylladbclusterverification.Verify(ctx, sc, rkcClusterMap)
 		err = scylladbclusterverification.WaitForFullQuorum(ctx, rkcClusterMap, sc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_finalizer.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_finalizer.go
@@ -4,6 +4,7 @@ package multidatacenter
 
 import (
 	"context"
+
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"


### PR DESCRIPTION
**Description of your changes:**

Framework CleanupInterface which had two responsiblities was split into Cleaner and Collect interfaces. This allows to specify custom collectors for Cluster.

ScyllaDBClusters created during E2E tests now register a custom collector for each remote Cluster, collecting Namespaces originating from ScyllaDBCluster object in JustAfterEach step.
