### PR TITLE
Update helm templates for operator and manager to support custom namespace

### DIFF
--- a/helm/scylla-manager/templates/manager_configmap.yaml
+++ b/helm/scylla-manager/templates/manager_configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scylla-manager-config
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
 data:
   scylla-manager.yaml: |-
     http: :5080

--- a/helm/scylla-manager/templates/manager_deployment.yaml
+++ b/helm/scylla-manager/templates/manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scylla-manager
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
 spec:

--- a/helm/scylla-manager/templates/manager_networkpolicy.yaml
+++ b/helm/scylla-manager/templates/manager_networkpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   name: scylla-manager-to-scylla-pod
 spec:
   policyTypes:
@@ -14,4 +14,4 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: scylla-manager
+          kubernetes.io/metadata.name: {{ .Release.Namespace }}

--- a/helm/scylla-manager/templates/manager_service.yaml
+++ b/helm/scylla-manager/templates/manager_service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
   name: scylla-manager
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: api

--- a/helm/scylla-manager/templates/manager_serviceaccount.yaml
+++ b/helm/scylla-manager/templates/manager_serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-manager.serviceAccountName" . }}
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/scylla-manager/templates/manager_servicemonitor.yaml
+++ b/helm/scylla-manager/templates/manager_servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: scylla-manager
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceMonitor.labels }}
   labels:
     {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}

--- a/helm/scylla-operator/templates/certificate.yaml
+++ b/helm/scylla-operator/templates/certificate.yaml
@@ -3,10 +3,10 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "scylla-operator.certificateName" . }}
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-  - {{ include "scylla-operator.webhookServiceName" . }}.scylla-operator.svc
+  - {{ include "scylla-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
   issuerRef:
     kind: Issuer
     name: scylla-operator-selfsigned-issuer

--- a/helm/scylla-operator/templates/clusterrolebinding.yaml
+++ b/helm/scylla-operator/templates/clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "scylla-operator.serviceAccountName" . }}
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}

--- a/helm/scylla-operator/templates/issuer.yaml
+++ b/helm/scylla-operator/templates/issuer.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: scylla-operator-selfsigned-issuer
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 {{- end }}

--- a/helm/scylla-operator/templates/operator.deployment.yaml
+++ b/helm/scylla-operator/templates/operator.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scylla-operator
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-operator.labels" . | nindent 4 }}
 spec:

--- a/helm/scylla-operator/templates/operator.pdb.yaml
+++ b/helm/scylla-operator/templates/operator.pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-operator
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:

--- a/helm/scylla-operator/templates/operator.serviceaccount.yaml
+++ b/helm/scylla-operator/templates/operator.serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-operator.serviceAccountName" . }}
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/scylla-operator/templates/validatingwebhook.yaml
+++ b/helm/scylla-operator/templates/validatingwebhook.yaml
@@ -2,14 +2,14 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: scylla-operator/{{ include "scylla-operator.certificateName" . }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "scylla-operator.certificateName" . }}
   name: scylla-operator
 webhooks:
 - name: webhook.scylla.scylladb.com
   clientConfig:
     service:
       name: {{ include "scylla-operator.webhookServiceName" . }}
-      namespace: scylla-operator
+      namespace: {{ .Release.Namespace }}
       path: /validate
   admissionReviewVersions:
   - v1

--- a/helm/scylla-operator/templates/webhookserver.deployment.yaml
+++ b/helm/scylla-operator/templates/webhookserver.deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   name: webhook-server
   labels:
     app.kubernetes.io/name: webhook-server

--- a/helm/scylla-operator/templates/webhookserver.pdb.yaml
+++ b/helm/scylla-operator/templates/webhookserver.pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-server
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:

--- a/helm/scylla-operator/templates/webhookserver.service.yaml
+++ b/helm/scylla-operator/templates/webhookserver.service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   name: {{ include "scylla-operator.webhookServiceName" . }}
   labels:
     app.kubernetes.io/name: webhook-server

--- a/helm/scylla-operator/templates/webhookserver.serviceaccount.yaml
+++ b/helm/scylla-operator/templates/webhookserver.serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   name: webhook-server
   labels:
     app.kubernetes.io/name: webhook-server


### PR DESCRIPTION
# Update helm templates for operator and manager to support custom namespace

**Description of your changes:**
This PR updates the helm templates for the `scylla-operator` and `scylla-manager` to be able to be installed in any custom namespace defined in the `helm` cli. 

**Which issue is resolved by this Pull Request:**
Part of #2563 

**PS:**
We have tested this customized approach in an openshift cluster and seems working well.
