### PR TITLE
Fix ID propagation to ScyllaDBClusterRegistration's status

### DIFF
--- a/pkg/controller/scylladbmanagerclusterregistration/sync.go
+++ b/pkg/controller/scylladbmanagerclusterregistration/sync.go
@@ -65,6 +65,10 @@ func (smcrc *Controller) sync(ctx context.Context, key string) error {
 				return smcrc.syncFinalizer(ctx, smcr)
 			},
 		)
+		if err != nil {
+			return fmt.Errorf("can't finalize: %w", err)
+		}
+
 		return smcrc.updateStatus(ctx, smcr, status)
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Currently, if a colliding cluster exists in ScyllaDB Manager state, its ID will be incorrectly propagated to ScyllaDBManagerClusterRegistration status just before the cluster is deleted. This PR fixes it. It also adds a missing error check and missing progressing conditions.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-soon