### PR TITLE
Recommend using multi-rack clusters in documentation

### DIFF
--- a/docs/source/.internal/rf-warning.md
+++ b/docs/source/.internal/rf-warning.md
@@ -1,0 +1,5 @@
+```{warning}
+To ensure high availability and fault tolerance in ScyllaDB, it is crucial to **spread your nodes across multiple racks or availability zones**. As a general rule of thumb, you should use **as many racks as your desired replication factor**.
+
+For example, if your replication factor is `3`, deploy your nodes across **3 different racks or availability zones**. This minimizes the risk of data loss and ensures your cluster remains available even if an entire rack or zone fails.
+```

--- a/docs/source/resources/scyllaclusters/basics.md
+++ b/docs/source/resources/scyllaclusters/basics.md
@@ -46,6 +46,9 @@ IOW, please stay away from touching networking, listen or published addresses an
 
 Now we can create a simple ScyllaCluster to get ScyllaDB running.
 
+:::{include} ../../.internal/rf-warning.md
+:::
+
 :::{code-block} bash
 :linenos:
 :substitutions:
@@ -65,34 +68,100 @@ spec:
   - fs.aio-max-nr=30000000
   datacenter:
     name: us-east-1
-    racks:
-    - name: us-east-1a
-      members: 1
-      scyllaConfig: scylladb-config
-      storage:
-        capacity: 100Gi
-        storageClassName: scylladb-local-xfs
-      resources:
-        requests:
-          cpu: 1
-          memory: 8Gi
-        limits:
-          cpu: 1
-          memory: 8Gi
-      placement:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: scylla.scylladb.com/node-type
-                operator: In
-                values:
-                - scylla
-        tolerations:
-        - key: scylla-operator.scylladb.com/dedicated
-          operator: Equal
-          value: scyllaclusters
-          effect: NoSchedule
+  racks:
+  - name: us-east-1a
+    members: 1
+    scyllaConfig: scylladb-config
+    storage:
+      capacity: 100Gi
+      storageClassName: scylladb-local-xfs
+    resources:
+      requests:
+        cpu: 1
+        memory: 8Gi
+      limits:
+        cpu: 1
+        memory: 8Gi
+    placement:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - us-east-1a 
+            - key: scylla.scylladb.com/node-type
+              operator: In
+              values:
+              - scylla
+      tolerations:
+      - key: scylla-operator.scylladb.com/dedicated
+        operator: Equal
+        value: scyllaclusters
+        effect: NoSchedule
+  - name: us-east-1b
+    members: 1
+    scyllaConfig: scylladb-config
+    storage:
+      capacity: 100Gi
+      storageClassName: scylladb-local-xfs
+    resources:
+      requests:
+        cpu: 1
+        memory: 8Gi
+      limits:
+        cpu: 1
+        memory: 8Gi
+    placement:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - us-east-1b
+            - key: scylla.scylladb.com/node-type
+              operator: In
+              values:
+              - scylla
+      tolerations:
+      - key: scylla-operator.scylladb.com/dedicated
+        operator: Equal
+        value: scyllaclusters
+        effect: NoSchedule
+  - name: us-east-1c
+    members: 1
+    scyllaConfig: scylladb-config
+    storage:
+      capacity: 100Gi
+      storageClassName: scylladb-local-xfs
+    resources:
+      requests:
+        cpu: 1
+        memory: 8Gi
+      limits:
+        cpu: 1
+        memory: 8Gi
+    placement:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - us-east-1c
+            - key: scylla.scylladb.com/node-type
+              operator: In
+              values:
+              - scylla
+      tolerations:
+      - key: scylla-operator.scylladb.com/dedicated
+        operator: Equal
+        value: scyllaclusters
+        effect: NoSchedule
 EOF
 :::
 
@@ -145,6 +214,9 @@ When you change a ScyllaDB config option that's not live reloaded by ScyllaDB, o
 
 ScyllaCluster give you the freedom to chose how you want to spread you rack over your Kubernetes nodes with generic [placement options](api-scylla.scylladb.com-scyllaclusters-v1-.spec.datacenter.racks[].placement).
 Here is a quick example of how you'd use them to spread your racks across different availability zone:
+
+:::{include} ../../.internal/rf-warning.md
+:::
 
 :::::{tab-set}
 

--- a/docs/source/resources/scyllaclusters/multidc/multidc.md
+++ b/docs/source/resources/scyllaclusters/multidc/multidc.md
@@ -92,6 +92,9 @@ kubectl --context="${CONTEXT_DC1}" create ns scylla
 
 For this guide, let's assume that your cluster is running in `us-east-1` region and the nodes dedicated to running ScyllaDB nodes are running in zones `us-east-1a`, `us-east-1b` and `us-east-1c` correspondingly. If that is not the case, adjust the manifest accordingly.
 
+:::{include} ../../../.internal/rf-warning.md
+:::
+
 :::{caution}
 The `.spec.name` field of the ScyllaCluster objects represents the ScyllaDB cluster name and has to be consistent across all datacenters of this ScyllaDB cluster.
 The names of the datacenters, specified in `.spec.datacenter.name`, have to be unique across the entire multi-datacenter cluster.
@@ -349,6 +352,10 @@ Replace the values in `.spec.externalSeeds` of the below manifest with the Pod I
 The provided values are going to serve as initial contact points for the joining nodes of the second datacenter.
 
 For this guide, let's assume that the second cluster is running in `us-east-2` region and the nodes dedicated for running ScyllaDB nodes are running in zones `us-east-2a`, `us-east-2b` and `us-east-2c` correspondingly. If that is not the case, adjust the manifest accordingly.
+
+:::{include} ../../../.internal/rf-warning.md
+:::
+
 Having configured it, save the manifest as `dc2.yaml`:
 ```yaml
 apiVersion: scylla.scylladb.com/v1


### PR DESCRIPTION
We should highlight importance of running multi-rack clusters. A warning was added around examples, and example cluster was changed to multi-rack one.

![Screenshot From 2025-07-03 13-40-35](https://github.com/user-attachments/assets/c40acf63-f853-4203-9728-b18c944a2488)


