### PR TITLE
Enable importas linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,11 +4,31 @@ linters:
   enable:
     - unused
     - govet
+    - importas
     # More linters can be added, see supported ones: https://golangci-lint.run/usage/linters/
   exclusions:
     presets:
       - common-false-positives
       - std-error-handling
+  settings:
+    importas:
+      no-unaliased: true
+      alias:
+        # # e.g. k8s.io/api/core/v1 -> corev1
+        - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+          alias: ${1}${2}
+        # e.g. github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1 -> scyllav1alpha1
+        - pkg: github.com/scylladb/scylla-operator/pkg/api/(\w+)/(v\d+[\w\d]*)
+          alias: ${1}${2}
+        # e.g. k8s.io/apimachinery/pkg/util/errors -> apimachineryutilerrors
+        - pkg: k8s.io/apimachinery/pkg/util/(\w+)
+          alias: apimachineryutil${1}
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1/validation
+          alias: metav1validation
+        - pkg: github.com/scylladb/scylla-operator/pkg/helpers/slices
+          alias: oslices
 formatters:
   enable:
     - gofmt

--- a/pkg/api/scylla/v1alpha1/types_nodeconfig.go
+++ b/pkg/api/scylla/v1alpha1/types_nodeconfig.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,13 +88,13 @@ type NodeConfigNodeStatus struct {
 }
 
 func (c NodeConfigConditions) ToMetaV1Conditions() []metav1.Condition {
-	return slices.ConvertSlice(c, func(from NodeConfigCondition) metav1.Condition {
+	return oslices.ConvertSlice(c, func(from NodeConfigCondition) metav1.Condition {
 		return from.ToMetaV1Condition()
 	})
 }
 
 func NewNodeConfigConditions(cs []metav1.Condition) NodeConfigConditions {
-	return slices.ConvertSlice(cs, func(from metav1.Condition) NodeConfigCondition {
+	return oslices.ConvertSlice(cs, func(from metav1.Condition) NodeConfigCondition {
 		return NewNodeConfigCondition(from)
 	})
 }

--- a/pkg/api/scylla/validation/scylladbcluster_validation.go
+++ b/pkg/api/scylla/validation/scylladbcluster_validation.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
-	apimachinerymetav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
-	"k8s.io/apimachinery/pkg/util/sets"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	apimachineryutilsets "k8s.io/apimachinery/pkg/util/sets"
 	apimachineryutilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -29,7 +29,7 @@ func ValidateScyllaDBClusterSpec(spec *scyllav1alpha1.ScyllaDBClusterSpec, fldPa
 	var allErrs field.ErrorList
 
 	if spec.Metadata != nil {
-		allErrs = append(allErrs, apimachinerymetav1validation.ValidateLabels(spec.Metadata.Labels, fldPath.Child("metadata", "labels"))...)
+		allErrs = append(allErrs, metav1validation.ValidateLabels(spec.Metadata.Labels, fldPath.Child("metadata", "labels"))...)
 		allErrs = append(allErrs, apimachineryvalidation.ValidateAnnotations(spec.Metadata.Annotations, fldPath.Child("metadata", "annotations"))...)
 	}
 
@@ -89,7 +89,7 @@ func ValidateScyllaDBClusterDatacenterTemplate(dcTemplate *scyllav1alpha1.Scylla
 	var allErrs field.ErrorList
 
 	if dcTemplate.Metadata != nil {
-		allErrs = append(allErrs, apimachinerymetav1validation.ValidateLabels(dcTemplate.Metadata.Labels, fldPath.Child("metadata", "labels"))...)
+		allErrs = append(allErrs, metav1validation.ValidateLabels(dcTemplate.Metadata.Labels, fldPath.Child("metadata", "labels"))...)
 		allErrs = append(allErrs, apimachineryvalidation.ValidateAnnotations(dcTemplate.Metadata.Annotations, fldPath.Child("metadata", "annotations"))...)
 	}
 
@@ -117,7 +117,7 @@ func ValidateScyllaDBClusterDatacenterTemplate(dcTemplate *scyllav1alpha1.Scylla
 	}
 
 	if dcTemplate.TopologyLabelSelector != nil {
-		allErrs = append(allErrs, apimachinerymetav1validation.ValidateLabels(dcTemplate.TopologyLabelSelector, fldPath.Child("topologyLabelSelector"))...)
+		allErrs = append(allErrs, metav1validation.ValidateLabels(dcTemplate.TopologyLabelSelector, fldPath.Child("topologyLabelSelector"))...)
 	}
 
 	if dcTemplate.ScyllaDB != nil {
@@ -153,7 +153,7 @@ func ValidateScyllaDBClusterNodeService(nodeService *scyllav1alpha1.NodeServiceT
 	var allErrs field.ErrorList
 
 	if len(nodeService.Type) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("type"), fmt.Sprintf("supported values: %s", strings.Join(slices.ConvertSlice(supportedNodeServiceTypes, slices.ToString[scyllav1alpha1.NodeServiceType]), ", "))))
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), fmt.Sprintf("supported values: %s", strings.Join(oslices.ConvertSlice(supportedNodeServiceTypes, oslices.ToString[scyllav1alpha1.NodeServiceType]), ", "))))
 	} else {
 		allErrs = append(allErrs, validateEnum(nodeService.Type, supportedNodeServiceTypes, fldPath.Child("type"))...)
 	}
@@ -217,14 +217,14 @@ func ValidateScyllaDBClusterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBCluster,
 
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec.ClusterName, old.Spec.ClusterName, fldPath.Child("clusterName"))...)
 
