### PR TITLE
Stop relying on KUBECONFIG_DIR env var in E2E machinery

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -13,18 +13,6 @@ source "$( dirname "${BASH_SOURCE[0]}" )/../../lib/kube.sh"
 # It is used in multi-datacenter setups.
 declare -A WORKER_KUBECONFIGS
 
-# TODO: remove once CI job is updated to define KUBECONFIG and WORKER_KUBECONFIGS instead of KUBECONFIG_DIR
-if [[ -n "${KUBECONFIG_DIR+x}" ]]; then
-  unset KUBECONFIG
-  for f in $( find "$( realpath "${KUBECONFIG_DIR}" )" -maxdepth 1 -type f -name '*.kubeconfig' ); do
-    # For multi-datacenter suites, designate the first kubeconfig as the "control plane" cluster.
-    KUBECONFIG="${KUBECONFIG:-${f}}"
-    WORKER_KUBECONFIGS["$( basename "${f}" '.kubeconfig' )"]="${f}"
-  done
-
-  export KUBECONFIG
-fi
-
 # KUBECONFIG is the kubeconfig file used to connect to the cluster.
 # In multi-datacenter setups, it is the control plane cluster kubeconfig.
 if [ -z "${KUBECONFIG+x}" ]; then


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** As the changes in CI jobs have already been merged, we can now stop relying on the KUBECONFIG_DIR env var and instead use KUBECONFIG and WORKER_KUBECONFIGS directly.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-longterm
/cc czeslavo