### PR TITLE
Use ignition container to validate sysctls in e2e

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
@@ -57,7 +57,7 @@ var _ = g.Describe("ScyllaCluster sysctl", func() {
 			f.ClientConfig(),
 			f.Namespace(),
 			podName,
-			"scylla",
+			naming.ScyllaDBIgnitionContainerName,
 			[]string{"/usr/sbin/sysctl", "--values", fsAIOMaxNRKey},
 			nil,
 		)


### PR DESCRIPTION
During e2e, test exec'd into a Pod to validate whether sysctls were applied. It used `scylla` container which no longer has `sysctl` binary. Switched to `scylladb-ignition` which uses `scylla-operator` image having it.

/cc czeslavo 