### PR TITLE
Consider ScyllaDBDatacenter having no Status Conditions as not rolled out

### DIFF
--- a/pkg/controllerhelpers/scylla.go
+++ b/pkg/controllerhelpers/scylla.go
@@ -296,6 +296,10 @@ func GetRackNodeCount(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string) (
 }
 
 func IsScyllaDBDatacenterRolledOut(sdc *scyllav1alpha1.ScyllaDBDatacenter) (bool, error) {
+	if sdc == nil || len(sdc.Status.Conditions) == 0 {
+		return false, nil
+	}
+
 	if !helpers.IsStatusConditionPresentAndTrue(sdc.Status.Conditions, scyllav1alpha1.AvailableCondition, sdc.Generation) {
 		return false, nil
 	}


### PR DESCRIPTION
Function used to determine whether given ScyllaDBDatacenter is rolled out didn't consider case when provided object is nil, or whether it has any Status Conditions, returning wrong value.

