### PR TITLE
Revert "Migrate rate limiting queue to typed version"

### DIFF
--- a/pkg/controller/manager/sync.go
+++ b/pkg/controller/manager/sync.go
@@ -12,8 +12,8 @@ import (
 	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
@@ -97,8 +97,12 @@ func (c *Controller) getManagerClusterState(ctx context.Context, sc *scyllav1.Sc
 	}, nil
 }
 
-func (c *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (c *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
+		return err
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing ScyllaCluster", "ScyllaCluster", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controller/nodeconfig/sync.go
+++ b/pkg/controller/nodeconfig/sync.go
@@ -19,13 +19,16 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-func (ncc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (ncc *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("can't split meta namespace cache key: %w", err)
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing NodeConfig", "NodeConfig", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controller/nodeconfigpod/controller.go
+++ b/pkg/controller/nodeconfigpod/controller.go
@@ -18,7 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
@@ -41,7 +40,7 @@ const (
 )
 
 var (
-	keyFunc          = controllerhelpers.DeletionHandlingObjectToNamespacedName
+	keyFunc          = cache.DeletionHandlingMetaNamespaceKeyFunc
 	podControllerGVK = corev1.SchemeGroupVersion.WithKind("Pod")
 )
 
@@ -58,7 +57,7 @@ type Controller struct {
 
 	eventRecorder record.EventRecorder
 
-	queue    workqueue.TypedRateLimitingInterface[types.NamespacedName]
+	queue    workqueue.RateLimitingInterface
 	handlers *controllerhelpers.Handlers[*corev1.Pod]
 }
 
@@ -91,12 +90,8 @@ func NewController(
 		},
 
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "NodeConfigCM-controller"}),
-		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[types.NamespacedName](),
-			workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
-				Name: "NodeConfigCM",
-			},
-		),
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NodeConfigCM"),
 	}
 
 	var err error
