### PR TITLE
Rename generic NodeConfig to match docs expectations

### DIFF
--- a/examples/generic/nodeconfig-alpha.yaml
+++ b/examples/generic/nodeconfig-alpha.yaml
@@ -1,7 +1,7 @@
 apiVersion: scylla.scylladb.com/v1alpha1
 kind: NodeConfig
 metadata:
-  name: cluster
+  name: scylladb-nodepool-1
 spec:
   localDiskSetup:
     loopDevices:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

In https://operator.docs.scylladb.com/master/installation/gitops.html#setting-up-local-storage-on-nodes-and-enabling-tuning we have instructions to wait for the `NodeConfig`'s `Reconciled` condition:

```
# Wait for NodeConfig to apply changes to the Kubernetes nodes.
kubectl wait --for='condition=Reconciled' --timeout=10m nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
```

This PR aligns the name of the `NodeConfig` used in the "Any platform (loop devices)" variant of instructions to match the command above. 

/priority important-longterm
/kind documentation
