### PR TITLE
[v1.16] Remove redundant wait for webhook CA secret in docs' GitOps installation steps

### DIFF
--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -55,11 +55,6 @@ kubectl wait --for='condition=established' crd/prometheuses.monitoring.coreos.co
 
 # Wait for prometheus operator deployment.
 kubectl -n=prometheus-operator rollout status --timeout=10m deployment.apps/prometheus-operator
-
-# Wait for webhook CA secret to be created.
-for i in {1..30}; do
-    { kubectl -n=cert-manager get secret/cert-manager-webhook-ca && break; } || sleep 1
-done
 :::
 
 ### {{productName}}
@@ -108,11 +103,6 @@ kubectl wait --for='condition=established' crd/scyllaclusters.scylla.scylladb.co
 
 # Wait for the components to deploy.
 kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/{scylla-operator,webhook-server}
-
-# Wait for webhook CA secret to be created.
-for i in {1..30}; do
-    { kubectl -n=cert-manager get secret/cert-manager-webhook-ca && break; } || sleep 1
-done
 :::
 
 ### Setting up local storage on nodes and enabling tuning


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** backport of https://github.com/scylladb/scylla-operator/pull/2569

/kind documentation
/priority important-longterm