### PR TITLE
Fix extraction of ScyllaDB Manager agent auth token from custom config secrets

### DIFF
--- a/pkg/controller/scylladbdatacenter/sync_agent_config.go
+++ b/pkg/controller/scylladbdatacenter/sync_agent_config.go
@@ -15,19 +15,11 @@ import (
 )
 
 func (sdcc *Controller) getAgentTokenFromAgentConfig(sdc *scyllav1alpha1.ScyllaDBDatacenter) (string, error) {
-	if len(sdc.Spec.Racks) == 0 {
-		return "", nil
-	}
-
-	if sdc.Spec.RackTemplate != nil && sdc.Spec.RackTemplate.ScyllaDBManagerAgent == nil {
-		return "", nil
-	}
-
 	var configSecret *string
 	if sdc.Spec.RackTemplate != nil && sdc.Spec.RackTemplate.ScyllaDBManagerAgent != nil && sdc.Spec.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
 		configSecret = sdc.Spec.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef
 	}
-	if sdc.Spec.Racks[0].ScyllaDBManagerAgent != nil && sdc.Spec.Racks[0].ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
+	if len(sdc.Spec.Racks) > 0 && sdc.Spec.Racks[0].ScyllaDBManagerAgent != nil && sdc.Spec.Racks[0].ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
 		configSecret = sdc.Spec.Racks[0].ScyllaDBManagerAgent.CustomConfigSecretRef
 	}
 	if configSecret == nil {
@@ -37,7 +29,7 @@ func (sdcc *Controller) getAgentTokenFromAgentConfig(sdc *scyllav1alpha1.ScyllaD
 	secretName := *configSecret
 	secret, err := sdcc.secretLister.Secrets(sdc.Namespace).Get(secretName)
 	if err != nil {
-		return "", fmt.Errorf("can't get secret %s/%s: %w", sdc.Namespace, secretName, err)
+		return "", fmt.Errorf("can't get secret %q: %w", naming.ManualRef(sdc.Namespace, secretName), err)
 	}
 
 	return helpers.GetAgentAuthTokenFromAgentConfigSecret(secret)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Since the introduction of v1alpha1.ScyllaDBDatacenter, custom ScyllaDBManager agent config secret can be set on multiple levels (templated or direct). We have to check for all of them to extract the auth token. Currently, the code returns too early if `spec.RackTemplate` is set and `spec.RackTemplate.ScyllaDBManagerAgent` is not, resulting in not taking `spec.Racks[].ScyllaDBManagerAgent.CustomConfigSecretRef` into account. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-soon
/cc zimnx