-	oldDatacenterNames := slices.ConvertSlice(old.Spec.Datacenters, func(dc scyllav1alpha1.ScyllaDBClusterDatacenter) string {
+	oldDatacenterNames := oslices.ConvertSlice(old.Spec.Datacenters, func(dc scyllav1alpha1.ScyllaDBClusterDatacenter) string {
 		return dc.Name
 	})
-	newDatacenterNames := slices.ConvertSlice(new.Spec.Datacenters, func(dc scyllav1alpha1.ScyllaDBClusterDatacenter) string {
+	newDatacenterNames := oslices.ConvertSlice(new.Spec.Datacenters, func(dc scyllav1alpha1.ScyllaDBClusterDatacenter) string {
 		return dc.Name
 	})
 
-	removedDatacenterNames := sets.New(oldDatacenterNames...).Difference(sets.New(newDatacenterNames...)).UnsortedList()
+	removedDatacenterNames := apimachineryutilsets.New(oldDatacenterNames...).Difference(apimachineryutilsets.New(newDatacenterNames...)).UnsortedList()
 	sort.Strings(removedDatacenterNames)
 
 	isDatacenterStatusUpToDate := func(sc *scyllav1alpha1.ScyllaDBCluster, dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
@@ -237,7 +237,7 @@ func ValidateScyllaDBClusterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBCluster,
 				continue
 			}
 
-			oldDCStatus, _, ok := slices.Find(old.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
+			oldDCStatus, _, ok := oslices.Find(old.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
 				return dcStatus.Name == removedDCName
 			})
 			if !ok {
@@ -302,8 +302,8 @@ func ValidateScyllaDBClusterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBCluster,
 	newRacks := collectRacks(new)
 	oldRacks := collectRacks(old)
 
-	removedRacks := slices.Filter(oldRacks, func(odr dcRackProperties) bool {
-		_, _, ok := slices.Find(newRacks, func(ndr dcRackProperties) bool {
+	removedRacks := oslices.Filter(oldRacks, func(odr dcRackProperties) bool {
+		_, _, ok := oslices.Find(newRacks, func(ndr dcRackProperties) bool {
 			return ndr.rack == odr.rack && ndr.datacenter == odr.datacenter
 		})
 		return !ok
@@ -314,7 +314,7 @@ func ValidateScyllaDBClusterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBCluster,
 	}
 
 	for _, removedRack := range removedRacks {
-		oldDCStatus, _, ok := slices.Find(old.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
+		oldDCStatus, _, ok := oslices.Find(old.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
 			return dcStatus.Name == removedRack.datacenter
 		})
 		if !ok {
@@ -322,7 +322,7 @@ func ValidateScyllaDBClusterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBCluster,
 			continue
 		}
 
-		oldRackStatus, _, ok := slices.Find(oldDCStatus.Racks, func(rackStatus scyllav1alpha1.ScyllaDBClusterRackStatus) bool {
+		oldRackStatus, _, ok := oslices.Find(oldDCStatus.Racks, func(rackStatus scyllav1alpha1.ScyllaDBClusterRackStatus) bool {
 			return rackStatus.Name == removedRack.rack
 		})
 
@@ -356,7 +356,7 @@ func ValidateScyllaDBClusterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBCluster,
 
 	for _, newRack := range newRacks {
 		var oldRackStorage *scyllav1alpha1.StorageOptions
-		oldRack, _, ok := slices.Find(oldRacks, func(oldRack dcRackProperties) bool {
+		oldRack, _, ok := oslices.Find(oldRacks, func(oldRack dcRackProperties) bool {
 			return oldRack.datacenter == newRack.datacenter && oldRack.rack == newRack.rack && oldRack.level == newRack.level
 		})
 		if ok {
@@ -370,7 +370,7 @@ func ValidateScyllaDBClusterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBCluster,
 		var oldDatacenterStorage, newDatacenterStorage *scyllav1alpha1.StorageOptions
 		var oldDatacenterRackTemplateStorage, newDatacenterRackTemplateStorage *scyllav1alpha1.StorageOptions
 
-		oldDC, _, ok := slices.Find(old.Spec.Datacenters, func(oldDC scyllav1alpha1.ScyllaDBClusterDatacenter) bool {
+		oldDC, _, ok := oslices.Find(old.Spec.Datacenters, func(oldDC scyllav1alpha1.ScyllaDBClusterDatacenter) bool {
 			return oldDC.Name == newDC.Name
 		})
 		if ok {

--- a/pkg/api/scylla/validation/scylladbmanagerclusterregistration_validation.go
+++ b/pkg/api/scylla/validation/scylladbmanagerclusterregistration_validation.go
@@ -9,7 +9,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
+	apimachineryutilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -55,7 +55,7 @@ func ValidateLocalScyllaDBReference(localScyllaDBReference *scyllav1alpha1.Local
 	if len(localScyllaDBReference.Name) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
 	} else {
-		for _, msg := range validation.IsDNS1123Subdomain(localScyllaDBReference.Name) {
+		for _, msg := range apimachineryutilvalidation.IsDNS1123Subdomain(localScyllaDBReference.Name) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), localScyllaDBReference.Name, msg))
 		}
 	}

--- a/pkg/api/scylla/validation/scyllaoperatorconfig.go
+++ b/pkg/api/scylla/validation/scyllaoperatorconfig.go
@@ -9,7 +9,7 @@ import (
 	"github.com/blang/semver/v4"
 	imgreference "github.com/containers/image/v5/docker/reference"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
-	apimachineryvalidationutils "k8s.io/apimachinery/pkg/util/validation"
+	apimachineryutilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -65,8 +65,8 @@ func ValidateScyllaOperatorConfigSpec(spec *scyllav1alpha1.ScyllaOperatorConfigS
 	}
 
 	if spec.ConfiguredClusterDomain != nil {
-		allErrs = append(allErrs, apimachineryvalidationutils.IsFullyQualifiedDomainName(fldPath.Child("configuredClusterDomain"), *spec.ConfiguredClusterDomain)...)
-		for _, msg := range apimachineryvalidationutils.IsValidLabelValue(*spec.ConfiguredClusterDomain) {
+		allErrs = append(allErrs, apimachineryutilvalidation.IsFullyQualifiedDomainName(fldPath.Child("configuredClusterDomain"), *spec.ConfiguredClusterDomain)...)
+		for _, msg := range apimachineryutilvalidation.IsValidLabelValue(*spec.ConfiguredClusterDomain) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("configuredClusterDomain"), *spec.ConfiguredClusterDomain, msg))
 		}
 	}

--- a/pkg/cmd/generateapireference/options.go
+++ b/pkg/cmd/generateapireference/options.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 type GenerateAPIRefsOptions struct {
@@ -50,7 +50,7 @@ func (o *GenerateAPIRefsOptions) Validate(args []string) error {
 		}
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *GenerateAPIRefsOptions) Complete(args []string) error {

--- a/pkg/cmd/generateapireference/scheme.go
+++ b/pkg/cmd/generateapireference/scheme.go
@@ -4,7 +4,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var (
@@ -13,5 +13,5 @@ var (
 )
 
 func init() {
-	utilruntime.Must(apiextensionsv1.AddToScheme(Scheme))
+	apimachineryutilruntime.Must(apiextensionsv1.AddToScheme(Scheme))
 }

--- a/pkg/cmd/operator/cleanupjob.go
+++ b/pkg/cmd/operator/cleanupjob.go
@@ -15,8 +15,8 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 )
@@ -83,7 +83,7 @@ func (o *CleanupJobOptions) Validate() error {
 		errs = append(errs, fmt.Errorf("node-address cannot be empty"))
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *CleanupJobOptions) Complete() error {
@@ -148,7 +148,7 @@ func (o *CleanupJobOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.
 		stopCleanupCtx, stopCleanupCtxCancel := context.WithTimeout(context.Background(), stopCleanupOperationTimeout)
 		defer stopCleanupCtxCancel()
 
-		wait.UntilWithContext(stopCleanupCtx, func(ctx context.Context) {
+		apimachineryutilwait.UntilWithContext(stopCleanupCtx, func(ctx context.Context) {
 			err := o.scyllaClient.StopCleanup(ctx, o.NodeAddress)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("can't stop the cleanup: %w", err))
@@ -159,7 +159,7 @@ func (o *CleanupJobOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.
 	default:
 	}
 
-	err := apierrors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return fmt.Errorf("can't clean up: %w", err)
 	}
@@ -196,7 +196,7 @@ func (o *CleanupJobOptions) runCleanup(ctx context.Context) error {
 		klog.InfoS("Finished keyspace cleanup", "keyspace", keyspace, "duration", time.Since(startTime))
 	}
 
-	err = apierrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/operator/gather.go
+++ b/pkg/cmd/operator/gather.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	kgenericclioptions "k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/klog/v2"
@@ -115,7 +115,7 @@ func (o *GatherOptions) Validate(args []string) error {
 		return errors.New("at least one resource argument needs to be specified")
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *GatherOptions) Complete(args []string) error {

--- a/pkg/cmd/operator/gatherbase.go
+++ b/pkg/cmd/operator/gatherbase.go
@@ -12,8 +12,8 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilrand "k8s.io/apimachinery/pkg/util/rand"
 	kgenericclioptions "k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
 	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
@@ -82,7 +82,7 @@ func (o *GatherBaseOptions) Validate() error {
 		}
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *GatherBaseOptions) Complete() error {
@@ -105,7 +105,7 @@ func (o *GatherBaseOptions) Complete() error {
 
 	ignoreDestDirExists := false
 	if len(o.DestDir) == 0 {
-		o.DestDir = fmt.Sprintf("%s-%s", o.GathererName, utilrand.String(12))
+		o.DestDir = fmt.Sprintf("%s-%s", o.GathererName, apimachineryutilrand.String(12))
 	} else {
 		// We have already made sure that the dir doesn't exist or is empty in validation.
 		ignoreDestDirExists = true

--- a/pkg/cmd/operator/ignition.go
+++ b/pkg/cmd/operator/ignition.go
@@ -12,7 +12,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/cmd/operator/probeserver"
 	"github.com/scylladb/scylla-operator/pkg/controller/ignition"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/scylladb/scylla-operator/pkg/version"
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -114,15 +114,15 @@ func (o *IgnitionOptions) Validate(args []string) error {
 		}
 	}
 
-	if !slices.ContainsItem(validation.SupportedScyllaV1Alpha1BroadcastAddressTypes, scyllav1alpha1.BroadcastAddressType(o.NodesBroadcastAddressTypeString)) {
+	if !oslices.ContainsItem(validation.SupportedScyllaV1Alpha1BroadcastAddressTypes, scyllav1alpha1.BroadcastAddressType(o.NodesBroadcastAddressTypeString)) {
 		errs = append(errs, fmt.Errorf("unsupported value of nodes-broadcast-address-type %q, supported ones are: %v", o.NodesBroadcastAddressTypeString, validation.SupportedScyllaV1Alpha1BroadcastAddressTypes))
 	}
 
-	if !slices.ContainsItem(validation.SupportedScyllaV1Alpha1BroadcastAddressTypes, scyllav1alpha1.BroadcastAddressType(o.ClientsBroadcastAddressTypeString)) {
+	if !oslices.ContainsItem(validation.SupportedScyllaV1Alpha1BroadcastAddressTypes, scyllav1alpha1.BroadcastAddressType(o.ClientsBroadcastAddressTypeString)) {
 		errs = append(errs, fmt.Errorf("unsupported value of clients-broadcast-address-type %q, supported ones are: %v", o.ClientsBroadcastAddressTypeString, validation.SupportedScyllaV1Alpha1BroadcastAddressTypes))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *IgnitionOptions) Complete(args []string) error {

--- a/pkg/cmd/operator/manager_controller.go
+++ b/pkg/cmd/operator/manager_controller.go
@@ -17,7 +17,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -92,7 +92,7 @@ func (o *ManagerControllerOptions) Validate() error {
 	errs = append(errs, o.InClusterReflection.Validate())
 	errs = append(errs, o.LeaderElection.Validate())
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *ManagerControllerOptions) Complete() error {

--- a/pkg/cmd/operator/mustgather.go
+++ b/pkg/cmd/operator/mustgather.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -108,7 +108,7 @@ func (o *MustGatherOptions) Validate() error {
 
 	errs = append(errs, o.GatherBaseOptions.Validate())
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *MustGatherOptions) Complete() error {
@@ -342,5 +342,5 @@ func (o *MustGatherOptions) run(ctx context.Context) error {
 		}
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/cmd/operator/nodesetupdaemon.go
+++ b/pkg/cmd/operator/nodesetupdaemon.go
@@ -22,8 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -143,7 +143,7 @@ func (o *NodeSetupDaemonOptions) Validate() error {
 		errs = append(errs, fmt.Errorf("kubelet-pod-resources-endpoint can't be empty"))
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *NodeSetupDaemonOptions) Complete() error {
@@ -209,7 +209,7 @@ func (o *NodeSetupDaemonOptions) Run(streams genericclioptions.IOStreams, cmd *c
 	))
 
 	var node *corev1.Node
-	err = wait.ExponentialBackoffWithContext(ctx, retry.DefaultBackoff, func(fCtx context.Context) (bool, error) {
+	err = apimachineryutilwait.ExponentialBackoffWithContext(ctx, retry.DefaultBackoff, func(fCtx context.Context) (bool, error) {
 		node, err = o.kubeClient.CoreV1().Nodes().Get(fCtx, o.NodeName, metav1.GetOptions{})
 		if err != nil {
 			klog.V(2).InfoS("Can't get Node", "Node", o.NodeName, "Error", err.Error())

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -40,8 +40,8 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/validation"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -188,12 +188,12 @@ func (o *OperatorOptions) Validate() error {
 		))
 	}
 
-	msg := validation.IsInRange(o.CQLSIngressPort, 0, 65535)
+	msg := apimachineryutilvalidation.IsInRange(o.CQLSIngressPort, 0, 65535)
 	if len(msg) != 0 {
 		errs = append(errs, fmt.Errorf("invalid secure cql ingress port %d: %s", o.CQLSIngressPort, msg))
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *OperatorOptions) Complete(cmd *cobra.Command) error {

--- a/pkg/cmd/operator/probeserver/scylladbapistatus.go
+++ b/pkg/cmd/operator/probeserver/scylladbapistatus.go
@@ -15,7 +15,7 @@ import (
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -102,7 +102,7 @@ func (o *ScyllaDBAPIStatusOptions) Validate(args []string) error {
 		}
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *ScyllaDBAPIStatusOptions) Complete(args []string) error {

--- a/pkg/cmd/operator/probeserver/serveprobes.go
+++ b/pkg/cmd/operator/probeserver/serveprobes.go
@@ -14,7 +14,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 )
@@ -41,7 +41,7 @@ func (o *ServeProbesOptions) AddFlags(cmd *cobra.Command) {
 func (o *ServeProbesOptions) Validate(args []string) error {
 	var errs []error
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *ServeProbesOptions) Complete(args []string) error {

--- a/pkg/cmd/operator/rlimitsjob.go
+++ b/pkg/cmd/operator/rlimitsjob.go
@@ -16,7 +16,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 )
@@ -75,7 +75,7 @@ func (o *RlimitsJobOptions) Validate() error {
 		errs = append(errs, fmt.Errorf("pid cannot be zero"))
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *RlimitsJobOptions) Complete() error {

--- a/pkg/cmd/operator/sidecar.go
+++ b/pkg/cmd/operator/sidecar.go
@@ -11,7 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
 	sidecarcontroller "github.com/scylladb/scylla-operator/pkg/controller/sidecar"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/sidecar/config"
 	"github.com/scylladb/scylla-operator/pkg/sidecar/identity"
 	"github.com/scylladb/scylla-operator/pkg/signals"
@@ -20,7 +20,7 @@ import (
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -113,15 +113,15 @@ func (o *SidecarOptions) Validate() error {
 		}
 	}
 
-	if !slices.ContainsItem(validation.SupportedScyllaV1Alpha1BroadcastAddressTypes, scyllav1alpha1.BroadcastAddressType(o.NodesBroadcastAddressTypeString)) {
+	if !oslices.ContainsItem(validation.SupportedScyllaV1Alpha1BroadcastAddressTypes, scyllav1alpha1.BroadcastAddressType(o.NodesBroadcastAddressTypeString)) {
 		errs = append(errs, fmt.Errorf("unsupported value of nodes-broadcast-address-type %q, supported ones are: %v", o.NodesBroadcastAddressTypeString, validation.SupportedScyllaV1Alpha1BroadcastAddressTypes))
 	}
 
-	if !slices.ContainsItem(validation.SupportedScyllaV1Alpha1BroadcastAddressTypes, scyllav1alpha1.BroadcastAddressType(o.ClientsBroadcastAddressTypeString)) {
+	if !oslices.ContainsItem(validation.SupportedScyllaV1Alpha1BroadcastAddressTypes, scyllav1alpha1.BroadcastAddressType(o.ClientsBroadcastAddressTypeString)) {
 		errs = append(errs, fmt.Errorf("unsupported value of clients-broadcast-address-type %q, supported ones are: %v", o.ClientsBroadcastAddressTypeString, validation.SupportedScyllaV1Alpha1BroadcastAddressTypes))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *SidecarOptions) Complete() error {

--- a/pkg/cmd/operator/webhooks.go
+++ b/pkg/cmd/operator/webhooks.go
@@ -28,7 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -150,7 +150,7 @@ func (o *WebhookOptions) Validate() error {
 		return errors.New("port can't be zero")
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *WebhookOptions) Complete() error {

--- a/pkg/cmd/operator/webhooks_test.go
+++ b/pkg/cmd/operator/webhooks_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 )
 
@@ -183,7 +183,7 @@ func TestWebhookOptionsRunWithReload(t *testing.T) {
 		}
 	}
 
-	err = wait.PollImmediate(pollInterval, pollTimeout, hasExpectedCertificate(initialCertSerialNumber))
+	err = apimachineryutilwait.PollImmediate(pollInterval, pollTimeout, hasExpectedCertificate(initialCertSerialNumber))
 	if err != nil {
 		t.Fatalf("can't observe the initial certificate: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestWebhookOptionsRunWithReload(t *testing.T) {
 		t.Fatalf("can't create a file: %v", err)
 	}
 
-	err = wait.PollImmediate(pollInterval, pollTimeout, hasExpectedCertificate(updatedCertSerialNumber))
+	err = apimachineryutilwait.PollImmediate(pollInterval, pollTimeout, hasExpectedCertificate(updatedCertSerialNumber))
 	if err != nil {
 		t.Errorf("certificate wasn't updated: %v", err)
 	}

--- a/pkg/cmd/releasenotes/options.go
+++ b/pkg/cmd/releasenotes/options.go
@@ -10,7 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
 	githubql "github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
-	"k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 type GenerateOptions struct {
@@ -79,7 +79,7 @@ func (o *GenerateOptions) Validate() error {
 		errs = append(errs, fmt.Errorf(`repository must be in "owner/name" format`))
 	}
 
-	return errors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *GenerateOptions) Complete(ctx context.Context) error {

--- a/pkg/cmd/releasenotes/releasenotes.go
+++ b/pkg/cmd/releasenotes/releasenotes.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sort"
 
-	"k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -66,7 +66,7 @@ func (o *GenerateOptions) Run(ctx context.Context) error {
 		filteredPRs = append(filteredPRs, pr)
 	}
 	if errs != nil {
-		return errors.NewAggregate(errs)
+		return apimachineryutilerrors.NewAggregate(errs)
 	}
 
 	if err := renderReleaseNotes(o.Out, o.ContainerImageName, o.ReleaseName, o.PreviousReleaseName, filteredPRs); err != nil {

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -9,11 +9,11 @@ import (
 	configassets "github.com/scylladb/scylla-operator/assets/config"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 )
 
@@ -110,7 +110,7 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 		},
 		", ",
 	)))
-	utilruntime.Must(cmd.PersistentFlags().MarkDeprecated("delete-namespace-policy", "--delete-namespace-policy is deprecated - please use --cleanup-policy instead"))
+	apimachineryutilruntime.Must(cmd.PersistentFlags().MarkDeprecated("delete-namespace-policy", "--delete-namespace-policy is deprecated - please use --cleanup-policy instead"))
 	cmd.PersistentFlags().StringVarP(&o.CleanupPolicyUntyped, "cleanup-policy", "", o.CleanupPolicyUntyped, fmt.Sprintf("Cleanup policy. Allowed values are [%s].", strings.Join(
 		[]string{
 			string(framework.CleanupPolicyAlways),
@@ -123,15 +123,15 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&o.IngressController.IngressClassName, "ingress-controller-ingress-class-name", "", o.IngressController.IngressClassName, "Ingress class name under which ingress controller is registered")
 	cmd.PersistentFlags().StringToStringVarP(&o.IngressController.CustomAnnotations, "ingress-controller-custom-annotations", "", o.IngressController.CustomAnnotations, "Custom annotations required by the ingress controller")
 	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.NodeServiceType, "scyllacluster-node-service-type", "", o.ScyllaClusterOptionsUntyped.NodeServiceType, fmt.Sprintf("Kubernetes service type that the ScyllaCluster nodes are exposed with. Allowed values are [%s].", strings.Join(
-		slices.ConvertSlice(supportedNodeServiceTypes, slices.ToString[scyllav1.NodeServiceType]),
+		oslices.ConvertSlice(supportedNodeServiceTypes, oslices.ToString[scyllav1.NodeServiceType]),
 		", ",
 	)))
 	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType, "scyllacluster-nodes-broadcast-address-type", "", o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType, fmt.Sprintf("Type of address that the ScyllaCluster nodes broadcast for communication with other nodes. Allowed values are [%s].", strings.Join(
-		slices.ConvertSlice(supportedBroadcastAddressTypes, slices.ToString[scyllav1.BroadcastAddressType]),
+		oslices.ConvertSlice(supportedBroadcastAddressTypes, oslices.ToString[scyllav1.BroadcastAddressType]),
 		", ",
 	)))
 	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType, "scyllacluster-clients-broadcast-address-type", "", o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType, fmt.Sprintf("Type of address that the ScyllaCluster nodes broadcast for communication with clients. Allowed values are [%s].", strings.Join(
-		slices.ConvertSlice(supportedBroadcastAddressTypes, slices.ToString[scyllav1.BroadcastAddressType]),
+		oslices.ConvertSlice(supportedBroadcastAddressTypes, oslices.ToString[scyllav1.BroadcastAddressType]),
 		", ",
 	)))
 	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.StorageClassName, "scyllacluster-storageclass-name", "", o.ScyllaClusterOptionsUntyped.StorageClassName, fmt.Sprintf("Name of the StorageClass to request for ScyllaCluster storage."))
@@ -161,15 +161,15 @@ func (o *TestFrameworkOptions) Validate(args []string) error {
 		errors = append(errors, fmt.Errorf("invalid DeleteTestingNSPolicy: %q", p))
 	}
 
-	if !slices.ContainsItem(supportedNodeServiceTypes, scyllav1.NodeServiceType(o.ScyllaClusterOptionsUntyped.NodeServiceType)) {
+	if !oslices.ContainsItem(supportedNodeServiceTypes, scyllav1.NodeServiceType(o.ScyllaClusterOptionsUntyped.NodeServiceType)) {
 		errors = append(errors, fmt.Errorf("invalid scylla-cluster-node-service-type: %q", o.ScyllaClusterOptionsUntyped.NodeServiceType))
 	}
 
-	if !slices.ContainsItem(supportedBroadcastAddressTypes, scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType)) {
+	if !oslices.ContainsItem(supportedBroadcastAddressTypes, scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType)) {
 		errors = append(errors, fmt.Errorf("invalid scylla-cluster-nodes-broadcast-address-type: %q", o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType))
 	}
 
-	if !slices.ContainsItem(supportedBroadcastAddressTypes, scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType)) {
+	if !oslices.ContainsItem(supportedBroadcastAddressTypes, scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType)) {
 		errors = append(errors, fmt.Errorf("invalid scylla-cluster-clients-broadcast-address-type: %q", o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType))
 	}
 
@@ -235,7 +235,7 @@ func (o *TestFrameworkOptions) Validate(args []string) error {
 		}
 	}
 
-	return apierrors.NewAggregate(errors)
+	return apimachineryutilerrors.NewAggregate(errors)
 }
 
 func (o *TestFrameworkOptions) Complete(args []string) error {
@@ -283,7 +283,7 @@ func (o *TestFrameworkOptions) Complete(args []string) error {
 	}
 
 	framework.TestContext = &framework.TestContextType{
-		RestConfigs: slices.ConvertSlice(o.ClientConfigs, func(cc genericclioptions.ClientConfig) *rest.Config {
+		RestConfigs: oslices.ConvertSlice(o.ClientConfigs, func(cc genericclioptions.ClientConfig) *rest.Config {
 			return cc.RestConfig
 		}),
 		ArtifactsDir:                o.ArtifactsDir,

--- a/pkg/cmd/tests/tests_run.go
+++ b/pkg/cmd/tests/tests_run.go
@@ -22,13 +22,13 @@ import (
 	gomegaformat "github.com/onsi/gomega/format"
 	"github.com/scylladb/scylla-operator/pkg/cmdutil"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	ginkgotest "github.com/scylladb/scylla-operator/pkg/test/ginkgo"
 	"github.com/scylladb/scylla-operator/pkg/thirdparty/github.com/onsi/ginkgo/v2/exposedinternal/parallel_support"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -91,7 +91,7 @@ func NewRunOptions(streams genericclioptions.IOStreams, testSuites ginkgotest.Te
 func NewRunCommand(streams genericclioptions.IOStreams, testSuites ginkgotest.TestSuites, userAgent string) *cobra.Command {
 	o := NewRunOptions(streams, testSuites, userAgent)
 
-	testSuiteNames := slices.ConvertSlice(testSuites, func(ts *ginkgotest.TestSuite) string {
+	testSuiteNames := oslices.ConvertSlice(testSuites, func(ts *ginkgotest.TestSuite) string {
 		return ts.Name
 	})
 
@@ -196,7 +196,7 @@ func (o *RunOptions) Validate(args []string) error {
 		errs = append(errs, fmt.Errorf("can't select more then 1 suite"))
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *RunOptions) Complete(args []string) error {
@@ -207,7 +207,7 @@ func (o *RunOptions) Complete(args []string) error {
 		errs = append(errs, err)
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *RunOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Command) error {
@@ -326,7 +326,7 @@ func (o *RunOptions) run(ctx context.Context, streams genericclioptions.IOStream
 	commonArgs = append(commonArgs, fmt.Sprintf("--%s=%v", cmdutil.FlagLogLevelKey, o.ParallelLogLevel))
 
 	// Propagate random seed to child processes.
-	if !slices.Contains(commonArgs, func(arg string) bool {
+	if !oslices.Contains(commonArgs, func(arg string) bool {
 		return strings.HasPrefix(arg, fmt.Sprintf("--%s", randomSeedFlagKey))
 	}) {
 		commonArgs = append(commonArgs, fmt.Sprintf("--%s=%v", randomSeedFlagKey, suiteConfig.RandomSeed))
@@ -367,7 +367,7 @@ func (o *RunOptions) run(ctx context.Context, streams genericclioptions.IOStream
 		server.RegisterAlive(e.id, func() bool { return e.cmd.ProcessState == nil || !e.cmd.ProcessState.Exited() })
 	}
 	if len(errs) != 0 {
-		return apierrors.NewAggregate(errs)
+		return apimachineryutilerrors.NewAggregate(errs)
 	}
 
 	// We need to wait for all the processes in parallel so the Alive function can read the status,
@@ -395,7 +395,7 @@ func (o *RunOptions) run(ctx context.Context, streams genericclioptions.IOStream
 
 	wg.Wait()
 
-	err = apierrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return fmt.Errorf("can't wait for processes: %w", err)
 	}

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -62,7 +62,7 @@ func NewCmd(streams genericclioptions.IOStreams) *cobra.Command {
 func (o *Options) Validate() error {
 	var errs []error
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (o *Options) Complete() error {

--- a/pkg/cmdutil/helpers.go
+++ b/pkg/cmdutil/helpers.go
@@ -13,7 +13,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -58,7 +58,7 @@ func ReadFlagsFromEnv(prefix string, cmd *cobra.Command) error {
 		return
 	})
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func InstallKlog(cmd *cobra.Command) {

--- a/pkg/controller/globalscylladbmanager/controller.go
+++ b/pkg/controller/globalscylladbmanager/controller.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -120,7 +120,7 @@ func (gsmc *Controller) updateScyllaDBManagerClusterRegistration(old, cur interf
 	if currentSMCR.UID != oldSMCR.UID {
 		key, err := keyFunc(oldSMCR)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("can't get key for object %#v: %w", oldSMCR, err))
+			apimachineryutilruntime.HandleError(fmt.Errorf("can't get key for object %#v: %w", oldSMCR, err))
 			return
 		}
 
@@ -150,12 +150,12 @@ func (gsmc *Controller) deleteScyllaDBManagerClusterRegistration(obj interface{}
 		var tombstone cache.DeletedFinalStateUnknown
 		tombstone, ok = obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("can't get object from tombstone %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("can't get object from tombstone %#v", obj))
 			return
 		}
 		smcr, ok = tombstone.Obj.(*scyllav1alpha1.ScyllaDBManagerClusterRegistration)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contains an object that is not a ScyllaDBManagerClusterRegistration %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("tombstone contains an object that is not a ScyllaDBManagerClusterRegistration %#v", obj))
 			return
 		}
 	}
@@ -191,7 +191,7 @@ func (gsmc *Controller) updateScyllaDBDatacenter(old, cur interface{}) {
 	if currentSDC.UID != oldSDC.UID {
 		key, err := keyFunc(oldSDC)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("can't get key for object %#v: %w", oldSDC, err))
+			apimachineryutilruntime.HandleError(fmt.Errorf("can't get key for object %#v: %w", oldSDC, err))
 			return
 		}
 
@@ -216,12 +216,12 @@ func (gsmc *Controller) deleteScyllaDBDatacenter(obj interface{}) {
 		var tombstone cache.DeletedFinalStateUnknown
 		tombstone, ok = obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("can't get object from tombstone %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("can't get object from tombstone %#v", obj))
 			return
 		}
 		sdc, ok = tombstone.Obj.(*scyllav1alpha1.ScyllaDBDatacenter)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contains an object that is not a ScyllaDBDatacenter %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("tombstone contains an object that is not a ScyllaDBDatacenter %#v", obj))
 			return
 		}
 	}
@@ -256,7 +256,7 @@ func (gsmc *Controller) updateNamespace(old, cur interface{}) {
 	if currentNS.UID != oldNS.UID {
 		key, err := keyFunc(oldNS)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("can't get key for object %#v: %w", oldNS, err))
+			apimachineryutilruntime.HandleError(fmt.Errorf("can't get key for object %#v: %w", oldNS, err))
 			return
 		}
 
@@ -285,12 +285,12 @@ func (gsmc *Controller) deleteNamespace(obj interface{}) {
 		var tombstone cache.DeletedFinalStateUnknown
 		tombstone, ok = obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("can't get object from tombstone %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("can't get object from tombstone %#v", obj))
 			return
 		}
 		ns, ok = tombstone.Obj.(*corev1.Namespace)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contains an object that is not a Namespace %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("tombstone contains an object that is not a Namespace %#v", obj))
 			return
 		}
 	}

--- a/pkg/controller/globalscylladbmanager/sync_scylladbmanagerclusterregistrations.go
+++ b/pkg/controller/globalscylladbmanager/sync_scylladbmanagerclusterregistrations.go
@@ -13,7 +13,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	"k8s.io/apimachinery/pkg/api/errors"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -54,7 +54,7 @@ func (gsmc *Controller) syncScyllaDBManagerClusterRegistrations(ctx context.Cont
 			errs = append(errs, fmt.Errorf("can't prune ScyllaDBManagerClusterRegistration(s) in Namespace %q: %w", ns, err))
 		}
 	}
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (gsmc *Controller) syncScyllaDBManagerClusterRegistrations(ctx context.Cont
 		}
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func makeScyllaDBManagerClusterRegistrationsForScyllaDBDatacenters(sdcs []*scyllav1alpha1.ScyllaDBDatacenter) (map[string][]*scyllav1alpha1.ScyllaDBManagerClusterRegistration, error) {
@@ -84,5 +84,5 @@ func makeScyllaDBManagerClusterRegistrationsForScyllaDBDatacenters(sdcs []*scyll
 		requiredScyllaDBManagerClusterRegistrations[sdc.Namespace] = append(requiredScyllaDBManagerClusterRegistrations[sdc.Namespace], required)
 	}
 
-	return requiredScyllaDBManagerClusterRegistrations, utilerrors.NewAggregate(errs)
+	return requiredScyllaDBManagerClusterRegistrations, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/manager/controller.go
+++ b/pkg/controller/manager/controller.go
@@ -17,9 +17,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -138,7 +138,7 @@ func (c *Controller) processNextItem(ctx context.Context) bool {
 	defer cancel()
 	err := c.sync(ctx, key.(string))
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
-	err = utilerrors.Reduce(err)
+	err = apimachineryutilerrors.Reduce(err)
 	switch {
 	case err == nil:
 		c.queue.Forget(key)
@@ -151,7 +151,7 @@ func (c *Controller) processNextItem(ctx context.Context) bool {
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
 
 	default:
-		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 	}
 
 	c.queue.AddRateLimited(key)
@@ -165,7 +165,7 @@ func (c *Controller) runWorker(ctx context.Context) {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting controller", "controller", "ScyllaManager")
 
@@ -185,7 +185,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			wait.UntilWithContext(ctx, c.runWorker, time.Second)
+			apimachineryutilwait.UntilWithContext(ctx, c.runWorker, time.Second)
 		}()
 	}
 

--- a/pkg/controller/manager/sync.go
+++ b/pkg/controller/manager/sync.go
@@ -9,10 +9,10 @@ import (
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla-manager/models"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -35,7 +35,7 @@ func (c *Controller) getManagerClusterState(ctx context.Context, sc *scyllav1.Sc
 
 	clusterName := naming.ManagerClusterName(sc)
 	// Cluster names in manager state are unique, so it suffices to only find one with a matching name.
-	managerCluster, _, found := slices.Find(managerClusters, func(c *models.Cluster) bool {
+	managerCluster, _, found := oslices.Find(managerClusters, func(c *models.Cluster) bool {
 		return c.Name == clusterName
 	})
 	if !found {
@@ -155,10 +155,10 @@ func (c *Controller) sync(ctx context.Context, key string) error {
 	err = c.updateStatus(ctx, sc, status)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("can't update status: %w", err))
-		return utilerrors.NewAggregate(errs)
+		return apimachineryutilerrors.NewAggregate(errs)
 	}
 
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/manager/sync_action.go
+++ b/pkg/controller/manager/sync_action.go
@@ -12,11 +12,11 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla-manager/models"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	hashutil "github.com/scylladb/scylla-operator/pkg/util/hash"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -105,7 +105,7 @@ func syncTasks(clusterID string, sc *scyllav1.ScyllaCluster, state *managerClust
 	var errs []error
 	var actions []action
 
-	repairTaskSpecNames := sets.New(slices.ConvertSlice(sc.Spec.Repairs, func(b scyllav1.RepairTaskSpec) string {
+	repairTaskSpecNames := apimachineryutilsets.New(oslices.ConvertSlice(sc.Spec.Repairs, func(b scyllav1.RepairTaskSpec) string {
 		return b.Name
 	})...)
 	for taskName, task := range state.RepairTasks {
@@ -120,7 +120,7 @@ func syncTasks(clusterID string, sc *scyllav1.ScyllaCluster, state *managerClust
 		})
 	}
 
-	backupTaskSpecNames := sets.New(slices.ConvertSlice(sc.Spec.Backups, func(b scyllav1.BackupTaskSpec) string {
+	backupTaskSpecNames := apimachineryutilsets.New(oslices.ConvertSlice(sc.Spec.Backups, func(b scyllav1.BackupTaskSpec) string {
 		return b.Name
 	})...)
 	for taskName, task := range state.BackupTasks {
@@ -147,7 +147,7 @@ func syncTasks(clusterID string, sc *scyllav1.ScyllaCluster, state *managerClust
 	}
 	actions = append(actions, backupActions...)
 
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func syncBackupTasks(clusterID string, cluster *scyllav1.ScyllaCluster, state *m
 		}
 	}
 
-	err := utilerrors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +219,7 @@ func syncRepairTasks(clusterID string, cluster *scyllav1.ScyllaCluster, state *m
 		}
 	}
 
-	err := utilerrors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +456,7 @@ func setTaskStatusError(taskType string, taskName string, taskErr string, status
 }
 
 func updateRepairTaskStatusError(repairTaskStatuses *[]scyllav1.RepairTaskStatus, repairTaskStatus scyllav1.RepairTaskStatus) {
-	_, i, ok := slices.Find(*repairTaskStatuses, func(rts scyllav1.RepairTaskStatus) bool {
+	_, i, ok := oslices.Find(*repairTaskStatuses, func(rts scyllav1.RepairTaskStatus) bool {
 		return rts.Name == repairTaskStatus.Name
 	})
 
@@ -469,7 +469,7 @@ func updateRepairTaskStatusError(repairTaskStatuses *[]scyllav1.RepairTaskStatus
 }
 
 func updateBackupTaskStatusError(backupTaskStatuses *[]scyllav1.BackupTaskStatus, backupTaskStatus scyllav1.BackupTaskStatus) {
-	_, i, ok := slices.Find(*backupTaskStatuses, func(bts scyllav1.BackupTaskStatus) bool {
+	_, i, ok := oslices.Find(*backupTaskStatuses, func(bts scyllav1.BackupTaskStatus) bool {
 		return bts.Name == backupTaskStatus.Name
 	})
 

--- a/pkg/controller/nodeconfig/controller.go
+++ b/pkg/controller/nodeconfig/controller.go
@@ -21,9 +21,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	rbacv1informers "k8s.io/client-go/informers/rbac/v1"
@@ -434,7 +434,7 @@ func (ncc *Controller) processNextItem(ctx context.Context) bool {
 	defer cancel()
 	err := ncc.sync(ctx, key.(string))
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
-	err = utilerrors.Reduce(err)
+	err = apimachineryutilerrors.Reduce(err)
 	switch {
 	case err == nil:
 		ncc.queue.Forget(key)
@@ -447,7 +447,7 @@ func (ncc *Controller) processNextItem(ctx context.Context) bool {
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
 
 	default:
-		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 	}
 
 	ncc.queue.AddRateLimited(key)
@@ -461,7 +461,7 @@ func (ncc *Controller) runWorker(ctx context.Context) {
 }
 
 func (ncc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting controller", "controller", ControllerName)
 
@@ -481,7 +481,7 @@ func (ncc *Controller) Run(ctx context.Context, workers int) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			wait.UntilWithContext(ctx, ncc.runWorker, time.Second)
+			apimachineryutilwait.UntilWithContext(ctx, ncc.runWorker, time.Second)
 		}()
 	}
 

--- a/pkg/controller/nodeconfig/sync.go
+++ b/pkg/controller/nodeconfig/sync.go
@@ -19,7 +19,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -102,7 +102,7 @@ func (ncc *Controller) sync(ctx context.Context, key string) error {
 		objectErrs = append(objectErrs, err)
 	}
 
-	objectErr := utilerrors.NewAggregate(objectErrs)
+	objectErr := apimachineryutilerrors.NewAggregate(objectErrs)
 	if objectErr != nil {
 		return objectErr
 	}
@@ -355,7 +355,7 @@ func (ncc *Controller) sync(ctx context.Context, key string) error {
 
 	if len(aggregationErrs) > 0 {
 		errs = append(errs, aggregationErrs...)
-		return utilerrors.NewAggregate(errs)
+		return apimachineryutilerrors.NewAggregate(errs)
 	}
 
 	for _, c := range nodeAvailableConditions {
@@ -383,7 +383,7 @@ func (ncc *Controller) sync(ctx context.Context, key string) error {
 		errs = append(errs, fmt.Errorf("can't update status: %w", err))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (ncc *Controller) getNamespaces() (map[string]*corev1.Namespace, error) {
@@ -501,7 +501,7 @@ func (ncc *Controller) getMatchingNodes(nc *scyllav1alpha1.NodeConfig) ([]*corev
 		}
 	}
 
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +558,7 @@ func aggregateNodeStatusConditions(generation int64, conditions []metav1.Conditi
 		nodeAggregateConditions = append(nodeAggregateConditions, nodeAggregateCondition)
 	}
 
-	err := utilerrors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/nodeconfig/sync_clusterrolebindings.go
+++ b/pkg/controller/nodeconfig/sync_clusterrolebindings.go
@@ -11,7 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (ncc *Controller) makeClusterRoleBindings() []*rbacv1.ClusterRoleBinding {
@@ -52,7 +52,7 @@ func (ncc *Controller) pruneClusterRoleBindings(ctx context.Context, requiredClu
 			continue
 		}
 	}
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (ncc *Controller) syncClusterRoleBindings(ctx context.Context, nc *scyllav1alpha1.NodeConfig, clusterRoleBindings map[string]*rbacv1.ClusterRoleBinding) ([]metav1.Condition, error) {
@@ -79,5 +79,5 @@ func (ncc *Controller) syncClusterRoleBindings(ctx context.Context, nc *scyllav1
 			continue
 		}
 	}
-	return progressingConditions, utilerrors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodeconfig/sync_clusterroles.go
+++ b/pkg/controller/nodeconfig/sync_clusterroles.go
@@ -11,7 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (ncc *Controller) makeClusterRoles() []*rbacv1.ClusterRole {
@@ -52,7 +52,7 @@ func (ncc *Controller) pruneClusterRoles(ctx context.Context, requiredClusterRol
 			continue
 		}
 	}
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (ncc *Controller) syncClusterRoles(ctx context.Context, nc *scyllav1alpha1.NodeConfig, clusterRoles map[string]*rbacv1.ClusterRole) ([]metav1.Condition, error) {
@@ -80,5 +80,5 @@ func (ncc *Controller) syncClusterRoles(ctx context.Context, nc *scyllav1alpha1.
 		}
 	}
 
-	return progressingConditions, utilerrors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodeconfig/sync_daemonsets.go
+++ b/pkg/controller/nodeconfig/sync_daemonsets.go
@@ -14,7 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (ncc *Controller) syncDaemonSet(
@@ -78,5 +78,5 @@ func (ncc *Controller) syncDaemonSet(
 		}
 	}
 
-	return progressingConditions, utilerrors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodeconfig/sync_namespaces.go
+++ b/pkg/controller/nodeconfig/sync_namespaces.go
@@ -11,7 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (ncc *Controller) makeNamespaces() []*corev1.Namespace {
@@ -52,7 +52,7 @@ func (ncc *Controller) pruneNamespaces(ctx context.Context, requiredNamespaces [
 			continue
 		}
 	}
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (ncc *Controller) syncNamespaces(ctx context.Context, nc *scyllav1alpha1.NodeConfig, namespaces map[string]*corev1.Namespace) ([]metav1.Condition, error) {
@@ -80,5 +80,5 @@ func (ncc *Controller) syncNamespaces(ctx context.Context, nc *scyllav1alpha1.No
 			continue
 		}
 	}
-	return progressingConditions, utilerrors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodeconfig/sync_rolebindings.go
+++ b/pkg/controller/nodeconfig/sync_rolebindings.go
@@ -12,7 +12,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (ncc *Controller) syncRoleBindings(
@@ -54,5 +54,5 @@ func (ncc *Controller) syncRoleBindings(
 			continue
 		}
 	}
-	return progressingConditions, utilerrors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodeconfig/sync_roles.go
+++ b/pkg/controller/nodeconfig/sync_roles.go
@@ -12,7 +12,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (ncc *Controller) syncRoles(ctx context.Context, nc *scyllav1alpha1.NodeConfig, roles map[string]*rbacv1.Role) ([]metav1.Condition, error) {
@@ -51,5 +51,5 @@ func (ncc *Controller) syncRoles(ctx context.Context, nc *scyllav1alpha1.NodeCon
 		}
 	}
 
-	return progressingConditions, utilerrors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodeconfig/sync_serviceaccounts.go
+++ b/pkg/controller/nodeconfig/sync_serviceaccounts.go
@@ -11,7 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (ncc *Controller) makeServiceAccounts() []*corev1.ServiceAccount {
@@ -54,7 +54,7 @@ func (ncc *Controller) pruneServiceAccounts(ctx context.Context, requiredService
 			continue
 		}
 	}
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (ncc *Controller) syncServiceAccounts(ctx context.Context, nc *scyllav1alpha1.NodeConfig, serviceAccounts map[string]*corev1.ServiceAccount) ([]metav1.Condition, error) {
@@ -82,5 +82,5 @@ func (ncc *Controller) syncServiceAccounts(ctx context.Context, nc *scyllav1alph
 		}
 	}
 
-	return progressingConditions, utilerrors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodeconfigpod/controller.go
+++ b/pkg/controller/nodeconfigpod/controller.go
@@ -18,9 +18,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -146,7 +146,7 @@ func (ncpc *Controller) enqueueAllScyllaPodsOnNode(depth int, obj kubeinterfaces
 
 	allPods, err := ncpc.podLister.List(naming.ScyllaSelector())
 	if err != nil {
-		utilruntime.HandleError(err)
+		apimachineryutilruntime.HandleError(err)
 		return
 	}
 
@@ -170,7 +170,7 @@ func (ncpc *Controller) enqueueAllScyllaPodsForNodeConfig(depth int, obj kubeint
 
 	allNodes, err := ncpc.nodeLister.List(labels.Everything())
 	if err != nil {
-		utilruntime.HandleError(err)
+		apimachineryutilruntime.HandleError(err)
 		return
 	}
 
@@ -178,7 +178,7 @@ func (ncpc *Controller) enqueueAllScyllaPodsForNodeConfig(depth int, obj kubeint
 	for _, node := range allNodes {
 		matching, err := controllerhelpers.IsNodeConfigSelectingNode(nodeConfig, node)
 		if err != nil {
-			utilruntime.HandleError(err)
+			apimachineryutilruntime.HandleError(err)
 			return
 		}
 
@@ -275,7 +275,7 @@ func (ncpc *Controller) processNextItem(ctx context.Context) bool {
 	defer cancel()
 	err := ncpc.sync(ctx, key.(string))
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
-	err = utilerrors.Reduce(err)
+	err = apimachineryutilerrors.Reduce(err)
 	switch {
 	case err == nil:
 		ncpc.queue.Forget(key)
@@ -288,7 +288,7 @@ func (ncpc *Controller) processNextItem(ctx context.Context) bool {
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
 
 	default:
-		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 	}
 
 	ncpc.queue.AddRateLimited(key)
@@ -302,7 +302,7 @@ func (ncpc *Controller) runWorker(ctx context.Context) {
 }
 
 func (ncpc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting controller", "controller", ControllerName)
 
@@ -322,7 +322,7 @@ func (ncpc *Controller) Run(ctx context.Context, workers int) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			wait.UntilWithContext(ctx, ncpc.runWorker, time.Second)
+			apimachineryutilwait.UntilWithContext(ctx, ncpc.runWorker, time.Second)
 		}()
 	}
 

--- a/pkg/controller/nodeconfigpod/sync.go
+++ b/pkg/controller/nodeconfigpod/sync.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -71,7 +71,7 @@ func (ncpc *Controller) sync(ctx context.Context, key string) error {
 		objectErrs = append(objectErrs, err)
 	}
 
-	objectErr := utilerrors.NewAggregate(objectErrs)
+	objectErr := apimachineryutilerrors.NewAggregate(objectErrs)
 	if objectErr != nil {
 		return objectErr
 	}
@@ -83,5 +83,5 @@ func (ncpc *Controller) sync(ctx context.Context, key string) error {
 		errs = append(errs, err)
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodeconfigpod/sync_configmaps.go
+++ b/pkg/controller/nodeconfigpod/sync_configmaps.go
@@ -15,7 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -120,7 +120,7 @@ func (ncpc *Controller) pruneConfigMaps(ctx context.Context, required *corev1.Co
 		}
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (ncpc *Controller) syncConfigMaps(

--- a/pkg/controller/nodesetup/controller.go
+++ b/pkg/controller/nodesetup/controller.go
@@ -20,9 +20,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -176,7 +176,7 @@ func (nsc *Controller) processNextItem(ctx context.Context) bool {
 	defer cancel()
 	err := nsc.sync(ctx)
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
-	err = utilerrors.Reduce(err)
+	err = apimachineryutilerrors.Reduce(err)
 	switch {
 	case err == nil:
 		nsc.queue.Forget(key)
@@ -189,7 +189,7 @@ func (nsc *Controller) processNextItem(ctx context.Context) bool {
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
 
 	default:
-		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 	}
 
 	nsc.queue.AddRateLimited(key)
@@ -203,7 +203,7 @@ func (nsc *Controller) runWorker(ctx context.Context) {
 }
 
 func (nsc *Controller) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting controller", "controller", ControllerName)
 
@@ -222,7 +222,7 @@ func (nsc *Controller) Run(ctx context.Context) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		wait.UntilWithContext(ctx, nsc.runWorker, time.Second)
+		apimachineryutilwait.UntilWithContext(ctx, nsc.runWorker, time.Second)
 	}()
 
 	<-ctx.Done()

--- a/pkg/controller/nodesetup/status.go
+++ b/pkg/controller/nodesetup/status.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
+	apimachineryutilsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -28,12 +28,12 @@ var deprecatedConditionTypeFormats = []string{
 func (nsc *Controller) calculateStatus(nc *scyllav1alpha1.NodeConfig) *scyllav1alpha1.NodeConfigStatus {
 	status := nc.Status.DeepCopy()
 
-	deprecatedConditionTypes := sets.New(slices.ConvertSlice(deprecatedConditionTypeFormats, func(conditionTypeFormat string) string {
+	deprecatedConditionTypes := apimachineryutilsets.New(oslices.ConvertSlice(deprecatedConditionTypeFormats, func(conditionTypeFormat string) string {
 		return fmt.Sprintf(conditionTypeFormat, nsc.nodeName)
 	})...)
 
 	statusConditions := status.Conditions.ToMetaV1Conditions()
-	status.Conditions = scyllav1alpha1.NewNodeConfigConditions(slices.FilterOut(statusConditions, func(c metav1.Condition) bool {
+	status.Conditions = scyllav1alpha1.NewNodeConfigConditions(oslices.FilterOut(statusConditions, func(c metav1.Condition) bool {
 		return deprecatedConditionTypes.Has(c.Type)
 	}))
 

--- a/pkg/controller/nodesetup/sync.go
+++ b/pkg/controller/nodesetup/sync.go
@@ -13,7 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -147,7 +147,7 @@ func (nsc *Controller) sync(ctx context.Context) error {
 
 	if len(aggregationErrs) > 0 {
 		errs = append(errs, aggregationErrs...)
-		return utilerrors.NewAggregate(errs)
+		return apimachineryutilerrors.NewAggregate(errs)
 	}
 
 	apimeta.SetStatusCondition(&statusConditions, nodeSetupAvailableCondition)
@@ -160,5 +160,5 @@ func (nsc *Controller) sync(ctx context.Context) error {
 		errs = append(errs, fmt.Errorf("can't update status: %w", err))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodesetup/sync_filesystems.go
+++ b/pkg/controller/nodesetup/sync_filesystems.go
@@ -10,7 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/disks"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -63,7 +63,7 @@ func (nsc *Controller) syncFilesystems(ctx context.Context, nc *scyllav1alpha1.N
 		)
 	}
 
-	err := utilerrors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("failed to create filesystems: %w", err)
 	}

--- a/pkg/controller/nodesetup/sync_loopdevices.go
+++ b/pkg/controller/nodesetup/sync_loopdevices.go
@@ -10,13 +10,13 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/disks"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/util/losetup"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
 )
@@ -76,7 +76,7 @@ func (nsc *Controller) syncLoopDevices(ctx context.Context, nc *scyllav1alpha1.N
 		)
 	}
 
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("failed to create loop devices: %w", err)
 	}
@@ -87,7 +87,7 @@ func (nsc *Controller) syncLoopDevices(ctx context.Context, nc *scyllav1alpha1.N
 func (nsc *Controller) pruneLoopDevices(ctx context.Context, nc *scyllav1alpha1.NodeConfig, existingLoopDevices []loopDevice, requiredLoopDeviceImages []loopDevice) error {
 	var errs []error
 	for _, ld := range existingLoopDevices {
-		_, _, isRequired := slices.Find(requiredLoopDeviceImages, func(rld loopDevice) bool {
+		_, _, isRequired := oslices.Find(requiredLoopDeviceImages, func(rld loopDevice) bool {
 			return equality.Semantic.DeepEqual(ld, rld)
 		})
 		if isRequired {
@@ -114,7 +114,7 @@ func (nsc *Controller) pruneLoopDevices(ctx context.Context, nc *scyllav1alpha1.
 		)
 	}
 
-	err := utilerrors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return fmt.Errorf("failed to delete stale loop devices: %w", err)
 	}
@@ -148,7 +148,7 @@ func discoverNodeConfigLoopDevices(ctx context.Context, executor exec.Interface,
 		loopDeviceToSymlink[ldName] = ds
 	}
 
-	ncSystemLoopDevices := slices.Filter(systemLoopDevices, func(device *losetup.LoopDevice) bool {
+	ncSystemLoopDevices := oslices.Filter(systemLoopDevices, func(device *losetup.LoopDevice) bool {
 		_, ok := loopDeviceToSymlink[device.Name]
 		return ok
 	})

--- a/pkg/controller/nodesetup/sync_mounts.go
+++ b/pkg/controller/nodesetup/sync_mounts.go
@@ -11,7 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/disks"
 	"github.com/scylladb/scylla-operator/pkg/systemd"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -62,7 +62,7 @@ func (nsc *Controller) syncMounts(ctx context.Context, nc *scyllav1alpha1.NodeCo
 		errs = append(errs, fmt.Errorf("can't ensure units: %w", err))
 	}
 
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't create mounts: %w", err)
 	}

--- a/pkg/controller/nodesetup/sync_raids.go
+++ b/pkg/controller/nodesetup/sync_raids.go
@@ -18,7 +18,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/util/blkutils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
 )
@@ -97,7 +97,7 @@ func (nsc *Controller) syncRAIDs(ctx context.Context, nc *scyllav1alpha1.NodeCon
 		}
 	}
 
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("failed to create raids: %w", err)
 	}

--- a/pkg/controller/nodetune/status.go
+++ b/pkg/controller/nodetune/status.go
@@ -6,19 +6,19 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
-func (ncdc *Controller) calculateStatus(nc *v1alpha1.NodeConfig) *v1alpha1.NodeConfigStatus {
+func (ncdc *Controller) calculateStatus(nc *scyllav1alpha1.NodeConfig) *scyllav1alpha1.NodeConfigStatus {
 	status := nc.Status.DeepCopy()
 
 	return status
 }
 
-func (ncdc *Controller) updateStatus(ctx context.Context, currentNC *v1alpha1.NodeConfig, status *v1alpha1.NodeConfigStatus) error {
+func (ncdc *Controller) updateStatus(ctx context.Context, currentNC *scyllav1alpha1.NodeConfig, status *scyllav1alpha1.NodeConfigStatus) error {
 	if apiequality.Semantic.DeepEqual(currentNC.Status, status) {
 		return nil
 	}

--- a/pkg/controller/nodetune/sync.go
+++ b/pkg/controller/nodetune/sync.go
@@ -17,7 +17,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -85,7 +85,7 @@ func (ncdc *Controller) sync(ctx context.Context) error {
 		objectErrs = append(objectErrs, err)
 	}
 
-	objectErr := utilerrors.NewAggregate(objectErrs)
+	objectErr := apimachineryutilerrors.NewAggregate(objectErrs)
 	if objectErr != nil {
 		return objectErr
 	}
@@ -157,7 +157,7 @@ func (ncdc *Controller) sync(ctx context.Context) error {
 
 	if len(aggregationErrs) > 0 {
 		errs = append(errs, aggregationErrs...)
-		return utilerrors.NewAggregate(errs)
+		return apimachineryutilerrors.NewAggregate(errs)
 	}
 
 	apimeta.SetStatusCondition(&statusConditions, nodeTuneAvailableCondition)
@@ -172,5 +172,5 @@ func (ncdc *Controller) sync(ctx context.Context) error {
 		errs = append(errs, fmt.Errorf("can't update status: %w", err))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodetune/sync_jobs.go
+++ b/pkg/controller/nodetune/sync_jobs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/c9s/goprocinfo/linux"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	"github.com/scylladb/scylla-operator/pkg/semver"
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -186,7 +186,7 @@ func (ncdc *Controller) makeJobsForContainers(ctx context.Context) ([]*batchv1.J
 		return nil, fmt.Errorf("can't list local scylla pods: %w", err)
 	}
 
-	localScyllaPods = slices.FilterOut(localScyllaPods, func(pod *corev1.Pod) bool {
+	localScyllaPods = oslices.FilterOut(localScyllaPods, func(pod *corev1.Pod) bool {
 		return pod.DeletionTimestamp != nil
 	})
 
@@ -388,5 +388,5 @@ func (ncdc *Controller) pruneJobs(ctx context.Context, jobs map[string]*batchv1.
 			continue
 		}
 	}
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/nodetune/tune.go
+++ b/pkg/controller/nodetune/tune.go
@@ -12,7 +12,7 @@ import (
 	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/cri"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/kubelet"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/util/cpuset"
@@ -108,7 +108,7 @@ func cpusetFromKubelet(ctx context.Context, podResourcesClient kubelet.PodResour
 			continue
 		}
 
-		cr, _, ok := slices.Find(pr.Containers, func(cr *podresourcesv1.ContainerResources) bool {
+		cr, _, ok := oslices.Find(pr.Containers, func(cr *podresourcesv1.ContainerResources) bool {
 			return cr.Name == containerName
 		})
 		if !ok {
@@ -116,7 +116,7 @@ func cpusetFromKubelet(ctx context.Context, podResourcesClient kubelet.PodResour
 			continue
 		}
 
-		cpuIDs := slices.ConvertSlice(cr.CpuIds, func(cpuid int64) int {
+		cpuIDs := oslices.ConvertSlice(cr.CpuIds, func(cpuid int64) int {
 			return int(cpuid)
 		})
 		sort.Ints(cpuIDs)

--- a/pkg/controller/orphanedpv/controller.go
+++ b/pkg/controller/orphanedpv/controller.go
@@ -15,9 +15,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -128,7 +128,7 @@ func (opc *Controller) processNextItem(ctx context.Context) bool {
 	}
 
 	// Make sure we always have an aggregate to process and all nested errors are flattened.
-	allErrors := utilerrors.Flatten(utilerrors.NewAggregate([]error{syncErr}))
+	allErrors := apimachineryutilerrors.Flatten(apimachineryutilerrors.NewAggregate([]error{syncErr}))
 	var remainingErrors []error
 	for _, err := range allErrors.Errors() {
 		switch {
@@ -146,9 +146,9 @@ func (opc *Controller) processNextItem(ctx context.Context) bool {
 		}
 	}
 
-	err := utilerrors.NewAggregate(remainingErrors)
+	err := apimachineryutilerrors.NewAggregate(remainingErrors)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 	}
 
 	opc.queue.AddRateLimited(key)
@@ -162,7 +162,7 @@ func (opc *Controller) runWorker(ctx context.Context) {
 }
 
 func (opc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting controller", "controller", "OrphanedPV")
 
@@ -181,7 +181,7 @@ func (opc *Controller) Run(ctx context.Context, workers int) {
 		opc.wg.Add(1)
 		go func() {
 			defer opc.wg.Done()
-			wait.UntilWithContext(ctx, opc.runWorker, time.Second)
+			apimachineryutilwait.UntilWithContext(ctx, opc.runWorker, time.Second)
 		}()
 	}
 
@@ -189,12 +189,12 @@ func (opc *Controller) Run(ctx context.Context, workers int) {
 	opc.wg.Add(1)
 	go func() {
 		defer opc.wg.Done()
-		wait.UntilWithContext(ctx, func(ctx context.Context) {
+		apimachineryutilwait.UntilWithContext(ctx, func(ctx context.Context) {
 			klog.V(4).InfoS("Periodically enqueuing all ScyllaClusters")
 
 			sdcs, err := opc.scyllaDBDatacenterLister.ScyllaDBDatacenters(corev1.NamespaceAll).List(labels.Everything())
 			if err != nil {
-				utilruntime.HandleError(err)
+				apimachineryutilruntime.HandleError(err)
 				return
 			}
 
@@ -210,7 +210,7 @@ func (opc *Controller) Run(ctx context.Context, workers int) {
 func (opc *Controller) enqueue(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
 	key, err := keyFunc(sdc)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", sdc, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", sdc, err))
 		return
 	}
 
@@ -228,7 +228,7 @@ func (opc *Controller) enqueueAllScyllaDBDatacentersOnBackground() {
 		// by the ScyllaDBDatacenter handler.
 		sdcs, err := opc.scyllaDBDatacenterLister.ScyllaDBDatacenters(corev1.NamespaceAll).List(labels.Everything())
 		if err != nil {
-			utilruntime.HandleError(err)
+			apimachineryutilruntime.HandleError(err)
 			return
 		}
 
@@ -245,7 +245,7 @@ func (opc *Controller) updateNode(old, cur interface{}) {
 	if currentNode.UID != oldNode.UID {
 		key, err := keyFunc(oldNode)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldNode, err))
+			apimachineryutilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldNode, err))
 			return
 		}
 		opc.deleteNode(cache.DeletedFinalStateUnknown{
@@ -260,12 +260,12 @@ func (opc *Controller) deleteNode(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		node, ok = tombstone.Obj.(*corev1.Node)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Node %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Node %#v", obj))
 			return
 		}
 	}
@@ -289,7 +289,7 @@ func (opc *Controller) updateScyllaDBDatacenter(old, cur interface{}) {
 	if currentSDC.UID != oldSDC.UID {
 		key, err := keyFunc(oldSDC)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldSDC, err))
+			apimachineryutilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldSDC, err))
 			return
 		}
 		opc.deleteScyllaDBDatacenter(cache.DeletedFinalStateUnknown{
@@ -307,12 +307,12 @@ func (opc *Controller) deleteScyllaDBDatacenter(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		sdc, ok = tombstone.Obj.(*scyllav1alpha1.ScyllaDBDatacenter)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ScyllaDBDatacenter %#v", obj))
+			apimachineryutilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ScyllaDBDatacenter %#v", obj))
 			return
 		}
 	}

--- a/pkg/controller/orphanedpv/sync.go
+++ b/pkg/controller/orphanedpv/sync.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -68,7 +68,7 @@ func (opc *Controller) getPVsForScyllaDBDatacenter(ctx context.Context, sdc *scy
 		}
 	}
 
-	return pis, requeueReasons, utilerrors.NewAggregate(errs)
+	return pis, requeueReasons, apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (opc *Controller) sync(ctx context.Context, key string) error {
@@ -164,7 +164,7 @@ func (opc *Controller) sync(ctx context.Context, key string) error {
 		klog.V(2).InfoS("Marked service for replacement", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KRef(sdc.Namespace, pi.ServiceName))
 	}
 
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/remotekubernetescluster/controller.go
+++ b/pkg/controller/remotekubernetescluster/controller.go
@@ -20,9 +20,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -151,7 +151,7 @@ func (rkcc *Controller) processNextItem(ctx context.Context) bool {
 
 	err := rkcc.sync(ctx, key.(string))
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
-	err = utilerrors.Reduce(err)
+	err = apimachineryutilerrors.Reduce(err)
 	switch {
 	case err == nil:
 		rkcc.queue.Forget(key)
@@ -164,7 +164,7 @@ func (rkcc *Controller) processNextItem(ctx context.Context) bool {
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
 
 	default:
-		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 	}
 
 	rkcc.queue.AddRateLimited(key)
@@ -178,7 +178,7 @@ func (rkcc *Controller) runWorker(ctx context.Context) {
 }
 
 func (rkcc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting controller", "controller", ControllerName)
 
@@ -198,7 +198,7 @@ func (rkcc *Controller) Run(ctx context.Context, workers int) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			wait.UntilWithContext(ctx, rkcc.runWorker, time.Second)
+			apimachineryutilwait.UntilWithContext(ctx, rkcc.runWorker, time.Second)
 		}()
 	}
 
@@ -292,7 +292,7 @@ func (rkcc *Controller) enqueueRemoteKubernetesClustersReferencedByScyllaDBClust
 	for _, dc := range sc.Spec.Datacenters {
 		rkc, err := rkcc.remoteKubernetesClusterLister.Get(dc.RemoteKubernetesClusterName)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("couldn't get RemoteKubernetesCluster %q: %w", dc.RemoteKubernetesClusterName, err))
+			apimachineryutilruntime.HandleError(fmt.Errorf("couldn't get RemoteKubernetesCluster %q: %w", dc.RemoteKubernetesClusterName, err))
 			continue
 		}
 		rkcc.handlers.Enqueue(depth+1, rkc, op)

--- a/pkg/controller/remotekubernetescluster/sync.go
+++ b/pkg/controller/remotekubernetescluster/sync.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -60,7 +60,7 @@ func (rkcc *Controller) sync(ctx context.Context, key string) error {
 		return rkcc.updateStatus(ctx, rkc, status)
 	}
 
-	if !slices.ContainsItem(rkc.GetFinalizers(), naming.RemoteKubernetesClusterFinalizer) {
+	if !oslices.ContainsItem(rkc.GetFinalizers(), naming.RemoteKubernetesClusterFinalizer) {
 		err = rkcc.addFinalizer(ctx, rkc)
 		if err != nil {
 			return fmt.Errorf("can't add finalizer: %w", err)
@@ -105,5 +105,5 @@ func (rkcc *Controller) sync(ctx context.Context, key string) error {
 		errs = append(errs, err)
 	}
 
-	return errors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/remotekubernetescluster/sync_dynamicclusterhandlers.go
+++ b/pkg/controller/remotekubernetescluster/sync_dynamicclusterhandlers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -47,5 +47,5 @@ func (rkcc *Controller) syncDynamicClusterHandlers(ctx context.Context, rkc *scy
 		}
 	}
 
-	return progressingConditions, errors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/remotekubernetescluster/sync_finalizer.go
+++ b/pkg/controller/remotekubernetescluster/sync_finalizer.go
@@ -9,7 +9,7 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +22,7 @@ func (rkcc *Controller) syncFinalizer(ctx context.Context, rkc *scyllav1alpha1.R
 	var progressingConditions []metav1.Condition
 	var err error
 
-	if !slices.ContainsItem(rkc.GetFinalizers(), naming.RemoteKubernetesClusterFinalizer) {
+	if !oslices.ContainsItem(rkc.GetFinalizers(), naming.RemoteKubernetesClusterFinalizer) {
 		klog.V(4).InfoS("Object is already finalized", "RemoteKubernetesCluster", klog.KObj(rkc), "UID", rkc.UID)
 		return progressingConditions, nil
 	}

--- a/pkg/controller/remotekubernetescluster/sync_healthchecks.go
+++ b/pkg/controller/remotekubernetescluster/sync_healthchecks.go
@@ -9,7 +9,7 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/klog/v2"
 )
@@ -94,7 +94,7 @@ func (rkcc *Controller) syncClientHealthchecks(ctx context.Context, key string, 
 		})
 	}
 
-	err := errors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't run healthcheck probes: %w", err)
 	}

--- a/pkg/controller/scyllacluster/controller.go
+++ b/pkg/controller/scyllacluster/controller.go
@@ -26,9 +26,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	batchv1informers "k8s.io/client-go/informers/batch/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -233,7 +233,7 @@ func (scmc *Controller) processNextItem(ctx context.Context) bool {
 
 	err := scmc.sync(ctx, key.(string))
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
-	err = utilerrors.Reduce(err)
+	err = apimachineryutilerrors.Reduce(err)
 	switch {
 	case err == nil:
 		scmc.queue.Forget(key)
@@ -246,7 +246,7 @@ func (scmc *Controller) processNextItem(ctx context.Context) bool {
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
 
 	default:
-		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 	}
 
 	scmc.queue.AddRateLimited(key)
@@ -260,7 +260,7 @@ func (scmc *Controller) runWorker(ctx context.Context) {
 }
 
 func (scmc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting controller", "controller", ControllerName)
 
@@ -280,7 +280,7 @@ func (scmc *Controller) Run(ctx context.Context, workers int) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			wait.UntilWithContext(ctx, scmc.runWorker, time.Second)
+			apimachineryutilwait.UntilWithContext(ctx, scmc.runWorker, time.Second)
 		}()
 	}
 

--- a/pkg/controller/scyllacluster/status.go
+++ b/pkg/controller/scyllacluster/status.go
@@ -7,7 +7,7 @@ import (
 
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/kubeinterfaces"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -71,6 +71,6 @@ func isOwnedByAnyFunc[T kubeinterfaces.ObjectInterface](allowedOwners []types.UI
 			return false
 		}
 
-		return slices.ContainsItem(allowedOwners, controllerRef.UID)
+		return oslices.ContainsItem(allowedOwners, controllerRef.UID)
 	}
 }

--- a/pkg/controller/scyllacluster/sync.go
+++ b/pkg/controller/scyllacluster/sync.go
@@ -10,7 +10,7 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -191,7 +191,7 @@ func (scmc *Controller) sync(ctx context.Context, key string) error {
 		releaseErrs = append(releaseErrs, err)
 	}
 
-	releaseErr := utilerrors.NewAggregate(releaseErrs)
+	releaseErr := apimachineryutilerrors.NewAggregate(releaseErrs)
 	if releaseErr != nil {
 		return releaseErr
 	}
@@ -232,10 +232,10 @@ func (scmc *Controller) sync(ctx context.Context, key string) error {
 		allowedOwnerUIDs = append(allowedOwnerUIDs, sdc.UID)
 	}
 
-	configMaps = slices.Filter(configMaps, isOwnedByAnyFunc[*corev1.ConfigMap](allowedOwnerUIDs))
-	services = slices.Filter(services, isOwnedByAnyFunc[*corev1.Service](allowedOwnerUIDs))
+	configMaps = oslices.Filter(configMaps, isOwnedByAnyFunc[*corev1.ConfigMap](allowedOwnerUIDs))
+	services = oslices.Filter(services, isOwnedByAnyFunc[*corev1.Service](allowedOwnerUIDs))
 
-	objectErr := utilerrors.NewAggregate(objectErrs)
+	objectErr := apimachineryutilerrors.NewAggregate(objectErrs)
 	if objectErr != nil {
 		return objectErr
 	}
@@ -264,5 +264,5 @@ func (scmc *Controller) sync(ctx context.Context, key string) error {
 	err = scmc.updateStatus(ctx, sc, status)
 	errs = append(errs, err)
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/scylladbcluster/sync.go
+++ b/pkg/controller/scylladbcluster/sync.go
@@ -10,7 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/controllertools"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -64,7 +64,7 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 	type remoteCT = *scyllav1alpha1.RemoteOwner
 	var objectErrMaps map[string][]error
 
-	remoteClusterNames := slices.ConvertSlice(sc.Spec.Datacenters, func(dc scyllav1alpha1.ScyllaDBClusterDatacenter) string {
+	remoteClusterNames := oslices.ConvertSlice(sc.Spec.Datacenters, func(dc scyllav1alpha1.ScyllaDBClusterDatacenter) string {
 		return dc.RemoteKubernetesClusterName
 	})
 
@@ -267,7 +267,7 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 		objectErrs := objectErrMaps[dc.RemoteKubernetesClusterName]
 
 		var err error
-		err = utilerrors.NewAggregate(objectErrs)
+		err = apimachineryutilerrors.NewAggregate(objectErrs)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("can't sync remote datacenter %q: %w", dc.RemoteKubernetesClusterName, err))
 			continue
@@ -403,7 +403,7 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 		errs = append(errs, err)
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (scc *Controller) chooseRemoteControllers(sc *scyllav1alpha1.ScyllaDBCluster, remoteRemoteOwnersMap map[string]map[string]*scyllav1alpha1.RemoteOwner) map[string]metav1.Object {

--- a/pkg/controller/scylladbcluster/sync_configmap.go
+++ b/pkg/controller/scylladbcluster/sync_configmap.go
@@ -10,7 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (scc *Controller) syncRemoteConfigMaps(
@@ -61,7 +61,7 @@ func (scc *Controller) syncRemoteConfigMaps(
 		}
 	}
 
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't apply configmap(s): %w", err)
 	}

--- a/pkg/controller/scylladbcluster/sync_finalizer.go
+++ b/pkg/controller/scylladbcluster/sync_finalizer.go
@@ -8,14 +8,14 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -77,7 +77,7 @@ func (scc *Controller) syncFinalizer(ctx context.Context, sc *scyllav1alpha1.Scy
 			continue
 		}
 
-		clientRemoteNamespaces[dc.RemoteKubernetesClusterName] = slices.ConvertSlice(rnss.Items, pointer.Ptr[corev1.Namespace])
+		clientRemoteNamespaces[dc.RemoteKubernetesClusterName] = oslices.ConvertSlice(rnss.Items, pointer.Ptr[corev1.Namespace])
 	}
 
 	deletionProgressingCondition, err = scc.deleteRemoteNamespaces(ctx, sc, clientRemoteNamespaces)
@@ -125,7 +125,7 @@ func (scc *Controller) deleteRemoteNamespaces(ctx context.Context, sc *scyllav1a
 		}
 	}
 
-	err := errors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't delete remote namespaces: %w", err)
 	}
@@ -134,7 +134,7 @@ func (scc *Controller) deleteRemoteNamespaces(ctx context.Context, sc *scyllav1a
 }
 
 func (scc *Controller) hasFinalizer(finalizers []string) bool {
-	return slices.ContainsItem(finalizers, naming.ScyllaDBClusterFinalizer)
+	return oslices.ContainsItem(finalizers, naming.ScyllaDBClusterFinalizer)
 }
 
 func (scc *Controller) addFinalizer(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster) error {

--- a/pkg/controller/scylladbcluster/sync_secrets.go
+++ b/pkg/controller/scylladbcluster/sync_secrets.go
@@ -10,7 +10,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (scc *Controller) syncRemoteSecrets(
@@ -61,7 +61,7 @@ func (scc *Controller) syncRemoteSecrets(
 		}
 	}
 
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't apply secret(s): %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/controller.go
+++ b/pkg/controller/scylladbdatacenter/controller.go
@@ -23,9 +23,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	batchv1informers "k8s.io/client-go/informers/batch/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -246,7 +246,7 @@ func (sdcc *Controller) processNextItem(ctx context.Context) bool {
 
 	err := sdcc.sync(ctx, key.(string))
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
-	err = utilerrors.Reduce(err)
+	err = apimachineryutilerrors.Reduce(err)
 	switch {
 	case err == nil:
 		sdcc.queue.Forget(key)
@@ -259,7 +259,7 @@ func (sdcc *Controller) processNextItem(ctx context.Context) bool {
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
 
 	default:
-		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 	}
 
 	sdcc.queue.AddRateLimited(key)
@@ -273,7 +273,7 @@ func (sdcc *Controller) runWorker(ctx context.Context) {
 }
 
 func (sdcc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting controller", "controller", ControllerName)
 
@@ -293,7 +293,7 @@ func (sdcc *Controller) Run(ctx context.Context, workers int) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			wait.UntilWithContext(ctx, sdcc.runWorker, time.Second)
+			apimachineryutilwait.UntilWithContext(ctx, sdcc.runWorker, time.Second)
 		}()
 	}
 

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -16,7 +16,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/features"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
@@ -28,7 +28,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	apimachineryutilintstr "k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 )
@@ -194,7 +194,7 @@ func MemberService(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName, name string
 		svc.Spec.ExternalTrafficPolicy = getValueOrDefault(ns.ExternalTrafficPolicy, "")
 	}
 
-	rackSpec, _, ok := slices.Find(sdc.Spec.Racks, func(rs scyllav1alpha1.RackSpec) bool {
+	rackSpec, _, ok := oslices.Find(sdc.Spec.Racks, func(rs scyllav1alpha1.RackSpec) bool {
 		return rs.Name == rackName
 	})
 	if !ok {
@@ -361,7 +361,7 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 
 	var existingDataPVCTemplate *corev1.PersistentVolumeClaim
 	if existingSts != nil {
-		pvc, _, ok := slices.Find(existingSts.Spec.VolumeClaimTemplates, func(pvc corev1.PersistentVolumeClaim) bool {
+		pvc, _, ok := oslices.Find(existingSts.Spec.VolumeClaimTemplates, func(pvc corev1.PersistentVolumeClaim) bool {
 			return pvc.Name == naming.PVCTemplateName
 		})
 		if !ok {
@@ -830,7 +830,7 @@ exec /mnt/shared/scylla-operator sidecar \
 								PeriodSeconds:    int32(10),
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Port: intstr.FromInt(naming.ScyllaDBAPIStatusProbePort),
+										Port: apimachineryutilintstr.FromInt(naming.ScyllaDBAPIStatusProbePort),
 										Path: naming.LivenessProbePath,
 									},
 								},
@@ -843,7 +843,7 @@ exec /mnt/shared/scylla-operator sidecar \
 								PeriodSeconds:    int32(10),
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Port: intstr.FromInt(naming.ScyllaDBAPIStatusProbePort),
+										Port: apimachineryutilintstr.FromInt(naming.ScyllaDBAPIStatusProbePort),
 										Path: naming.LivenessProbePath,
 									},
 								},
@@ -857,7 +857,7 @@ exec /mnt/shared/scylla-operator sidecar \
 								PeriodSeconds:    int32(readinessPeriodSeconds),
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Port: intstr.FromInt(naming.ScyllaDBAPIStatusProbePort),
+										Port: apimachineryutilintstr.FromInt(naming.ScyllaDBAPIStatusProbePort),
 										Path: naming.ReadinessProbePath,
 									},
 								},
@@ -919,7 +919,7 @@ wait
 								PeriodSeconds:    int32(5),
 								ProbeHandler: corev1.ProbeHandler{
 									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt32(naming.ScyllaDBAPIStatusProbePort),
+										Port: apimachineryutilintstr.FromInt32(naming.ScyllaDBAPIStatusProbePort),
 									},
 								},
 							},
@@ -972,7 +972,7 @@ wait
 								PeriodSeconds:    int32(5),
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Port: intstr.FromInt32(naming.ScyllaDBIgnitionProbePort),
+										Port: apimachineryutilintstr.FromInt32(naming.ScyllaDBIgnitionProbePort),
 										Path: naming.ReadinessProbePath,
 									},
 								},
@@ -1245,7 +1245,7 @@ exec scylla-manager-agent \
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt32(10001),
+					Port: apimachineryutilintstr.FromInt32(10001),
 				},
 			},
 		},
@@ -1290,7 +1290,7 @@ exec scylla-manager-agent \
 }
 
 func MakePodDisruptionBudget(sdc *scyllav1alpha1.ScyllaDBDatacenter) *policyv1.PodDisruptionBudget {
-	maxUnavailable := intstr.FromInt(1)
+	maxUnavailable := apimachineryutilintstr.FromInt(1)
 
 	selectorLabels := naming.ClusterLabels(sdc)
 

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -19,7 +19,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	apimachineryutilintstr "k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
@@ -1046,7 +1046,7 @@ exec /mnt/shared/scylla-operator sidecar \
 									PeriodSeconds:    int32(10),
 									ProbeHandler: corev1.ProbeHandler{
 										HTTPGet: &corev1.HTTPGetAction{
-											Port: intstr.FromInt(8080),
+											Port: apimachineryutilintstr.FromInt(8080),
 											Path: "/healthz",
 										},
 									},
@@ -1057,7 +1057,7 @@ exec /mnt/shared/scylla-operator sidecar \
 									PeriodSeconds:    int32(10),
 									ProbeHandler: corev1.ProbeHandler{
 										HTTPGet: &corev1.HTTPGetAction{
-											Port: intstr.FromInt(8080),
+											Port: apimachineryutilintstr.FromInt(8080),
 											Path: "/healthz",
 										},
 									},
@@ -1068,7 +1068,7 @@ exec /mnt/shared/scylla-operator sidecar \
 									PeriodSeconds:    int32(10),
 									ProbeHandler: corev1.ProbeHandler{
 										HTTPGet: &corev1.HTTPGetAction{
-											Port: intstr.FromInt(8080),
+											Port: apimachineryutilintstr.FromInt(8080),
 											Path: "/readyz",
 										},
 									},
@@ -1123,7 +1123,7 @@ wait`),
 									PeriodSeconds:    int32(5),
 									ProbeHandler: corev1.ProbeHandler{
 										TCPSocket: &corev1.TCPSocketAction{
-											Port: intstr.FromInt32(naming.ScyllaDBAPIStatusProbePort),
+											Port: apimachineryutilintstr.FromInt32(naming.ScyllaDBAPIStatusProbePort),
 										},
 									},
 								},
@@ -1166,7 +1166,7 @@ wait`),
 									PeriodSeconds:    int32(5),
 									ProbeHandler: corev1.ProbeHandler{
 										HTTPGet: &corev1.HTTPGetAction{
-											Port: intstr.FromInt32(42081),
+											Port: apimachineryutilintstr.FromInt32(42081),
 											Path: "/readyz",
 										},
 									},
@@ -1225,7 +1225,7 @@ exec scylla-manager-agent \
 								ReadinessProbe: &corev1.Probe{
 									ProbeHandler: corev1.ProbeHandler{
 										TCPSocket: &corev1.TCPSocketAction{
-											Port: intstr.FromInt32(10001),
+											Port: apimachineryutilintstr.FromInt32(10001),
 										},
 									},
 								},

--- a/pkg/controller/scylladbdatacenter/sync.go
+++ b/pkg/controller/scylladbdatacenter/sync.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -186,7 +186,7 @@ func (sdcc *Controller) sync(ctx context.Context, key string) error {
 		objectErrs = append(objectErrs, err)
 	}
 
-	objectErr := utilerrors.NewAggregate(objectErrs)
+	objectErr := apimachineryutilerrors.NewAggregate(objectErrs)
 	if objectErr != nil {
 		return objectErr
 	}
@@ -343,5 +343,5 @@ func (sdcc *Controller) sync(ctx context.Context, key string) error {
 		errs = append(errs, err)
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/scylladbdatacenter/sync_agent_config.go
+++ b/pkg/controller/scylladbdatacenter/sync_agent_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
+	apimachineryutilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 func (sdcc *Controller) getAgentTokenFromAgentConfig(sdc *scyllav1alpha1.ScyllaDBDatacenter) (string, error) {
@@ -73,7 +73,7 @@ func (sdcc *Controller) syncAgentToken(
 
 	// If we still don't have the token, we generate a random one.
 	if len(token) == 0 {
-		token = rand.String(128)
+		token = apimachineryutilrand.String(128)
 	}
 
 	secret, err := MakeAgentAuthTokenSecret(sdc, token)

--- a/pkg/controller/scylladbdatacenter/sync_certs.go
+++ b/pkg/controller/scylladbdatacenter/sync_certs.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 )
@@ -467,5 +467,5 @@ func (sdcc *Controller) syncCerts(
 		))
 	}
 
-	return progressingConditions, errors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/scylladbdatacenter/sync_config.go
+++ b/pkg/controller/scylladbdatacenter/sync_config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncConfigs(
@@ -34,5 +34,5 @@ func (sdcc *Controller) syncConfigs(
 		}
 	}
 
-	return progressingConditions, errors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/scylladbdatacenter/sync_ingress.go
+++ b/pkg/controller/scylladbdatacenter/sync_ingress.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncIngresses(
@@ -52,7 +52,7 @@ func (sdcc *Controller) syncIngresses(
 		})
 		deletionErrors = append(deletionErrors, err)
 	}
-	err = utilerrors.NewAggregate(deletionErrors)
+	err = apimachineryutilerrors.NewAggregate(deletionErrors)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't delete ingress(s): %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/sync_jobs.go
+++ b/pkg/controller/scylladbdatacenter/sync_jobs.go
@@ -17,7 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncJobs(
@@ -91,7 +91,7 @@ func (sdcc *Controller) syncJobs(
 			})
 		}
 	}
-	err = utilerrors.NewAggregate(errs)
+	err = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return progressingConditions, err
 	}

--- a/pkg/controller/scylladbdatacenter/sync_pdb.go
+++ b/pkg/controller/scylladbdatacenter/sync_pdb.go
@@ -9,7 +9,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncPodDisruptionBudgets(
@@ -44,7 +44,7 @@ func (sdcc *Controller) syncPodDisruptionBudgets(
 		})
 		deletionErrors = append(deletionErrors, err)
 	}
-	err = utilerrors.NewAggregate(deletionErrors)
+	err = apimachineryutilerrors.NewAggregate(deletionErrors)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't delete pdb(s): %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/sync_rolebindings.go
+++ b/pkg/controller/scylladbdatacenter/sync_rolebindings.go
@@ -9,7 +9,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncRoleBindings(
@@ -44,7 +44,7 @@ func (sdcc *Controller) syncRoleBindings(
 		})
 		deletionErrors = append(deletionErrors, err)
 	}
-	err = utilerrors.NewAggregate(deletionErrors)
+	err = apimachineryutilerrors.NewAggregate(deletionErrors)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't delete role binding(s): %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/sync_serviceaccounts.go
+++ b/pkg/controller/scylladbdatacenter/sync_serviceaccounts.go
@@ -9,7 +9,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncServiceAccounts(
@@ -44,7 +44,7 @@ func (sdcc *Controller) syncServiceAccounts(
 		})
 		deletionErrors = append(deletionErrors, err)
 	}
-	err = utilerrors.NewAggregate(deletionErrors)
+	err = apimachineryutilerrors.NewAggregate(deletionErrors)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't delete service account(s): %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/sync_services.go
+++ b/pkg/controller/scylladbdatacenter/sync_services.go
@@ -9,7 +9,7 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	"github.com/scylladb/scylla-operator/pkg/scyllafeatures"
@@ -19,7 +19,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -86,7 +86,7 @@ func (sdcc *Controller) pruneServices(
 			errs = append(errs, fmt.Errorf("service %s/%s is missing %q label", svc.Namespace, svc.Name, naming.RackNameLabel))
 			continue
 		}
-		rackSpec, _, ok := slices.Find(sdc.Spec.Racks, func(spec scyllav1alpha1.RackSpec) bool {
+		rackSpec, _, ok := oslices.Find(sdc.Spec.Racks, func(spec scyllav1alpha1.RackSpec) bool {
 			return spec.Name == rackName
 		})
 		if !ok {
@@ -195,7 +195,7 @@ func (sdcc *Controller) pruneServices(
 			continue
 		}
 	}
-	return progressingConditions, utilerrors.NewAggregate(errs)
+	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (sdcc *Controller) syncServices(

--- a/pkg/controller/scylladbmanagerclusterregistration/sync.go
+++ b/pkg/controller/scylladbmanagerclusterregistration/sync.go
@@ -12,7 +12,7 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/controllertools"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -121,7 +121,7 @@ func (smcrc *Controller) sync(ctx context.Context, key string) error {
 
 	if len(aggregationErrs) > 0 {
 		errs = append(errs, aggregationErrs...)
-		return utilerrors.NewAggregate(errs)
+		return apimachineryutilerrors.NewAggregate(errs)
 	}
 
 	apimeta.SetStatusCondition(&status.Conditions, progressingCondition)
@@ -132,7 +132,7 @@ func (smcrc *Controller) sync(ctx context.Context, key string) error {
 		errs = append(errs, fmt.Errorf("can't update status: %w", err))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (smcrc *Controller) getManagerClient(_ context.Context, _ *scyllav1alpha1.ScyllaDBManagerClusterRegistration) (*managerclient.Client, error) {
@@ -156,7 +156,7 @@ func isManagedByGlobalScyllaDBManagerInstance(smcr *scyllav1alpha1.ScyllaDBManag
 }
 
 func (smcrc *Controller) hasFinalizer(finalizers []string) bool {
-	return slices.ContainsItem(finalizers, naming.ScyllaDBManagerClusterRegistrationFinalizer)
+	return oslices.ContainsItem(finalizers, naming.ScyllaDBManagerClusterRegistrationFinalizer)
 }
 
 func (smcrc *Controller) addFinalizer(ctx context.Context, smcr *scyllav1alpha1.ScyllaDBManagerClusterRegistration) error {

--- a/pkg/controller/scylladbmanagerclusterregistration/sync_manager.go
+++ b/pkg/controller/scylladbmanagerclusterregistration/sync_manager.go
@@ -11,7 +11,7 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers/managerclienterrors"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	hashutil "github.com/scylladb/scylla-operator/pkg/util/hash"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -216,7 +216,7 @@ func getScyllaDBManagerCluster(ctx context.Context, smcr *scyllav1alpha1.ScyllaD
 	}
 
 	// Cluster names in manager state are unique, so it suffices to only find one with a matching name.
-	managerCluster, _, found := slices.Find(managerClusters, func(c *models.Cluster) bool {
+	managerCluster, _, found := oslices.Find(managerClusters, func(c *models.Cluster) bool {
 		return c.Name == managerClusterName
 	})
 

--- a/pkg/controller/scylladbmonitoring/controller.go
+++ b/pkg/controller/scylladbmonitoring/controller.go
@@ -24,9 +24,9 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	networkingv1informers "k8s.io/client-go/informers/networking/v1"
@@ -532,7 +532,7 @@ func (smc *Controller) processNextItem(ctx context.Context) bool {
 
 	err := smc.sync(ctx, key.(string))
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
-	err = utilerrors.Reduce(err)
+	err = apimachineryutilerrors.Reduce(err)
 	switch {
 	case err == nil:
 		smc.queue.Forget(key)
@@ -545,7 +545,7 @@ func (smc *Controller) processNextItem(ctx context.Context) bool {
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
 
 	default:
-		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 	}
 
 	smc.queue.AddRateLimited(key)
@@ -559,7 +559,7 @@ func (smc *Controller) runWorker(ctx context.Context) {
 }
 
 func (smc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting controller", "controller", "ScyllaDBMonitoring")
 
@@ -579,7 +579,7 @@ func (smc *Controller) Run(ctx context.Context, workers int) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			wait.UntilWithContext(ctx, smc.runWorker, time.Second)
+			apimachineryutilwait.UntilWithContext(ctx, smc.runWorker, time.Second)
 		}()
 	}
 

--- a/pkg/controller/scylladbmonitoring/main_test.go
+++ b/pkg/controller/scylladbmonitoring/main_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	prometheusv1assets "github.com/scylladb/scylla-operator/assets/monitoring/prometheus/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func TestMain(m *testing.M) {
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	err := utilerrors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		_, _ = fmt.Fprint(os.Stderr, err)
 		os.Exit(1)

--- a/pkg/controller/scylladbmonitoring/sync.go
+++ b/pkg/controller/scylladbmonitoring/sync.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -217,7 +217,7 @@ func (smc *Controller) sync(ctx context.Context, key string) error {
 		objectErrs = append(objectErrs, fmt.Errorf("can't get service monitors: %w", err))
 	}
 
-	objectErr := utilerrors.NewAggregate(objectErrs)
+	objectErr := apimachineryutilerrors.NewAggregate(objectErrs)
 	if objectErr != nil {
 		return objectErr
 	}
@@ -292,5 +292,5 @@ func (smc *Controller) sync(ctx context.Context, key string) error {
 		errs = append(errs, err)
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/scylladbmonitoring/sync_grafana.go
+++ b/pkg/controller/scylladbmonitoring/sync_grafana.go
@@ -29,8 +29,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/rand"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 const (
@@ -133,7 +133,7 @@ func makeGrafanaAdminCredentials(sm *scyllav1alpha1.ScyllaDBMonitoring, secrets 
 	}
 
 	if len(existingPassword) == 0 {
-		existingPassword = []byte(rand.String(grafanaPasswordLength))
+		existingPassword = []byte(apimachineryutilrand.String(grafanaPasswordLength))
 	}
 
 	return grafanav1alpha1assets.GrafanaAdminCredentialsSecretTemplate.Get().RenderObject(map[string]any{
@@ -350,7 +350,7 @@ func (smc *Controller) syncGrafana(
 	requiredIngress, _, err := makeGrafanaIngress(sm)
 	renderErrors = append(renderErrors, err)
 
-	renderError := kutilerrors.NewAggregate(renderErrors)
+	renderError := apimachineryutilerrors.NewAggregate(renderErrors)
 	if renderError != nil {
 		return progressingConditions, renderError
 	}
@@ -441,7 +441,7 @@ func (smc *Controller) syncGrafana(
 	)
 	pruneErrors = append(pruneErrors, err)
 
-	pruneError := kutilerrors.NewAggregate(pruneErrors)
+	pruneError := apimachineryutilerrors.NewAggregate(pruneErrors)
 	if pruneError != nil {
 		return progressingConditions, pruneError
 	}
@@ -597,7 +597,7 @@ func (smc *Controller) syncGrafana(
 		}
 	}
 
-	applyError := kutilerrors.NewAggregate(applyErrors)
+	applyError := apimachineryutilerrors.NewAggregate(applyErrors)
 	if applyError != nil {
 		return progressingConditions, applyError
 	}

--- a/pkg/controller/scylladbmonitoring/sync_grafana_test.go
+++ b/pkg/controller/scylladbmonitoring/sync_grafana_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func Test_makeGrafanaIngress(t *testing.T) {
@@ -244,7 +244,7 @@ func Test_makeGrafanaDashboards(t *testing.T) {
 			if err == nil {
 				for _, cm := range cms {
 					errMessages := apimachineryvalidation.NameIsDNSSubdomain(cm.Name, false)
-					validationErr := utilerrors.NewAggregate(oslices.ConvertSlice[error](errMessages, func(s string) error {
+					validationErr := apimachineryutilerrors.NewAggregate(oslices.ConvertSlice[error](errMessages, func(s string) error {
 						return errors.New(s)
 					}))
 
@@ -704,7 +704,7 @@ spec:
 			if err == nil {
 				for _, v := range deployment.Spec.Template.Spec.Volumes {
 					errMessages := apimachineryvalidation.NameIsDNSSubdomain(v.Name, false)
-					validationErr := utilerrors.NewAggregate(oslices.ConvertSlice[error](errMessages, func(s string) error {
+					validationErr := apimachineryutilerrors.NewAggregate(oslices.ConvertSlice[error](errMessages, func(s string) error {
 						return errors.New(s)
 					}))
 

--- a/pkg/controller/scylladbmonitoring/sync_prometheus.go
+++ b/pkg/controller/scylladbmonitoring/sync_prometheus.go
@@ -12,7 +12,7 @@ import (
 	ocrypto "github.com/scylladb/scylla-operator/pkg/crypto"
 	monitoringv1 "github.com/scylladb/scylla-operator/pkg/externalapi/monitoring/v1"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	okubecrypto "github.com/scylladb/scylla-operator/pkg/kubecrypto"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
@@ -24,7 +24,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func getPrometheusLabels(sm *scyllav1alpha1.ScyllaDBMonitoring) labels.Set {
@@ -323,7 +323,7 @@ func (smc *Controller) syncPrometheus(
 	requiredScyllaDBServiceMonitor, _, err := makeScyllaDBServiceMonitor(sm)
 	renderErrors = append(renderErrors, err)
 
-	renderError := kutilerrors.NewAggregate(renderErrors)
+	renderError := apimachineryutilerrors.NewAggregate(renderErrors)
 	if renderError != nil {
 		return progressingConditions, renderError
 	}
@@ -333,7 +333,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		slices.ToSlice(requiredPrometheusSA),
+		oslices.ToSlice(requiredPrometheusSA),
 		serviceAccounts,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.CoreV1().ServiceAccounts(sm.Namespace).Delete,
@@ -344,7 +344,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		slices.ToSlice(requiredPrometheusService),
+		oslices.ToSlice(requiredPrometheusService),
 		services,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.CoreV1().Services(sm.Namespace).Delete,
@@ -355,7 +355,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		slices.ToSlice(requiredPrometheusRoleBinding),
+		oslices.ToSlice(requiredPrometheusRoleBinding),
 		roleBindings,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.RbacV1().RoleBindings(sm.Namespace).Delete,
@@ -366,7 +366,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		slices.ToSlice(requiredPrometheus),
+		oslices.ToSlice(requiredPrometheus),
 		prometheuses,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.monitoringClient.Prometheuses(sm.Namespace).Delete,
@@ -377,7 +377,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		slices.FilterOutNil(slices.ToSlice(requiredIngress)),
+		oslices.FilterOutNil(oslices.ToSlice(requiredIngress)),
 		ingresses,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.kubeClient.NetworkingV1().Ingresses(sm.Namespace).Delete,
@@ -388,7 +388,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		slices.ToSlice(requiredLatencyPrometheusRule, requiredAlertsPrometheusRule, requiredTablePrometheusRule),
+		oslices.ToSlice(requiredLatencyPrometheusRule, requiredAlertsPrometheusRule, requiredTablePrometheusRule),
 		prometheusRules,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.monitoringClient.PrometheusRules(sm.Namespace).Delete,
@@ -399,7 +399,7 @@ func (smc *Controller) syncPrometheus(
 
 	err = controllerhelpers.Prune(
 		ctx,
-		slices.ToSlice(requiredScyllaDBServiceMonitor),
+		oslices.ToSlice(requiredScyllaDBServiceMonitor),
 		serviceMonitors,
 		&controllerhelpers.PruneControlFuncs{
 			DeleteFunc: smc.monitoringClient.ServiceMonitors(sm.Namespace).Delete,
@@ -430,7 +430,7 @@ func (smc *Controller) syncPrometheus(
 	)
 	pruneErrors = append(pruneErrors, err)
 
-	pruneError := kutilerrors.NewAggregate(pruneErrors)
+	pruneError := apimachineryutilerrors.NewAggregate(pruneErrors)
 	if pruneError != nil {
 		return progressingConditions, pruneError
 	}
@@ -577,7 +577,7 @@ func (smc *Controller) syncPrometheus(
 		))
 	}
 
-	applyError := kutilerrors.NewAggregate(applyErrors)
+	applyError := apimachineryutilerrors.NewAggregate(applyErrors)
 	if applyError != nil {
 		return progressingConditions, applyError
 	}

--- a/pkg/controller/scyllaoperatorconfig/sync.go
+++ b/pkg/controller/scyllaoperatorconfig/sync.go
@@ -9,7 +9,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -76,5 +76,5 @@ func (opc *Controller) sync(ctx context.Context) error {
 		}
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/scyllaoperatorconfig/sync_clusterdomain.go
+++ b/pkg/controller/scyllaoperatorconfig/sync_clusterdomain.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"fmt"
 
-	osscyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (socc *Controller) syncClusterDomain(
 	ctx context.Context,
-	soc *osscyllav1alpha1.ScyllaOperatorConfig,
-	status *osscyllav1alpha1.ScyllaOperatorConfigStatus,
+	soc *scyllav1alpha1.ScyllaOperatorConfig,
+	status *scyllav1alpha1.ScyllaOperatorConfigStatus,
 ) ([]metav1.Condition, error) {
 	var progressingConditions []metav1.Condition
 

--- a/pkg/controller/sidecar/sync.go
+++ b/pkg/controller/sidecar/sync.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -210,5 +210,5 @@ func (c *Controller) sync(ctx context.Context) error {
 		}
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controllerhelpers/convert.go
+++ b/pkg/controllerhelpers/convert.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"maps"
 
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	osnaming "github.com/scylladb/scylla-operator/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -49,7 +49,7 @@ func ConvertEndpointSlicesToEndpoints(endpointSlices []*discoveryv1.EndpointSlic
 				}
 			}
 
-			ports := slices.ConvertSlice[corev1.EndpointPort, discoveryv1.EndpointPort](es.Ports, func(port discoveryv1.EndpointPort) corev1.EndpointPort {
+			ports := oslices.ConvertSlice[corev1.EndpointPort, discoveryv1.EndpointPort](es.Ports, func(port discoveryv1.EndpointPort) corev1.EndpointPort {
 				ep := corev1.EndpointPort{
 					AppProtocol: port.AppProtocol,
 				}

--- a/pkg/controllerhelpers/handlers.go
+++ b/pkg/controllerhelpers/handlers.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -79,7 +79,7 @@ func (h *Handlers[T]) Enqueue(depth int, untypedObj kubeinterfaces.ObjectInterfa
 
 	key, err := h.keyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
 		return
 	}
 
@@ -107,7 +107,7 @@ func (h *Handlers[T]) EnqueueAllFunc(enqueueFunc EnqueueFuncType) EnqueueFuncTyp
 	return func(depth int, untypedObj kubeinterfaces.ObjectInterface, op HandlerOperationType) {
 		controllerObjs, err := h.getterLister.List(untypedObj.GetNamespace(), labels.Everything())
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("couldn't list all controller objects for %T: %w", untypedObj, err))
+			apimachineryutilruntime.HandleError(fmt.Errorf("couldn't list all controller objects for %T: %w", untypedObj, err))
 			return
 		}
 
@@ -130,12 +130,12 @@ func (h *Handlers[QT]) EnqueueOwnerFunc(enqueueFunc EnqueueFuncType) EnqueueFunc
 
 		owner, err := h.getterLister.Get(obj.GetNamespace(), controllerRef.Name)
 		if err != nil {
-			utilruntime.HandleError(err)
+			apimachineryutilruntime.HandleError(err)
 			return
 		}
 
 		if owner.GetUID() != controllerRef.UID {
-			utilruntime.HandleError(err)
+			apimachineryutilruntime.HandleError(err)
 			return
 		}
 
@@ -167,7 +167,7 @@ func (h *Handlers[QT]) HandleUpdateWithDepth(depth int, oldUntyped, curUntyped a
 	if cur.GetUID() != old.GetUID() {
 		key, err := h.keyFunc(old)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", old, err))
+			apimachineryutilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", old, err))
 			return
 		}
 

--- a/pkg/controllerhelpers/prune.go
+++ b/pkg/controllerhelpers/prune.go
@@ -7,7 +7,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resource"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 )
@@ -61,5 +61,5 @@ func Prune[T kubeinterfaces.ObjectInterface](ctx context.Context, requiredObject
 		}
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/controllerhelpers/release.go
+++ b/pkg/controllerhelpers/release.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/kubeinterfaces"
 	"github.com/scylladb/scylla-operator/pkg/resource"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -62,7 +62,7 @@ func ReleaseObjects[CT, T kubeinterfaces.ObjectInterface](ctx context.Context, c
 }
 
 func GetDeleteOwnerReferenceMergePatchBytes(obj metav1.Object, controllerUID types.UID) ([]byte, error) {
-	newOwnerRefs := slices.FilterOut(obj.GetOwnerReferences(), func(ownerRef metav1.OwnerReference) bool {
+	newOwnerRefs := oslices.FilterOut(obj.GetOwnerReferences(), func(ownerRef metav1.OwnerReference) bool {
 		return ownerRef.UID == controllerUID
 	})
 

--- a/pkg/controllerhelpers/scylla.go
+++ b/pkg/controllerhelpers/scylla.go
@@ -7,13 +7,13 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	corev1schedulinghelpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
@@ -108,7 +108,7 @@ func GetRequiredScyllaHosts(sdc *scyllav1alpha1.ScyllaDBDatacenter, services map
 			hosts = append(hosts, host)
 		}
 	}
-	var err error = errors.NewAggregate(errs)
+	var err error = apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func IsScyllaPod(pod *corev1.Pod) bool {
 }
 
 func GetRackNodeCount(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string) (*int32, error) {
-	rackSpec, _, ok := slices.Find(sdc.Spec.Racks, func(spec scyllav1alpha1.RackSpec) bool {
+	rackSpec, _, ok := oslices.Find(sdc.Spec.Racks, func(spec scyllav1alpha1.RackSpec) bool {
 		return spec.Name == rackName
 	})
 	if !ok {

--- a/pkg/controllerhelpers/scylla_test.go
+++ b/pkg/controllerhelpers/scylla_test.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -511,7 +511,7 @@ func TestGetRequiredScyllaHosts(t *testing.T) {
 				secondPod,
 			},
 			expected: nil,
-			expectedError: utilerrors.NewAggregate([]error{
+			expectedError: apimachineryutilerrors.NewAggregate([]error{
 				fmt.Errorf(`service "test/simple-cluster-us-east1-us-east1-b-1" does not exist`),
 			}),
 		},
@@ -526,7 +526,7 @@ func TestGetRequiredScyllaHosts(t *testing.T) {
 				firstPod,
 			},
 			expected: nil,
-			expectedError: utilerrors.NewAggregate([]error{
+			expectedError: apimachineryutilerrors.NewAggregate([]error{
 				fmt.Errorf(`can't get pod "test/simple-cluster-us-east1-us-east1-b-1": %w`, apierrors.NewNotFound(corev1.Resource("pod"), "simple-cluster-us-east1-us-east1-b-1")),
 			}),
 		},
@@ -594,7 +594,7 @@ func TestGetRequiredScyllaHosts(t *testing.T) {
 				secondPod,
 			},
 			expected: nil,
-			expectedError: utilerrors.NewAggregate([]error{
+			expectedError: apimachineryutilerrors.NewAggregate([]error{
 				fmt.Errorf(`can't get scylla host for service "test/simple-cluster-us-east1-us-east1-b-1": %w`, fmt.Errorf(`service "test/simple-cluster-us-east1-us-east1-b-1" does not have a ClusterIP address`)),
 			}),
 		},

--- a/pkg/controllerhelpers/wait.go
+++ b/pkg/controllerhelpers/wait.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -136,7 +136,7 @@ func WaitForObjectState[Object, ListObject runtime.Object](ctx context.Context, 
 		}
 	})
 	if err != nil {
-		if wait.Interrupted(err) {
+		if apimachineryutilwait.Interrupted(err) {
 			err = fmt.Errorf("waiting has been interupted (%s): %w", acs.GetStateString(), err)
 		}
 		return *new(Object), err

--- a/pkg/controllertools/observer.go
+++ b/pkg/controllertools/observer.go
@@ -9,9 +9,9 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/scheme"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -99,7 +99,7 @@ func (o *Observer) processNextItem(ctx context.Context) bool {
 
 	err := o.syncFunc(ctx)
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
-	err = utilerrors.Reduce(err)
+	err = apimachineryutilerrors.Reduce(err)
 	switch {
 	case err == nil:
 		o.queue.Forget(key)
@@ -117,7 +117,7 @@ func (o *Observer) processNextItem(ctx context.Context) bool {
 		return true
 
 	default:
-		utilruntime.HandleError(fmt.Errorf("sync loop has failed: %w", err))
+		apimachineryutilruntime.HandleError(fmt.Errorf("sync loop has failed: %w", err))
 
 	}
 
@@ -132,7 +132,7 @@ func (o *Observer) runWorker(ctx context.Context) {
 }
 
 func (o *Observer) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer apimachineryutilruntime.HandleCrash()
 
 	klog.InfoS("Starting observer", "Name", o.name)
 
@@ -152,7 +152,7 @@ func (o *Observer) Run(ctx context.Context) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		wait.UntilWithContext(ctx, o.runWorker, time.Second)
+		apimachineryutilwait.UntilWithContext(ctx, o.runWorker, time.Second)
 	}()
 
 	<-ctx.Done()

--- a/pkg/controllertools/refmanager.go
+++ b/pkg/controllertools/refmanager.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -137,7 +137,7 @@ func (m *ControllerRefManager[T]) ClaimObjects(objects []T) (map[string]T, error
 			claimedMap[obj.GetName()] = obj
 		}
 	}
-	return claimedMap, utilerrors.NewAggregate(errors)
+	return claimedMap, apimachineryutilerrors.NewAggregate(errors)
 }
 
 func (m *ControllerRefManager[T]) AdoptObject(obj T) error {

--- a/pkg/cri/client.go
+++ b/pkg/cri/client.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 )
@@ -135,10 +135,10 @@ func getConnection(ctx context.Context, endpoints []string) (conn *grpc.ClientCo
 	}
 
 	if len(successfulConns) == 0 {
-		return nil, apierrors.NewAggregate(errs)
+		return nil, apimachineryutilerrors.NewAggregate(errs)
 	}
 
-	klog.V(2).InfoS("Connected to CRI endpoint", "Successful", successfulEndpoints, "Other attempts", apierrors.NewAggregate(errs))
+	klog.V(2).InfoS("Connected to CRI endpoint", "Successful", successfulEndpoints, "Other attempts", apimachineryutilerrors.NewAggregate(errs))
 
 	return successfulConns[0], nil
 }

--- a/pkg/disks/loop.go
+++ b/pkg/disks/loop.go
@@ -13,7 +13,7 @@ import (
 	"slices"
 
 	"github.com/scylladb/scylla-operator/pkg/util/losetup"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
 )
@@ -203,7 +203,7 @@ func deleteEmptyDeviceSymlinkDir(symlinksDir string) (err error) {
 	defer func() {
 		dirCloseErr := d.Close()
 		if dirCloseErr != nil {
-			err = utilerrors.NewAggregate([]error{err, dirCloseErr})
+			err = apimachineryutilerrors.NewAggregate([]error{err, dirCloseErr})
 		}
 	}()
 

--- a/pkg/disks/raid.go
+++ b/pkg/disks/raid.go
@@ -17,7 +17,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	oexec "github.com/scylladb/scylla-operator/pkg/util/exec"
 	"k8s.io/apimachinery/pkg/api/equality"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
 )
@@ -106,7 +106,7 @@ func MakeRAID0(ctx context.Context, executor exec.Interface, sysfsPath, devtmpfs
 			// It's idempotent.
 			stdout, stderr, startErr := oexec.RunCommand(ctx, executor, "udevadm", "control", "--start-exec-queue")
 			if startErr != nil {
-				err = utilerrors.NewAggregate([]error{err, fmt.Errorf("can't start udevadm exec queue: %w, stdout: %q, stderr: %q", startErr, stdout.String(), stderr.String())})
+				err = apimachineryutilerrors.NewAggregate([]error{err, fmt.Errorf("can't start udevadm exec queue: %w, stdout: %q, stderr: %q", startErr, stdout.String(), stderr.String())})
 			}
 		}()
 	}

--- a/pkg/externalapi/monitoring/v1/types.go
+++ b/pkg/externalapi/monitoring/v1/types.go
@@ -17,10 +17,10 @@
 package v1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	apimachineryutilintstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -97,7 +97,7 @@ type ProxyConfig struct {
 	// It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
 	// +optional
 	// +mapType:=atomic
-	ProxyConnectHeader map[string][]v1.SecretKeySelector `json:"proxyConnectHeader,omitempty"`
+	ProxyConnectHeader map[string][]corev1.SecretKeySelector `json:"proxyConnectHeader,omitempty"`
 }
 
 // ObjectReference references a PodMonitor, ServiceMonitor, Probe or PrometheusRule object.
@@ -202,11 +202,11 @@ type EmbeddedPersistentVolumeClaim struct {
 	// Defines the desired characteristics of a volume requested by a pod author.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
 	// +optional
-	Spec v1.PersistentVolumeClaimSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
+	Spec corev1.PersistentVolumeClaimSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// +optional
 	// Deprecated: this field is never set.
-	Status v1.PersistentVolumeClaimStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+	Status corev1.PersistentVolumeClaimStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // EmbeddedObjectMetadata contains a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta
@@ -309,7 +309,7 @@ type WebTLSConfig struct {
 	// It is mutually exclusive with `keyFile`.
 	//
 	// +optional
-	KeySecret v1.SecretKeySelector `json:"keySecret,omitempty"`
+	KeySecret corev1.SecretKeySelector `json:"keySecret,omitempty"`
 	// Path to the TLS private key file in the container for the web server.
 	//
 	// If defined, either `cert` or `certFile` must be defined.
@@ -396,7 +396,7 @@ type Endpoint struct {
 	// Service. The port must be specified with the container's port property.
 	//
 	// +optional
-	TargetPort *intstr.IntOrString `json:"targetPort,omitempty"`
+	TargetPort *apimachineryutilintstr.IntOrString `json:"targetPort,omitempty"`
 
 	// HTTP path from which to scrape for metrics.
 	//
@@ -445,7 +445,7 @@ type Endpoint struct {
 	// +optional
 	//
 	// Deprecated: use `authorization` instead.
-	BearerTokenSecret *v1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
+	BearerTokenSecret *corev1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
 
 	// `authorization` configures the Authorization header credentials to use when
 	// scraping the target.
@@ -556,7 +556,7 @@ type OAuth2 struct {
 
 	// `clientSecret` specifies a key of a Secret containing the OAuth2
 	// client's secret.
-	ClientSecret v1.SecretKeySelector `json:"clientSecret"`
+	ClientSecret corev1.SecretKeySelector `json:"clientSecret"`
 
 	// `tokenURL` configures the URL to fetch the token from.
 	//
@@ -591,19 +591,19 @@ type OAuth2 struct {
 type BasicAuth struct {
 	// `username` specifies a key of a Secret containing the username for
 	// authentication.
-	Username v1.SecretKeySelector `json:"username,omitempty"`
+	Username corev1.SecretKeySelector `json:"username,omitempty"`
 
 	// `password` specifies a key of a Secret containing the password for
 	// authentication.
-	Password v1.SecretKeySelector `json:"password,omitempty"`
+	Password corev1.SecretKeySelector `json:"password,omitempty"`
 }
 
 // SecretOrConfigMap allows to specify data as a Secret or ConfigMap. Fields are mutually exclusive.
 type SecretOrConfigMap struct {
 	// Secret containing data to use for the targets.
-	Secret *v1.SecretKeySelector `json:"secret,omitempty"`
+	Secret *corev1.SecretKeySelector `json:"secret,omitempty"`
 	// ConfigMap containing data to use for the targets.
-	ConfigMap *v1.ConfigMapKeySelector `json:"configMap,omitempty"`
+	ConfigMap *corev1.ConfigMapKeySelector `json:"configMap,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=TLS10;TLS11;TLS12;TLS13
@@ -625,7 +625,7 @@ type SafeTLSConfig struct {
 	Cert SecretOrConfigMap `json:"cert,omitempty"`
 
 	// Secret containing the client key file for the targets.
-	KeySecret *v1.SecretKeySelector `json:"keySecret,omitempty"`
+	KeySecret *corev1.SecretKeySelector `json:"keySecret,omitempty"`
 
 	// Used to verify the hostname for the targets.
 	// +optional

--- a/pkg/externalapi/monitoring/v1/types_alertmanager.go
+++ b/pkg/externalapi/monitoring/v1/types_alertmanager.go
@@ -18,7 +18,7 @@ package v1
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -82,7 +82,7 @@ type AlertmanagerSpec struct {
 	// Image pull policy for the 'alertmanager', 'init-config-reloader' and 'config-reloader' containers.
 	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
 	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
-	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// Version the cluster should be on.
 	Version string `json:"version,omitempty"`
 	// Tag of Alertmanager container image to be deployed. Defaults to the value of `version`.
@@ -100,7 +100,7 @@ type AlertmanagerSpec struct {
 	// An optional list of references to secrets in the same namespace
 	// to use for pulling prometheus and alertmanager images from registries
 	// see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
-	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// Secrets is a list of Secrets in the same namespace as the Alertmanager
 	// object, which shall be mounted into the Alertmanager Pods.
 	// Each Secret is added to the StatefulSet definition as a volume named `secret-<secret-name>`.
@@ -144,11 +144,11 @@ type AlertmanagerSpec struct {
 	// Volumes allows configuration of additional volumes on the output StatefulSet definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of
 	// StorageSpec objects.
-	Volumes []v1.Volume `json:"volumes,omitempty"`
+	Volumes []corev1.Volume `json:"volumes,omitempty"`
 	// VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition.
 	// VolumeMounts specified will be appended to other VolumeMounts in the alertmanager container,
 	// that are generated as a result of StorageSpec objects.
-	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 	// The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
 	// The default behavior is all PVCs are retained.
 	// This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
@@ -171,16 +171,16 @@ type AlertmanagerSpec struct {
 	// Define which Nodes the Pods are scheduled on.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Define resources requests and limits for single Pods.
-	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// If specified, the pod's scheduling constraints.
-	Affinity *v1.Affinity `json:"affinity,omitempty"`
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 	// If specified, the pod's tolerations.
-	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// If specified, the pod's topology spread constraints.
-	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// SecurityContext holds pod-level security attributes and common container settings.
 	// This defaults to the default PodSecurityContext.
-	SecurityContext *v1.PodSecurityContext `json:"securityContext,omitempty"`
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 	// Defines the DNS policy for the pods.
 	//
 	// +optional
@@ -204,7 +204,7 @@ type AlertmanagerSpec struct {
 	// `config-reloader`. Overriding containers is entirely outside the scope
 	// of what the maintainers will support and by doing so, you accept that
 	// this behaviour may break at any time without notice.
-	Containers []v1.Container `json:"containers,omitempty"`
+	Containers []corev1.Container `json:"containers,omitempty"`
 	// InitContainers allows adding initContainers to the pod definition. Those can be used to e.g.
 	// fetch secrets for injection into the Alertmanager configuration from external sources. Any
 	// errors during the execution of an initContainer will lead to a restart of the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
@@ -214,7 +214,7 @@ type AlertmanagerSpec struct {
 	// `init-config-reloader`. Overriding init containers is entirely outside the
 	// scope of what the maintainers will support and by doing so, you accept that
 	// this behaviour may break at any time without notice.
-	InitContainers []v1.Container `json:"initContainers,omitempty"`
+	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 	// Priority class assigned to the Pods
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
@@ -340,13 +340,13 @@ type AlertmanagerGlobalConfig struct {
 	HTTPConfig *HTTPConfig `json:"httpConfig,omitempty"`
 
 	// The default Slack API URL.
-	SlackAPIURL *v1.SecretKeySelector `json:"slackApiUrl,omitempty"`
+	SlackAPIURL *corev1.SecretKeySelector `json:"slackApiUrl,omitempty"`
 
 	// The default OpsGenie API URL.
-	OpsGenieAPIURL *v1.SecretKeySelector `json:"opsGenieApiUrl,omitempty"`
+	OpsGenieAPIURL *corev1.SecretKeySelector `json:"opsGenieApiUrl,omitempty"`
 
 	// The default OpsGenie API Key.
-	OpsGenieAPIKey *v1.SecretKeySelector `json:"opsGenieApiKey,omitempty"`
+	OpsGenieAPIKey *corev1.SecretKeySelector `json:"opsGenieApiKey,omitempty"`
 
 	// The default Pagerduty URL.
 	PagerdutyURL *string `json:"pagerdutyUrl,omitempty"`
@@ -413,7 +413,7 @@ type GlobalSMTPConfig struct {
 
 	// SMTP Auth using LOGIN and PLAIN.
 	// +optional
-	AuthPassword *v1.SecretKeySelector `json:"authPassword,omitempty"`
+	AuthPassword *corev1.SecretKeySelector `json:"authPassword,omitempty"`
 
 	// SMTP Auth using PLAIN
 	// +optional
@@ -421,7 +421,7 @@ type GlobalSMTPConfig struct {
 
 	// SMTP Auth using CRAM-MD5.
 	// +optional
-	AuthSecret *v1.SecretKeySelector `json:"authSecret,omitempty"`
+	AuthSecret *corev1.SecretKeySelector `json:"authSecret,omitempty"`
 
 	// The default SMTP TLS requirement.
 	// Note that Go does not support unencrypted connections to remote SMTP endpoints.
@@ -458,7 +458,7 @@ type HTTPConfig struct {
 	// The secret needs to be in the same namespace as the Alertmanager
 	// object and accessible by the Prometheus Operator.
 	// +optional
-	BearerTokenSecret *v1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
+	BearerTokenSecret *corev1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
 	// TLS configuration for the client.
 	// +optional
 	TLSConfig *SafeTLSConfig `json:"tlsConfig,omitempty"`

--- a/pkg/externalapi/monitoring/v1/types_podmonitor.go
+++ b/pkg/externalapi/monitoring/v1/types_podmonitor.go
@@ -17,9 +17,9 @@
 package v1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	apimachineryutilintstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -201,7 +201,7 @@ type PodMetricsEndpoint struct {
 	// port must be specified with container port property.
 	//
 	// Deprecated: use 'port' or 'portNumber' instead.
-	TargetPort *intstr.IntOrString `json:"targetPort,omitempty"`
+	TargetPort *apimachineryutilintstr.IntOrString `json:"targetPort,omitempty"`
 
 	// HTTP path from which to scrape for metrics.
 	//
@@ -245,7 +245,7 @@ type PodMetricsEndpoint struct {
 	// +optional
 	//
 	// Deprecated: use `authorization` instead.
-	BearerTokenSecret v1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
+	BearerTokenSecret corev1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
 
 	// When true, `honorLabels` preserves the metric's labels when they collide
 	// with the target's labels.

--- a/pkg/externalapi/monitoring/v1/types_probe.go
+++ b/pkg/externalapi/monitoring/v1/types_probe.go
@@ -17,7 +17,7 @@
 package v1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -71,7 +71,7 @@ type ProbeSpec struct {
 	// Secret to mount to read bearer token for scraping targets. The secret
 	// needs to be in the same namespace as the probe and accessible by
 	// the Prometheus Operator.
-	BearerTokenSecret v1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
+	BearerTokenSecret corev1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
 	// BasicAuth allow an endpoint to authenticate over basic authentication.
 	// More info: https://prometheus.io/docs/operating/configuration/#endpoint
 	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`

--- a/pkg/externalapi/monitoring/v1/types_prometheus.go
+++ b/pkg/externalapi/monitoring/v1/types_prometheus.go
@@ -18,10 +18,10 @@ package v1
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	apimachineryutilintstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -68,7 +68,7 @@ const (
 	ShardAndResourceNameLabelSelector AdditionalLabelSelectors = "OnShard"
 )
 
-type CoreV1TopologySpreadConstraint v1.TopologySpreadConstraint
+type CoreV1TopologySpreadConstraint corev1.TopologySpreadConstraint
 
 type TopologySpreadConstraint struct {
 	CoreV1TopologySpreadConstraint `json:",inline"`
@@ -200,11 +200,11 @@ type CommonPrometheusFields struct {
 	// Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers.
 	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
 	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
-	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// An optional list of references to Secrets in the same namespace
 	// to use for pulling images from registries.
 	// See http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
-	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// Number of replicas of each shard to deploy for a Prometheus deployment.
 	// `spec.replicas` multiplied by `spec.shards` is the total number of Pods
@@ -350,12 +350,12 @@ type CommonPrometheusFields struct {
 	// Volumes allows the configuration of additional volumes on the output
 	// StatefulSet definition. Volumes specified will be appended to other
 	// volumes that are generated as a result of StorageSpec objects.
-	Volumes []v1.Volume `json:"volumes,omitempty"`
+	Volumes []corev1.Volume `json:"volumes,omitempty"`
 	// VolumeMounts allows the configuration of additional VolumeMounts.
 	//
 	// VolumeMounts will be appended to other VolumeMounts in the 'prometheus'
 	// container, that are generated as a result of StorageSpec objects.
-	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
 	// The default behavior is all PVCs are retained.
@@ -369,7 +369,7 @@ type CommonPrometheusFields struct {
 	Web *PrometheusWebSpec `json:"web,omitempty"`
 
 	// Defines the resources requests and limits of the 'prometheus' container.
-	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Defines on which Nodes the Pods are scheduled.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
@@ -400,10 +400,10 @@ type CommonPrometheusFields struct {
 
 	// Defines the Pods' affinity scheduling rules if specified.
 	// +optional
-	Affinity *v1.Affinity `json:"affinity,omitempty"`
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 	// Defines the Pods' tolerations if specified.
 	// +optional
-	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// Defines the pod's topology spread constraints if specified.
 	//+optional
@@ -422,7 +422,7 @@ type CommonPrometheusFields struct {
 	// SecurityContext holds pod-level security attributes and common container settings.
 	// This defaults to the default PodSecurityContext.
 	// +optional
-	SecurityContext *v1.PodSecurityContext `json:"securityContext,omitempty"`
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 
 	// Defines the DNS policy for the pods.
 	//
@@ -452,7 +452,7 @@ type CommonPrometheusFields struct {
 	// maintainers will support and by doing so, you accept that this behaviour
 	// may break at any time without notice.
 	// +optional
-	Containers []v1.Container `json:"containers,omitempty"`
+	Containers []corev1.Container `json:"containers,omitempty"`
 	// InitContainers allows injecting initContainers to the Pod definition. Those
 	// can be used to e.g.  fetch secrets for injection into the Prometheus
 	// configuration from external sources. Any errors during the execution of
@@ -469,7 +469,7 @@ type CommonPrometheusFields struct {
 	// maintainers will support and by doing so, you accept that this behaviour
 	// may break at any time without notice.
 	// +optional
-	InitContainers []v1.Container `json:"initContainers,omitempty"`
+	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
 	// AdditionalScrapeConfigs allows specifying a key of a Secret containing
 	// additional Prometheus scrape configurations. Scrape configurations
@@ -483,7 +483,7 @@ type CommonPrometheusFields struct {
 	// notes to ensure that no incompatible scrape configs are going to break
 	// Prometheus after the upgrade.
 	// +optional
-	AdditionalScrapeConfigs *v1.SecretKeySelector `json:"additionalScrapeConfigs,omitempty"`
+	AdditionalScrapeConfigs *corev1.SecretKeySelector `json:"additionalScrapeConfigs,omitempty"`
 
 	// APIServerConfig allows specifying a host and auth methods to access the
 	// Kuberntees API server.
@@ -1004,7 +1004,7 @@ type PrometheusSpec struct {
 	// to ensure that no incompatible alert relabel configs are going to break
 	// Prometheus after the upgrade.
 	// +optional
-	AdditionalAlertRelabelConfigs *v1.SecretKeySelector `json:"additionalAlertRelabelConfigs,omitempty"`
+	AdditionalAlertRelabelConfigs *corev1.SecretKeySelector `json:"additionalAlertRelabelConfigs,omitempty"`
 	// AdditionalAlertManagerConfigs specifies a key of a Secret containing
 	// additional Prometheus Alertmanager configurations. The Alertmanager
 	// configurations are appended to the configuration generated by the
@@ -1020,7 +1020,7 @@ type PrometheusSpec struct {
 	// to ensure that no incompatible AlertManager configs are going to break
 	// Prometheus after the upgrade.
 	// +optional
-	AdditionalAlertManagerConfigs *v1.SecretKeySelector `json:"additionalAlertManagerConfigs,omitempty"`
+	AdditionalAlertManagerConfigs *corev1.SecretKeySelector `json:"additionalAlertManagerConfigs,omitempty"`
 
 	// Defines the list of remote read configurations.
 	// +optional
@@ -1167,12 +1167,12 @@ type StorageSpec struct {
 	// EmptyDirVolumeSource to be used by the StatefulSet.
 	// If specified, it takes precedence over `ephemeral` and `volumeClaimTemplate`.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
-	EmptyDir *v1.EmptyDirVolumeSource `json:"emptyDir,omitempty"`
+	EmptyDir *corev1.EmptyDirVolumeSource `json:"emptyDir,omitempty"`
 	// EphemeralVolumeSource to be used by the StatefulSet.
 	// This is a beta field in k8s 1.21 and GA in 1.15.
 	// For lower versions, starting with k8s 1.19, it requires enabling the GenericEphemeralVolume feature gate.
 	// More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
-	Ephemeral *v1.EphemeralVolumeSource `json:"ephemeral,omitempty"`
+	Ephemeral *corev1.EphemeralVolumeSource `json:"ephemeral,omitempty"`
 	// Defines the PVC spec to be used by the Prometheus StatefulSets.
 	// The easiest way to use a volume that cannot be automatically provisioned
 	// is to use a label selector alongside manually created PersistentVolumes.
@@ -1250,7 +1250,7 @@ type ThanosSpec struct {
 	BaseImage *string `json:"baseImage,omitempty"`
 
 	// Defines the resources requests and limits of the Thanos sidecar.
-	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Defines the Thanos sidecar's configuration to upload TSDB blocks to object storage.
 	//
@@ -1258,7 +1258,7 @@ type ThanosSpec struct {
 	//
 	// objectStorageConfigFile takes precedence over this field.
 	// +optional
-	ObjectStorageConfig *v1.SecretKeySelector `json:"objectStorageConfig,omitempty"`
+	ObjectStorageConfig *corev1.SecretKeySelector `json:"objectStorageConfig,omitempty"`
 	// Defines the Thanos sidecar's configuration file to upload TSDB blocks to object storage.
 	//
 	// More info: https://thanos.io/tip/thanos/storage.md/
@@ -1292,7 +1292,7 @@ type ThanosSpec struct {
 	// in a breaking way.
 	//
 	// +optional
-	TracingConfig *v1.SecretKeySelector `json:"tracingConfig,omitempty"`
+	TracingConfig *corev1.SecretKeySelector `json:"tracingConfig,omitempty"`
 	// Defines the tracing configuration file for the Thanos sidecar.
 	//
 	// This field takes precedence over `tracingConfig`.
@@ -1347,7 +1347,7 @@ type ThanosSpec struct {
 	// VolumeMounts specified will be appended to other VolumeMounts in the
 	// 'thanos-sidecar' container.
 	// +optional
-	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// AdditionalArgs allows setting additional arguments for the Thanos container.
 	// The arguments are passed as-is to the Thanos container which may cause issues
@@ -1558,11 +1558,11 @@ type Sigv4 struct {
 	// AccessKey is the AWS API key. If not specified, the environment variable
 	// `AWS_ACCESS_KEY_ID` is used.
 	// +optional
-	AccessKey *v1.SecretKeySelector `json:"accessKey,omitempty"`
+	AccessKey *corev1.SecretKeySelector `json:"accessKey,omitempty"`
 	// SecretKey is the AWS API secret. If not specified, the environment
 	// variable `AWS_SECRET_ACCESS_KEY` is used.
 	// +optional
-	SecretKey *v1.SecretKeySelector `json:"secretKey,omitempty"`
+	SecretKey *corev1.SecretKeySelector `json:"secretKey,omitempty"`
 	// Profile is the named AWS profile used to authenticate.
 	Profile string `json:"profile,omitempty"`
 	// RoleArn is the named AWS profile used to authenticate.
@@ -1603,7 +1603,7 @@ type AzureOAuth struct {
 	ClientID string `json:"clientId"`
 	// `clientSecret` specifies a key of a Secret containing the client secret of the Azure Active Directory application that is being used to authenticate.
 	// +required
-	ClientSecret v1.SecretKeySelector `json:"clientSecret"`
+	ClientSecret corev1.SecretKeySelector `json:"clientSecret"`
 	// `tenantId` is the tenant ID of the Azure Active Directory application that is being used to authenticate.
 	// +required
 	// +kubebuilder:validation:MinLength=1
@@ -1836,7 +1836,7 @@ type AlertmanagerEndpoints struct {
 	Name string `json:"name"`
 
 	// Port on which the Alertmanager API is exposed.
-	Port intstr.IntOrString `json:"port"`
+	Port apimachineryutilintstr.IntOrString `json:"port"`
 
 	// Scheme to use when firing alerts.
 	Scheme string `json:"scheme,omitempty"`
@@ -1999,7 +1999,7 @@ type SafeAuthorization struct {
 	Type string `json:"type,omitempty"`
 
 	// Selects a key of a Secret in the namespace that contains the credentials for authentication.
-	Credentials *v1.SecretKeySelector `json:"credentials,omitempty"`
+	Credentials *corev1.SecretKeySelector `json:"credentials,omitempty"`
 }
 
 type Authorization struct {

--- a/pkg/externalapi/monitoring/v1/types_prometheusrule.go
+++ b/pkg/externalapi/monitoring/v1/types_prometheusrule.go
@@ -18,7 +18,7 @@ package v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	apimachineryutilintstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -99,7 +99,7 @@ type Rule struct {
 	// Only one of `record` and `alert` must be set.
 	Alert string `json:"alert,omitempty"`
 	// PromQL expression to evaluate.
-	Expr intstr.IntOrString `json:"expr"`
+	Expr apimachineryutilintstr.IntOrString `json:"expr"`
 	// Alerts are considered firing once they have been returned for this long.
 	// +optional
 	For *Duration `json:"for,omitempty"`

--- a/pkg/externalapi/monitoring/v1/types_thanos.go
+++ b/pkg/externalapi/monitoring/v1/types_thanos.go
@@ -17,7 +17,7 @@
 package v1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -93,12 +93,12 @@ type ThanosRulerSpec struct {
 	// Image pull policy for the 'thanos', 'init-config-reloader' and 'config-reloader' containers.
 	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
 	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
-	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// An optional list of references to secrets in the same namespace
 	// to use for pulling thanos images from registries
 	// see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
 	// +optional
-	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// When a ThanosRuler deployment is paused, no actions except for deletion
 	// will be performed on the underlying objects.
@@ -114,22 +114,22 @@ type ThanosRulerSpec struct {
 
 	// Resources defines the resource requirements for single Pods.
 	// If not provided, no requests/limits will be set
-	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// If specified, the pod's scheduling constraints.
 	// +optional
-	Affinity *v1.Affinity `json:"affinity,omitempty"`
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 	// If specified, the pod's tolerations.
 	// +optional
-	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// If specified, the pod's topology spread constraints.
 	// +optional
-	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
 	// SecurityContext holds pod-level security attributes and common container settings.
 	// This defaults to the default PodSecurityContext.
 	// +optional
-	SecurityContext *v1.PodSecurityContext `json:"securityContext,omitempty"`
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 
 	// Defines the DNS policy for the pods.
 	//
@@ -153,12 +153,12 @@ type ThanosRulerSpec struct {
 	// Volumes allows configuration of additional volumes on the output StatefulSet definition. Volumes specified will
 	// be appended to other volumes that are generated as a result of StorageSpec objects.
 	// +optional
-	Volumes []v1.Volume `json:"volumes,omitempty"`
+	Volumes []corev1.Volume `json:"volumes,omitempty"`
 	// VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition.
 	// VolumeMounts specified will be appended to other VolumeMounts in the ruler container,
 	// that are generated as a result of StorageSpec objects.
 	// +optional
-	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// Configures object storage.
 	//
@@ -169,7 +169,7 @@ type ThanosRulerSpec struct {
 	// `objectStorageConfigFile` takes precedence over this field.
 	//
 	// +optional
-	ObjectStorageConfig *v1.SecretKeySelector `json:"objectStorageConfig,omitempty"`
+	ObjectStorageConfig *corev1.SecretKeySelector `json:"objectStorageConfig,omitempty"`
 	// Configures the path of the object storage configuration file.
 	//
 	// The configuration format is defined at https://thanos.io/tip/thanos/storage.md/#configuring-access-to-object-storage
@@ -205,7 +205,7 @@ type ThanosRulerSpec struct {
 	// This field takes precedence over `queryEndpoints`.
 	//
 	// +optional
-	QueryConfig *v1.SecretKeySelector `json:"queryConfig,omitempty"`
+	QueryConfig *corev1.SecretKeySelector `json:"queryConfig,omitempty"`
 
 	// Configures the list of Alertmanager endpoints to send alerts to.
 	//
@@ -226,7 +226,7 @@ type ThanosRulerSpec struct {
 	// This field takes precedence over `alertmanagersUrl`.
 	//
 	// +optional
-	AlertManagersConfig *v1.SecretKeySelector `json:"alertmanagersConfig,omitempty"`
+	AlertManagersConfig *corev1.SecretKeySelector `json:"alertmanagersConfig,omitempty"`
 
 	// PrometheusRule objects to be selected for rule evaluation. An empty
 	// label selector matches all objects. A null label selector matches no
@@ -285,7 +285,7 @@ type ThanosRulerSpec struct {
 	// Overriding containers is entirely outside the scope of what the maintainers will support and by doing
 	// so, you accept that this behaviour may break at any time without notice.
 	// +optional
-	Containers []v1.Container `json:"containers,omitempty"`
+	Containers []corev1.Container `json:"containers,omitempty"`
 	// InitContainers allows adding initContainers to the pod definition. Those can be used to e.g.
 	// fetch secrets for injection into the ThanosRuler configuration from external sources. Any
 	// errors during the execution of an initContainer will lead to a restart of the Pod.
@@ -294,7 +294,7 @@ type ThanosRulerSpec struct {
 	// of what the maintainers will support and by doing so, you accept that this behaviour may break
 	// at any time without notice.
 	// +optional
-	InitContainers []v1.Container `json:"initContainers,omitempty"`
+	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
 	// Configures tracing.
 	//
@@ -308,7 +308,7 @@ type ThanosRulerSpec struct {
 	// `tracingConfigFile` takes precedence over this field.
 	//
 	//+optional
-	TracingConfig *v1.SecretKeySelector `json:"tracingConfig,omitempty"`
+	TracingConfig *corev1.SecretKeySelector `json:"tracingConfig,omitempty"`
 	// Configures the path of the tracing configuration file.
 	//
 	// The configuration format is defined at https://thanos.io/tip/thanos/tracing.md/#configuration
@@ -376,7 +376,7 @@ type ThanosRulerSpec struct {
 	// `alertRelabelConfigFile` takes precedence over this field.
 	//
 	// +optional
-	AlertRelabelConfigs *v1.SecretKeySelector `json:"alertRelabelConfigs,omitempty"`
+	AlertRelabelConfigs *corev1.SecretKeySelector `json:"alertRelabelConfigs,omitempty"`
 	// Configures the path to the alert relabeling configuration file.
 	//
 	// Alert relabel configuration must have the form as specified in the

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,7 +1,7 @@
 package features
 
 import (
-	"k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
 )
@@ -21,7 +21,7 @@ const (
 )
 
 func init() {
-	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+	apimachineryutilruntime.Must(utilfeature.DefaultMutableFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
 		AutomaticTLSCertificates: {
 			Default:    true,
 			PreRelease: featuregate.Beta,

--- a/pkg/gather/collect/collect.go
+++ b/pkg/gather/collect/collect.go
@@ -11,7 +11,7 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/kubeinterfaces"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
@@ -21,8 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -82,7 +82,7 @@ type Collector struct {
 	keepGoing        bool
 	logsLimitBytes   int64
 
-	collectedResources sets.Set[string]
+	collectedResources apimachineryutilsets.Set[string]
 }
 
 func NewCollector(
@@ -104,7 +104,7 @@ func NewCollector(
 		relatedResources:   relatedResources,
 		keepGoing:          keepGoing,
 		logsLimitBytes:     logsLimitBytes,
-		collectedResources: sets.Set[string]{},
+		collectedResources: apimachineryutilsets.Set[string]{},
 	}
 }
 
@@ -241,7 +241,7 @@ func retrieveContainerLogs(ctx context.Context, podClient corev1client.PodInterf
 func (c *Collector) collectContainerLogs(ctx context.Context, logsDir string, podMeta *metav1.ObjectMeta, podCSs []corev1.ContainerStatus, containerName string) error {
 	var err error
 
-	cs, _, found := slices.Find(podCSs, func(s corev1.ContainerStatus) bool {
+	cs, _, found := oslices.Find(podCSs, func(s corev1.ContainerStatus) bool {
 		return s.Name == containerName
 	})
 	if !found {
@@ -558,5 +558,5 @@ func (c *Collector) CollectResources(ctx context.Context, resourceInfo *Resource
 		}
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/genericclioptions/genericclioptions.go
+++ b/pkg/genericclioptions/genericclioptions.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/scylladb/scylla-operator/pkg/version"
 	"github.com/spf13/cobra"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -99,7 +99,7 @@ func (ccs *ClientConfigSet) Validate() error {
 		}
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (ccs *ClientConfigSet) Complete() error {
@@ -172,7 +172,7 @@ func (cc *ClientConfig) Validate() error {
 		errs = append(errs, fmt.Errorf("invalid client config base: %w", err))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (cc *ClientConfig) Complete() error {

--- a/pkg/helpers/mergepatch.go
+++ b/pkg/helpers/mergepatch.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	apimachineryutilstrategicpatch "k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
 func CreateTwoWayMergePatch[T runtime.Object](original, modified T) ([]byte, error) {
@@ -21,5 +21,5 @@ func CreateTwoWayMergePatch[T runtime.Object](original, modified T) ([]byte, err
 		return nil, fmt.Errorf("can't marshal new object: %w", err)
 	}
 
-	return strategicpatch.CreateTwoWayMergePatch(oldJson, newJson, modified)
+	return apimachineryutilstrategicpatch.CreateTwoWayMergePatch(oldJson, newJson, modified)
 }

--- a/pkg/itemgenerator/generator.go
+++ b/pkg/itemgenerator/generator.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
 
@@ -109,7 +109,7 @@ func (g *Generator[T]) runUnlimitedWorker(ctx context.Context) {
 func (g *Generator[T]) runRateLimitedWorker(ctx context.Context) {
 	klog.V(4).InfoS("Generator is starting rate limited worker", "Name", g.name)
 
-	wait.UntilWithContext(ctx, func(ctx context.Context) {
+	apimachineryutilwait.UntilWithContext(ctx, func(ctx context.Context) {
 		err := g.runWorker(ctx, g.rateLimitedBuffer)
 		if err != nil {
 			klog.ErrorS(err, "Generator rate limited worker encountered error", "Name", g.name)

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/uuid"
+	apimachineryutiluuid "k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -34,7 +34,7 @@ func Run(ctx context.Context, programName, lockName, lockNamespace string, clien
 		return err
 	}
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
-	id := hostname + "_" + string(uuid.NewUUID())
+	id := hostname + "_" + string(apimachineryutiluuid.NewUUID())
 	klog.V(4).Infof("Leader election ID is %q", id)
 
 	lock, err := resourcelock.New(

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -12,7 +12,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/util/hash"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimachineryvalidationutils "k8s.io/apimachinery/pkg/util/validation"
+	apimachineryutilvalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -298,6 +298,6 @@ func scyllaDBManagerClusterRegistrationName(kind, name string) (string, error) {
 	}
 
 	fullName := strings.ToLower(fmt.Sprintf("%s-%s", kind, name))
-	fullNameWithSuffix := fmt.Sprintf("%s-%s", fullName[:min(len(fullName), apimachineryvalidationutils.DNS1123SubdomainMaxLength-len(nameSuffix)-1)], nameSuffix)
+	fullNameWithSuffix := fmt.Sprintf("%s-%s", fullName[:min(len(fullName), apimachineryutilvalidation.DNS1123SubdomainMaxLength-len(nameSuffix)-1)], nameSuffix)
 	return fullNameWithSuffix, nil
 }

--- a/pkg/resourceapply/apps_test.go
+++ b/pkg/resourceapply/apps_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/client-go/tools/cache"
@@ -72,7 +72,7 @@ func TestApplyStatefulSet(t *testing.T) {
 
 	newStsWithHash := func() *appsv1.StatefulSet {
 		sts := newSts()
-		utilruntime.Must(SetHashAnnotation(sts))
+		apimachineryutilruntime.Must(SetHashAnnotation(sts))
 		return sts
 	}
 
@@ -155,7 +155,7 @@ func TestApplyStatefulSet(t *testing.T) {
 			expectedSts: func() *appsv1.StatefulSet {
 				sts := newSts()
 				sts.Spec.Replicas = pointer.Ptr(*sts.Spec.Replicas + 1)
-				utilruntime.Must(SetHashAnnotation(sts))
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
 				return sts
 			}(),
 			expectedChanged: true,
@@ -175,7 +175,7 @@ func TestApplyStatefulSet(t *testing.T) {
 			expectedSts: func() *appsv1.StatefulSet {
 				sts := newSts()
 				sts.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(sts))
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
 				return sts
 			}(),
 			expectedChanged: true,
@@ -195,7 +195,7 @@ func TestApplyStatefulSet(t *testing.T) {
 			expectedSts: func() *appsv1.StatefulSet {
 				sts := newSts()
 				sts.Spec.Template.Spec.Containers[0].Image += "-rc.0"
-				utilruntime.Must(SetHashAnnotation(sts))
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
 				return sts
 			}(),
 			expectedChanged: true,
@@ -243,7 +243,7 @@ func TestApplyStatefulSet(t *testing.T) {
 				sts := newSts()
 				sts.ResourceVersion = "21"
 				sts.Spec.Template.Spec.Containers[0].Image += "-rc.0"
-				utilruntime.Must(SetHashAnnotation(sts))
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
 				return sts
 			}(),
 			expectedChanged: true,
@@ -272,7 +272,7 @@ func TestApplyStatefulSet(t *testing.T) {
 				func() *appsv1.StatefulSet {
 					sts := newSts()
 					sts.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(sts))
+					apimachineryutilruntime.Must(SetHashAnnotation(sts))
 					return sts
 				}(),
 			},
@@ -292,7 +292,7 @@ func TestApplyStatefulSet(t *testing.T) {
 				func() *appsv1.StatefulSet {
 					sts := newSts()
 					sts.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(sts))
+					apimachineryutilruntime.Must(SetHashAnnotation(sts))
 					return sts
 				}(),
 			},
@@ -305,7 +305,7 @@ func TestApplyStatefulSet(t *testing.T) {
 			expectedSts: func() *appsv1.StatefulSet {
 				sts := newSts()
 				sts.Spec.Template.Spec.Containers[0].Image += "-rc.0"
-				utilruntime.Must(SetHashAnnotation(sts))
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
 				return sts
 			}(),
 			expectedChanged: true,
@@ -318,7 +318,7 @@ func TestApplyStatefulSet(t *testing.T) {
 				func() *appsv1.StatefulSet {
 					sts := newSts()
 					sts.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(sts))
+					apimachineryutilruntime.Must(SetHashAnnotation(sts))
 					return sts
 				}(),
 			},
@@ -328,7 +328,7 @@ func TestApplyStatefulSet(t *testing.T) {
 			}(),
 			expectedSts: func() *appsv1.StatefulSet {
 				sts := newSts()
-				utilruntime.Must(SetHashAnnotation(sts))
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
 				return sts
 			}(),
 			expectedChanged: true,
@@ -341,7 +341,7 @@ func TestApplyStatefulSet(t *testing.T) {
 				func() *appsv1.StatefulSet {
 					sts := newSts()
 					sts.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(sts))
+					apimachineryutilruntime.Must(SetHashAnnotation(sts))
 					return sts
 				}(),
 			},
@@ -361,7 +361,7 @@ func TestApplyStatefulSet(t *testing.T) {
 				func() *appsv1.StatefulSet {
 					sts := newSts()
 					sts.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(sts))
+					apimachineryutilruntime.Must(SetHashAnnotation(sts))
 					return sts
 				}(),
 			},
@@ -391,7 +391,7 @@ func TestApplyStatefulSet(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(sts))
+					apimachineryutilruntime.Must(SetHashAnnotation(sts))
 					sts.Annotations["a-1"] = "a-alpha-changed"
 					sts.Annotations["a-3"] = "a-resurrected"
 					sts.Annotations["a-custom"] = "custom-value"
@@ -428,7 +428,7 @@ func TestApplyStatefulSet(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(sts))
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
 				sts.Annotations["a-1"] = "a-alpha-changed"
 				sts.Annotations["a-3"] = "a-resurrected"
 				sts.Annotations["a-custom"] = "custom-value"
@@ -456,7 +456,7 @@ func TestApplyStatefulSet(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(sts))
+					apimachineryutilruntime.Must(SetHashAnnotation(sts))
 					sts.Annotations["a-1"] = "a-alpha-changed"
 					sts.Annotations["a-custom"] = "a-custom-value"
 					sts.Labels["l-1"] = "l-alpha-changed"
@@ -491,7 +491,7 @@ func TestApplyStatefulSet(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(sts))
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
 				delete(sts.Annotations, "a-3-")
 				sts.Annotations["a-custom"] = "a-custom-value"
 				delete(sts.Labels, "l-3-")
@@ -544,7 +544,7 @@ func TestApplyStatefulSet(t *testing.T) {
 						"foo": "bar",
 					},
 				}
-				utilruntime.Must(SetHashAnnotation(sts))
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
 				return sts
 			}(),
 			expectedChanged: true,
@@ -729,7 +729,7 @@ func TestApplyDaemonSet(t *testing.T) {
 
 	newDsWithHash := func() *appsv1.DaemonSet {
 		ds := newDS()
-		utilruntime.Must(SetHashAnnotation(ds))
+		apimachineryutilruntime.Must(SetHashAnnotation(ds))
 		return ds
 	}
 
@@ -811,7 +811,7 @@ func TestApplyDaemonSet(t *testing.T) {
 			expectedDaemonSet: func() *appsv1.DaemonSet {
 				ds := newDS()
 				ds.Spec.Template.Spec.Containers[0].Image = "differentimage:latest"
-				utilruntime.Must(SetHashAnnotation(ds))
+				apimachineryutilruntime.Must(SetHashAnnotation(ds))
 				return ds
 			}(),
 			expectedChanged: true,
@@ -831,7 +831,7 @@ func TestApplyDaemonSet(t *testing.T) {
 			expectedDaemonSet: func() *appsv1.DaemonSet {
 				ds := newDS()
 				ds.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(ds))
+				apimachineryutilruntime.Must(SetHashAnnotation(ds))
 				return ds
 			}(),
 			expectedChanged: true,
@@ -879,7 +879,7 @@ func TestApplyDaemonSet(t *testing.T) {
 				ds := newDS()
 				ds.ResourceVersion = "21"
 				ds.Spec.Template.Spec.Containers[0].Image += "-rc.0"
-				utilruntime.Must(SetHashAnnotation(ds))
+				apimachineryutilruntime.Must(SetHashAnnotation(ds))
 				return ds
 			}(),
 			expectedChanged: true,
@@ -908,7 +908,7 @@ func TestApplyDaemonSet(t *testing.T) {
 				func() *appsv1.DaemonSet {
 					sts := newDS()
 					sts.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(sts))
+					apimachineryutilruntime.Must(SetHashAnnotation(sts))
 					return sts
 				}(),
 			},
@@ -928,7 +928,7 @@ func TestApplyDaemonSet(t *testing.T) {
 				func() *appsv1.DaemonSet {
 					ds := newDS()
 					ds.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(ds))
+					apimachineryutilruntime.Must(SetHashAnnotation(ds))
 					return ds
 				}(),
 			},
@@ -938,7 +938,7 @@ func TestApplyDaemonSet(t *testing.T) {
 			}(),
 			expectedDaemonSet: func() *appsv1.DaemonSet {
 				ds := newDS()
-				utilruntime.Must(SetHashAnnotation(ds))
+				apimachineryutilruntime.Must(SetHashAnnotation(ds))
 				return ds
 			}(),
 			expectedChanged: true,
@@ -951,7 +951,7 @@ func TestApplyDaemonSet(t *testing.T) {
 				func() *appsv1.DaemonSet {
 					ds := newDS()
 					ds.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(ds))
+					apimachineryutilruntime.Must(SetHashAnnotation(ds))
 					return ds
 				}(),
 			},
@@ -980,7 +980,7 @@ func TestApplyDaemonSet(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(ds))
+					apimachineryutilruntime.Must(SetHashAnnotation(ds))
 					ds.Annotations["a-1"] = "a-alpha-changed"
 					ds.Annotations["a-3"] = "a-resurrected"
 					ds.Annotations["a-custom"] = "custom-value"
@@ -1016,7 +1016,7 @@ func TestApplyDaemonSet(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(ds))
+				apimachineryutilruntime.Must(SetHashAnnotation(ds))
 				ds.Annotations["a-1"] = "a-alpha-changed"
 				ds.Annotations["a-3"] = "a-resurrected"
 				ds.Annotations["a-custom"] = "custom-value"
@@ -1044,7 +1044,7 @@ func TestApplyDaemonSet(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(ds))
+					apimachineryutilruntime.Must(SetHashAnnotation(ds))
 					ds.Annotations["a-1"] = "a-alpha-changed"
 					ds.Annotations["a-custom"] = "a-custom-value"
 					ds.Labels["l-1"] = "l-alpha-changed"
@@ -1078,7 +1078,7 @@ func TestApplyDaemonSet(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(ds))
+				apimachineryutilruntime.Must(SetHashAnnotation(ds))
 				delete(ds.Annotations, "a-3-")
 				ds.Annotations["a-custom"] = "a-custom-value"
 				delete(ds.Labels, "l-3-")

--- a/pkg/resourceapply/core_test.go
+++ b/pkg/resourceapply/core_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -48,7 +48,7 @@ func TestApplyService(t *testing.T) {
 
 	newServiceWithHash := func() *corev1.Service {
 		svc := newService()
-		utilruntime.Must(SetHashAnnotation(svc))
+		apimachineryutilruntime.Must(SetHashAnnotation(svc))
 		return svc
 	}
 
@@ -135,7 +135,7 @@ func TestApplyService(t *testing.T) {
 				svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
 					Name: "https",
 				})
-				utilruntime.Must(SetHashAnnotation(svc))
+				apimachineryutilruntime.Must(SetHashAnnotation(svc))
 				return svc
 			}(),
 			expectedChanged: true,
@@ -155,7 +155,7 @@ func TestApplyService(t *testing.T) {
 			expectedService: func() *corev1.Service {
 				svc := newService()
 				svc.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(svc))
+				apimachineryutilruntime.Must(SetHashAnnotation(svc))
 				return svc
 			}(),
 			expectedChanged: true,
@@ -207,7 +207,7 @@ func TestApplyService(t *testing.T) {
 				svc := newService()
 				svc.ResourceVersion = "21"
 				svc.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(svc))
+				apimachineryutilruntime.Must(SetHashAnnotation(svc))
 				return svc
 			}(),
 			expectedChanged: true,
@@ -236,7 +236,7 @@ func TestApplyService(t *testing.T) {
 				func() *corev1.Service {
 					svc := newService()
 					svc.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(svc))
+					apimachineryutilruntime.Must(SetHashAnnotation(svc))
 					return svc
 				}(),
 			},
@@ -256,7 +256,7 @@ func TestApplyService(t *testing.T) {
 				func() *corev1.Service {
 					svc := newService()
 					svc.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(svc))
+					apimachineryutilruntime.Must(SetHashAnnotation(svc))
 					return svc
 				}(),
 			},
@@ -269,7 +269,7 @@ func TestApplyService(t *testing.T) {
 			expectedService: func() *corev1.Service {
 				svc := newService()
 				svc.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(svc))
+				apimachineryutilruntime.Must(SetHashAnnotation(svc))
 				return svc
 			}(),
 			expectedChanged: true,
@@ -282,7 +282,7 @@ func TestApplyService(t *testing.T) {
 				func() *corev1.Service {
 					svc := newService()
 					svc.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(svc))
+					apimachineryutilruntime.Must(SetHashAnnotation(svc))
 					return svc
 				}(),
 			},
@@ -292,7 +292,7 @@ func TestApplyService(t *testing.T) {
 			}(),
 			expectedService: func() *corev1.Service {
 				svc := newService()
-				utilruntime.Must(SetHashAnnotation(svc))
+				apimachineryutilruntime.Must(SetHashAnnotation(svc))
 				return svc
 			}(),
 			expectedChanged: true,
@@ -305,7 +305,7 @@ func TestApplyService(t *testing.T) {
 				func() *corev1.Service {
 					svc := newService()
 					svc.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(svc))
+					apimachineryutilruntime.Must(SetHashAnnotation(svc))
 					return svc
 				}(),
 			},
@@ -325,7 +325,7 @@ func TestApplyService(t *testing.T) {
 				func() *corev1.Service {
 					svc := newService()
 					svc.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(svc))
+					apimachineryutilruntime.Must(SetHashAnnotation(svc))
 					return svc
 				}(),
 			},
@@ -355,7 +355,7 @@ func TestApplyService(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(svc))
+					apimachineryutilruntime.Must(SetHashAnnotation(svc))
 					svc.Annotations["a-1"] = "a-alpha-changed"
 					svc.Annotations["a-3"] = "a-resurrected"
 					svc.Annotations["a-custom"] = "custom-value"
@@ -392,7 +392,7 @@ func TestApplyService(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(svc))
+				apimachineryutilruntime.Must(SetHashAnnotation(svc))
 				svc.Annotations["a-1"] = "a-alpha-changed"
 				svc.Annotations["a-3"] = "a-resurrected"
 				svc.Annotations["a-custom"] = "custom-value"
@@ -420,7 +420,7 @@ func TestApplyService(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(svc))
+					apimachineryutilruntime.Must(SetHashAnnotation(svc))
 					svc.Annotations["a-1"] = "a-alpha-changed"
 					svc.Annotations["a-custom"] = "a-custom-value"
 					svc.Labels["l-1"] = "l-alpha-changed"
@@ -455,7 +455,7 @@ func TestApplyService(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(svc))
+				apimachineryutilruntime.Must(SetHashAnnotation(svc))
 				delete(svc.Annotations, "a-3-")
 				svc.Annotations["a-custom"] = "a-custom-value"
 				delete(svc.Labels, "l-3-")
@@ -591,7 +591,7 @@ func TestApplySecret(t *testing.T) {
 
 	newSecretWithHash := func() *corev1.Secret {
 		secret := newSecret()
-		utilruntime.Must(SetHashAnnotation(secret))
+		apimachineryutilruntime.Must(SetHashAnnotation(secret))
 		return secret
 	}
 
@@ -674,7 +674,7 @@ func TestApplySecret(t *testing.T) {
 			expectedSecret: func() *corev1.Secret {
 				secret := newSecret()
 				secret.Data["tls.key"] = []byte("foo")
-				utilruntime.Must(SetHashAnnotation(secret))
+				apimachineryutilruntime.Must(SetHashAnnotation(secret))
 				return secret
 			}(),
 			expectedChanged: true,
@@ -694,7 +694,7 @@ func TestApplySecret(t *testing.T) {
 			expectedSecret: func() *corev1.Secret {
 				secret := newSecret()
 				secret.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(secret))
+				apimachineryutilruntime.Must(SetHashAnnotation(secret))
 				return secret
 			}(),
 			expectedChanged: true,
@@ -742,7 +742,7 @@ func TestApplySecret(t *testing.T) {
 				secret := newSecret()
 				secret.ResourceVersion = "21"
 				secret.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(secret))
+				apimachineryutilruntime.Must(SetHashAnnotation(secret))
 				return secret
 			}(),
 			expectedChanged: true,
@@ -771,7 +771,7 @@ func TestApplySecret(t *testing.T) {
 				func() *corev1.Secret {
 					secret := newSecret()
 					secret.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(secret))
+					apimachineryutilruntime.Must(SetHashAnnotation(secret))
 					return secret
 				}(),
 			},
@@ -791,7 +791,7 @@ func TestApplySecret(t *testing.T) {
 				func() *corev1.Secret {
 					secret := newSecret()
 					secret.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(secret))
+					apimachineryutilruntime.Must(SetHashAnnotation(secret))
 					return secret
 				}(),
 			},
@@ -804,7 +804,7 @@ func TestApplySecret(t *testing.T) {
 			expectedSecret: func() *corev1.Secret {
 				secret := newSecret()
 				secret.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(secret))
+				apimachineryutilruntime.Must(SetHashAnnotation(secret))
 				return secret
 			}(),
 			expectedChanged: true,
@@ -817,7 +817,7 @@ func TestApplySecret(t *testing.T) {
 				func() *corev1.Secret {
 					secret := newSecret()
 					secret.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(secret))
+					apimachineryutilruntime.Must(SetHashAnnotation(secret))
 					return secret
 				}(),
 			},
@@ -827,7 +827,7 @@ func TestApplySecret(t *testing.T) {
 			}(),
 			expectedSecret: func() *corev1.Secret {
 				secret := newSecret()
-				utilruntime.Must(SetHashAnnotation(secret))
+				apimachineryutilruntime.Must(SetHashAnnotation(secret))
 				return secret
 			}(),
 			expectedChanged: true,
@@ -840,7 +840,7 @@ func TestApplySecret(t *testing.T) {
 				func() *corev1.Secret {
 					secret := newSecret()
 					secret.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(secret))
+					apimachineryutilruntime.Must(SetHashAnnotation(secret))
 					return secret
 				}(),
 			},
@@ -860,7 +860,7 @@ func TestApplySecret(t *testing.T) {
 				func() *corev1.Secret {
 					secret := newSecret()
 					secret.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(secret))
+					apimachineryutilruntime.Must(SetHashAnnotation(secret))
 					return secret
 				}(),
 			},
@@ -890,7 +890,7 @@ func TestApplySecret(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(secret))
+					apimachineryutilruntime.Must(SetHashAnnotation(secret))
 					secret.Annotations["a-1"] = "a-alpha-changed"
 					secret.Annotations["a-3"] = "a-resurrected"
 					secret.Annotations["a-custom"] = "custom-value"
@@ -927,7 +927,7 @@ func TestApplySecret(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(secret))
+				apimachineryutilruntime.Must(SetHashAnnotation(secret))
 				secret.Annotations["a-1"] = "a-alpha-changed"
 				secret.Annotations["a-3"] = "a-resurrected"
 				secret.Annotations["a-custom"] = "custom-value"
@@ -955,7 +955,7 @@ func TestApplySecret(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(secret))
+					apimachineryutilruntime.Must(SetHashAnnotation(secret))
 					secret.Annotations["a-1"] = "a-alpha-changed"
 					secret.Annotations["a-custom"] = "a-custom-value"
 					secret.Labels["l-1"] = "l-alpha-changed"
@@ -990,7 +990,7 @@ func TestApplySecret(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(secret))
+				apimachineryutilruntime.Must(SetHashAnnotation(secret))
 				delete(secret.Annotations, "a-3-")
 				secret.Annotations["a-custom"] = "a-custom-value"
 				delete(secret.Labels, "l-3-")
@@ -1131,7 +1131,7 @@ func TestApplyServiceAccount(t *testing.T) {
 
 	newSAWithHash := func() *corev1.ServiceAccount {
 		sa := newSA()
-		utilruntime.Must(SetHashAnnotation(sa))
+		apimachineryutilruntime.Must(SetHashAnnotation(sa))
 		return sa
 	}
 
@@ -1221,7 +1221,7 @@ func TestApplyServiceAccount(t *testing.T) {
 			expectedSA: func() *corev1.ServiceAccount {
 				sa := newSA()
 				sa.AutomountServiceAccountToken = pointer.Ptr(true)
-				utilruntime.Must(SetHashAnnotation(sa))
+				apimachineryutilruntime.Must(SetHashAnnotation(sa))
 				return sa
 			}(),
 			expectedChanged: true,
@@ -1242,7 +1242,7 @@ func TestApplyServiceAccount(t *testing.T) {
 			expectedSA: func() *corev1.ServiceAccount {
 				sa := newSA()
 				sa.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(sa))
+				apimachineryutilruntime.Must(SetHashAnnotation(sa))
 				return sa
 			}(),
 			expectedChanged: true,
@@ -1292,7 +1292,7 @@ func TestApplyServiceAccount(t *testing.T) {
 				sa := newSA()
 				sa.ResourceVersion = "21"
 				sa.AutomountServiceAccountToken = pointer.Ptr(true)
-				utilruntime.Must(SetHashAnnotation(sa))
+				apimachineryutilruntime.Must(SetHashAnnotation(sa))
 				return sa
 			}(),
 			expectedChanged: true,
@@ -1321,7 +1321,7 @@ func TestApplyServiceAccount(t *testing.T) {
 			existing: []runtime.Object{
 				func() *corev1.ServiceAccount {
 					sa := newSAWithControllerRef()
-					utilruntime.Must(SetHashAnnotation(sa))
+					apimachineryutilruntime.Must(SetHashAnnotation(sa))
 					return sa
 				}(),
 			},
@@ -1337,7 +1337,7 @@ func TestApplyServiceAccount(t *testing.T) {
 			existing: []runtime.Object{
 				func() *corev1.ServiceAccount {
 					sa := newSA()
-					utilruntime.Must(SetHashAnnotation(sa))
+					apimachineryutilruntime.Must(SetHashAnnotation(sa))
 					return sa
 				}(),
 			},
@@ -1350,7 +1350,7 @@ func TestApplyServiceAccount(t *testing.T) {
 			expectedSA: func() *corev1.ServiceAccount {
 				sa := newSAWithControllerRef()
 				sa.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(sa))
+				apimachineryutilruntime.Must(SetHashAnnotation(sa))
 				return sa
 			}(),
 			expectedChanged: true,
@@ -1363,7 +1363,7 @@ func TestApplyServiceAccount(t *testing.T) {
 				func() *corev1.ServiceAccount {
 					sa := newSAWithControllerRef()
 					sa.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(sa))
+					apimachineryutilruntime.Must(SetHashAnnotation(sa))
 					return sa
 				}(),
 			},
@@ -1373,7 +1373,7 @@ func TestApplyServiceAccount(t *testing.T) {
 			}(),
 			expectedSA: func() *corev1.ServiceAccount {
 				sa := newSAWithControllerRef()
-				utilruntime.Must(SetHashAnnotation(sa))
+				apimachineryutilruntime.Must(SetHashAnnotation(sa))
 				return sa
 			}(),
 			expectedChanged: true,
@@ -1386,7 +1386,7 @@ func TestApplyServiceAccount(t *testing.T) {
 				func() *corev1.ServiceAccount {
 					sa := newSAWithControllerRef()
 					sa.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(sa))
+					apimachineryutilruntime.Must(SetHashAnnotation(sa))
 					return sa
 				}(),
 			},
@@ -1406,7 +1406,7 @@ func TestApplyServiceAccount(t *testing.T) {
 				func() *corev1.ServiceAccount {
 					sa := newSAWithControllerRef()
 					sa.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(sa))
+					apimachineryutilruntime.Must(SetHashAnnotation(sa))
 					return sa
 				}(),
 			},
@@ -1436,7 +1436,7 @@ func TestApplyServiceAccount(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(sa))
+					apimachineryutilruntime.Must(SetHashAnnotation(sa))
 					sa.Annotations["a-1"] = "a-alpha-changed"
 					sa.Annotations["a-3"] = "a-resurrected"
 					sa.Annotations["a-custom"] = "custom-value"
@@ -1473,7 +1473,7 @@ func TestApplyServiceAccount(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(sa))
+				apimachineryutilruntime.Must(SetHashAnnotation(sa))
 				sa.Annotations["a-1"] = "a-alpha-changed"
 				sa.Annotations["a-3"] = "a-resurrected"
 				sa.Annotations["a-custom"] = "custom-value"
@@ -1501,7 +1501,7 @@ func TestApplyServiceAccount(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(sa))
+					apimachineryutilruntime.Must(SetHashAnnotation(sa))
 					sa.Annotations["a-1"] = "a-alpha-changed"
 					sa.Annotations["a-custom"] = "a-custom-value"
 					sa.Labels["l-1"] = "l-alpha-changed"
@@ -1536,7 +1536,7 @@ func TestApplyServiceAccount(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(sa))
+				apimachineryutilruntime.Must(SetHashAnnotation(sa))
 				delete(sa.Annotations, "a-3-")
 				sa.Annotations["a-custom"] = "a-custom-value"
 				delete(sa.Labels, "l-3-")
@@ -1673,7 +1673,7 @@ func TestApplyConfigMap(t *testing.T) {
 
 	newConfigMapWithHash := func() *corev1.ConfigMap {
 		cm := newConfigMap()
-		utilruntime.Must(SetHashAnnotation(cm))
+		apimachineryutilruntime.Must(SetHashAnnotation(cm))
 		return cm
 	}
 
@@ -1755,7 +1755,7 @@ func TestApplyConfigMap(t *testing.T) {
 			expectedCM: func() *corev1.ConfigMap {
 				cm := newConfigMap()
 				cm.Data["tls.key"] = "foo"
-				utilruntime.Must(SetHashAnnotation(cm))
+				apimachineryutilruntime.Must(SetHashAnnotation(cm))
 				return cm
 			}(),
 			expectedChanged: true,
@@ -1775,7 +1775,7 @@ func TestApplyConfigMap(t *testing.T) {
 			expectedCM: func() *corev1.ConfigMap {
 				cm := newConfigMap()
 				cm.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(cm))
+				apimachineryutilruntime.Must(SetHashAnnotation(cm))
 				return cm
 			}(),
 			expectedChanged: true,
@@ -1823,7 +1823,7 @@ func TestApplyConfigMap(t *testing.T) {
 				cm := newConfigMap()
 				cm.ResourceVersion = "21"
 				cm.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(cm))
+				apimachineryutilruntime.Must(SetHashAnnotation(cm))
 				return cm
 			}(),
 			expectedChanged: true,
@@ -1852,7 +1852,7 @@ func TestApplyConfigMap(t *testing.T) {
 				func() *corev1.ConfigMap {
 					cm := newConfigMap()
 					cm.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(cm))
+					apimachineryutilruntime.Must(SetHashAnnotation(cm))
 					return cm
 				}(),
 			},
@@ -1872,7 +1872,7 @@ func TestApplyConfigMap(t *testing.T) {
 				func() *corev1.ConfigMap {
 					cm := newConfigMap()
 					cm.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(cm))
+					apimachineryutilruntime.Must(SetHashAnnotation(cm))
 					return cm
 				}(),
 			},
@@ -1882,7 +1882,7 @@ func TestApplyConfigMap(t *testing.T) {
 			}(),
 			expectedCM: func() *corev1.ConfigMap {
 				cm := newConfigMap()
-				utilruntime.Must(SetHashAnnotation(cm))
+				apimachineryutilruntime.Must(SetHashAnnotation(cm))
 				return cm
 			}(),
 			expectedChanged: true,
@@ -1895,7 +1895,7 @@ func TestApplyConfigMap(t *testing.T) {
 				func() *corev1.ConfigMap {
 					cm := newConfigMap()
 					cm.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(cm))
+					apimachineryutilruntime.Must(SetHashAnnotation(cm))
 					return cm
 				}(),
 			},
@@ -1924,7 +1924,7 @@ func TestApplyConfigMap(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(cm))
+					apimachineryutilruntime.Must(SetHashAnnotation(cm))
 					cm.Annotations["a-1"] = "a-alpha-changed"
 					cm.Annotations["a-3"] = "a-resurrected"
 					cm.Annotations["a-custom"] = "custom-value"
@@ -1960,7 +1960,7 @@ func TestApplyConfigMap(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(cm))
+				apimachineryutilruntime.Must(SetHashAnnotation(cm))
 				cm.Annotations["a-1"] = "a-alpha-changed"
 				cm.Annotations["a-3"] = "a-resurrected"
 				cm.Annotations["a-custom"] = "custom-value"
@@ -1988,7 +1988,7 @@ func TestApplyConfigMap(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(cm))
+					apimachineryutilruntime.Must(SetHashAnnotation(cm))
 					cm.Annotations["a-1"] = "a-alpha-changed"
 					cm.Annotations["a-custom"] = "a-custom-value"
 					cm.Labels["l-1"] = "l-alpha-changed"
@@ -2022,7 +2022,7 @@ func TestApplyConfigMap(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(configMap))
+				apimachineryutilruntime.Must(SetHashAnnotation(configMap))
 				delete(configMap.Annotations, "a-3-")
 				configMap.Annotations["a-custom"] = "a-custom-value"
 				delete(configMap.Labels, "l-3-")
@@ -2146,7 +2146,7 @@ func TestApplyNamespace(t *testing.T) {
 
 	newNSWithHash := func() *corev1.Namespace {
 		ns := newNS()
-		utilruntime.Must(SetHashAnnotation(ns))
+		apimachineryutilruntime.Must(SetHashAnnotation(ns))
 		return ns
 	}
 
@@ -2235,7 +2235,7 @@ func TestApplyNamespace(t *testing.T) {
 			expectedNS: func() *corev1.Namespace {
 				ns := newNS()
 				ns.Finalizers = []string{"boop"}
-				utilruntime.Must(SetHashAnnotation(ns))
+				apimachineryutilruntime.Must(SetHashAnnotation(ns))
 				return ns
 			}(),
 			expectedChanged: true,
@@ -2256,7 +2256,7 @@ func TestApplyNamespace(t *testing.T) {
 			expectedNS: func() *corev1.Namespace {
 				ns := newNS()
 				ns.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(ns))
+				apimachineryutilruntime.Must(SetHashAnnotation(ns))
 				return ns
 			}(),
 			expectedChanged: true,
@@ -2306,7 +2306,7 @@ func TestApplyNamespace(t *testing.T) {
 				ns := newNS()
 				ns.ResourceVersion = "21"
 				ns.Finalizers = []string{"boop"}
-				utilruntime.Must(SetHashAnnotation(ns))
+				apimachineryutilruntime.Must(SetHashAnnotation(ns))
 				return ns
 			}(),
 			expectedChanged: true,
@@ -2345,7 +2345,7 @@ func TestApplyNamespace(t *testing.T) {
 							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					}
-					utilruntime.Must(SetHashAnnotation(ns))
+					apimachineryutilruntime.Must(SetHashAnnotation(ns))
 					return ns
 				}(),
 			},
@@ -2371,7 +2371,7 @@ func TestApplyNamespace(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(ns))
+					apimachineryutilruntime.Must(SetHashAnnotation(ns))
 					ns.Annotations["a-1"] = "a-alpha-changed"
 					ns.Annotations["a-3"] = "a-resurrected"
 					ns.Annotations["a-custom"] = "custom-value"
@@ -2408,7 +2408,7 @@ func TestApplyNamespace(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(ns))
+				apimachineryutilruntime.Must(SetHashAnnotation(ns))
 				ns.Annotations["a-1"] = "a-alpha-changed"
 				ns.Annotations["a-3"] = "a-resurrected"
 				ns.Annotations["a-custom"] = "custom-value"
@@ -2436,7 +2436,7 @@ func TestApplyNamespace(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(ns))
+					apimachineryutilruntime.Must(SetHashAnnotation(ns))
 					ns.Annotations["a-1"] = "a-alpha-changed"
 					ns.Annotations["a-custom"] = "a-custom-value"
 					ns.Labels["l-1"] = "l-alpha-changed"
@@ -2471,7 +2471,7 @@ func TestApplyNamespace(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(ns))
+				apimachineryutilruntime.Must(SetHashAnnotation(ns))
 				delete(ns.Annotations, "a-3-")
 				ns.Annotations["a-custom"] = "a-custom-value"
 				delete(ns.Labels, "l-3-")
@@ -2624,7 +2624,7 @@ func TestApplyEndpoints(t *testing.T) {
 
 	newEndpointsWithHash := func() *corev1.Endpoints {
 		Endpoints := newEndpoints()
-		utilruntime.Must(SetHashAnnotation(Endpoints))
+		apimachineryutilruntime.Must(SetHashAnnotation(Endpoints))
 		return Endpoints
 	}
 
@@ -2710,7 +2710,7 @@ func TestApplyEndpoints(t *testing.T) {
 				endpoints.Subsets[0].Addresses = append(endpoints.Subsets[0].Addresses, corev1.EndpointAddress{
 					IP: "2.2.2.2",
 				})
-				utilruntime.Must(SetHashAnnotation(endpoints))
+				apimachineryutilruntime.Must(SetHashAnnotation(endpoints))
 				return endpoints
 			}(),
 			expectedChanged: true,
@@ -2730,7 +2730,7 @@ func TestApplyEndpoints(t *testing.T) {
 			expectedEndpoints: func() *corev1.Endpoints {
 				Endpoints := newEndpoints()
 				Endpoints.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(Endpoints))
+				apimachineryutilruntime.Must(SetHashAnnotation(Endpoints))
 				return Endpoints
 			}(),
 			expectedChanged: true,
@@ -2782,7 +2782,7 @@ func TestApplyEndpoints(t *testing.T) {
 				Endpoints := newEndpoints()
 				Endpoints.ResourceVersion = "21"
 				Endpoints.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(Endpoints))
+				apimachineryutilruntime.Must(SetHashAnnotation(Endpoints))
 				return Endpoints
 			}(),
 			expectedChanged: true,
@@ -2811,7 +2811,7 @@ func TestApplyEndpoints(t *testing.T) {
 				func() *corev1.Endpoints {
 					Endpoints := newEndpoints()
 					Endpoints.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(Endpoints))
+					apimachineryutilruntime.Must(SetHashAnnotation(Endpoints))
 					return Endpoints
 				}(),
 			},
@@ -2831,7 +2831,7 @@ func TestApplyEndpoints(t *testing.T) {
 				func() *corev1.Endpoints {
 					Endpoints := newEndpoints()
 					Endpoints.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(Endpoints))
+					apimachineryutilruntime.Must(SetHashAnnotation(Endpoints))
 					return Endpoints
 				}(),
 			},
@@ -2860,7 +2860,7 @@ func TestApplyEndpoints(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(Endpoints))
+					apimachineryutilruntime.Must(SetHashAnnotation(Endpoints))
 					Endpoints.Annotations["a-1"] = "a-alpha-changed"
 					Endpoints.Annotations["a-3"] = "a-resurrected"
 					Endpoints.Annotations["a-custom"] = "custom-value"
@@ -2896,7 +2896,7 @@ func TestApplyEndpoints(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(Endpoints))
+				apimachineryutilruntime.Must(SetHashAnnotation(Endpoints))
 				Endpoints.Annotations["a-1"] = "a-alpha-changed"
 				Endpoints.Annotations["a-3"] = "a-resurrected"
 				Endpoints.Annotations["a-custom"] = "custom-value"
@@ -2924,7 +2924,7 @@ func TestApplyEndpoints(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(Endpoints))
+					apimachineryutilruntime.Must(SetHashAnnotation(Endpoints))
 					Endpoints.Annotations["a-1"] = "a-alpha-changed"
 					Endpoints.Annotations["a-custom"] = "a-custom-value"
 					Endpoints.Labels["l-1"] = "l-alpha-changed"
@@ -2958,7 +2958,7 @@ func TestApplyEndpoints(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(Endpoints))
+				apimachineryutilruntime.Must(SetHashAnnotation(Endpoints))
 				delete(Endpoints.Annotations, "a-3-")
 				Endpoints.Annotations["a-custom"] = "a-custom-value"
 				delete(Endpoints.Labels, "l-3-")
@@ -3106,7 +3106,7 @@ func TestApplyPod(t *testing.T) {
 
 	newPodWithHash := func() *corev1.Pod {
 		pod := newPod()
-		utilruntime.Must(SetHashAnnotation(pod))
+		apimachineryutilruntime.Must(SetHashAnnotation(pod))
 		return pod
 	}
 
@@ -3189,7 +3189,7 @@ func TestApplyPod(t *testing.T) {
 			expectedPod: func() *corev1.Pod {
 				pod := newPod()
 				pod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU] = resource.MustParse("20m")
-				utilruntime.Must(SetHashAnnotation(pod))
+				apimachineryutilruntime.Must(SetHashAnnotation(pod))
 				return pod
 			}(),
 			expectedChanged: true,
@@ -3209,7 +3209,7 @@ func TestApplyPod(t *testing.T) {
 			expectedPod: func() *corev1.Pod {
 				pod := newPod()
 				pod.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pod))
+				apimachineryutilruntime.Must(SetHashAnnotation(pod))
 				return pod
 			}(),
 			expectedChanged: true,
@@ -3257,7 +3257,7 @@ func TestApplyPod(t *testing.T) {
 				pod := newPod()
 				pod.ResourceVersion = "21"
 				pod.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pod))
+				apimachineryutilruntime.Must(SetHashAnnotation(pod))
 				return pod
 			}(),
 			expectedChanged: true,
@@ -3286,7 +3286,7 @@ func TestApplyPod(t *testing.T) {
 				func() *corev1.Pod {
 					pod := newPod()
 					pod.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(pod))
+					apimachineryutilruntime.Must(SetHashAnnotation(pod))
 					return pod
 				}(),
 			},
@@ -3306,7 +3306,7 @@ func TestApplyPod(t *testing.T) {
 				func() *corev1.Pod {
 					pod := newPod()
 					pod.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(pod))
+					apimachineryutilruntime.Must(SetHashAnnotation(pod))
 					return pod
 				}(),
 			},
@@ -3319,7 +3319,7 @@ func TestApplyPod(t *testing.T) {
 			expectedPod: func() *corev1.Pod {
 				pod := newPod()
 				pod.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pod))
+				apimachineryutilruntime.Must(SetHashAnnotation(pod))
 				return pod
 			}(),
 			expectedChanged: true,
@@ -3332,7 +3332,7 @@ func TestApplyPod(t *testing.T) {
 				func() *corev1.Pod {
 					pod := newPod()
 					pod.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(pod))
+					apimachineryutilruntime.Must(SetHashAnnotation(pod))
 					return pod
 				}(),
 			},
@@ -3342,7 +3342,7 @@ func TestApplyPod(t *testing.T) {
 			}(),
 			expectedPod: func() *corev1.Pod {
 				pod := newPod()
-				utilruntime.Must(SetHashAnnotation(pod))
+				apimachineryutilruntime.Must(SetHashAnnotation(pod))
 				return pod
 			}(),
 			expectedChanged: true,
@@ -3355,7 +3355,7 @@ func TestApplyPod(t *testing.T) {
 				func() *corev1.Pod {
 					pod := newPod()
 					pod.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(pod))
+					apimachineryutilruntime.Must(SetHashAnnotation(pod))
 					return pod
 				}(),
 			},
@@ -3375,7 +3375,7 @@ func TestApplyPod(t *testing.T) {
 				func() *corev1.Pod {
 					pod := newPod()
 					pod.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(pod))
+					apimachineryutilruntime.Must(SetHashAnnotation(pod))
 					return pod
 				}(),
 			},
@@ -3405,7 +3405,7 @@ func TestApplyPod(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(pod))
+					apimachineryutilruntime.Must(SetHashAnnotation(pod))
 					pod.Annotations["a-1"] = "a-alpha-changed"
 					pod.Annotations["a-3"] = "a-resurrected"
 					pod.Annotations["a-custom"] = "custom-value"
@@ -3442,7 +3442,7 @@ func TestApplyPod(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(pod))
+				apimachineryutilruntime.Must(SetHashAnnotation(pod))
 				pod.Annotations["a-1"] = "a-alpha-changed"
 				pod.Annotations["a-3"] = "a-resurrected"
 				pod.Annotations["a-custom"] = "custom-value"
@@ -3470,7 +3470,7 @@ func TestApplyPod(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(pod))
+					apimachineryutilruntime.Must(SetHashAnnotation(pod))
 					pod.Annotations["a-1"] = "a-alpha-changed"
 					pod.Annotations["a-custom"] = "a-custom-value"
 					pod.Labels["l-1"] = "l-alpha-changed"
@@ -3505,7 +3505,7 @@ func TestApplyPod(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(pod))
+				apimachineryutilruntime.Must(SetHashAnnotation(pod))
 				delete(pod.Annotations, "a-3-")
 				pod.Annotations["a-custom"] = "a-custom-value"
 				delete(pod.Labels, "l-3-")
@@ -3650,7 +3650,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 
 	newPersistentVolumeClaimWithHash := func() *corev1.PersistentVolumeClaim {
 		pvc := newPersistentVolumeClaim()
-		utilruntime.Must(SetHashAnnotation(pvc))
+		apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 		return pvc
 	}
 
@@ -3737,7 +3737,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 				pvc.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{
 					corev1.ReadWriteMany,
 				}
-				utilruntime.Must(SetHashAnnotation(pvc))
+				apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 				return pvc
 			}(),
 			expectedChanged: true,
@@ -3757,7 +3757,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 			expectedPersistentVolumeClaim: func() *corev1.PersistentVolumeClaim {
 				pvc := newPersistentVolumeClaim()
 				pvc.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pvc))
+				apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 				return pvc
 			}(),
 			expectedChanged: true,
@@ -3805,7 +3805,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 				pvc := newPersistentVolumeClaim()
 				pvc.ResourceVersion = "21"
 				pvc.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pvc))
+				apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 				return pvc
 			}(),
 			expectedChanged: true,
@@ -3834,7 +3834,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 				func() *corev1.PersistentVolumeClaim {
 					pvc := newPersistentVolumeClaim()
 					pvc.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(pvc))
+					apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 					return pvc
 				}(),
 			},
@@ -3854,7 +3854,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 				func() *corev1.PersistentVolumeClaim {
 					pvc := newPersistentVolumeClaim()
 					pvc.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(pvc))
+					apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 					return pvc
 				}(),
 			},
@@ -3867,7 +3867,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 			expectedPersistentVolumeClaim: func() *corev1.PersistentVolumeClaim {
 				pvc := newPersistentVolumeClaim()
 				pvc.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pvc))
+				apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 				return pvc
 			}(),
 			expectedChanged: true,
@@ -3880,7 +3880,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 				func() *corev1.PersistentVolumeClaim {
 					pvc := newPersistentVolumeClaim()
 					pvc.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(pvc))
+					apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 					return pvc
 				}(),
 			},
@@ -3890,7 +3890,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 			}(),
 			expectedPersistentVolumeClaim: func() *corev1.PersistentVolumeClaim {
 				pvc := newPersistentVolumeClaim()
-				utilruntime.Must(SetHashAnnotation(pvc))
+				apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 				return pvc
 			}(),
 			expectedChanged: true,
@@ -3903,7 +3903,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 				func() *corev1.PersistentVolumeClaim {
 					pvc := newPersistentVolumeClaim()
 					pvc.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(pvc))
+					apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 					return pvc
 				}(),
 			},
@@ -3923,7 +3923,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 				func() *corev1.PersistentVolumeClaim {
 					pvc := newPersistentVolumeClaim()
 					pvc.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(pvc))
+					apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 					return pvc
 				}(),
 			},
@@ -3953,7 +3953,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(pvc))
+					apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 					pvc.Annotations["a-1"] = "a-alpha-changed"
 					pvc.Annotations["a-3"] = "a-resurrected"
 					pvc.Annotations["a-custom"] = "custom-value"
@@ -3990,7 +3990,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(pvc))
+				apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 				pvc.Annotations["a-1"] = "a-alpha-changed"
 				pvc.Annotations["a-3"] = "a-resurrected"
 				pvc.Annotations["a-custom"] = "custom-value"
@@ -4018,7 +4018,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(pvc))
+					apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 					pvc.Annotations["a-1"] = "a-alpha-changed"
 					pvc.Annotations["a-custom"] = "a-custom-value"
 					pvc.Labels["l-1"] = "l-alpha-changed"
@@ -4053,7 +4053,7 @@ func TestApplyPersistentVolumeClaim(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(pvc))
+				apimachineryutilruntime.Must(SetHashAnnotation(pvc))
 				delete(pvc.Annotations, "a-3-")
 				pvc.Annotations["a-custom"] = "a-custom-value"
 				delete(pvc.Labels, "l-3-")

--- a/pkg/resourceapply/discovery_test.go
+++ b/pkg/resourceapply/discovery_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	discoveryv1listers "k8s.io/client-go/listers/discovery/v1"
 	"k8s.io/client-go/tools/cache"
@@ -69,7 +69,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 
 	newEndpointSliceWithHash := func() *discoveryv1.EndpointSlice {
 		endpointSlice := newEndpointSlice()
-		utilruntime.Must(SetHashAnnotation(endpointSlice))
+		apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 		return endpointSlice
 	}
 
@@ -151,7 +151,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 			expectedEndpointSlice: func() *discoveryv1.EndpointSlice {
 				endpointSlice := newEndpointSlice()
 				endpointSlice.Endpoints[0].Addresses = append(endpointSlice.Endpoints[0].Addresses, "1.1.1.1")
-				utilruntime.Must(SetHashAnnotation(endpointSlice))
+				apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 				return endpointSlice
 			}(),
 			expectedChanged: true,
@@ -171,7 +171,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 			expectedEndpointSlice: func() *discoveryv1.EndpointSlice {
 				endpointSlice := newEndpointSlice()
 				endpointSlice.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(endpointSlice))
+				apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 				return endpointSlice
 			}(),
 			expectedChanged: true,
@@ -219,7 +219,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 				endpointSlice := newEndpointSlice()
 				endpointSlice.ResourceVersion = "21"
 				endpointSlice.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(endpointSlice))
+				apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 				return endpointSlice
 			}(),
 			expectedChanged: true,
@@ -248,7 +248,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 				func() *discoveryv1.EndpointSlice {
 					endpointSlice := newEndpointSlice()
 					endpointSlice.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(endpointSlice))
+					apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 					return endpointSlice
 				}(),
 			},
@@ -268,7 +268,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 				func() *discoveryv1.EndpointSlice {
 					endpointSlice := newEndpointSlice()
 					endpointSlice.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(endpointSlice))
+					apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 					return endpointSlice
 				}(),
 			},
@@ -297,7 +297,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(endpointSlice))
+					apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 					endpointSlice.Annotations["a-1"] = "a-alpha-changed"
 					endpointSlice.Annotations["a-3"] = "a-resurrected"
 					endpointSlice.Annotations["a-custom"] = "custom-value"
@@ -333,7 +333,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(endpointSlice))
+				apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 				endpointSlice.Annotations["a-1"] = "a-alpha-changed"
 				endpointSlice.Annotations["a-3"] = "a-resurrected"
 				endpointSlice.Annotations["a-custom"] = "custom-value"
@@ -361,7 +361,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(endpointSlice))
+					apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 					endpointSlice.Annotations["a-1"] = "a-alpha-changed"
 					endpointSlice.Annotations["a-custom"] = "a-custom-value"
 					endpointSlice.Labels["l-1"] = "l-alpha-changed"
@@ -395,7 +395,7 @@ func TestApplyEndpointSlice(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(endpointSlice))
+				apimachineryutilruntime.Must(SetHashAnnotation(endpointSlice))
 				delete(endpointSlice.Annotations, "a-3-")
 				endpointSlice.Annotations["a-custom"] = "a-custom-value"
 				delete(endpointSlice.Labels, "l-3-")

--- a/pkg/resourceapply/networking_test.go
+++ b/pkg/resourceapply/networking_test.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	networkingv1listers "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
@@ -56,7 +56,7 @@ func TestApplyIngress(t *testing.T) {
 
 	newIngressWithHash := func() *networkingv1.Ingress {
 		ingress := newIngress()
-		utilruntime.Must(SetHashAnnotation(ingress))
+		apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 		return ingress
 	}
 
@@ -138,7 +138,7 @@ func TestApplyIngress(t *testing.T) {
 			expectedIngress: func() *networkingv1.Ingress {
 				ingress := newIngress()
 				ingress.Spec.DefaultBackend.Service.Port.Number = 42
-				utilruntime.Must(SetHashAnnotation(ingress))
+				apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 				return ingress
 			}(),
 			expectedChanged: true,
@@ -158,7 +158,7 @@ func TestApplyIngress(t *testing.T) {
 			expectedIngress: func() *networkingv1.Ingress {
 				ingress := newIngress()
 				ingress.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(ingress))
+				apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 				return ingress
 			}(),
 			expectedChanged: true,
@@ -206,7 +206,7 @@ func TestApplyIngress(t *testing.T) {
 				ingress := newIngress()
 				ingress.ResourceVersion = "21"
 				ingress.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(ingress))
+				apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 				return ingress
 			}(),
 			expectedChanged: true,
@@ -235,7 +235,7 @@ func TestApplyIngress(t *testing.T) {
 				func() *networkingv1.Ingress {
 					ingress := newIngress()
 					ingress.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(ingress))
+					apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 					return ingress
 				}(),
 			},
@@ -255,7 +255,7 @@ func TestApplyIngress(t *testing.T) {
 				func() *networkingv1.Ingress {
 					ingress := newIngress()
 					ingress.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(ingress))
+					apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 					return ingress
 				}(),
 			},
@@ -284,7 +284,7 @@ func TestApplyIngress(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(ingress))
+					apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 					ingress.Annotations["a-1"] = "a-alpha-changed"
 					ingress.Annotations["a-3"] = "a-resurrected"
 					ingress.Annotations["a-custom"] = "custom-value"
@@ -320,7 +320,7 @@ func TestApplyIngress(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(ingress))
+				apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 				ingress.Annotations["a-1"] = "a-alpha-changed"
 				ingress.Annotations["a-3"] = "a-resurrected"
 				ingress.Annotations["a-custom"] = "custom-value"
@@ -348,7 +348,7 @@ func TestApplyIngress(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(ingress))
+					apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 					ingress.Annotations["a-1"] = "a-alpha-changed"
 					ingress.Annotations["a-custom"] = "a-custom-value"
 					ingress.Labels["l-1"] = "l-alpha-changed"
@@ -382,7 +382,7 @@ func TestApplyIngress(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(ingress))
+				apimachineryutilruntime.Must(SetHashAnnotation(ingress))
 				delete(ingress.Annotations, "a-3-")
 				ingress.Annotations["a-custom"] = "a-custom-value"
 				delete(ingress.Labels, "l-3-")

--- a/pkg/resourceapply/policy_test.go
+++ b/pkg/resourceapply/policy_test.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	policyv1listers "k8s.io/client-go/listers/policy/v1"
 	"k8s.io/client-go/tools/cache"
@@ -51,7 +51,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 
 	newPDBWithHash := func() *policyv1.PodDisruptionBudget {
 		pdb := newPDB()
-		utilruntime.Must(SetHashAnnotation(pdb))
+		apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 		return pdb
 	}
 
@@ -134,7 +134,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 			expectedPDB: func() *policyv1.PodDisruptionBudget {
 				pdb := newPDB()
 				pdb.Spec.Selector.MatchLabels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pdb))
+				apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 				return pdb
 			}(),
 			expectedChanged: true,
@@ -154,7 +154,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 			expectedPDB: func() *policyv1.PodDisruptionBudget {
 				pdb := newPDB()
 				pdb.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pdb))
+				apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 				return pdb
 			}(),
 			expectedChanged: true,
@@ -202,7 +202,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 				pdb := newPDB()
 				pdb.ResourceVersion = "21"
 				pdb.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pdb))
+				apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 				return pdb
 			}(),
 			expectedChanged: true,
@@ -231,7 +231,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 				func() *policyv1.PodDisruptionBudget {
 					pdb := newPDB()
 					pdb.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(pdb))
+					apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 					return pdb
 				}(),
 			},
@@ -251,7 +251,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 				func() *policyv1.PodDisruptionBudget {
 					pdb := newPDB()
 					pdb.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(pdb))
+					apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 					return pdb
 				}(),
 			},
@@ -264,7 +264,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 			expectedPDB: func() *policyv1.PodDisruptionBudget {
 				pdb := newPDB()
 				pdb.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(pdb))
+				apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 				return pdb
 			}(),
 			expectedChanged: true,
@@ -277,7 +277,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 				func() *policyv1.PodDisruptionBudget {
 					pdb := newPDB()
 					pdb.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(pdb))
+					apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 					return pdb
 				}(),
 			},
@@ -287,7 +287,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 			}(),
 			expectedPDB: func() *policyv1.PodDisruptionBudget {
 				pdb := newPDB()
-				utilruntime.Must(SetHashAnnotation(pdb))
+				apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 				return pdb
 			}(),
 			expectedChanged: true,
@@ -300,7 +300,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 				func() *policyv1.PodDisruptionBudget {
 					pdb := newPDB()
 					pdb.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(pdb))
+					apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 					return pdb
 				}(),
 			},
@@ -320,7 +320,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 				func() *policyv1.PodDisruptionBudget {
 					pdb := newPDB()
 					pdb.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(pdb))
+					apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 					return pdb
 				}(),
 			},
@@ -350,7 +350,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(pdb))
+					apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 					pdb.Annotations["a-1"] = "a-alpha-changed"
 					pdb.Annotations["a-3"] = "a-resurrected"
 					pdb.Annotations["a-custom"] = "custom-value"
@@ -387,7 +387,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(pdb))
+				apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 				pdb.Annotations["a-1"] = "a-alpha-changed"
 				pdb.Annotations["a-3"] = "a-resurrected"
 				pdb.Annotations["a-custom"] = "custom-value"
@@ -415,7 +415,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(pdb))
+					apimachineryutilruntime.Must(SetHashAnnotation(pdb))
 					pdb.Annotations["a-1"] = "a-alpha-changed"
 					pdb.Annotations["a-custom"] = "a-custom-value"
 					pdb.Labels["l-1"] = "l-alpha-changed"
@@ -450,7 +450,7 @@ func TestApplyPodDisruptionBudget(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(podDisruptionBudget))
+				apimachineryutilruntime.Must(SetHashAnnotation(podDisruptionBudget))
 				delete(podDisruptionBudget.Annotations, "a-3-")
 				podDisruptionBudget.Annotations["a-custom"] = "a-custom-value"
 				delete(podDisruptionBudget.Labels, "l-3-")

--- a/pkg/resourceapply/rbac_test.go
+++ b/pkg/resourceapply/rbac_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
@@ -45,7 +45,7 @@ func TestApplyClusterRole(t *testing.T) {
 
 	newCrWithHash := func() *rbacv1.ClusterRole {
 		cr := newCr()
-		utilruntime.Must(SetHashAnnotation(cr))
+		apimachineryutilruntime.Must(SetHashAnnotation(cr))
 		return cr
 	}
 
@@ -134,7 +134,7 @@ func TestApplyClusterRole(t *testing.T) {
 			expectedCr: func() *rbacv1.ClusterRole {
 				cr := newCr()
 				cr.Rules[0].Verbs = []string{"update"}
-				utilruntime.Must(SetHashAnnotation(cr))
+				apimachineryutilruntime.Must(SetHashAnnotation(cr))
 				return cr
 			}(),
 			expectedChanged: true,
@@ -155,7 +155,7 @@ func TestApplyClusterRole(t *testing.T) {
 			expectedCr: func() *rbacv1.ClusterRole {
 				cr := newCr()
 				cr.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(cr))
+				apimachineryutilruntime.Must(SetHashAnnotation(cr))
 				return cr
 			}(),
 			expectedChanged: true,
@@ -184,7 +184,7 @@ func TestApplyClusterRole(t *testing.T) {
 					Resources: []string{"daemonsets"},
 					Verbs:     []string{"get", "list", "watch"},
 				})
-				utilruntime.Must(SetHashAnnotation(cr))
+				apimachineryutilruntime.Must(SetHashAnnotation(cr))
 				return cr
 			}(),
 			expectedChanged: true,
@@ -234,7 +234,7 @@ func TestApplyClusterRole(t *testing.T) {
 				cr := newCr()
 				cr.ResourceVersion = "21"
 				cr.Rules[0].Verbs = []string{"update"}
-				utilruntime.Must(SetHashAnnotation(cr))
+				apimachineryutilruntime.Must(SetHashAnnotation(cr))
 				return cr
 			}(),
 			expectedChanged: true,
@@ -271,7 +271,7 @@ func TestApplyClusterRole(t *testing.T) {
 						Name:               "basic",
 						BlockOwnerDeletion: pointer.Ptr(true),
 					}}
-					utilruntime.Must(SetHashAnnotation(cr))
+					apimachineryutilruntime.Must(SetHashAnnotation(cr))
 					return cr
 				}(),
 			},
@@ -297,7 +297,7 @@ func TestApplyClusterRole(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(cr))
+					apimachineryutilruntime.Must(SetHashAnnotation(cr))
 					cr.Annotations["a-1"] = "a-alpha-changed"
 					cr.Annotations["a-3"] = "a-resurrected"
 					cr.Annotations["a-custom"] = "custom-value"
@@ -334,7 +334,7 @@ func TestApplyClusterRole(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(cr))
+				apimachineryutilruntime.Must(SetHashAnnotation(cr))
 				cr.Annotations["a-1"] = "a-alpha-changed"
 				cr.Annotations["a-3"] = "a-resurrected"
 				cr.Annotations["a-custom"] = "custom-value"
@@ -362,7 +362,7 @@ func TestApplyClusterRole(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(cr))
+					apimachineryutilruntime.Must(SetHashAnnotation(cr))
 					cr.Annotations["a-1"] = "a-alpha-changed"
 					cr.Annotations["a-custom"] = "a-custom-value"
 					cr.Labels["l-1"] = "l-alpha-changed"
@@ -397,7 +397,7 @@ func TestApplyClusterRole(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(clusterRole))
+				apimachineryutilruntime.Must(SetHashAnnotation(clusterRole))
 				delete(clusterRole.Annotations, "a-3-")
 				clusterRole.Annotations["a-custom"] = "a-custom-value"
 				delete(clusterRole.Labels, "l-3-")
@@ -535,7 +535,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 
 	newCrbWithHash := func() *rbacv1.ClusterRoleBinding {
 		cr := newCrb()
-		utilruntime.Must(SetHashAnnotation(cr))
+		apimachineryutilruntime.Must(SetHashAnnotation(cr))
 		return cr
 	}
 
@@ -624,7 +624,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 			expectedCrb: func() *rbacv1.ClusterRoleBinding {
 				crb := newCrb()
 				crb.Subjects[0].Name = "different-name"
-				utilruntime.Must(SetHashAnnotation(crb))
+				apimachineryutilruntime.Must(SetHashAnnotation(crb))
 				return crb
 			}(),
 			expectedChanged: true,
@@ -653,7 +653,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 					Kind:     "ClusterRole",
 					Name:     "different-name",
 				}
-				utilruntime.Must(SetHashAnnotation(crb))
+				apimachineryutilruntime.Must(SetHashAnnotation(crb))
 				return crb
 			}(),
 			expectedChanged: true,
@@ -677,7 +677,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 			expectedCrb: func() *rbacv1.ClusterRoleBinding {
 				crb := newCrb()
 				crb.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(crb))
+				apimachineryutilruntime.Must(SetHashAnnotation(crb))
 				return crb
 			}(),
 			expectedChanged: true,
@@ -727,7 +727,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 				crb := newCrb()
 				crb.ResourceVersion = "21"
 				crb.Subjects[0].Name = "different-name"
-				utilruntime.Must(SetHashAnnotation(crb))
+				apimachineryutilruntime.Must(SetHashAnnotation(crb))
 				return crb
 			}(),
 			expectedChanged: true,
@@ -766,7 +766,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 							BlockOwnerDeletion: pointer.Ptr(true),
 						},
 					}
-					utilruntime.Must(SetHashAnnotation(crb))
+					apimachineryutilruntime.Must(SetHashAnnotation(crb))
 					return crb
 				}(),
 			},
@@ -792,7 +792,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(crb))
+					apimachineryutilruntime.Must(SetHashAnnotation(crb))
 					crb.Annotations["a-1"] = "a-alpha-changed"
 					crb.Annotations["a-3"] = "a-resurrected"
 					crb.Annotations["a-custom"] = "custom-value"
@@ -829,7 +829,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(crb))
+				apimachineryutilruntime.Must(SetHashAnnotation(crb))
 				crb.Annotations["a-1"] = "a-alpha-changed"
 				crb.Annotations["a-3"] = "a-resurrected"
 				crb.Annotations["a-custom"] = "custom-value"
@@ -857,7 +857,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(crb))
+					apimachineryutilruntime.Must(SetHashAnnotation(crb))
 					crb.Annotations["a-1"] = "a-alpha-changed"
 					crb.Annotations["a-custom"] = "a-custom-value"
 					crb.Labels["l-1"] = "l-alpha-changed"
@@ -892,7 +892,7 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(crb))
+				apimachineryutilruntime.Must(SetHashAnnotation(crb))
 				delete(crb.Annotations, "a-3-")
 				crb.Annotations["a-custom"] = "a-custom-value"
 				delete(crb.Labels, "l-3-")
@@ -1036,7 +1036,7 @@ func TestApplyRoleBinding(t *testing.T) {
 
 	newRBWithHash := func() *rbacv1.RoleBinding {
 		rb := newRB()
-		utilruntime.Must(SetHashAnnotation(rb))
+		apimachineryutilruntime.Must(SetHashAnnotation(rb))
 		return rb
 	}
 
@@ -1126,7 +1126,7 @@ func TestApplyRoleBinding(t *testing.T) {
 			expectedRB: func() *rbacv1.RoleBinding {
 				rb := newRB()
 				rb.RoleRef.Name = "changed"
-				utilruntime.Must(SetHashAnnotation(rb))
+				apimachineryutilruntime.Must(SetHashAnnotation(rb))
 				return rb
 			}(),
 			expectedChanged: true,
@@ -1150,7 +1150,7 @@ func TestApplyRoleBinding(t *testing.T) {
 			expectedRB: func() *rbacv1.RoleBinding {
 				rb := newRB()
 				rb.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(rb))
+				apimachineryutilruntime.Must(SetHashAnnotation(rb))
 				return rb
 			}(),
 			expectedChanged: true,
@@ -1208,7 +1208,7 @@ func TestApplyRoleBinding(t *testing.T) {
 				rb := newRB()
 				rb.ResourceVersion = "21"
 				rb.Labels = map[string]string{"changed": "changed"}
-				utilruntime.Must(SetHashAnnotation(rb))
+				apimachineryutilruntime.Must(SetHashAnnotation(rb))
 				return rb
 			}(),
 			expectedChanged: true,
@@ -1237,7 +1237,7 @@ func TestApplyRoleBinding(t *testing.T) {
 			existing: []runtime.Object{
 				func() *rbacv1.RoleBinding {
 					rb := newRBWithControllerRef()
-					utilruntime.Must(SetHashAnnotation(rb))
+					apimachineryutilruntime.Must(SetHashAnnotation(rb))
 					return rb
 				}(),
 			},
@@ -1253,7 +1253,7 @@ func TestApplyRoleBinding(t *testing.T) {
 			existing: []runtime.Object{
 				func() *rbacv1.RoleBinding {
 					rb := newRB()
-					utilruntime.Must(SetHashAnnotation(rb))
+					apimachineryutilruntime.Must(SetHashAnnotation(rb))
 					return rb
 				}(),
 			},
@@ -1266,7 +1266,7 @@ func TestApplyRoleBinding(t *testing.T) {
 			expectedRB: func() *rbacv1.RoleBinding {
 				rb := newRBWithControllerRef()
 				rb.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(rb))
+				apimachineryutilruntime.Must(SetHashAnnotation(rb))
 				return rb
 			}(),
 			expectedChanged: true,
@@ -1279,7 +1279,7 @@ func TestApplyRoleBinding(t *testing.T) {
 				func() *rbacv1.RoleBinding {
 					rb := newRBWithControllerRef()
 					rb.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(rb))
+					apimachineryutilruntime.Must(SetHashAnnotation(rb))
 					return rb
 				}(),
 			},
@@ -1289,7 +1289,7 @@ func TestApplyRoleBinding(t *testing.T) {
 			}(),
 			expectedRB: func() *rbacv1.RoleBinding {
 				rb := newRBWithControllerRef()
-				utilruntime.Must(SetHashAnnotation(rb))
+				apimachineryutilruntime.Must(SetHashAnnotation(rb))
 				return rb
 			}(),
 			expectedChanged: true,
@@ -1302,7 +1302,7 @@ func TestApplyRoleBinding(t *testing.T) {
 				func() *rbacv1.RoleBinding {
 					rb := newRBWithControllerRef()
 					rb.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(rb))
+					apimachineryutilruntime.Must(SetHashAnnotation(rb))
 					return rb
 				}(),
 			},
@@ -1322,7 +1322,7 @@ func TestApplyRoleBinding(t *testing.T) {
 				func() *rbacv1.RoleBinding {
 					rb := newRBWithControllerRef()
 					rb.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(rb))
+					apimachineryutilruntime.Must(SetHashAnnotation(rb))
 					return rb
 				}(),
 			},
@@ -1352,7 +1352,7 @@ func TestApplyRoleBinding(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(rb))
+					apimachineryutilruntime.Must(SetHashAnnotation(rb))
 					rb.Annotations["a-1"] = "a-alpha-changed"
 					rb.Annotations["a-3"] = "a-resurrected"
 					rb.Annotations["a-custom"] = "custom-value"
@@ -1390,7 +1390,7 @@ func TestApplyRoleBinding(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(roleBinding))
+				apimachineryutilruntime.Must(SetHashAnnotation(roleBinding))
 				roleBinding.Annotations["a-1"] = "a-alpha-changed"
 				roleBinding.Annotations["a-3"] = "a-resurrected"
 				roleBinding.Annotations["a-custom"] = "custom-value"
@@ -1418,7 +1418,7 @@ func TestApplyRoleBinding(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(rb))
+					apimachineryutilruntime.Must(SetHashAnnotation(rb))
 					rb.Annotations["a-1"] = "a-alpha-changed"
 					rb.Annotations["a-custom"] = "a-custom-value"
 					rb.Labels["l-1"] = "l-alpha-changed"
@@ -1454,7 +1454,7 @@ func TestApplyRoleBinding(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(rb))
+				apimachineryutilruntime.Must(SetHashAnnotation(rb))
 				delete(rb.Annotations, "a-3-")
 				rb.Annotations["a-custom"] = "a-custom-value"
 				delete(rb.Labels, "l-3-")
@@ -1597,7 +1597,7 @@ func TestApplyRole(t *testing.T) {
 
 	newRoleWithHash := func() *rbacv1.Role {
 		role := newRole()
-		utilruntime.Must(SetHashAnnotation(role))
+		apimachineryutilruntime.Must(SetHashAnnotation(role))
 		return role
 	}
 
@@ -1679,7 +1679,7 @@ func TestApplyRole(t *testing.T) {
 			expectedRole: func() *rbacv1.Role {
 				role := newRole()
 				role.Rules[0].Verbs = []string{"update"}
-				utilruntime.Must(SetHashAnnotation(role))
+				apimachineryutilruntime.Must(SetHashAnnotation(role))
 				return role
 			}(),
 			expectedChanged: true,
@@ -1699,7 +1699,7 @@ func TestApplyRole(t *testing.T) {
 			expectedRole: func() *rbacv1.Role {
 				cm := newRole()
 				cm.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(cm))
+				apimachineryutilruntime.Must(SetHashAnnotation(cm))
 				return cm
 			}(),
 			expectedChanged: true,
@@ -1747,7 +1747,7 @@ func TestApplyRole(t *testing.T) {
 				role := newRole()
 				role.ResourceVersion = "21"
 				role.Labels["foo"] = "bar"
-				utilruntime.Must(SetHashAnnotation(role))
+				apimachineryutilruntime.Must(SetHashAnnotation(role))
 				return role
 			}(),
 			expectedChanged: true,
@@ -1776,7 +1776,7 @@ func TestApplyRole(t *testing.T) {
 				func() *rbacv1.Role {
 					role := newRole()
 					role.OwnerReferences = nil
-					utilruntime.Must(SetHashAnnotation(role))
+					apimachineryutilruntime.Must(SetHashAnnotation(role))
 					return role
 				}(),
 			},
@@ -1796,7 +1796,7 @@ func TestApplyRole(t *testing.T) {
 				func() *rbacv1.Role {
 					role := newRole()
 					role.OwnerReferences[0].Kind = "WrongKind"
-					utilruntime.Must(SetHashAnnotation(role))
+					apimachineryutilruntime.Must(SetHashAnnotation(role))
 					return role
 				}(),
 			},
@@ -1806,7 +1806,7 @@ func TestApplyRole(t *testing.T) {
 			}(),
 			expectedRole: func() *rbacv1.Role {
 				role := newRole()
-				utilruntime.Must(SetHashAnnotation(role))
+				apimachineryutilruntime.Must(SetHashAnnotation(role))
 				return role
 			}(),
 			expectedChanged: true,
@@ -1819,7 +1819,7 @@ func TestApplyRole(t *testing.T) {
 				func() *rbacv1.Role {
 					role := newRole()
 					role.OwnerReferences[0].UID = "42"
-					utilruntime.Must(SetHashAnnotation(role))
+					apimachineryutilruntime.Must(SetHashAnnotation(role))
 					return role
 				}(),
 			},
@@ -1848,7 +1848,7 @@ func TestApplyRole(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "",
 					}
-					utilruntime.Must(SetHashAnnotation(role))
+					apimachineryutilruntime.Must(SetHashAnnotation(role))
 					role.Annotations["a-1"] = "a-alpha-changed"
 					role.Annotations["a-3"] = "a-resurrected"
 					role.Annotations["a-custom"] = "custom-value"
@@ -1884,7 +1884,7 @@ func TestApplyRole(t *testing.T) {
 					"l-2":  "l-beta",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(role))
+				apimachineryutilruntime.Must(SetHashAnnotation(role))
 				role.Annotations["a-1"] = "a-alpha-changed"
 				role.Annotations["a-3"] = "a-resurrected"
 				role.Annotations["a-custom"] = "custom-value"
@@ -1912,7 +1912,7 @@ func TestApplyRole(t *testing.T) {
 						"l-2":  "l-beta",
 						"l-3-": "l-resurrected",
 					}
-					utilruntime.Must(SetHashAnnotation(role))
+					apimachineryutilruntime.Must(SetHashAnnotation(role))
 					role.Annotations["a-1"] = "a-alpha-changed"
 					role.Annotations["a-custom"] = "a-custom-value"
 					role.Labels["l-1"] = "l-alpha-changed"
@@ -1946,7 +1946,7 @@ func TestApplyRole(t *testing.T) {
 					"l-2":  "l-beta-x",
 					"l-3-": "",
 				}
-				utilruntime.Must(SetHashAnnotation(role))
+				apimachineryutilruntime.Must(SetHashAnnotation(role))
 				delete(role.Annotations, "a-3-")
 				role.Annotations["a-custom"] = "a-custom-value"
 				delete(role.Labels, "l-3-")

--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -37,5 +37,5 @@ var (
 )
 
 func init() {
-	utilruntime.Must(AddToScheme(Scheme))
+	apimachineryutilruntime.Must(AddToScheme(Scheme))
 }

--- a/pkg/scyllaclient/config.go
+++ b/pkg/scyllaclient/config.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // Config specifies the Client configuration.
@@ -54,5 +54,5 @@ func (c *Config) Validate() error {
 		errs = append(errs, fmt.Errorf("missing port"))
 	}
 
-	return apierrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/systemd/daemon.go
+++ b/pkg/systemd/daemon.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/coreos/go-systemd/v22/dbus"
 	godbus "github.com/godbus/dbus/v5"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilsets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 var ErrNotExist = errors.New("unit does not exist")
@@ -135,12 +135,12 @@ func (c *SystemdControl) GetUnitStatuses(ctx context.Context, unitFiles []string
 		return nil, fmt.Errorf("can't list units %q: %w", strings.Join(unitFiles, ", "), transformSystemdError(err))
 	}
 
-	unitNameSet := sets.New(unitFiles...)
-	dbusUnitStatuses = slices.Filter(dbusUnitStatuses, func(us dbus.UnitStatus) bool {
+	unitNameSet := apimachineryutilsets.New(unitFiles...)
+	dbusUnitStatuses = oslices.Filter(dbusUnitStatuses, func(us dbus.UnitStatus) bool {
 		return unitNameSet.Has(us.Name)
 	})
 
-	unitStatuses := slices.ConvertSlice(dbusUnitStatuses, func(us dbus.UnitStatus) UnitStatus {
+	unitStatuses := oslices.ConvertSlice(dbusUnitStatuses, func(us dbus.UnitStatus) UnitStatus {
 		return UnitStatus{
 			Name:        us.Name,
 			LoadState:   us.LoadState,
@@ -151,7 +151,7 @@ func (c *SystemdControl) GetUnitStatuses(ctx context.Context, unitFiles []string
 	getUnitName := func(us UnitStatus) string {
 		return us.Name
 	}
-	missingUnitNames := unitNameSet.Difference(sets.New(slices.ConvertSlice(unitStatuses, getUnitName)...)).UnsortedList()
+	missingUnitNames := unitNameSet.Difference(apimachineryutilsets.New(oslices.ConvertSlice(unitStatuses, getUnitName)...)).UnsortedList()
 
 	var unitPropertiesErrs []error
 	for _, name := range missingUnitNames {
@@ -179,7 +179,7 @@ func (c *SystemdControl) GetUnitStatuses(ctx context.Context, unitFiles []string
 		unitStatuses = append(unitStatuses, us)
 	}
 
-	err = utilerrors.NewAggregate(unitPropertiesErrs)
+	err = apimachineryutilerrors.NewAggregate(unitPropertiesErrs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/systemd/daemon_test.go
+++ b/pkg/systemd/daemon_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/rand"
+	apimachineryutilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 func hasSystemdRunning() (bool, error) {
@@ -51,7 +51,7 @@ func TestSystemdControl_ErrNotExist(t *testing.T) {
 	}
 	defer sc.Close()
 
-	notExistingUnitName := fmt.Sprintf("%s.mount", rand.String(32))
+	notExistingUnitName := fmt.Sprintf("%s.mount", apimachineryutilrand.String(32))
 
 	err = sc.EnableUnits(ctx, []string{notExistingUnitName})
 	verifyError(err)

--- a/pkg/systemd/unit.go
+++ b/pkg/systemd/unit.go
@@ -10,11 +10,11 @@ import (
 	"path/filepath"
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 )
@@ -174,21 +174,21 @@ func (m *UnitManager) EnsureUnits(ctx context.Context, nc *scyllav1alpha1.NodeCo
 		)
 	}
 
-	unitStatuses, err := control.GetUnitStatuses(ctx, slices.ConvertSlice(requiredUnits, func(unit *NamedUnit) string {
+	unitStatuses, err := control.GetUnitStatuses(ctx, oslices.ConvertSlice(requiredUnits, func(unit *NamedUnit) string {
 		return unit.FileName
 	}))
 	if err != nil {
 		return progressingMessages, fmt.Errorf("can't get unit statuses: %w", err)
 	}
 
-	foundUnitStatuses := slices.FilterOut(unitStatuses, func(status UnitStatus) bool {
+	foundUnitStatuses := oslices.FilterOut(unitStatuses, func(status UnitStatus) bool {
 		return status.LoadState == loadStateNotFound
 	})
-	existingUnitsSet := sets.New(slices.ConvertSlice(foundUnitStatuses, func(status UnitStatus) string {
+	existingUnitsSet := apimachineryutilsets.New(oslices.ConvertSlice(foundUnitStatuses, func(status UnitStatus) string {
 		return status.Name
 	})...)
 
-	managedUnitsSet := sets.New(status.ManagedUnits...)
+	managedUnitsSet := apimachineryutilsets.New(status.ManagedUnits...)
 
 	// Do not try to reconcile units which are not managed by us.
 	var managedRequiredUnits []*NamedUnit
@@ -204,7 +204,7 @@ func (m *UnitManager) EnsureUnits(ctx context.Context, nc *scyllav1alpha1.NodeCo
 
 	// First save the updated list of managed units,
 	// so we can clean up in the next run, if we were interrupted.
-	status.ManagedUnits = slices.ConvertSlice(managedRequiredUnits, func(unit *NamedUnit) string {
+	status.ManagedUnits = oslices.ConvertSlice(managedRequiredUnits, func(unit *NamedUnit) string {
 		return unit.FileName
 	})
 
@@ -290,5 +290,5 @@ func (m *UnitManager) EnsureUnits(ctx context.Context, nc *scyllav1alpha1.NodeCo
 		}
 	}
 
-	return progressingMessages, apierrors.NewAggregate(errs)
+	return progressingMessages, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/systemd/unit_test.go
+++ b/pkg/systemd/unit_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -342,7 +342,7 @@ func Test_unitManager_EnsureUnits(t *testing.T) {
 			},
 			expectedProgressingMessages: nil,
 			expectedErrFunc: func(_ string) error {
-				return apierrors.NewAggregate([]error{
+				return apimachineryutilerrors.NewAggregate([]error{
 					fmt.Errorf(`required unit "foreign.mount" already exists and is not managed by us`),
 				})
 			},
@@ -408,7 +408,7 @@ func Test_unitManager_EnsureUnits(t *testing.T) {
 				`Awaiting unit "failed.mount" to be in active state "active".`,
 			},
 			expectedErrFunc: func(_ string) error {
-				return apierrors.NewAggregate([]error{
+				return apimachineryutilerrors.NewAggregate([]error{
 					fmt.Errorf(`unit "failed.mount" is in a "failed" active state`),
 				})
 			},
@@ -484,7 +484,7 @@ func Test_unitManager_EnsureUnits(t *testing.T) {
 				`Awaiting unit "failed.mount" to be in active state "active".`,
 			},
 			expectedErrFunc: func(_ string) error {
-				return apierrors.NewAggregate([]error{
+				return apimachineryutilerrors.NewAggregate([]error{
 					fmt.Errorf(`required unit "foreign.mount" already exists and is not managed by us`),
 					fmt.Errorf(`unit "failed.mount" is in a "failed" active state`),
 				})
@@ -565,10 +565,10 @@ func Test_unitManager_EnsureUnits(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			unexpectedEntries := slices.Filter(entries, func(entry os.DirEntry) bool {
+			unexpectedEntries := oslices.Filter(entries, func(entry os.DirEntry) bool {
 				return !entry.IsDir() &&
 					entry.Name() != m.getStatusName() &&
-					!slices.Contains(
+					!oslices.Contains(
 						tc.expectedUnits,
 						func(v *NamedUnit) bool {
 							return v.FileName == entry.Name()
@@ -577,7 +577,7 @@ func Test_unitManager_EnsureUnits(t *testing.T) {
 			})
 
 			if len(unexpectedEntries) != 0 {
-				unexpectedEntryNames := slices.ConvertSlice(unexpectedEntries, func(entry os.DirEntry) string {
+				unexpectedEntryNames := oslices.ConvertSlice(unexpectedEntries, func(entry os.DirEntry) string {
 					return entry.Name()
 				})
 				t.Errorf("Unexpected files were created: %q", strings.Join(unexpectedEntryNames, ","))

--- a/pkg/util/blkutils/lsblk.go
+++ b/pkg/util/blkutils/lsblk.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	oexec "github.com/scylladb/scylla-operator/pkg/util/exec"
-	"k8s.io/apimachinery/pkg/util/json"
+	apimachineryutiljson "k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/utils/exec"
 )
 
@@ -69,7 +69,7 @@ func ListBlockDevices(ctx context.Context, executor exec.Interface, devices ...s
 	}
 
 	output := &lsblkOutput{}
-	err = json.Unmarshal(stdout.Bytes(), output)
+	err = apimachineryutiljson.Unmarshal(stdout.Bytes(), output)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal lsblk output %q: %w", stdout.String(), err)
 	}

--- a/pkg/util/errors/multiline.go
+++ b/pkg/util/errors/multiline.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 type aggregate struct {
@@ -12,7 +12,7 @@ type aggregate struct {
 	sep     string
 }
 
-var _ utilerrors.Aggregate = &aggregate{}
+var _ apimachineryutilerrors.Aggregate = &aggregate{}
 
 func NewAggregate(errList []error, sep string) error {
 	var errs []error
@@ -70,7 +70,7 @@ func (agg *aggregate) visit(f func(err error) bool) bool {
 				return match
 			}
 
-		case utilerrors.Aggregate:
+		case apimachineryutilerrors.Aggregate:
 			for _, nestedErr := range err.Errors() {
 				match := f(nestedErr)
 				if match {

--- a/pkg/util/parallel/parallel.go
+++ b/pkg/util/parallel/parallel.go
@@ -3,7 +3,7 @@
 package parallel
 
 import (
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func ForEach(length int, f func(i int) error) error {
@@ -21,5 +21,5 @@ func ForEach(length int, f func(i int) error) error {
 		errs = append(errs, <-errCh)
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return apimachineryutilerrors.NewAggregate(errs)
 }

--- a/pkg/util/parallel/parallel_test.go
+++ b/pkg/util/parallel/parallel_test.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"testing"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func TestForEach(t *testing.T) {
@@ -59,7 +59,7 @@ func TestForEach(t *testing.T) {
 					panic("out of range")
 				}
 			},
-			expectedErr: utilerrors.NewAggregate([]error{anError(0)}),
+			expectedErr: apimachineryutilerrors.NewAggregate([]error{anError(0)}),
 		},
 		{
 			name:   "two errors",
@@ -72,7 +72,7 @@ func TestForEach(t *testing.T) {
 					panic("out of range")
 				}
 			},
-			expectedErr: utilerrors.NewAggregate([]error{anError(0), anError(1)}),
+			expectedErr: apimachineryutilerrors.NewAggregate([]error{anError(0), anError(1)}),
 		},
 		{
 			name:   "mixed",
@@ -87,7 +87,7 @@ func TestForEach(t *testing.T) {
 					panic("out of range")
 				}
 			},
-			expectedErr: utilerrors.NewAggregate([]error{nil, anError(1), nil, anError(3), nil}),
+			expectedErr: apimachineryutilerrors.NewAggregate([]error{nil, anError(1), nil, anError(3), nil}),
 		},
 	}
 
@@ -97,7 +97,7 @@ func TestForEach(t *testing.T) {
 
 			// Sort the errors to avoid random ordering from parallelism.
 			if gotErr != nil {
-				errs := gotErr.(utilerrors.Aggregate).Errors()
+				errs := gotErr.(apimachineryutilerrors.Aggregate).Errors()
 				sort.Slice(errs, func(i, j int) bool {
 					return errs[i].Error() < errs[j].Error()
 				})

--- a/pkg/util/yaml/yaml.go
+++ b/pkg/util/yaml/yaml.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	apiyaml "k8s.io/apimachinery/pkg/util/yaml"
+	apimachineryutilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -16,7 +16,7 @@ import (
 func ToUnstructured(rawyaml io.Reader) ([]unstructured.Unstructured, error) {
 	var objs []unstructured.Unstructured
 
-	reader := apiyaml.NewYAMLReader(bufio.NewReader(rawyaml))
+	reader := apimachineryutilyaml.NewYAMLReader(bufio.NewReader(rawyaml))
 	count := 1
 	for {
 		// Read one YAML document at a time, until io.EOF is returned

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -20,7 +20,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -293,7 +293,7 @@ func CreateUserNamespace(ctx context.Context, clusterName string, labels map[str
 	}
 	name := generateName()
 	sr := g.CurrentSpecReport()
-	err := wait.PollImmediate(2*time.Second, 30*time.Second, func() (bool, error) {
+	err := apimachineryutilwait.PollImmediate(2*time.Second, 30*time.Second, func() (bool, error) {
 		var err error
 		// We want to know the name ahead, even if the api call fails.
 		ns, err = adminClient.CoreV1().Namespaces().Create(

--- a/test/e2e/scheme/install.go
+++ b/test/e2e/scheme/install.go
@@ -4,14 +4,14 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	cqlclientv1alpha1 "github.com/scylladb/scylla-operator/pkg/scylla/api/cqlclient/v1alpha1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 func init() {
-	utilruntime.Must(kubernetesscheme.AddToScheme(Scheme))
+	apimachineryutilruntime.Must(kubernetesscheme.AddToScheme(Scheme))
 
-	utilruntime.Must(scyllav1.Install(Scheme))
-	utilruntime.Must(scyllav1alpha1.Install(Scheme))
-	utilruntime.Must(cqlclientv1alpha1.Install(Scheme))
+	apimachineryutilruntime.Must(scyllav1.Install(Scheme))
+	apimachineryutilruntime.Must(scyllav1alpha1.Install(Scheme))
+	apimachineryutilruntime.Must(cqlclientv1alpha1.Install(Scheme))
 }

--- a/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
+	apimachineryutilrand "k8s.io/apimachinery/pkg/util/rand"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
@@ -71,7 +71,7 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 		clientPod, err = controllerhelpers.WaitForPodState(waitCtx1, f.KubeClient().CoreV1().Pods(clientPod.Namespace), clientPod.Name, controllerhelpers.WaitForStateOptions{}, utils.PodIsRunning)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		raidName := rand.String(8)
+		raidName := apimachineryutilrand.String(8)
 		mountPath := fmt.Sprintf("/var/lib/disk-setup-%s", f.Namespace())
 		hostMountPath := path.Join("/host", mountPath)
 

--- a/test/e2e/set/nodeconfig/verify.go
+++ b/test/e2e/set/nodeconfig/verify.go
@@ -6,7 +6,7 @@ import (
 
 	o "github.com/onsi/gomega"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
@@ -249,6 +249,6 @@ func verifyNodeConfig(ctx context.Context, kubeClient kubernetes.Interface, nc *
 		return nodeStatus.Name
 	}
 
-	tunedNodes := slices.ConvertSlice(slices.Filter(nc.Status.NodeStatuses, isNodeStatusNodeTuned), getNodeStatusName)
+	tunedNodes := oslices.ConvertSlice(oslices.Filter(nc.Status.NodeStatuses, isNodeStatusNodeTuned), getNodeStatusName)
 	o.Expect(tunedNodes).To(o.ConsistOf(dsNodeNames))
 }

--- a/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
+++ b/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
@@ -10,7 +10,7 @@ import (
 	o "github.com/onsi/gomega"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -54,7 +54,7 @@ var _ = g.Describe("RemoteKubernetesCluster finalizer", func() {
 
 		const expectedFinalizer = "scylla-operator.scylladb.com/remotekubernetescluster-protection"
 		hasRKCFinalizer := func(rkc *scyllav1alpha1.RemoteKubernetesCluster) (bool, error) {
-			return slices.ContainsItem(rkc.Finalizers, expectedFinalizer), nil
+			return oslices.ContainsItem(rkc.Finalizers, expectedFinalizer), nil
 		}
 
 		rkc, err = controllerhelpers.WaitForRemoteKubernetesClusterState(waitCtx1, cluster.ScyllaAdminClient().ScyllaV1alpha1().RemoteKubernetesClusters(), rkc.Name, controllerhelpers.WaitForStateOptions{},

--- a/test/e2e/set/scyllacluster/scyllacluster_alternator.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_alternator.go
@@ -24,7 +24,7 @@ import (
 	o "github.com/onsi/gomega"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	scyllafixture "github.com/scylladb/scylla-operator/test/e2e/fixture/scylla"
@@ -153,7 +153,7 @@ authorizer: CassandraAuthorizer
 			fmt.Sprintf("%s.%s.svc", naming.MemberServiceNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, 0), sc.Namespace),
 			"scylla.operator.rocks",
 		))
-		alternatorServingCertIPStrings := slices.ConvertSlice[string](
+		alternatorServingCertIPStrings := oslices.ConvertSlice[string](
 			alternatorServingCert.IPAddresses,
 			func(from net.IP) string {
 				return from.String()

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -9,7 +9,7 @@ import (
 	o "github.com/onsi/gomega"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
@@ -105,7 +105,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 			}
 		}
 
-		cleanupJobsCreated := slices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
+		cleanupJobsCreated := oslices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
 			return e.Action == watch.Added &&
 				e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup) &&
 				e.Obj.Annotations[naming.CleanupJobTokenRingHashAnnotation] == tokenRingHash
@@ -152,7 +152,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 
 		o.Expect(jobEvents).NotTo(o.BeEmpty())
 
-		cleanupJobsCreated = slices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
+		cleanupJobsCreated = oslices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
 			return e.Action == watch.Added &&
 				e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup) &&
 				e.Obj.Annotations[naming.CleanupJobTokenRingHashAnnotation] == tokenRingHash

--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
+	apimachineryutilrand "k8s.io/apimachinery/pkg/util/rand"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -350,7 +350,7 @@ var _ = g.Describe("ScyllaCluster", func() {
 				NodeService: &scyllav1.NodeServiceTemplate{
 					Type: scyllav1.NodeServiceTypeLoadBalancer,
 					// Change to non-default LB class to avoid conflicts on status when running in cloud
-					LoadBalancerClass: pointer.Ptr(fmt.Sprintf("lb-class-%s", rand.String(6))),
+					LoadBalancerClass: pointer.Ptr(fmt.Sprintf("lb-class-%s", apimachineryutilrand.String(6))),
 				},
 				BroadcastOptions: &scyllav1.NodeBroadcastOptions{
 					Nodes: scyllav1.BroadcastOptions{

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
@@ -70,7 +70,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 			}).String(),
 		}))
 
-		o.Expect(utilerrors.NewAggregate(errs)).NotTo(o.HaveOccurred())
+		o.Expect(apimachineryutilerrors.NewAggregate(errs)).NotTo(o.HaveOccurred())
 	})
 
 	g.It("should replace a node with orphaned PV", func() {
@@ -270,7 +270,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
 				}
 				return false, nil
 			})
-			if errors.Is(err, wait.ErrWaitTimeout) && errors.Is(provisionerCtx.Err(), context.Canceled) {
+			if errors.Is(err, apimachineryutilwait.ErrWaitTimeout) && errors.Is(provisionerCtx.Err(), context.Canceled) {
 				return
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -20,7 +20,7 @@ import (
 	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 var _ = g.Describe("Scylla Manager integration", func() {
@@ -175,7 +175,7 @@ var _ = g.Describe("Scylla Manager integration", func() {
 		o.Expect(sc.Status.ManagerID).NotTo(o.BeNil())
 
 		framework.By("Waiting for repair to finish")
-		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(context.Context) (done bool, err error) {
+		err = apimachineryutilwait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(context.Context) (done bool, err error) {
 			repairProgress, err := managerClient.RepairProgress(ctx, *sc.Status.ManagerID, repairTask.ID, "latest")
 			if err != nil {
 				return false, err

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -26,7 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -220,7 +220,7 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 
 		var backupProgress managerclient.BackupProgress
 		framework.By("Waiting for backup to finish")
-		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(context.Context) (done bool, err error) {
+		err = apimachineryutilwait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(context.Context) (done bool, err error) {
 			backupProgress, err = managerClient.BackupProgress(ctx, *sourceSC.Status.ManagerID, backupTask.ID, "latest")
 			if err != nil {
 				return false, err

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
@@ -11,7 +11,7 @@ import (
 	o "github.com/onsi/gomega"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
@@ -167,7 +167,7 @@ var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter
 
 			clusterClient := rkcClusterMap[dc.RemoteKubernetesClusterName]
 
-			dcStatus, _, ok := slices.Find(sc.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
+			dcStatus, _, ok := oslices.Find(sc.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
 				return dc.Name == dcStatus.Name
 			})
 			o.Expect(ok).To(o.BeTrue())

--- a/test/e2e/set/scylladbdatacenter/scylladbdatacenter_globalmanager.go
+++ b/test/e2e/set/scylladbdatacenter/scylladbdatacenter_globalmanager.go
@@ -10,7 +10,7 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers/managerclienterrors"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
@@ -26,7 +26,7 @@ var _ = g.Describe("ScyllaDBDatacenter integration with global ScyllaDB Manager"
 	f := framework.NewFramework("scylladbdatacenter")
 
 	hasDeletionFinalizer := func(smcr *scyllav1alpha1.ScyllaDBManagerClusterRegistration) (bool, error) {
-		return slices.ContainsItem(smcr.Finalizers, naming.ScyllaDBManagerClusterRegistrationFinalizer), nil
+		return oslices.ContainsItem(smcr.Finalizers, naming.ScyllaDBManagerClusterRegistrationFinalizer), nil
 	}
 
 	g.It("should register labeled ScyllaDBDatacenter and deregister it when it's unlabeled", func(ctx g.SpecContext) {

--- a/test/e2e/utils/clusters.go
+++ b/test/e2e/utils/clusters.go
@@ -8,7 +8,7 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/gather/collect"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	corev1 "k8s.io/api/core/v1"
@@ -236,7 +236,7 @@ func RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx context.Context, sc
 	for _, dc := range sc.Spec.Datacenters {
 		cluster := rkcClusterMap[dc.RemoteKubernetesClusterName]
 
-		dcStatus, _, ok := slices.Find(sc.Status.Datacenters, func(status scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
+		dcStatus, _, ok := oslices.Find(sc.Status.Datacenters, func(status scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
 			return status.Name == dc.Name
 		})
 		if !ok {

--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -13,9 +13,9 @@ import (
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/gocqlx/v2/table"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	apimachineryutilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 const nRows = 10
@@ -47,7 +47,7 @@ func NewDataInserter(hosts []string, options ...DataInserterOption) (*DataInsert
 }
 
 func NewMultiDCDataInserter(dcHosts map[string][]string, options ...DataInserterOption) (*DataInserter, error) {
-	keyspace := utilrand.String(8)
+	keyspace := apimachineryutilrand.String(8)
 	table := table.New(table.Metadata{
 		Name:    fmt.Sprintf(`"%s"."test"`, keyspace),
 		Columns: []string{"id", "data"},
@@ -55,7 +55,7 @@ func NewMultiDCDataInserter(dcHosts map[string][]string, options ...DataInserter
 	})
 	data := make([]*TestData, 0, nRows)
 	for i := range nRows {
-		data = append(data, &TestData{Id: i, Data: utilrand.String(32)})
+		data = append(data, &TestData{Id: i, Data: apimachineryutilrand.String(32)})
 	}
 
 	replicationFactor := make(map[string]int, len(dcHosts))
@@ -75,7 +75,7 @@ func NewMultiDCDataInserter(dcHosts map[string][]string, options ...DataInserter
 	}
 
 	if di.session == nil {
-		err := di.SetClientEndpoints(slices.Flatten(helpers.GetMapValues(dcHosts)))
+		err := di.SetClientEndpoints(oslices.Flatten(helpers.GetMapValues(dcHosts)))
 		if err != nil {
 			return nil, fmt.Errorf("can't set client endpoints: %w", err)
 		}

--- a/test/e2e/utils/exec.go
+++ b/test/e2e/utils/exec.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -38,7 +38,7 @@ func ExecWithOptions(ctx context.Context, config *rest.Config, client corev1clie
 		Namespace(options.Namespace).
 		SubResource("exec").
 		Param("container", options.ContainerName)
-	req.VersionedParams(&v1.PodExecOptions{
+	req.VersionedParams(&corev1.PodExecOptions{
 		Container: options.ContainerName,
 		Command:   options.Command,
 		Stdin:     options.Stdin != nil,

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -22,7 +22,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	ocrypto "github.com/scylladb/scylla-operator/pkg/crypto"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
@@ -34,7 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
@@ -388,7 +388,7 @@ func GetBroadcastAddresses(ctx context.Context, client corev1client.CoreV1Interf
 	}
 
 	var broadcastAddresses []string
-	for _, svc := range slices.ConvertSlice(serviceList.Items, pointer.Ptr[corev1.Service]) {
+	for _, svc := range oslices.ConvertSlice(serviceList.Items, pointer.Ptr[corev1.Service]) {
 		podName := naming.PodNameFromService(svc)
 		pod, err := client.Pods(sc.Namespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
@@ -683,7 +683,7 @@ func waitForFullQuorum(ctx context.Context, client corev1client.CoreV1Interface,
 
 	// Wait for node status to propagate and reach consistency.
 	// This can take a while so let's set a large enough timeout to avoid flakes.
-	return wait.PollImmediateWithContext(ctx, 1*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
+	return apimachineryutilwait.PollImmediateWithContext(ctx, 1*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
 		allSeeAllAsUN := true
 		infoMessages := make([]string, 0, len(hosts))
 		var errs []error

--- a/test/e2e/utils/linux/net/net.go
+++ b/test/e2e/utils/linux/net/net.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 )
 
 const (
@@ -225,10 +225,10 @@ func ParseProcNetEntries(data string) (ProcNetEntries, error) {
 }
 
 func (pe ProcNetEntries) FilterListen() []AddressPort {
-	filtered := slices.Filter(pe, func(entry ProcNetEntry) bool {
+	filtered := oslices.Filter(pe, func(entry ProcNetEntry) bool {
 		return entry.State == EntryStateListen
 	})
-	return slices.ConvertSlice(filtered, func(from ProcNetEntry) AddressPort {
+	return oslices.ConvertSlice(filtered, func(from ProcNetEntry) AddressPort {
 		return from.LocalAddress
 	})
 }

--- a/test/e2e/utils/observer.go
+++ b/test/e2e/utils/observer.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/scylladb/scylla-operator/pkg/kubeinterfaces"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	watchutils "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/watch"
@@ -55,7 +55,7 @@ func (o *ObjectObserver[T]) Start(ctx context.Context) error {
 		})
 
 		if err != nil {
-			if errors.Is(ctx.Err(), context.Canceled) && wait.Interrupted(err) {
+			if errors.Is(ctx.Err(), context.Canceled) && apimachineryutilwait.Interrupted(err) {
 				o.errChan <- nil
 				return
 			}

--- a/test/e2e/utils/v1alpha1/helpers.go
+++ b/test/e2e/utils/v1alpha1/helpers.go
@@ -16,7 +16,7 @@ import (
 	scyllaclientset "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -140,7 +140,7 @@ func GetBroadcastAddresses(ctx context.Context, client corev1client.CoreV1Interf
 	}
 
 	var broadcastAddresses []string
-	for _, svc := range slices.ConvertSlice(serviceList.Items, pointer.Ptr[corev1.Service]) {
+	for _, svc := range oslices.ConvertSlice(serviceList.Items, pointer.Ptr[corev1.Service]) {
 		podName := naming.PodNameFromService(svc)
 		pod, err := client.Pods(sdc.Namespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
@@ -286,7 +286,7 @@ func WaitForFullQuorum(ctx context.Context, client corev1client.CoreV1Interface,
 
 	// Wait for node status to propagate and reach consistency.
 	// This can take a while so let's set a large enough timeout to avoid flakes.
-	return wait.PollImmediateWithContext(ctx, 1*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
+	return apimachineryutilwait.PollImmediateWithContext(ctx, 1*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
 		allSeeAllAsUN := true
 		infoMessages := make([]string, 0, len(hosts))
 		var errs []error
@@ -326,7 +326,7 @@ func WaitForFullQuorum(ctx context.Context, client corev1client.CoreV1Interface,
 }
 
 func GetRemoteDatacenterScyllaConfigClient(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, remoteScyllaAdminClient *scyllaclientset.Clientset, remoteKubeAdminClient *kubernetes.Clientset, agentAuthToken string) (*scyllaclient.ConfigClient, error) {
-	dcStatus, _, ok := slices.Find(sc.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
+	dcStatus, _, ok := oslices.Find(sc.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
 		return dc.Name == dcStatus.Name
 	})
 	if !ok {

--- a/test/e2e/utils/verification/scylladbcluster/cql.go
+++ b/test/e2e/utils/verification/scylladbcluster/cql.go
@@ -6,15 +6,15 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	utilsv1alpha1 "github.com/scylladb/scylla-operator/test/e2e/utils/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func WaitForFullQuorum(ctx context.Context, rkcClusterMap map[string]framework.ClusterInterface, sc *v1alpha1.ScyllaDBCluster) error {
+func WaitForFullQuorum(ctx context.Context, rkcClusterMap map[string]framework.ClusterInterface, sc *scyllav1alpha1.ScyllaDBCluster) error {
 	allBroadcastAddresses := map[string][]string{}
 	var sortedAllBroadcastAddresses []string
 
@@ -26,7 +26,7 @@ func WaitForFullQuorum(ctx context.Context, rkcClusterMap map[string]framework.C
 			continue
 		}
 
-		dcStatus, _, ok := slices.Find(sc.Status.Datacenters, func(dcStatus v1alpha1.ScyllaDBClusterDatacenterStatus) bool {
+		dcStatus, _, ok := oslices.Find(sc.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
 			return dcStatus.Name == dc.Name
 		})
 		if !ok {
@@ -63,7 +63,7 @@ func WaitForFullQuorum(ctx context.Context, rkcClusterMap map[string]framework.C
 			continue
 		}
 
-		dcStatus, _, ok := slices.Find(sc.Status.Datacenters, func(dcStatus v1alpha1.ScyllaDBClusterDatacenterStatus) bool {
+		dcStatus, _, ok := oslices.Find(sc.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
 			return dcStatus.Name == dc.Name
 		})
 		if !ok {

--- a/test/e2e/utils/verification/scylladbcluster/verify.go
+++ b/test/e2e/utils/verification/scylladbcluster/verify.go
@@ -7,7 +7,7 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	scylladbclustercontroller "github.com/scylladb/scylla-operator/pkg/controller/scylladbcluster"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
@@ -15,7 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	apimachineryutilintstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func Verify(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, rkcClusterMap map[string]framework.ClusterInterface) {
@@ -179,7 +179,7 @@ func Verify(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, rkcClusterM
 		cluster := rkcClusterMap[dc.RemoteKubernetesClusterName]
 		o.Expect(cluster).NotTo(o.BeNil())
 
-		dcStatus, _, ok := slices.Find(sc.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
+		dcStatus, _, ok := oslices.Find(sc.Status.Datacenters, func(dcStatus scyllav1alpha1.ScyllaDBClusterDatacenterStatus) bool {
 			return dcStatus.Name == dc.Name
 		})
 		o.Expect(ok).To(o.BeTrue())
@@ -210,7 +210,7 @@ func Verify(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, rkcClusterM
 		o.Expect(dcStatus.AvailableNodes).ToNot(o.BeNil())
 		o.Expect(*dcStatus.AvailableNodes).To(o.Equal(dcNodeCount))
 
-		otherDCs := slices.FilterOut(sc.Spec.Datacenters, func(otherDC scyllav1alpha1.ScyllaDBClusterDatacenter) bool {
+		otherDCs := oslices.FilterOut(sc.Spec.Datacenters, func(otherDC scyllav1alpha1.ScyllaDBClusterDatacenter) bool {
 			return dc.Name == otherDC.Name
 		})
 
@@ -226,25 +226,25 @@ func Verify(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, rkcClusterM
 					Name:       "inter-node",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       7000,
-					TargetPort: intstr.IntOrString{IntVal: 7000},
+					TargetPort: apimachineryutilintstr.IntOrString{IntVal: 7000},
 				},
 				{
 					Name:       "inter-node-ssl",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       7001,
-					TargetPort: intstr.IntOrString{IntVal: 7001},
+					TargetPort: apimachineryutilintstr.IntOrString{IntVal: 7001},
 				},
 				{
 					Name:       "cql",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       9042,
-					TargetPort: intstr.IntOrString{IntVal: 9042},
+					TargetPort: apimachineryutilintstr.IntOrString{IntVal: 9042},
 				},
 				{
 					Name:       "cql-ssl",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       9142,
-					TargetPort: intstr.IntOrString{IntVal: 9142},
+					TargetPort: apimachineryutilintstr.IntOrString{IntVal: 9142},
 				},
 			}))
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Enable `importas` linter to enforce some packages to be always imported with a predefined alias.

This is good for keeping the aliases consistent across the codebase as it reduces cognitive load when an alias has to be defined, and makes reading code easier in the long run.

Note to reviewers: I picked some common packages, but if you think there's more that we could enforce, I'm open to adding such.

