### PR TITLE
fix the permissions granted to ClusterRole scyllacluster-member

### DIFF
--- a/helm/scylla-operator/templates/scyllacluster_member_clusterrole_def.yaml
+++ b/helm/scylla-operator/templates/scyllacluster_member_clusterrole_def.yaml
@@ -12,6 +12,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**Description of your changes:**

Adds a missing permission - cache/reflector.go:200 in the scylladb-ignition container requires it and errors with the following if it's not set:

"Failed to watch" err="pods \"scylladb-us-west1-us-west1-0\" is forbidden: User \"system:serviceaccount:scylla:scylladb-member\" cannot watch resource \"pods\" in API group \"\" in the namespace \"scylla\"" logger="UnhandledError" reflector="k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285" type="*v1.Pod"

**Which issue is resolved by this Pull Request:**
No issue.
