### PR TITLE
Stop building docs for 1.13 and 1.14

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ redirects_file = "./redirections.yaml"
 TAGS = []
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
-BRANCHES = ['master', 'v1.13', 'v1.14', 'v1.15', 'v1.16']
+BRANCHES = ['master', 'v1.15', 'v1.16']
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["master"]
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** 1.13 and 1.14 are EOL now, we should stop building docs for corresponding branches to reduce the maintenance cost (e.g. backporting https://github.com/scylladb/scylla-operator/pull/2613).

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-longterm