### PR TITLE
Use HostIDs instead of broadcasted addresses as node identifier for E2E quorum check

### DIFF
--- a/pkg/scyllaclient/model.go
+++ b/pkg/scyllaclient/model.go
@@ -157,6 +157,15 @@ func (s NodeStatusInfoSlice) Hosts() []string {
 	return hosts
 }
 
+// HostIDs returns slice of HostID of all nodes.
+func (s NodeStatusInfoSlice) HostIDs() []string {
+	var hostIDs []string
+	for _, h := range s {
+		hostIDs = append(hostIDs, h.HostID)
+	}
+	return hostIDs
+}
+
 // LiveHosts returns slice of address of nodes in UN state.
 func (s NodeStatusInfoSlice) LiveHosts() []string {
 	var hosts []string
@@ -177,4 +186,15 @@ func (s NodeStatusInfoSlice) DownHosts() []string {
 		}
 	}
 	return hosts
+}
+
+// DownHostIDs returns slice of HostID of nodes that are down.
+func (s NodeStatusInfoSlice) DownHostIDs() []string {
+	var hostIDs []string
+	for _, h := range s {
+		if h.Status == NodeStatusDown {
+			hostIDs = append(hostIDs, h.HostID)
+		}
+	}
+	return hostIDs
 }

--- a/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
@@ -47,10 +47,11 @@ var _ = g.Describe("ScyllaCluster", func() {
 		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
-		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
+		hostAddresses, hostUUIDs, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(hosts).To(o.HaveLen(membersCount))
-		di := verification.InsertAndVerifyCQLData(ctx, hosts)
+		o.Expect(hostUUIDs).To(o.HaveLen(membersCount))
+		o.Expect(hostAddresses).To(o.HaveLen(membersCount))
+		di := verification.InsertAndVerifyCQLData(ctx, hostAddresses)
 		defer di.Close()
 
 		framework.By("Deleting the ScyllaCluster")
@@ -108,11 +109,13 @@ var _ = g.Describe("ScyllaCluster", func() {
 		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
-		oldHosts := hosts
-		hosts, err = utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
+		oldHostUUIDs := hostUUIDs
+		oldHostAddresses := hostAddresses
+		hostAddresses, hostUUIDs, err = utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(hosts).To(o.HaveLen(len(oldHosts)))
-		err = di.SetClientEndpoints(hosts)
+		o.Expect(hostAddresses).To(o.HaveLen(len(oldHostAddresses)))
+		o.Expect(hostUUIDs).To(o.HaveLen(len(oldHostUUIDs)))
+		err = di.SetClientEndpoints(hostAddresses)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		verification.VerifyCQLData(ctx, di)
 	})

--- a/test/e2e/utils/verification/scylladbdatacenter/cql.go
+++ b/test/e2e/utils/verification/scylladbdatacenter/cql.go
@@ -23,14 +23,14 @@ func WaitForFullQuorum(ctx context.Context, client corev1client.CoreV1Interface,
 }
 
 func waitForFullQuorum(ctx context.Context, client corev1client.CoreV1Interface, sdc *scyllav1alpha1.ScyllaDBDatacenter) error {
-	broadcastAddresses, err := utilsv1alpha1.GetBroadcastAddresses(ctx, client, sdc)
+	hostIDs, err := utilsv1alpha1.GetHostIDs(ctx, client, sdc)
 	if err != nil {
 		return fmt.Errorf("can't get broadcast addresses for ScyllaDBDatacenter %q: %w", naming.ObjRef(sdc), err)
 	}
 
-	sort.Strings(broadcastAddresses)
+	sort.Strings(hostIDs)
 
-	err = utilsv1alpha1.WaitForFullQuorum(ctx, client, sdc, broadcastAddresses)
+	err = utilsv1alpha1.WaitForFullQuorum(ctx, client, sdc, hostIDs)
 	if err != nil {
 		return fmt.Errorf("can't wait for scylla nodes to reach status consistency: %w", err)
 	}


### PR DESCRIPTION
Node IP addresses are unreliable identifier as they may be ephemeral.
This turned out to be an issue with reboostrap e2e using ScyllaDB 2025.2.0.