### PR TITLE
Fix order of namespace collection in multidc boostrap e2e

### DIFF
--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
@@ -29,10 +29,10 @@ var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter
 
 		sc := f.GetDefaultScyllaDBCluster(rkcMap)
 
-		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
+		sc, err = f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc, err = f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		err = utils.RegisterCollectionOfRemoteScyllaDBClusterNamespaces(ctx, sc, rkcClusterMap)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for the ScyllaDBCluster %q roll out (RV=%s)", sc.Name, sc.ResourceVersion)


### PR DESCRIPTION
Registration was executed before ScyllaDBCluster was created, meaning it's Namespace was empty which caused registration that depends on Namespace to register wrong name for collection.

Thanks @rzetelskik for noticing it!
/cc rzetelskik
