### PR TITLE
Strip ScyllaDB Manager client errors propagated to objects' statuses from non-idemponent information and unify log levels

### DIFF
--- a/pkg/controller/scylladbmanagerclusterregistration/sync_finalizer.go
+++ b/pkg/controller/scylladbmanagerclusterregistration/sync_finalizer.go
@@ -59,6 +59,7 @@ func (smcrc *Controller) syncFinalizer(ctx context.Context, smcr *scyllav1alpha1
 	if found {
 		err = managerClient.DeleteCluster(ctx, managerCluster.ID)
 		if err != nil {
+			klog.V(4).InfoS("Failed to delete ScyllaDB Manager cluster", "ScyllaDBManagerClusterRegistration", klog.KObj(smcr), "UID", smcr.UID, "ScyllaDBManagerClusterName", managerCluster.Name, "ScyllaDBManagerClusterID", managerCluster.ID, "Error", err)
 			return progressingConditions, fmt.Errorf("can't delete ScyllaDB Manager cluster: %w", err)
 		}
 

--- a/pkg/helpers/managerclienterrors/managerclienterrors.go
+++ b/pkg/helpers/managerclienterrors/managerclienterrors.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime"
+	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
 )
 
 func IsNotFound(err error) bool {
@@ -28,4 +29,20 @@ func codeForError(err error) int {
 	}
 
 	return 0
+}
+
+// GetPayloadMessage extracts the message from an error that implements the GetPayload method.
+// If the error does not implement the GetPayload method, it returns the error's string representation.
+func GetPayloadMessage(err error) string {
+	var payloadResponse interface {
+		GetPayload() *managerclient.ErrorResponse
+	}
+	if errors.As(err, &payloadResponse) {
+		payload := payloadResponse.GetPayload()
+		if payload != nil {
+			return payload.Message
+		}
+	}
+
+	return err.Error()
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** ScyllaDB Manager client can contain unique TraceIDs, which, when propagated to status conditions, may lead to status update hot loops, as the trace ID changes on every reconciliation, leading to subsequent updates. To prevent this, in this PR I add a method that allows for stripping the error of non-idempotent information. To retain the trace IDs, the errors are now also logged with debug level. The existing messages' levels are unified.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-soon