### PR TITLE
Add minimal golangci-lint config and fix found issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,16 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - unused
+    - govet
+    # More linters can be added, see supported ones: https://golangci-lint.run/usage/linters/
+  exclusions:
+    presets:
+      - common-false-positives
+      - std-error-handling
+formatters:
+  enable:
+    - gofmt
+    - goimports
+    - gci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,16 @@ A subset of useful commands:
 
 Check `make help` for more.
 
+### Dependencies
+
+Most of the dependencies are managed by Go modules. Some Makefile targets require additional tools to be installed, and
+it's up to the developer to ensure they are available in the environment:
+
+- [yq](https://github.com/mikefarah/yq)
+- [jq](https://github.com/jqlang/jq)
+- [helm](https://github.com/helm/helm)
+- [golangci-lint](https://github.com/golangci/golangci-lint)
+
 ## Coding convention
 
 Follow these guidelines for writing and structuring your code:

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -10,10 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/scylladb/scylla-operator/pkg/util/timeutc"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/scylladb/scylla-operator/pkg/util/httpx"
+	"github.com/scylladb/scylla-operator/pkg/util/timeutc"
 )
 
 func TestParseBearerAuth(t *testing.T) {

--- a/pkg/cmd/operator/sidecar.go
+++ b/pkg/cmd/operator/sidecar.go
@@ -9,7 +9,6 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
-	scyllaversionedclient "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
 	sidecarcontroller "github.com/scylladb/scylla-operator/pkg/controller/sidecar"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
 	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
@@ -42,8 +41,7 @@ type SidecarOptions struct {
 	nodesBroadcastAddressType   scyllav1alpha1.BroadcastAddressType
 	clientsBroadcastAddressType scyllav1alpha1.BroadcastAddressType
 
-	kubeClient   kubernetes.Interface
-	scyllaClient scyllaversionedclient.Interface
+	kubeClient kubernetes.Interface
 }
 
 func NewSidecarOptions(streams genericclioptions.IOStreams) *SidecarOptions {

--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -7,15 +7,13 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/cmdutil"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
 	ginkgotest "github.com/scylladb/scylla-operator/pkg/test/ginkgo"
+	_ "github.com/scylladb/scylla-operator/test/e2e" // Include suites
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/spf13/cobra"
 	"go.uber.org/automaxprocs/maxprocs"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/templates"
-
-	// Include suites
-	_ "github.com/scylladb/scylla-operator/test/e2e"
 )
 
 const (

--- a/pkg/controller/nodeconfig/controller.go
+++ b/pkg/controller/nodeconfig/controller.go
@@ -48,7 +48,6 @@ const (
 var (
 	keyFunc                 = cache.DeletionHandlingMetaNamespaceKeyFunc
 	nodeConfigControllerGVK = scyllav1alpha1.GroupVersion.WithKind("NodeConfig")
-	daemonSetControllerGVK  = appsv1.SchemeGroupVersion.WithKind("DaemonSet")
 )
 
 type Controller struct {

--- a/pkg/controller/nodetune/controller.go
+++ b/pkg/controller/nodetune/controller.go
@@ -63,7 +63,6 @@ type Controller struct {
 
 	nodeConfigLister          scyllav1alpha1listers.NodeConfigLister
 	localScyllaPodsLister     corev1listers.PodLister
-	configMapLister           corev1listers.ConfigMapLister
 	namespacedDaemonSetLister appsv1listers.DaemonSetLister
 	namespacedJobLister       batchv1listers.JobLister
 	selfPodLister             corev1listers.PodLister

--- a/pkg/controller/nodetune/sync.go
+++ b/pkg/controller/nodetune/sync.go
@@ -21,25 +21,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func (ncdc *Controller) getCanAdoptFunc(ctx context.Context) func() error {
-	return func() error {
-		fresh, err := ncdc.scyllaClient.ScyllaV1alpha1().NodeConfigs().Get(ctx, ncdc.nodeConfigName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-
-		if fresh.UID != ncdc.nodeConfigUID {
-			return fmt.Errorf("original NodeConfig %v is gone: got uid %v, wanted %v", ncdc.nodeConfigName, fresh.UID, ncdc.nodeConfigUID)
-		}
-
-		if fresh.GetDeletionTimestamp() != nil {
-			return fmt.Errorf("%v has just been deleted at %v", fresh.Name, fresh.DeletionTimestamp)
-		}
-
-		return nil
-	}
-}
-
 func (ncdc *Controller) sync(ctx context.Context) error {
 	startTime := time.Now()
 	klog.V(4).InfoS("Started sync", "startTime", startTime)

--- a/pkg/controller/nodetune/tune.go
+++ b/pkg/controller/nodetune/tune.go
@@ -18,7 +18,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/util/cpuset"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/kubelet/pkg/apis/podresources/v1"
+	podresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 )
 
 const (
@@ -108,7 +108,7 @@ func cpusetFromKubelet(ctx context.Context, podResourcesClient kubelet.PodResour
 			continue
 		}
 
-		cr, _, ok := slices.Find(pr.Containers, func(cr *v1.ContainerResources) bool {
+		cr, _, ok := slices.Find(pr.Containers, func(cr *podresourcesv1.ContainerResources) bool {
 			return cr.Name == containerName
 		})
 		if !ok {

--- a/pkg/controller/remotekubernetescluster/controller.go
+++ b/pkg/controller/remotekubernetescluster/controller.go
@@ -205,17 +205,6 @@ func (rkcc *Controller) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func (rkcc *Controller) enqueue(rkc *scyllav1alpha1.RemoteKubernetesCluster) {
-	key, err := keyFunc(rkc)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", rkc, err))
-		return
-	}
-
-	klog.V(4).InfoS("Enqueuing", "RemoteKubernetesCluster", klog.KObj(rkc))
-	rkcc.queue.Add(key)
-}
-
 func (rkcc *Controller) addRemoteKubernetesCluster(obj interface{}) {
 	rkcc.handlers.HandleAdd(
 		obj.(*scyllav1alpha1.RemoteKubernetesCluster),

--- a/pkg/controller/scylladbcluster/controller.go
+++ b/pkg/controller/scylladbcluster/controller.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	corev1informers "k8s.io/client-go/informers/core/v1"
-
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	scyllaclient "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
 	scyllav1alpha1informers "github.com/scylladb/scylla-operator/pkg/client/scylla/informers/externalversions/scylla/v1alpha1"
@@ -28,6 +26,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -417,29 +416,6 @@ func (scc *Controller) deleteRemoteRemoteOwner(obj interface{}) {
 	scc.handlers.HandleDelete(
 		obj,
 		scc.enqueueThroughRemoteOwnerLabel,
-	)
-}
-
-func (scc *Controller) addScyllaDBDatacenter(obj interface{}) {
-	scc.handlers.HandleAdd(
-		obj.(*scyllav1alpha1.ScyllaDBDatacenter),
-		scc.enqueueThroughParentLabel,
-	)
-}
-
-func (scc *Controller) updateScyllaDBDatacenter(old, cur interface{}) {
-	scc.handlers.HandleUpdate(
-		old.(*scyllav1alpha1.ScyllaDBDatacenter),
-		cur.(*scyllav1alpha1.ScyllaDBDatacenter),
-		scc.enqueueThroughParentLabel,
-		scc.deleteScyllaDBDatacenter,
-	)
-}
-
-func (scc *Controller) deleteScyllaDBDatacenter(obj interface{}) {
-	scc.handlers.HandleDelete(
-		obj,
-		scc.enqueueThroughParentLabel,
 	)
 }
 

--- a/pkg/kubelet/podresourcesclient.go
+++ b/pkg/kubelet/podresourcesclient.go
@@ -13,11 +13,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
-	"k8s.io/kubelet/pkg/apis/podresources/v1"
+	podresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 )
 
 type PodResourcesClient interface {
-	List(ctx context.Context) ([]*v1.PodResources, error)
+	List(ctx context.Context) ([]*podresourcesv1.PodResources, error)
 	Close() error
 }
 
@@ -54,17 +54,17 @@ func NewPodResourcesClient(ctx context.Context, endpoint string) (*PodResourcesC
 
 	return &PodResourcesClientImpl{
 		conn:   conn,
-		client: v1.NewPodResourcesListerClient(conn),
+		client: podresourcesv1.NewPodResourcesListerClient(conn),
 	}, nil
 }
 
 type PodResourcesClientImpl struct {
 	conn   *grpc.ClientConn
-	client v1.PodResourcesListerClient
+	client podresourcesv1.PodResourcesListerClient
 }
 
-func (c *PodResourcesClientImpl) List(ctx context.Context) ([]*v1.PodResources, error) {
-	resp, err := c.client.List(ctx, &v1.ListPodResourcesRequest{})
+func (c *PodResourcesClientImpl) List(ctx context.Context) ([]*podresourcesv1.PodResources, error) {
+	resp, err := c.client.List(ctx, &podresourcesv1.ListPodResourcesRequest{})
 	if err != nil {
 		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
 			return nil, nil

--- a/pkg/resource/helpers.go
+++ b/pkg/resource/helpers.go
@@ -11,14 +11,6 @@ import (
 
 var Scheme = scheme.Scheme
 
-func newUnknownGVK() *schema.GroupVersionKind {
-	return &schema.GroupVersionKind{
-		Group:   "unknown",
-		Version: "unknown",
-		Kind:    "unknown",
-	}
-}
-
 func GetObjectGVK(object runtime.Object) (*schema.GroupVersionKind, error) {
 	gvk := object.GetObjectKind().GroupVersionKind()
 	if len(gvk.Kind) > 0 {

--- a/pkg/scyllaclient/client_ping.go
+++ b/pkg/scyllaclient/client_ping.go
@@ -4,8 +4,6 @@ package scyllaclient
 
 import (
 	"context"
-	"net"
-	"net/url"
 	"time"
 
 	"github.com/scylladb/scylla-operator/pkg/util/timeutc"
@@ -20,19 +18,6 @@ func (c *Client) Ping(ctx context.Context, host string) (time.Duration, error) {
 	t := timeutc.Now()
 	err := c.ping(ctx, host)
 	return timeutc.Since(t), err
-}
-
-func (c *Client) newURL(host, path string) url.URL {
-	port := "80"
-	if c.config.Scheme == "https" {
-		port = "443"
-	}
-
-	return url.URL{
-		Scheme: c.config.Scheme,
-		Host:   net.JoinHostPort(host, port),
-		Path:   path,
-	}
 }
 
 func (c *Client) ping(ctx context.Context, host string) error {

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/magiconair/properties"
 	"github.com/pkg/errors"
-	scyllaversionedclient "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/sidecar/identity"
@@ -35,12 +34,9 @@ const (
 	entrypointPath                      = "/docker-entrypoint.py"
 )
 
-var scyllaJMXPaths = []string{"/usr/lib/scylla/jmx/scylla-jmx", "/opt/scylladb/jmx/scylla-jmx"}
-
 type ScyllaConfig struct {
 	member        *identity.Member
 	kubeClient    kubernetes.Interface
-	scyllaClient  scyllaversionedclient.Interface
 	cpuCount      int
 	externalSeeds []string
 }

--- a/pkg/sidecar/config/config_test.go
+++ b/pkg/sidecar/config/config_test.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -273,22 +271,6 @@ func TestAllowedCPUs(t *testing.T) {
 		t.Error(err)
 	}
 	t.Log(cpusAllowed)
-}
-
-func writeTempFile(t *testing.T, namePattern, content string) string {
-	tmp, err := ioutil.TempFile(os.TempDir(), namePattern)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := io.WriteString(tmp, content); err != nil {
-		t.Error(err)
-	}
-	if err := tmp.Close(); err != nil {
-		t.Error(err)
-	}
-
-	return tmp.Name()
 }
 
 func TestScyllaArguments(t *testing.T) {

--- a/pkg/util/blkutils/lsblk_test.go
+++ b/pkg/util/blkutils/lsblk_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/scylladb/scylla-operator/pkg/util/blkutils"
 	"github.com/scylladb/scylla-operator/pkg/util/exectest"
-	"k8s.io/utils/exec/testing"
+	testingexec "k8s.io/utils/exec/testing"
 )
 
 func TestGetPartitionUUID(t *testing.T) {

--- a/test/e2e/set/scyllacluster/config.go
+++ b/test/e2e/set/scyllacluster/config.go
@@ -6,6 +6,4 @@ import (
 
 const (
 	testTimeout = 45 * time.Minute
-
-	multiDatacenterTestTimeout = 3 * time.Hour
 )

--- a/test/e2e/set/scylladbcluster/multidatacenter/config.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/config.go
@@ -1,23 +1,9 @@
 package multidatacenter
 
 import (
-	"github.com/scylladb/scylla-operator/pkg/gather/collect"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"time"
 )
 
 const (
 	testTimeout = 1 * time.Hour
-)
-
-var (
-	remoteKubernetesClusterResourceInfo = collect.ResourceInfo{
-		Resource: schema.GroupVersionResource{
-			Group:    "scylla.scylladb.com",
-			Version:  "v1alpha1",
-			Resource: "remotekubernetesclusters",
-		},
-		Scope: meta.RESTScopeRoot,
-	}
 )

--- a/test/e2e/utils/clusters.go
+++ b/test/e2e/utils/clusters.go
@@ -5,16 +5,15 @@ import (
 	"fmt"
 	"time"
 
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/gather/collect"
 	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
-	"k8s.io/apimachinery/pkg/api/meta"
-
-	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"

--- a/test/e2e/utils/config.go
+++ b/test/e2e/utils/config.go
@@ -26,6 +26,4 @@ const (
 
 	baseManagerSyncTimeout = 3 * time.Minute
 	managerTaskSyncTimeout = 30 * time.Second
-
-	nodeConfigRolloutTimeout = 3 * time.Minute
 )

--- a/test/e2e/utils/verification/scylladbcluster/cql.go
+++ b/test/e2e/utils/verification/scylladbcluster/cql.go
@@ -11,7 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	utilsv1alpha1 "github.com/scylladb/scylla-operator/test/e2e/utils/v1alpha1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func WaitForFullQuorum(ctx context.Context, rkcClusterMap map[string]framework.ClusterInterface, sc *v1alpha1.ScyllaDBCluster) error {
@@ -36,7 +36,7 @@ func WaitForFullQuorum(ctx context.Context, rkcClusterMap map[string]framework.C
 			return fmt.Errorf("unexpected nil remote namespace name in %q datacenter status", dc.Name)
 		}
 
-		sdc, err := clusterClient.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBDatacenters(*dcStatus.RemoteNamespaceName).Get(ctx, naming.ScyllaDBDatacenterName(sc, &dc), v1.GetOptions{})
+		sdc, err := clusterClient.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBDatacenters(*dcStatus.RemoteNamespaceName).Get(ctx, naming.ScyllaDBDatacenterName(sc, &dc), metav1.GetOptions{})
 		if err != nil {
 			errs = append(errs, fmt.Errorf("can't get ScyllaDBDatacenter %q: %w", dc.Name, err))
 			continue
@@ -73,7 +73,7 @@ func WaitForFullQuorum(ctx context.Context, rkcClusterMap map[string]framework.C
 			return fmt.Errorf("unexpected nil remote namespace name in %q datacenter status", dc.Name)
 		}
 
-		sdc, err := clusterClient.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBDatacenters(*dcStatus.RemoteNamespaceName).Get(ctx, naming.ScyllaDBDatacenterName(sc, &dc), v1.GetOptions{})
+		sdc, err := clusterClient.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBDatacenters(*dcStatus.RemoteNamespaceName).Get(ctx, naming.ScyllaDBDatacenterName(sc, &dc), metav1.GetOptions{})
 		if err != nil {
 			errs = append(errs, fmt.Errorf("can't get ScyllaDBDatacenter %q: %w", dc.Name, err))
 			continue


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

This adds a minimal configuration for golangci-lint. It enables two linters: `unused` and `govet` (already used before). It also enables formatters: `gofmt` (already used before) , `goimports` and `gci` (for strict grouping). Issues found by linters are fixed in this PR.

Makefile targets `verify-lint` and `update-lint` were added. `verify-gofmt` and `update-gofmt` were adjusted to rely on `golangci-lint fmt` that calls all formatters defined in the config file.

`verify-gofmt` and `update-gofmt` were dropped from `verify` and `update` top-level targets as they are covered by `verify-lint` and `update-lint` that were added to those.

Relies on https://github.com/scylladb/scylla-operator-images/pull/95 for CI image.

/kind cleanup
/priority awaiting-more-evidence