### PR TITLE
Use ephemeralcontainer to validate prlimits in e2e

### DIFF
--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -15,4 +15,4 @@ operatorTests:
   scyllaDBVersions:
     updateFrom: "2025.1.1" # One patch lower than .operator.scyllaDBVersion
     upgradeFrom: "6.2.3" # One minor lower than .operator.scyllaDBVersion
-  nodeSetupImage: "quay.io/scylladb/scylla-operator-images:node-setup-v0.0.3@sha256:c6b3de240cc5c884d5c617485bae35c51572cdfd39b6431d2e1f759c7d7feea1"
+  nodeSetupImage: "quay.io/scylladb/scylla-operator-images:node-setup-v0.0.4@sha256:8d77b91db6cffb40337e3db9c9a2f73f190eda9f9e547a752f0beab8aea322ef"

--- a/pkg/gather/collect/collect.go
+++ b/pkg/gather/collect/collect.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -218,21 +217,9 @@ func retrieveContainerLogs(ctx context.Context, podClient corev1client.PodInterf
 		}
 	}()
 
-	logsReq := podClient.GetLogs(podName, logOptions)
-	readCloser, err := logsReq.Stream(ctx)
+	err = GetPodLogs(ctx, podClient, dest, podName, logOptions)
 	if err != nil {
-		return fmt.Errorf("can't create a log stream: %w", err)
-	}
-	defer func() {
-		err := readCloser.Close()
-		if err != nil {
-			klog.ErrorS(err, "can't close log stream", "Path", destinationPath, "Pod", podName, "Container", logOptions.Container)
-		}
-	}()
-
-	_, err = io.Copy(dest, readCloser)
-	if err != nil {
-		return fmt.Errorf("can't read logs: %w", err)
+		return fmt.Errorf("can't get pod logs: %w", err)
 	}
 
 	return nil

--- a/pkg/gather/collect/helpers.go
+++ b/pkg/gather/collect/helpers.go
@@ -1,0 +1,32 @@
+package collect
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+)
+
+func GetPodLogs(ctx context.Context, podClient corev1client.PodInterface, writer io.Writer, podName string, logOptions *corev1.PodLogOptions) error {
+	logsReq := podClient.GetLogs(podName, logOptions)
+	readCloser, err := logsReq.Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("can't create a log stream: %w", err)
+	}
+	defer func() {
+		err := readCloser.Close()
+		if err != nil {
+			klog.ErrorS(err, "can't close log stream", "Pod", podName, "Container", logOptions.Container)
+		}
+	}()
+
+	_, err = io.Copy(writer, readCloser)
+	if err != nil {
+		return fmt.Errorf("can't read logs: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
`prlimit` binary we used in the e2e test to validate if process limit was changed is no longer available in Scylla container image. Instead relying on Scylla container image, we switch to `node-setup` image we control.

/cc czeslavo 