### PR TITLE
Remove required reviewers from OWNERS' dependency filter

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,7 +7,7 @@ filters:
     reviewers:
     - operator-review-autoassignees
   "go\\.(mod|sum)$":
-    required_reviewers:
+    reviewers:
     - operator-approvers
     labels:
     - area/dependency


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** `required_reviewers` in OWNERS' dependency filter doesn't align with our intentions as it requests a review from every person in the group. This PR switches it to `reviewers` to respect the minimum number of reviewers configured to request reviews from. 

**Which issue is resolved by this Pull Request:**
Resolves #

/kind cleanup
/priority important-longterm