### PR TITLE
Add runtime information collection to must-gather

### DIFF
--- a/pkg/cmd/operator/gather.go
+++ b/pkg/cmd/operator/gather.go
@@ -150,6 +150,7 @@ func (o *GatherOptions) run(ctx context.Context) error {
 	collector := collect.NewCollector(
 		o.DestDir,
 		o.GetPrinters(),
+		o.restConfig,
 		o.discoveryClient,
 		o.kubeClient.CoreV1(),
 		o.dynamicClient,

--- a/pkg/cmd/operator/gatherbase.go
+++ b/pkg/cmd/operator/gatherbase.go
@@ -28,6 +28,7 @@ type GatherBaseOptions struct {
 	GathererName string
 	ConfigFlags  *kgenericclioptions.ConfigFlags
 
+	restConfig      *rest.Config
 	kubeClient      kubernetes.Interface
 	dynamicClient   dynamic.Interface
 	discoveryClient discovery.DiscoveryInterface
@@ -90,6 +91,8 @@ func (o *GatherBaseOptions) Complete() error {
 	if err != nil {
 		return fmt.Errorf("can't create RESTConfig: %w", err)
 	}
+
+	o.restConfig = restConfig
 
 	o.kubeClient, err = kubernetes.NewForConfig(restConfig)
 	if err != nil {

--- a/pkg/cmd/operator/mustgather.go
+++ b/pkg/cmd/operator/mustgather.go
@@ -258,6 +258,7 @@ func (o *MustGatherOptions) run(ctx context.Context) error {
 	collector := collect.NewCollector(
 		o.DestDir,
 		o.GetPrinters(),
+		o.restConfig,
 		o.discoveryClient,
 		o.kubeClient.CoreV1(),
 		o.dynamicClient,

--- a/pkg/controllerhelpers/core.go
+++ b/pkg/controllerhelpers/core.go
@@ -301,3 +301,8 @@ func GetScyllaContainerID(pod *corev1.Pod) (string, error) {
 
 	return cs.ContainerID, nil
 }
+
+func IsNodeConfigPod(pod *corev1.Pod) bool {
+	_, ok := pod.Labels[naming.NodeConfigNameLabel]
+	return ok
+}

--- a/pkg/gather/collect/collect_test.go
+++ b/pkg/gather/collect/collect_test.go
@@ -17,6 +17,7 @@ import (
 	dynamicfakeclient "k8s.io/client-go/dynamic/fake"
 	kubefakeclient "k8s.io/client-go/kubernetes/fake"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 )
 
@@ -716,6 +717,7 @@ metadata:
 				[]ResourcePrinterInterface{
 					&OmitManagedFieldsPrinter{Delegate: &YAMLPrinter{}},
 				},
+				&rest.Config{},
 				fakeDiscoveryClient,
 				fakeKubeClient.CoreV1(),
 				fakeDynamicClient,

--- a/pkg/gather/collect/podcollector.go
+++ b/pkg/gather/collect/podcollector.go
@@ -1,0 +1,323 @@
+package collect
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
+	"github.com/scylladb/scylla-operator/pkg/scheme"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/klog/v2"
+)
+
+type PodRuntimeCollector struct {
+	Filter  func(pod *corev1.Pod) bool
+	Collect func(context.Context, *corev1.Pod, *ResourceInfo) error
+}
+
+type PodCollector struct {
+	restConfig     *rest.Config
+	corev1Client   corev1client.CoreV1Interface
+	resourceWriter *ResourceWriter
+	logsLimitBytes int64
+
+	podRuntimeCollectors []PodRuntimeCollector
+}
+
+func NewPodCollector(restConfig *rest.Config, corev1Client corev1client.CoreV1Interface, resourceWriter *ResourceWriter, logsLimitBytes int64) *PodCollector {
+	pc := &PodCollector{
+		restConfig:     restConfig,
+		corev1Client:   corev1Client,
+		resourceWriter: resourceWriter,
+		logsLimitBytes: logsLimitBytes,
+	}
+
+	pc.podRuntimeCollectors = []PodRuntimeCollector{
+		{
+			Collect: pc.collectPodLogs,
+		},
+		{
+			Filter:  controllerhelpers.IsScyllaContainerRunning,
+			Collect: pc.collectContainerCommandOutputFunc(naming.ScyllaContainerName, "nodetool-status.log", []string{"nodetool", "status"}),
+		},
+		{
+			Filter:  controllerhelpers.IsScyllaContainerRunning,
+			Collect: pc.collectContainerCommandOutputFunc(naming.ScyllaContainerName, "nodetool-gossipinfo.log", []string{"nodetool", "gossipinfo"}),
+		},
+		{
+			Filter:  controllerhelpers.IsScyllaContainerRunning,
+			Collect: pc.collectContainerCommandOutputFunc(naming.ScyllaContainerName, "df.log", []string{"df", "-h"}),
+		},
+		{
+			Filter:  controllerhelpers.IsScyllaContainerRunning,
+			Collect: pc.collectContainerCommandOutputFunc(naming.ScyllaContainerName, "io_properties.yaml", []string{"cat", "/etc/scylla.d/io_properties.yaml"}),
+		},
+		{
+			Filter: controllerhelpers.IsScyllaContainerRunning,
+			Collect: pc.collectContainerCommandOutputFunc(naming.ScyllaContainerName, "scylla-rlimits.log", []string{
+				"bash",
+				"-euEo",
+				"pipefail",
+				"-O",
+				"inherit_errexit",
+				"-c",
+				`prlimit --pid=$(pidof scylla)`}),
+		},
+		{
+			Filter:  controllerhelpers.IsNodeConfigPod,
+			Collect: pc.collectContainerCommandOutputFunc(naming.NodeConfigAppName, "kubelet-cpu_manager_state.log", []string{"cat", "/host/var/lib/kubelet/cpu_manager_state"}),
+		},
+	}
+
+	return pc
+}
+
+func (c *PodCollector) Collect(ctx context.Context, u *unstructured.Unstructured, resourceInfo *ResourceInfo) error {
+	pod := &corev1.Pod{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, pod)
+	if err != nil {
+		return fmt.Errorf("can't convert secret from unstructured: %w", err)
+	}
+
+	err = c.resourceWriter.WriteResource(ctx, pod, resourceInfo)
+	if err != nil {
+		return fmt.Errorf("can't write resource %q: %w", resourceInfo, err)
+	}
+
+	err = c.collectPodRuntimeInformation(ctx, pod, resourceInfo)
+	if err != nil {
+		return fmt.Errorf("can't collect runtime information: %w", err)
+	}
+
+	return nil
+}
+
+func writeContainerLogsToFile(ctx context.Context, podClient corev1client.PodInterface, destinationPath string, podName string, logOptions *corev1.PodLogOptions) error {
+	dest, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		return fmt.Errorf("can't open file %q: %w", destinationPath, err)
+	}
+	defer func() {
+		err := dest.Close()
+		if err != nil {
+			klog.ErrorS(err, "can't close file", "Path", destinationPath)
+		}
+	}()
+
+	logsReq := podClient.GetLogs(podName, logOptions)
+	readCloser, err := logsReq.Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("can't create a log stream: %w", err)
+	}
+	defer func() {
+		err := readCloser.Close()
+		if err != nil {
+			klog.ErrorS(err, "can't close log stream", "Path", destinationPath, "Pod", podName, "Container", logOptions.Container)
+		}
+	}()
+
+	_, err = io.Copy(dest, readCloser)
+	if err != nil {
+		return fmt.Errorf("can't read logs: %w", err)
+	}
+
+	return nil
+}
+
+func (c *PodCollector) collectContainerLogs(ctx context.Context, logsDir string, podMeta *metav1.ObjectMeta, podCSs []corev1.ContainerStatus, containerName string) error {
+	var err error
+
+	cs, _, found := oslices.Find(podCSs, func(s corev1.ContainerStatus) bool {
+		return s.Name == containerName
+	})
+	if !found {
+		klog.InfoS("Container doesn't yet have a status", "Pod", naming.ObjRef(podMeta), "Container", containerName)
+		return nil
+	}
+
+	var limitBytes *int64
+	if c.logsLimitBytes > 0 {
+		limitBytes = pointer.Ptr(c.logsLimitBytes)
+	}
+
+	logOptions := &corev1.PodLogOptions{
+		Container:  containerName,
+		Timestamps: true,
+		Follow:     false,
+		LimitBytes: limitBytes,
+	}
+
+	// TODO: Tolerate errors in case state changes in the meantime (like when a pod is being restarted in backoff)
+	//       It's error prone to just ignore it, maybe we should retry and refreshing the state and retrying instead.
+	//       https://github.com/scylladb/scylla-operator/issues/1400
+
+	if cs.State.Running != nil {
+		// Retrieve current logs.
+		logOptions.Previous = false
+		err = writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".current"), podMeta.Name, logOptions)
+		if err != nil {
+			return fmt.Errorf("can't retrieve pod logs for container %q in pod %q: %w", containerName, naming.ObjRef(podMeta), err)
+		}
+	}
+
+	if cs.LastTerminationState.Terminated != nil {
+		logOptions.Previous = true
+		err = writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".previous"), podMeta.Name, logOptions)
+		if err != nil {
+			return fmt.Errorf("can't retrieve previous pod logs for container %q in pod %q: %w", containerName, naming.ObjRef(podMeta), err)
+		}
+	}
+
+	return nil
+}
+
+func (c *PodCollector) collectPodRuntimeInformation(ctx context.Context, pod *corev1.Pod, resourceInfo *ResourceInfo) error {
+	var errs []error
+	for _, fc := range c.podRuntimeCollectors {
+		if fc.Filter != nil && !fc.Filter(pod) {
+			continue
+		}
+
+		err := fc.Collect(ctx, pod, resourceInfo)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't collect Pod %q runtime information: %w", naming.ObjRef(pod), err))
+		}
+	}
+
+	return nil
+}
+
+func (c *PodCollector) collectPodLogs(ctx context.Context, pod *corev1.Pod, resourceInfo *ResourceInfo) error {
+	podDir, err := c.createPodDirectory(pod, resourceInfo)
+	if err != nil {
+		return fmt.Errorf("can't create pod directory: %w", err)
+	}
+
+	for _, container := range pod.Spec.InitContainers {
+		err := c.collectContainerLogs(ctx, podDir, &pod.ObjectMeta, pod.Status.InitContainerStatuses, container.Name)
+		if err != nil {
+			return fmt.Errorf("can't collect logs for init container %q in pod %q: %w", container.Name, naming.ObjRef(pod), err)
+		}
+	}
+
+	for _, container := range pod.Spec.Containers {
+		err := c.collectContainerLogs(ctx, podDir, &pod.ObjectMeta, pod.Status.ContainerStatuses, container.Name)
+		if err != nil {
+			return fmt.Errorf("can't collect logs for container %q in pod %q: %w", container.Name, naming.ObjRef(pod), err)
+		}
+	}
+
+	for _, container := range pod.Spec.EphemeralContainers {
+		err := c.collectContainerLogs(ctx, podDir, &pod.ObjectMeta, pod.Status.EphemeralContainerStatuses, container.Name)
+		if err != nil {
+			return fmt.Errorf("can't collect logs for ephemeral container %q in pod %q: %w", container.Name, naming.ObjRef(pod), err)
+		}
+	}
+
+	return nil
+}
+
+func (c *PodCollector) createPodDirectory(pod *corev1.Pod, resourceInfo *ResourceInfo) (string, error) {
+	resourceDir, err := c.resourceWriter.GetResourceDir(pod, resourceInfo)
+	if err != nil {
+		return "", fmt.Errorf("can't get resourceDir: %q", err)
+	}
+	podDir := filepath.Join(resourceDir, pod.GetName())
+
+	err = os.MkdirAll(podDir, 0770)
+	if err != nil {
+		return "", fmt.Errorf("can't create pod dir %q: %w", podDir, err)
+	}
+
+	return podDir, nil
+}
+
+func (c *PodCollector) executeRemoteCommand(ctx context.Context, pod *corev1.Pod, containerName string, command []string) (stdout, stderr bytes.Buffer, err error) {
+	execReq := c.corev1Client.RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: containerName,
+			Command:   command,
+			Stdin:     false,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, runtime.NewParameterCodec(scheme.Scheme))
+
+	executor, err := remotecommand.NewWebSocketExecutor(c.restConfig, http.MethodPost, execReq.URL().String())
+	if err != nil {
+		return stdout, stderr, fmt.Errorf("can't create websocket executor for pod %q: %w", naming.ObjRef(pod), err)
+	}
+
+	err = executor.StreamWithContext(
+		ctx,
+		remotecommand.StreamOptions{
+			Stdout: &stdout,
+			Stderr: &stderr,
+			Tty:    false,
+		})
+	if err != nil {
+		return stdout, stderr, fmt.Errorf("can't execute command %q on Pod %q: %w", command, naming.ObjRef(pod), err)
+	}
+
+	return stdout, stderr, nil
+}
+
+func (c *PodCollector) collectContainerCommandOutputFunc(containerName string, filename string, command []string) func(context.Context, *corev1.Pod, *ResourceInfo) error {
+	return func(ctx context.Context, pod *corev1.Pod, resourceInfo *ResourceInfo) error {
+		klog.V(4).InfoS("Collecting container command output", "Namespace", pod.Namespace, "Pod", pod.Name, "Container", containerName, "Command", command)
+
+		podDir, err := c.createPodDirectory(pod, resourceInfo)
+		if err != nil {
+			return fmt.Errorf("can't create pod directory: %w", err)
+		}
+
+		stdout, stderr, err := c.executeRemoteCommand(ctx, pod, containerName, command)
+		if err != nil {
+			return fmt.Errorf("can't execute remote command %q on Pod %q: %w", command, naming.ObjRef(pod), err)
+		}
+
+		filePath := filepath.Join(podDir, filename)
+		err = saveNonEmptyBufferToFile(&stdout, filePath)
+		if err != nil {
+			return fmt.Errorf("can't save stdout: %w", err)
+		}
+
+		err = saveNonEmptyBufferToFile(&stderr, fmt.Sprintf("%s.stderr", filePath))
+		if err != nil {
+			return fmt.Errorf("can't save stderr: %w", err)
+		}
+
+		return nil
+	}
+}
+
+func saveNonEmptyBufferToFile(buffer *bytes.Buffer, filePath string) error {
+	if buffer.Len() == 0 {
+		return nil
+	}
+
+	err := os.WriteFile(filePath, buffer.Bytes(), 0666)
+	if err != nil {
+		return fmt.Errorf("can't write to file %q: %w", filePath, err)
+	}
+
+	return nil
+}

