### PR TITLE
Mark 1.17 docs as stable

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,11 +83,11 @@ smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
 BRANCHES = ['master', 'v1.15', 'v1.16', 'v1.17']
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", 'v1.17']
+UNSTABLE_VERSIONS = ["master"]
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.
-smv_latest_version = 'v1.16'
+smv_latest_version = 'v1.17'
 smv_rename_latest_version = 'stable'
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"


### PR DESCRIPTION
Marks the 1.17 docs as stable.

/hold
for #2637 

/cc zimnx rzetelskik
/kind documentation
/priority important-soon