### PR TITLE
Do not install prometheus-operator in OpenShift

### DIFF
--- a/hack/.ci/run-e2e-openshift-aws-release.sh
+++ b/hack/.ci/run-e2e-openshift-aws-release.sh
@@ -31,6 +31,11 @@ export SO_SKIPPED_TESTS
 SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=${parent_dir}/manifests/cluster/nodeconfig-openshift-aws.yaml}"
 export SO_NODECONFIG_PATH
 
+# TODO: When https://github.com/scylladb/scylla-operator/issues/2490 is completed,
+# we should make sure we have all required CRDs in the OpenShift cluster.
+SO_DISABLE_PROMETHEUS_OPERATOR="${SO_DISABLE_PROMETHEUS_OPERATOR:-true}"
+export SO_DISABLE_PROMETHEUS_OPERATOR
+
 run-deploy-script-in-all-clusters "${parent_dir}/../ci-deploy-release.sh"
 
 apply-e2e-workarounds

--- a/hack/.ci/run-e2e-openshift-aws.sh
+++ b/hack/.ci/run-e2e-openshift-aws.sh
@@ -34,6 +34,11 @@ export SO_NODECONFIG_PATH
 SO_CSI_DRIVER_PATH="${SO_CSI_DRIVER_PATH=${parent_dir}/manifests/namespaces/local-csi-driver/}"
 export SO_CSI_DRIVER_PATH
 
+# TODO: When https://github.com/scylladb/scylla-operator/issues/2490 is completed,
+# we should make sure we have all required CRDs in the OpenShift cluster.
+SO_DISABLE_PROMETHEUS_OPERATOR="${SO_DISABLE_PROMETHEUS_OPERATOR:-true}"
+export SO_DISABLE_PROMETHEUS_OPERATOR
+
 run-deploy-script-in-all-clusters "${parent_dir}/../ci-deploy.sh"
 
 apply-e2e-workarounds


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

It's a fix for broken CI logic that was previously working fine because we had `REENTRANT` set (https://github.com/scylladb/scylla-operator/commit/e6e4e3422b093ee3e73f28247fb960e39ae953ef removed that) for OpenShift jobs (so instead of `kubectl create` we were running `kubectl apply`).

Prometheus Operator installation and verification are completely skipped for OpenShift clusters - it's fine as long as we do not support external Prometheus instances in `ScyllaDBMonitoring` (https://github.com/scylladb/scylla-operator/issues/2490) and do not test that on OpenShift. 

Extracted from https://github.com/scylladb/scylla-operator/pull/2743. 