### PR TITLE
Merge the Dependabot schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,11 @@ updates:
   schedule:
     interval: weekly
     day: wednesday
-    time: '11:00' # UTC
+    time: '5:00' # UTC
   labels:
   - priority/important-longterm
   - kind/dependency-bump
   groups:
-    k8s.io:
-        applies-to: version-updates
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
     gomod:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
Because k8s.io version bumps are less painful than originally expected, it no longer makes sense to bump them separately from the rest of the go modules.

This PR therefore merges the two package groups into one.

Also changes the schedule so that a PR should be ready when maintainers in Europe show up to work on Wednesday.

/cc rzetelskik
/kind machinery
/priority important-longterm