@@ -278,7 +273,7 @@ func (ncpc *Controller) processNextItem(ctx context.Context) bool {
 
 	ctx, cancel := context.WithTimeout(ctx, maxSyncDuration)
 	defer cancel()
-	err := ncpc.sync(ctx, key)
+	err := ncpc.sync(ctx, key.(string))
 	// TODO: Do smarter filtering then just Reduce to handle cases like 2 conflict errors.
 	err = apimachineryutilerrors.Reduce(err)
 	switch {

--- a/pkg/controller/nodeconfigpod/sync.go
+++ b/pkg/controller/nodeconfigpod/sync.go
@@ -12,13 +12,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-func (ncpc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (ncpc *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
+		return err
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing Pod", "Pod", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controller/nodesetup/controller.go
+++ b/pkg/controller/nodesetup/controller.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	keyFunc                 = controllerhelpers.DeletionHandlingObjectToNamespacedName
+	keyFunc                 = cache.DeletionHandlingMetaNamespaceKeyFunc
 	nodeConfigControllerGVK = scyllav1alpha1.GroupVersion.WithKind("NodeConfig")
 )
 
@@ -51,7 +51,7 @@ type Controller struct {
 
 	eventRecorder record.EventRecorder
 
-	queue    workqueue.TypedRateLimitingInterface[types.NamespacedName]
+	queue    workqueue.RateLimitingInterface
 	handlers *controllerhelpers.Handlers[*scyllav1alpha1.NodeConfig]
 
 	nodeName       string
@@ -97,12 +97,7 @@ func NewController(
 
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "nodesetup-controller"}),
 
-		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[types.NamespacedName](),
-			workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
-				Name: "NodeSetup",
-			},
-		),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NodeSetup"),
 
 		nodeName:       nodeName,
 		nodeUID:        nodeUID,

--- a/pkg/controller/orphanedpv/sync.go
+++ b/pkg/controller/orphanedpv/sync.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
@@ -70,8 +71,12 @@ func (opc *Controller) getPVsForScyllaDBDatacenter(ctx context.Context, sdc *scy
 	return pis, requeueReasons, apimachineryutilerrors.NewAggregate(errs)
 }
 
-func (opc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (opc *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
+		return err
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing ScyllaDBDatacenter", "ScyllaDBDatacenter", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controller/remotekubernetescluster/sync.go
+++ b/pkg/controller/remotekubernetescluster/sync.go
@@ -12,13 +12,17 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-func (rkcc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	_, name := key.Namespace, key.Name
+func (rkcc *Controller) sync(ctx context.Context, key string) error {
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
+		return err
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing remote kubernetes cluster", "RemoteKubernetesCluster", name, "startTime", startTime)

--- a/pkg/controller/remotekubernetescluster/sync_healthchecks.go
+++ b/pkg/controller/remotekubernetescluster/sync_healthchecks.go
@@ -9,7 +9,6 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/klog/v2"
@@ -20,7 +19,7 @@ const (
 	remoteKubeClientName   = "RemoteKubernetes"
 )
 
-func (rkcc *Controller) syncClientHealthchecks(ctx context.Context, key types.NamespacedName, rkc *scyllav1alpha1.RemoteKubernetesCluster, status *scyllav1alpha1.RemoteKubernetesClusterStatus) ([]metav1.Condition, error) {
+func (rkcc *Controller) syncClientHealthchecks(ctx context.Context, key string, rkc *scyllav1alpha1.RemoteKubernetesCluster, status *scyllav1alpha1.RemoteKubernetesClusterStatus) ([]metav1.Condition, error) {
 	var progressingConditions []metav1.Condition
 	var errs []error
 

--- a/pkg/controller/scyllacluster/sync.go
+++ b/pkg/controller/scyllacluster/sync.go
@@ -23,11 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-func (scmc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (scmc *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
+		return err
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing ScyllaCluster", "ScyllaCluster", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controller/scylladbcluster/sync.go
+++ b/pkg/controller/scylladbcluster/sync.go
@@ -18,14 +18,18 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-func (scc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (scc *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
+		return err
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing ScyllaDBCluster", "ScyllaDBCluster", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controller/scylladbdatacenter/sync.go
+++ b/pkg/controller/scylladbdatacenter/sync.go
@@ -17,13 +17,17 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-func (sdcc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (sdcc *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
+		return err
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing ScyllaCluster", "ScyllaDBDatacenter", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -472,7 +472,7 @@ func (sdcc *Controller) createMissingStatefulSets(
 
 func (sdcc *Controller) syncStatefulSets(
 	ctx context.Context,
-	key types.NamespacedName,
+	key string,
 	sdc *scyllav1alpha1.ScyllaDBDatacenter,
 	status *scyllav1alpha1.ScyllaDBDatacenterStatus,
 	statefulSets map[string]*appsv1.StatefulSet,

--- a/pkg/controller/scylladbmanagerclusterregistration/sync.go
+++ b/pkg/controller/scylladbmanagerclusterregistration/sync.go
@@ -18,11 +18,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-func (smcrc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (smcrc *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
+		return err
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing ScyllaDBManagerClusterRegistration", "ScyllaDBManagerClusterRegistration", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controller/scylladbmanagertask/sync.go
+++ b/pkg/controller/scylladbmanagertask/sync.go
@@ -17,11 +17,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-func (smtc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (smtc *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "cacheKey", key)
+		return err
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing ScyllaDBManagerTask", "ScyllaDBManagerTask", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controller/scylladbmonitoring/sync.go
+++ b/pkg/controller/scylladbmonitoring/sync.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
@@ -31,8 +31,11 @@ func getSelector(sm *scyllav1alpha1.ScyllaDBMonitoring) labels.Selector {
 	return labels.SelectorFromSet(getLabels(sm))
 }
 
-func (smc *Controller) sync(ctx context.Context, key types.NamespacedName) error {
-	namespace, name := key.Namespace, key.Name
+func (smc *Controller) sync(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("can't split meta namespace cache key %q: %w", key, err)
+	}
 
 	startTime := time.Now()
 	klog.V(4).InfoS("Started syncing ScyllaDBMonitoring", "ScyllaDBMonitoring", klog.KRef(namespace, name), "startTime", startTime)

--- a/pkg/controllertools/observer.go
+++ b/pkg/controllertools/observer.go
@@ -23,7 +23,7 @@ type ObserverSyncFunc = func(ctx context.Context) error
 
 type Observer struct {
 	name          string
-	queue         workqueue.TypedRateLimitingInterface[string]
+	queue         workqueue.RateLimitingInterface
 	syncFunc      ObserverSyncFunc
 	eventRecorder record.EventRecorder
 	cachesToSync  []cache.InformerSynced
@@ -36,9 +36,9 @@ func NewObserver(name string, eventsClient corev1client.EventInterface, syncFunc
 
 	return &Observer{
 		name: name,
-		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{
+		queue: workqueue.NewRateLimitingQueueWithConfig(
+			workqueue.DefaultControllerRateLimiter(),
+			workqueue.RateLimitingQueueConfig{
 				Name: name,
 			}),
 		syncFunc:      syncFunc,


### PR DESCRIPTION
Reverts scylladb/scylla-operator#2689.

`cache.DeletedFinalStateUnknown` events can also be generated by the informers. With this change we wouldn't handle those.

/kind bug
/priority important-soon
/cc zimnx