### PR TITLE
Make E2E suite timeout configurable through an env variable

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -213,6 +213,7 @@ function run-e2e {
   FIELD_MANAGER="${FIELD_MANAGER:-run-e2e-script}"
   SO_BUCKET_NAME="${SO_BUCKET_NAME:-}"
   SO_E2E_PARALLELISM="${SO_E2E_PARALLELISM:-0}"
+  SO_E2E_TIMEOUT="${SO_E2E_TIMEOUT:-24h}"
 
   config_file="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../../../assets/config/config.yaml")"
   SCYLLADB_VERSION="${SCYLLADB_VERSION:-$(yq '.operator.scyllaDBVersion' "$config_file")}"
@@ -278,6 +279,7 @@ spec:
     - --color=false
     - --artifacts-dir=/tmp/artifacts
     - "--parallelism=${SO_E2E_PARALLELISM}"
+    - "--timeout=${SO_E2E_TIMEOUT}"
     - "--feature-gates=${SCYLLA_OPERATOR_FEATURE_GATES}"
     - "--ingress-controller-address=${ingress_controller_address}"
     - "--ingress-controller-ingress-class-name=${ingress_class_name}"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR makes test runner timeout propagated to the suite config configurable through an env variable. This allows for a graceful termination of the test runner before the entire process is killed in a CI job, see an example where the suite timeout was configured to 60m and the process timeout to 90m here: https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2658/pull-scylla-operator-master-e2e-gke-parallel/1927403497972568064.

**Which issue is resolved by this Pull Request:**
Resolves #

/cc
