### PR TITLE
[v1.17] Make the Git references in docs point at the release branch instead of `master`

### DIFF
--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -20,6 +20,7 @@ In case you already have a supported version of each of these dependencies insta
 
 #### Cert Manager
 
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 kubectl apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/third-party/cert-manager.yaml
@@ -44,7 +45,7 @@ done
 
 #### Prometheus Operator
 
-
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 kubectl -n=prometheus-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/third-party/prometheus-operator.yaml
@@ -63,6 +64,7 @@ kubectl -n=prometheus-operator rollout status --timeout=10m deployment.apps/prom
 
 Once you have the dependencies installed and available in your cluster, it is the time to install {{productName}}.
 
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/deploy/operator.yaml
@@ -118,6 +120,7 @@ Please review the [NodeConfig](../resources/nodeconfigs.md) and adjust it for yo
 :::::{tab-set}
 
 ::::{tab-item} GKE (NVMe)
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/gke/nodeconfig-alpha.yaml
@@ -126,6 +129,7 @@ END_CODE_BLOCK
 ::::
 
 ::::{tab-item} EKS (NVMe)
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/eks/nodeconfig-alpha.yaml
@@ -139,6 +143,7 @@ This NodeConfig sets up loop devices instead of NVMe disks and is only intended 
 Do not expect meaningful performance with this setup.
 :::
 
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/generic/nodeconfig-alpha.yaml
@@ -159,6 +164,7 @@ kubectl wait --for='condition=Reconciled' --timeout=10m nodeconfigs.scylla.scyll
 
 ### Local CSI driver
 
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
@@ -179,6 +185,7 @@ kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-cs
 
 ::::{tab-item} Production (sized)
 
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/deploy/manager-prod.yaml
@@ -189,6 +196,7 @@ END_CODE_BLOCK
 
 ::::{tab-item} Development (sized)
 
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/deploy/manager-dev.yaml

--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -20,13 +20,14 @@ In case you already have a supported version of each of these dependencies insta
 
 #### Cert Manager
 
