### PR TITLE
Ensure runtime namespaces are collected regardless of ScyllaDBCluster rollout success

### DIFF
--- a/pkg/controller/scylladbcluster/resource.go
+++ b/pkg/controller/scylladbcluster/resource.go
@@ -44,15 +44,15 @@ func MakeRemoteRemoteOwners(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alph
 }
 
 func MakeRemoteNamespaces(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter, managingClusterDomain string) ([]*corev1.Namespace, error) {
-	suffix, err := naming.GenerateNameHash(sc.Namespace, dc.Name)
+	name, err := naming.RemoteNamespaceName(sc, dc)
 	if err != nil {
-		return nil, fmt.Errorf("can't generate namespace name suffix: %w", err)
+		return nil, fmt.Errorf("can't get namespace name: %w", err)
 	}
 
 	return []*corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   fmt.Sprintf("%s-%s", sc.Namespace, suffix),
+				Name:   name,
 				Labels: naming.ScyllaDBClusterDatacenterLabels(sc, dc, managingClusterDomain),
 			},
 		},

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -305,3 +305,12 @@ func scyllaDBManagerClusterRegistrationName(kind, name string) (string, error) {
 	fullNameWithSuffix := fmt.Sprintf("%s-%s", fullName[:min(len(fullName), apimachineryutilvalidation.DNS1123SubdomainMaxLength-len(nameSuffix)-1)], nameSuffix)
 	return fullNameWithSuffix, nil
 }
+
+func RemoteNamespaceName(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1alpha1.ScyllaDBClusterDatacenter) (string, error) {
+	suffix, err := GenerateNameHash(sc.Namespace, dc.Name)
+	if err != nil {
+		return "", fmt.Errorf("can't generate namespace name suffix: %w", err)
+	}
+
+	return fmt.Sprintf("%s-%s", sc.Namespace, suffix), nil
+}

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
@@ -26,7 +26,12 @@ var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Creating ScyllaDBCluster")
+
 		sc := f.GetDefaultScyllaDBCluster(rkcMap)
+
+		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		sc, err = f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -34,9 +39,6 @@ var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter
 		waitCtx2, waitCtx2Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
 		defer waitCtx2Cancel()
 		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx2, f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaDBClusterRolledOut)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		scylladbclusterverification.Verify(ctx, sc, rkcClusterMap)

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
@@ -151,13 +151,13 @@ var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter
 		sc, err = f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(userNS.Name).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		framework.By("Waiting for the ScyllaDBCluster %q roll out (RV=%s)", sc.Name, sc.ResourceVersion)
 		waitCtx2, waitCtx2Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
 		defer waitCtx2Cancel()
 		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx2, f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaDBClusterRolledOut)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		scylladbclusterverification.Verify(ctx, sc, rkcClusterMap)

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_fault_tolerance.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_fault_tolerance.go
@@ -71,13 +71,13 @@ var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter
 		sc, err = f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		framework.By("Waiting for the ScyllaDBCluster %q roll out (RV=%s)", sc.Name, sc.ResourceVersion)
 		waitCtx2, waitCtx2Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
 		defer waitCtx2Cancel()
 		sc, err = controllerhelpers.WaitForScyllaDBClusterState(waitCtx2, f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaDBClusterRolledOut)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		scylladbclusterverification.Verify(ctx, sc, rkcClusterMap)

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_finalizer.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_finalizer.go
@@ -34,6 +34,9 @@ var _ = g.Describe("ScyllaDBCluster finalizer", framework.MultiDatacenter, func(
 		sc, err = f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		framework.By("Waiting for the ScyllaDBCluster %q roll out (RV=%s)", sc.Name, sc.ResourceVersion)
 		waitCtx2, waitCtx2Cancel := utils.ContextForMultiDatacenterScyllaDBClusterRollout(ctx, sc)
 		defer waitCtx2Cancel()


### PR DESCRIPTION
Previously, runtime namespaces created during ScyllaDBCluster rollout were only registered for collection after a successful rollout, making it hard to debug failed deployments.
This change introduces a NotFound-tolerant namespace collector and moves namespace registration earlier in the flow, ensuring they are always collected if created.