### PR TITLE
Fix GitOps local-csi-driver installation command

### DIFF
--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -156,7 +156,7 @@ kubectl wait --for='condition=Reconciled' --timeout=10m nodeconfigs.scylla.scyll
 :::{code-block} shell
 :substitutions:
 
-kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/local-volume-provisioner/local-csi-driver/{00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_driver.serviceaccount,10_provisioner_clusterrole,20_provisioner_clusterrolebinding,50_daemonset}.yaml
+kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
 :::
 
 :::{code-block} shell


### PR DESCRIPTION
**Description of your changes:**

The command used for installing `local-volume-provisioner` in GitOps installation docs was referring to no longer existing files:

```shell
kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/scylladb/scylla-operator/master/examples/common/local-volume-provisioner/local-csi-driver/{00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_driver.serviceaccount,10_provisioner_clusterrole,20_provisioner_clusterrolebinding,50_daemonset}.yaml
namespace/local-csi-driver serverside-applied
storageclass.storage.k8s.io/scylladb-local-xfs serverside-applied
csidriver.storage.k8s.io/local.csi.scylladb.com serverside-applied
daemonset.apps/local-csi-driver serverside-applied
unable to read URL "https://raw.githubusercontent.com/scylladb/scylla-operator/master/examples/common/local-volume-provisioner/local-csi-driver/10_driver.serviceaccount.yaml", server reported 404 Not Found, status code=404
unable to read URL "https://raw.githubusercontent.com/scylladb/scylla-operator/master/examples/common/local-volume-provisioner/local-csi-driver/10_provisioner_clusterrole.yaml", server reported 404 Not Found, status code=404
unable to read URL "https://raw.githubusercontent.com/scylladb/scylla-operator/master/examples/common/local-volume-provisioner/local-csi-driver/20_provisioner_clusterrolebinding.yaml", server reported 404 Not Found, status code=404
```

This PR aligns it with the current contents of the https://github.com/scylladb/scylla-operator/tree/master/examples/common/local-volume-provisioner/local-csi-driver directory so that appropriate files are applied.

 /kind documentation