### PR TITLE
[1.17] Make the Git references in docs point to the release branch instead of master

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,7 +55,7 @@ myst_heading_anchors = 6
 myst_substitutions = {
   "productName": "Scylla Operator",
   "repository": "scylladb/scylla-operator",
-  "revision": "master",
+  "revision": "v1.17",
   "imageRepository": "docker.io/scylladb/scylla",
   "imageTag": "2025.1.2",
   "enterpriseImageRepository": "docker.io/scylladb/scylla-enterprise",


### PR DESCRIPTION
Before this PR, the gitops guide and the quickstart point to the files on the `master` branch in the operator repo.

After this PR, these documents point to these files on the `v1.17` branch instead.

A separate PR will include this discovered need (to set the `revision` constant upon new minor version release) in the release instructions.