### PR TITLE
Fix ScyllaDB Manager task adoption in case of missing owner UID label

### DIFF
--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -252,7 +252,9 @@ const (
 	ScyllaDBManagerClusterRegistrationFinalizer              = "scylla-operator.scylladb.com/scylladbmanagerclusterregistration-deletion"
 	ScyllaDBManagerClusterRegistrationNameOverrideAnnotation = "internal.scylla-operator.scylladb.com/scylladb-manager-cluster-name-override"
 
-	ScyllaDBManagerTaskFinalizer                                   = "scylla-operator.scylladb.com/scylladbmanagertask-deletion"
+	ScyllaDBManagerTaskFinalizer = "scylla-operator.scylladb.com/scylladbmanagertask-deletion"
+	// ScyllaDBManagerTaskMissingOwnerUIDForceAdoptAnnotation is used to annotate a ScyllaDBManagerTask to force adoption of a matching task in ScyllaDB Manager state that is missing an owner UID label.
+	ScyllaDBManagerTaskMissingOwnerUIDForceAdoptAnnotation         = "internal.scylla-operator.scylladb.com/scylladb-manager-task-missing-owner-uid-force-adopt"
 	ScyllaDBManagerTaskNameOverrideAnnotation                      = "internal.scylla-operator.scylladb.com/scylladb-manager-task-name-override"
 	ScyllaDBManagerTaskScheduleIntervalOverrideAnnotation          = "internal.scylla-operator.scylladb.com/scylladb-manager-task-schedule-interval-override"
 	ScyllaDBManagerTaskScheduleStartDateOverrideAnnotation         = "internal.scylla-operator.scylladb.com/scylladb-manager-task-schedule-start-date-override"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Standalone ScyllaDB Manager controller does not label tasks created in ScyllaDB Manager with an OwnerUID label. Therefore the existing controller logic is broken and the tasks migrated from v1.ScyllaCluster would get recreated. This PR introduces an internal annotation that allows forcing adoption. It also changes the logic in case when the ownerUID labels exists but doesn't match the object to return an error instead of adopting.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-soon