-:::{code-block} shell
-:substitutions:
+{{"""
+BEGIN_CODE_BLOCK
+kubectl apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/third-party/cert-manager.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
 
-kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/cert-manager.yaml
-:::
-
 :::{code-block} shell
+
 # Wait for CRDs to propagate to all apiservers.
 kubectl wait --for condition=established --timeout=60s crd/certificates.cert-manager.io crd/issuers.cert-manager.io
 
@@ -43,11 +44,12 @@ done
 
 #### Prometheus Operator
 
-:::{code-block} shell
-:substitutions:
 
-kubectl -n=prometheus-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/prometheus-operator.yaml
-:::
+{{"""
+BEGIN_CODE_BLOCK
+kubectl -n=prometheus-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/third-party/prometheus-operator.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
 
 :::{code-block} shell
 # Wait for CRDs to propagate to all apiservers.
@@ -61,11 +63,11 @@ kubectl -n=prometheus-operator rollout status --timeout=10m deployment.apps/prom
 
 Once you have the dependencies installed and available in your cluster, it is the time to install {{productName}}.
 
-:::{code-block} shell
-:substitutions:
-
-kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/operator.yaml
-:::
+{{"""
+BEGIN_CODE_BLOCK
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/deploy/operator.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
 
 ::::{caution}
 {{productName}} deployment references its own image that it later runs alongside each ScyllaDB instance. Therefore, you have to also replace the image in the environment variable called `SCYLLA_OPERATOR_IMAGE`:
@@ -116,17 +118,19 @@ Please review the [NodeConfig](../resources/nodeconfigs.md) and adjust it for yo
 :::::{tab-set}
 
 ::::{tab-item} GKE (NVMe)
-:::{code-block} shell
-:substitutions:
-kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/gke/nodeconfig-alpha.yaml
-:::
+{{"""
+BEGIN_CODE_BLOCK
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/gke/nodeconfig-alpha.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
 ::::
 
 ::::{tab-item} EKS (NVMe)
-:::{code-block} shell
-:substitutions:
-kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/eks/nodeconfig-alpha.yaml
-:::
+{{"""
+BEGIN_CODE_BLOCK
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/eks/nodeconfig-alpha.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
 ::::
 
 ::::{tab-item} Any platform (Loop devices)
@@ -134,10 +138,12 @@ kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.
 This NodeConfig sets up loop devices instead of NVMe disks and is only intended for development purposes when you don't have the NVMe disks available.
 Do not expect meaningful performance with this setup.
 :::
-:::{code-block} shell
-:substitutions:
-kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/generic/nodeconfig-alpha.yaml
-:::
+
+{{"""
+BEGIN_CODE_BLOCK
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/generic/nodeconfig-alpha.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
 ::::
 
 :::::
@@ -153,11 +159,11 @@ kubectl wait --for='condition=Reconciled' --timeout=10m nodeconfigs.scylla.scyll
 
 ### Local CSI driver
 
-:::{code-block} shell
-:substitutions:
-
-kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
-:::
+{{"""
+BEGIN_CODE_BLOCK
+kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
 
 :::{code-block} shell
 # Wait for it to deploy.
@@ -172,17 +178,23 @@ kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-cs
 :::::{tab-set}
 
 ::::{tab-item} Production (sized)
-:::{code-block} shell
-:substitutions:
-kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/manager-prod.yaml
-:::
+
+{{"""
+BEGIN_CODE_BLOCK
+kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/deploy/manager-prod.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+
 ::::
 
 ::::{tab-item} Development (sized)
-:::{code-block} shell
-:substitutions:
-kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/manager-dev.yaml
-:::
+
+{{"""
+BEGIN_CODE_BLOCK
+kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/deploy/manager-dev.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+
 ::::
 
 :::::

--- a/docs/source/quickstarts/eks.md
+++ b/docs/source/quickstarts/eks.md
@@ -15,6 +15,7 @@ If you don't have those already, or are not available through your package manag
 ## Creating an EKS cluster
 
 First, let's create a declarative config to used with eksctl
+% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
 {{"""
 BEGIN_CODE_BLOCK
 curl --fail --retry 5 --retry-all-errors -o 'clusterconfig.eksctl.yaml' -L https://raw.githubusercontent.com/REPO/BRANCH/examples/eks/clusterconfig.eksctl.yaml

--- a/docs/source/quickstarts/eks.md
+++ b/docs/source/quickstarts/eks.md
@@ -15,11 +15,11 @@ If you don't have those already, or are not available through your package manag
 ## Creating an EKS cluster
 
 First, let's create a declarative config to used with eksctl
-:::{code-block} bash
-:substitutions:
-
-curl --fail --retry 5 --retry-all-errors -o 'clusterconfig.eksctl.yaml' -L https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/eks/clusterconfig.eksctl.yaml
-:::
+{{"""
+BEGIN_CODE_BLOCK
+curl --fail --retry 5 --retry-all-errors -o 'clusterconfig.eksctl.yaml' -L https://raw.githubusercontent.com/REPO/BRANCH/examples/eks/clusterconfig.eksctl.yaml
+END_CODE_BLOCK
+""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} bash").replace("END_CODE_BLOCK", ":::")}}
 
 With the config ready, we can easily create an EKS cluster by running
 


### PR DESCRIPTION
This PR is a second attempt at what #2726 did not achieve.

Before this PR, the branch part in the GitHub URLs was not correctly rendered, because it always pointed to "master".

The reason is that for all versions, `sphinx-multiversion` evaluates the `conf.py` originating from `master` and ignores the `conf.py` on the branch being rendered. This causes the `revision` value to always come from `master`, resulting in all links pointing to `master`. Which means that any change to the manifests can break all earlier minor versions, which is unacceptable.

This PR achieves 2 things
- replaces the incorrect `revision` field with `env.config.smv_current_version` which has the right branch name :tada: 
- works around the fact that (in our setup) MyST's `substitution` plugin (for reasons beyond my comprehension) only allows "elaborate" Jinja templates (=such that are anything more than trivial resolution of values coming directly from `myst_substitutions`) outside of `code-block`s. We still want to render the code block, so we make the templates render a `code-block` without it being directly interpretable as a `code-block`, which would prevent proper evaluation of the Jinja expression.

I am **very** unproud of the style of this solution, but it achieves:
- correct links (finally!!)
- rich rendering of the code block

at the expense of hackiness that makes me feel bad about it. I think that a reasonable next step is to reach out to the maintainers of our docs stack for a better solution to replace this abomination.

-----------

Notes to reviewers:
- I am more than happy to accept suggestions for a less hacky solution - please try them locally first. Many good ideas have been tried before I arrived at this.
- We need the effect of this PR for 1.18 (because of substantial breaking changes to the manifests in this version). We should reach out to the docs stack experts (cc @dgarcia360 @annastuchlik) to find a more elegant solution going forward, but not at the expense of delaying (or otherwise distracting us from) a timely and correct 1.18 release.
- Once this PR merges, I intend to port it to `master` and to `v1.16` as well.