--- a/pkg/gather/collect/resourcecollector.go
+++ b/pkg/gather/collect/resourcecollector.go
@@ -1,0 +1,11 @@
+package collect
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type ResourceCollector interface {
+	Collect(ctx context.Context, u *unstructured.Unstructured, resourceInfo *ResourceInfo) error
+}

--- a/pkg/gather/collect/resourcewriter.go
+++ b/pkg/gather/collect/resourcewriter.go
@@ -1,0 +1,98 @@
+package collect
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/scylladb/scylla-operator/pkg/kubeinterfaces"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/klog/v2"
+)
+
+type ResourceWriter struct {
+	baseDir  string
+	printers []ResourcePrinterInterface
+}
+
+func NewResourceWriter(baseDir string, printers []ResourcePrinterInterface) *ResourceWriter {
+	return &ResourceWriter{
+		baseDir:  baseDir,
+		printers: printers,
+	}
+}
+
+func (c *ResourceWriter) GetResourceDir(obj kubeinterfaces.ObjectInterface, resourceInfo *ResourceInfo) (string, error) {
+	scope := resourceInfo.Scope.Name()
+	switch scope {
+	case meta.RESTScopeNameNamespace:
+		return filepath.Join(
+			c.baseDir,
+			namespacesDirName,
+			obj.GetNamespace(),
+			resourceInfo.Resource.GroupResource().String(),
+		), nil
+
+	case meta.RESTScopeNameRoot:
+		return filepath.Join(
+			c.baseDir,
+			clusterScopedDirName,
+			resourceInfo.Resource.GroupResource().String(),
+		), nil
+
+	default:
+		return "", fmt.Errorf("unrecognized scope %q", scope)
+	}
+}
+
+func (c *ResourceWriter) WriteObject(ctx context.Context, dirPath string, obj kubeinterfaces.ObjectInterface, resourceInfo *ResourceInfo) error {
+	var err error
+	for _, printer := range c.printers {
+		filePath := filepath.Join(dirPath, obj.GetName()+printer.GetSuffix())
+		err = writeObject(printer, filePath, resourceInfo, obj)
+		if err != nil {
+			return fmt.Errorf("can't write object: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *ResourceWriter) WriteResource(ctx context.Context, obj kubeinterfaces.ObjectInterface, resourceInfo *ResourceInfo) error {
+	resourceDir, err := c.GetResourceDir(obj, resourceInfo)
+	if err != nil {
+		return fmt.Errorf("can't get resourceDir: %q", err)
+	}
+
+	err = os.MkdirAll(resourceDir, 0770)
+	if err != nil {
+		return fmt.Errorf("can't create resource dir %q: %w", resourceDir, err)
+	}
+
+	err = c.WriteObject(ctx, resourceDir, obj, resourceInfo)
+	if err != nil {
+		return fmt.Errorf("can't write object: %w", err)
+	}
+
+	return nil
+}
+
+func writeObject(printer ResourcePrinterInterface, filePath string, resourceInfo *ResourceInfo, obj kubeinterfaces.ObjectInterface) error {
+	buf := bytes.NewBuffer(nil)
+	err := printer.PrintObj(resourceInfo, obj, buf)
+	if err != nil {
+		return fmt.Errorf("can't print object %q (%s): %w", naming.ObjRef(obj), resourceInfo.Resource, err)
+	}
+
+	err = os.WriteFile(filePath, buf.Bytes(), 0770)
+	if err != nil {
+		return fmt.Errorf("can't write file %q: %w", filePath, err)
+	}
+
+	klog.V(4).InfoS("Written resource", "Path", filePath)
+
+	return nil
+}

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -81,7 +81,7 @@ func (c *Cluster) GetArtifactsDir() string {
 func (c *Cluster) CreateUserNamespace(ctx context.Context) (*corev1.Namespace, Client) {
 	ns, nsClient := c.createNamespace(ctx, c.KubeAdminClient(), c.AdminClientConfig())
 
-	cc := NewNamespaceCleanerCollector(c.KubeAdminClient(), c.DynamicAdminClient(), ns)
+	cc := NewNamespaceCleanerCollector(c.AdminClientConfig(), c.KubeAdminClient(), c.DynamicAdminClient(), ns)
 	c.AddCleaners(cc)
 	c.AddCollectors(cc)
 

--- a/test/e2e/framework/dump.go
+++ b/test/e2e/framework/dump.go
@@ -12,9 +12,10 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 )
 
-func DumpResource(ctx context.Context, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, corev1Client corev1client.CoreV1Interface, artifactsDir string, resourceInfo *collect.ResourceInfo, namespace string, name string) error {
+func DumpResource(ctx context.Context, restConfig *rest.Config, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, corev1Client corev1client.CoreV1Interface, artifactsDir string, resourceInfo *collect.ResourceInfo, namespace string, name string) error {
 	collector := collect.NewCollector(
 		artifactsDir,
 		[]collect.ResourcePrinterInterface{
@@ -22,6 +23,7 @@ func DumpResource(ctx context.Context, discoveryClient discovery.DiscoveryInterf
 				Delegate: &collect.YAMLPrinter{},
 			},
 		},
+		restConfig,
 		discoveryClient,
 		corev1Client,
 		dynamicClient,
@@ -42,9 +44,10 @@ func DumpResource(ctx context.Context, discoveryClient discovery.DiscoveryInterf
 	return nil
 }
 
-func DumpNamespace(ctx context.Context, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, corev1Client corev1client.CoreV1Interface, artifactsDir string, name string) error {
+func DumpNamespace(ctx context.Context, restConfig *rest.Config, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, corev1Client corev1client.CoreV1Interface, artifactsDir string, name string) error {
 	return DumpResource(
 		ctx,
+		restConfig,
 		discoveryClient,
 		dynamicClient,
 		corev1Client,

--- a/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
@@ -127,6 +127,7 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 
 		rc := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			nodeConfigResourceInfo,
@@ -266,6 +267,7 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 
 		rc := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			nodeConfigResourceInfo,
@@ -551,6 +553,7 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 
 		rc := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			nodeConfigResourceInfo,

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -60,6 +60,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		nc := ncTemplate.DeepCopy()
 		rc := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			nodeConfigResourceInfo,
@@ -127,6 +128,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 
 		ncRC := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			nodeConfigResourceInfo,
@@ -225,6 +227,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 		}
 		rqRC := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			resourceQuotaResourceInfo,
@@ -246,6 +249,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, func() {
 
 		ncRC := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			nodeConfigResourceInfo,

--- a/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
+++ b/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
@@ -36,6 +36,7 @@ var _ = g.Describe("RemoteKubernetesCluster finalizer", func() {
 
 		rc := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			remoteKubernetesClusterResourceInfo,

--- a/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_status.go
+++ b/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_status.go
@@ -52,6 +52,7 @@ var _ = g.Describe("ScyllaOperatorConfig ", framework.Serial, func() {
 
 		rc := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			socResourceInfo,

--- a/test/e2e/utils/clusters.go
+++ b/test/e2e/utils/clusters.go
@@ -61,6 +61,7 @@ func SetUpRemoteKubernetesClustersFromRestConfigs(ctx context.Context, restConfi
 
 		rc := framework.NewRestoringCleaner(
 			ctx,
+			f.AdminClientConfig(),
 			f.KubeAdminClient(),
 			f.DynamicAdminClient(),
 			remoteKubernetesClusterResourceInfo,
@@ -252,7 +253,7 @@ func RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx context.Context, sc
 			return fmt.Errorf("can't get remote Namespace %q: %w", *dcStatus.RemoteNamespaceName, err)
 		}
 
-		cluster.AddCollectors(framework.NewNamespaceCleanerCollector(cluster.KubeAdminClient(), cluster.DynamicAdminClient(), dcNs))
+		cluster.AddCollectors(framework.NewNamespaceCleanerCollector(cluster.AdminClientConfig(), cluster.KubeAdminClient(), cluster.DynamicAdminClient(), dcNs))
 	}
 
 	return nil


### PR DESCRIPTION
Adds support for collecting runtime information via commands run in filtered Pods. Initial data includes `nodetool status`, `nodetool gossipinfo`, `df -h`, Scylla process limits, iotune results (io_properites.yaml), and kubelet `cpuManagerPolicy`.

/cc