### PR TITLE
Fix NonRetriableError matching

### DIFF
--- a/pkg/controller/scylladbmanagerclusterregistration/controller.go
+++ b/pkg/controller/scylladbmanagerclusterregistration/controller.go
@@ -168,13 +168,12 @@ func (smcrc *Controller) processNextItem(ctx context.Context) bool {
 	case apierrors.IsAlreadyExists(err):
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
 
-	default:
-		if controllertools.IsNonRetriable(err) {
-			klog.InfoS("Hit non-retriable error. Dropping the item from the queue.", "Error", err)
-			smcrc.queue.Forget(key)
-			return true
-		}
+	case controllertools.IsNonRetriable(err):
+		klog.InfoS("Hit non-retriable error. Dropping the item from the queue.", "Error", err)
+		smcrc.queue.Forget(key)
+		return true
 
+	default:
 		utilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))
 
 	}

--- a/pkg/controllertools/errors.go
+++ b/pkg/controllertools/errors.go
@@ -8,6 +8,10 @@ type NonRetriableError struct {
 	error
 }
 
+func (e NonRetriableError) Unwrap() error {
+	return e.error
+}
+
 func NonRetriable(err error) error {
 	return NonRetriableError{err}
 }
@@ -17,5 +21,5 @@ func NewNonRetriable(message string) error {
 }
 
 func IsNonRetriable(err error) bool {
-	return errors.Is(err, NonRetriableError{})
+	return errors.As(err, &NonRetriableError{})
 }

--- a/pkg/controllertools/errors_test.go
+++ b/pkg/controllertools/errors_test.go
@@ -1,0 +1,136 @@
+// Copyright (C) 2025 ScyllaDB
+
+package controllertools
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsNonRetriable(t *testing.T) {
+	t.Parallel()
+
+	regularErr := errors.New("regular error")
+	nonRetriableErr := NonRetriable(regularErr)
+
+	tt := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "regular error",
+			err:      regularErr,
+			expected: false,
+		},
+		{
+			name:     "non-retriable error",
+			err:      nonRetriableErr,
+			expected: true,
+		},
+		{
+			name:     "wrapped non-retriable error",
+			err:      fmt.Errorf("wrapped: %w", nonRetriableErr),
+			expected: true,
+		},
+		{
+			name:     "aggregated non-retriable error",
+			err:      errors.Join(nonRetriableErr, regularErr),
+			expected: true,
+		},
+		{
+			name:     "aggregated, wrapped non-retriable error",
+			err:      errors.Join(fmt.Errorf("wrapped: %w", nonRetriableErr), regularErr),
+			expected: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsNonRetriable(tc.err)
+			if got != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestUnwrap(t *testing.T) {
+	t.Parallel()
+
+	regularErr := errors.New("regular error")
+	nonRetriableErr := NonRetriable(regularErr)
+
+	type customErr struct {
+		error
+	}
+
+	tt := []struct {
+		name     string
+		err      error
+		target   any
+		expected bool
+	}{
+		{
+			name:     "nil err as non-retriable",
+			err:      nil,
+			target:   &NonRetriableError{},
+			expected: false,
+		},
+		{
+			name:     "regular err as non-retriable",
+			err:      regularErr,
+			target:   &NonRetriableError{},
+			expected: false,
+		},
+		{
+			name:     "non-retriable regular err as non-retriable",
+			err:      nonRetriableErr,
+			target:   &NonRetriableError{},
+			expected: true,
+		},
+		{
+			name:     "wrapped non-retriable regular err as non-retriable",
+			err:      fmt.Errorf("wrapped: %w", nonRetriableErr),
+			target:   &NonRetriableError{},
+			expected: true,
+		},
+		{
+			name:     "aggregated non-retriable regular err as non-retriable",
+			err:      errors.Join(nonRetriableErr, regularErr),
+			target:   &NonRetriableError{},
+			expected: true,
+		},
+		{
+			name:     "non-retriable regular err as regular",
+			err:      nonRetriableErr,
+			target:   &regularErr,
+			expected: true,
+		},
+		{
+			name:     "non-retriable custom err as custom",
+			err:      NonRetriable(customErr{errors.New("custom error")}),
+			target:   &customErr{},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := errors.As(tc.err, tc.target)
+			if got != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR fixes the function matching non-retriable errors. `errors.Is` is meant for comparing with sentinel errors as it checks for equality. The NonRetriableError, being a wrapper, fails the equality test.

The PR also implements `Unwrap()` method for NonRetriableError to allow errors.As/errors.Is to be (correctly) used for wrapped errors.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-soon