### PR TITLE
Update restore from backup documentation page

### DIFF
--- a/docs/source/resources/scyllaclusters/nodeoperations/restore.md
+++ b/docs/source/resources/scyllaclusters/nodeoperations/restore.md
@@ -141,7 +141,12 @@ Snapshot Tag:   sm_20240105115931UTC
 +---------------+-------------+----------+----------+------------+--------+
 ```
 
-As suggested in the progress output, you will need to execute a rolling restart of the ScyllaCluster.
+As suggested in the progress output, you will need to execute a rolling restart of the ScyllaCluster **if you are using ScyllaDB 5.4/2024.1 or older**. For ScyllaDB 2024.2 and newer, a rolling restart is not required after restoring the schema.
+
+For more details, refer to the ScyllaDB Manager Restore documentation:
+- [Old Restore Schema Documentation](https://manager.docs.scylladb.com/stable/restore/old-restore-schema.html) (for ScyllaDB 5.4/2024.1 or older)
+- [New Restore Schema Documentation](https://manager.docs.scylladb.com/stable/restore/restore-schema.html) (for ScyllaDB 2024.2 and newer)
+
 ```console
 kubectl patch scyllacluster/target --type=merge -p='{"spec": {"forceRedeploymentReason": "schema restored"}}'
 ```


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Update restore from backup documentation page - rolling restart needed only for ScyllaDB 5.4/2024.1 or older

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2085
