### PR TITLE
Fix JUnit and JSON report setup for Ginkgo in test runner

### DIFF
--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -3,11 +3,9 @@ package tests
 import (
 	"fmt"
 	"os"
-	"path"
 	"regexp"
 	"strings"
 
-	"github.com/onsi/ginkgo/v2"
 	configassets "github.com/scylladb/scylla-operator/assets/config"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
@@ -308,12 +306,6 @@ func (o *TestFrameworkOptions) Complete(args []string) error {
 			IngressClassName:  o.IngressController.IngressClassName,
 			CustomAnnotations: o.IngressController.CustomAnnotations,
 		}
-	}
-
-	if len(o.ArtifactsDir) != 0 {
-		_, reporterConfig := ginkgo.GinkgoConfiguration()
-		reporterConfig.JUnitReport = path.Join(o.ArtifactsDir, "e2e.junit.xml")
-		reporterConfig.JSONReport = path.Join(o.ArtifactsDir, "e2e.json")
 	}
 
 	return nil

--- a/pkg/cmd/tests/tests_run.go
+++ b/pkg/cmd/tests/tests_run.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -264,6 +265,11 @@ func (o *RunOptions) run(ctx context.Context, streams genericclioptions.IOStream
 	if len(o.SkipStrings) != 0 {
 		klog.InfoS("Overriding SkipStrings", "From", suiteConfig.SkipStrings, "To", o.SkipStrings)
 		suiteConfig.SkipStrings = o.SkipStrings
+	}
+
+	if len(o.ArtifactsDir) != 0 {
+		reporterConfig.JUnitReport = path.Join(o.ArtifactsDir, "junit.e2e.xml")
+		reporterConfig.JSONReport = path.Join(o.ArtifactsDir, "e2e.json")
 	}
 
 	// Not configurable. We are opinionated about these.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR fixes the JUnit and JSON reporters configuration for Ginkgo in our test runner. It also adjusts the JUnit file path to match the regex configured for the JUnit lens in prow's spyglass configuration.

**Which issue is resolved by this Pull Request:**
Resolves #

/cc