### PR TITLE
Mirror ScyllaDBCluster Secrets referred from Volumes

### DIFF
--- a/pkg/controller/scylladbcluster/resource.go
+++ b/pkg/controller/scylladbcluster/resource.go
@@ -1085,29 +1085,10 @@ func makeMirroredRemoteSecrets(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1a
 	var progressingConditions []metav1.Condition
 	var requiredRemoteSecrets []*corev1.Secret
 
-	var secretsToMirror []string
-
-	if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent != nil && sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-		secretsToMirror = append(secretsToMirror, *sc.Spec.DatacenterTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
-	}
-
-	if sc.Spec.DatacenterTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent != nil && sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-		secretsToMirror = append(secretsToMirror, *sc.Spec.DatacenterTemplate.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
-	}
-
-	if dc.ScyllaDBManagerAgent != nil && dc.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-		secretsToMirror = append(secretsToMirror, *dc.ScyllaDBManagerAgent.CustomConfigSecretRef)
-	}
-
-	if dc.RackTemplate != nil && dc.RackTemplate.ScyllaDBManagerAgent != nil && dc.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-		secretsToMirror = append(secretsToMirror, *dc.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
-	}
-
-	for _, rack := range dc.Racks {
-		if rack.ScyllaDBManagerAgent != nil && rack.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
-			secretsToMirror = append(secretsToMirror, *rack.ScyllaDBManagerAgent.CustomConfigSecretRef)
-		}
-	}
+	secretsToMirror := slices.Concat(
+		getSecretsToMirrorForAllDCs(sc),
+		getSecretsToMirrorForDC(&dc.ScyllaDBClusterDatacenterTemplate),
+	)
 
 	var errs []error
 	for _, secretName := range secretsToMirror {
@@ -1147,6 +1128,80 @@ func makeMirroredRemoteSecrets(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyllav1a
 	}
 
 	return progressingConditions, requiredRemoteSecrets, nil
+}
+
+// getSecretsToMirrorForAllDCs collects the names of Secrets to mirror for all Datacenters in the ScyllaDBCluster.
+func getSecretsToMirrorForAllDCs(sc *scyllav1alpha1.ScyllaDBCluster) []string {
+	if sc.Spec.DatacenterTemplate == nil {
+		return nil
+	}
+
+	return getSecretsToMirrorForDC(sc.Spec.DatacenterTemplate)
+}
+
+// getSecretsToMirrorForDC collects the names of Secrets to mirror for a specific Datacenter.
+func getSecretsToMirrorForDC(dc *scyllav1alpha1.ScyllaDBClusterDatacenterTemplate) []string {
+	var secretsToMirror []string
+
+	// ScyllaDBManagerAgent.CustomConfigSecretRef.
+	if dc.ScyllaDBManagerAgent != nil && dc.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
+		secretsToMirror = append(secretsToMirror, *dc.ScyllaDBManagerAgent.CustomConfigSecretRef)
+	}
+
+	// ScyllaDBManagerAgent.Volumes.
+	if dc.ScyllaDBManagerAgent != nil {
+		secretsToMirror = append(secretsToMirror, collectSecretNamesFromVolumes(dc.ScyllaDBManagerAgent.Volumes)...)
+	}
+
+	// RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef.
+	if dc.RackTemplate != nil && dc.RackTemplate.ScyllaDBManagerAgent != nil && dc.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
+		secretsToMirror = append(secretsToMirror, *dc.RackTemplate.ScyllaDBManagerAgent.CustomConfigSecretRef)
+	}
+
+	// RackTemplate.ScyllaDBManagerAgent.Volumes.
+	if dc.RackTemplate != nil && dc.RackTemplate.ScyllaDBManagerAgent != nil {
+		secretsToMirror = append(secretsToMirror, collectSecretNamesFromVolumes(dc.RackTemplate.ScyllaDBManagerAgent.Volumes)...)
+	}
+
+	// RackTemplate.ScyllaDB.Volumes.
+	if dc.RackTemplate != nil && dc.RackTemplate.ScyllaDB != nil {
+		secretsToMirror = append(secretsToMirror, collectSecretNamesFromVolumes(dc.RackTemplate.ScyllaDB.Volumes)...)
+	}
+
+	// ScyllaDB.Volumes.
+	if dc.ScyllaDB != nil {
+		secretsToMirror = append(secretsToMirror, collectSecretNamesFromVolumes(dc.ScyllaDB.Volumes)...)
+	}
+
+	for _, rack := range dc.Racks {
+		// Racks[].ScyllaDBManagerAgent.CustomConfigSecretRef.
+		if rack.ScyllaDBManagerAgent != nil && rack.ScyllaDBManagerAgent.CustomConfigSecretRef != nil {
+			secretsToMirror = append(secretsToMirror, *rack.ScyllaDBManagerAgent.CustomConfigSecretRef)
+		}
+
+		// Racks[].ScyllaDBManagerAgent.Volumes.
+		if rack.ScyllaDBManagerAgent != nil {
+			secretsToMirror = append(secretsToMirror, collectSecretNamesFromVolumes(rack.ScyllaDBManagerAgent.Volumes)...)
+		}
+
+		// Racks[].ScyllaDB.Volumes.
+		if rack.ScyllaDB != nil {
+			secretsToMirror = append(secretsToMirror, collectSecretNamesFromVolumes(rack.ScyllaDB.Volumes)...)
+		}
+	}
+
+	return secretsToMirror
+}
+
+// collectSecretNamesFromVolumes collects the names of Secrets from the given Volumes.
+func collectSecretNamesFromVolumes(volumes []corev1.Volume) []string {
+	var secretNames []string
+	for _, volume := range volumes {
+		if volume.Secret != nil && volume.Secret.SecretName != "" {
+			secretNames = append(secretNames, volume.Secret.SecretName)
+		}
+	}
+	return secretNames
 }
 
 // makeLocalServices creates a slice of control-plane Services for the ScyllaDBCluster.

--- a/pkg/controller/scylladbcluster/resource_test.go
+++ b/pkg/controller/scylladbcluster/resource_test.go
@@ -3,6 +3,8 @@ package scylladbcluster
 import (
 	"fmt"
 	"reflect"
+	"slices"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -4422,5 +4424,278 @@ func Test_mergePortSpecSlices(t *testing.T) {
 				t.Errorf("expected and got port specs differ: %s", cmp.Diff(tc.expected, got, cmpopts.EquateComparable(portSpec{})))
 			}
 		})
+	}
+}
+
+func Test_getSecretsToMirrorForAllDCs(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name     string
+		sc       *scyllav1alpha1.ScyllaDBCluster
+		expected []string
+	}{
+		{
+			name:     "No secrets to mirror",
+			sc:       &scyllav1alpha1.ScyllaDBCluster{},
+			expected: []string{},
+		},
+		{
+			name: "All possible secrets from CustomConfigSecretRef",
+			sc: &scyllav1alpha1.ScyllaDBCluster{
+				Spec: scyllav1alpha1.ScyllaDBClusterSpec{
+					DatacenterTemplate: &scyllav1alpha1.ScyllaDBClusterDatacenterTemplate{
+						ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+							CustomConfigSecretRef: pointer.Ptr("scyllaDBManagerAgent.customConfigSecretRef"),
+						},
+						RackTemplate: &scyllav1alpha1.RackTemplate{
+							ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+								CustomConfigSecretRef: pointer.Ptr("rackTemplate.scyllaDBManagerAgent.customConfigSecretRef"),
+							},
+						},
+					},
+				},
+			},
+			expected: []string{
+				"scyllaDBManagerAgent.customConfigSecretRef",
+				"rackTemplate.scyllaDBManagerAgent.customConfigSecretRef",
+			},
+		},
+		{
+			name: "All possible secrets from Volumes",
+			sc: &scyllav1alpha1.ScyllaDBCluster{
+				Spec: scyllav1alpha1.ScyllaDBClusterSpec{
+					DatacenterTemplate: &scyllav1alpha1.ScyllaDBClusterDatacenterTemplate{
+						ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+							Volumes: makeVolumesReferringSecret("scylladb.volumes"),
+						},
+						ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+							Volumes: makeVolumesReferringSecret("scyllaDBManagerAgent.volumes"),
+						},
+						RackTemplate: &scyllav1alpha1.RackTemplate{
+							ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+								Volumes: makeVolumesReferringSecret("rackTemplate.scyllaDB.volumes"),
+							},
+							ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+								Volumes: makeVolumesReferringSecret("rackTemplate.scyllaDBManagerAgent.volumes"),
+							},
+						},
+						Racks: []scyllav1alpha1.RackSpec{
+							{
+								RackTemplate: scyllav1alpha1.RackTemplate{
+									ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+										Volumes: makeVolumesReferringSecret("racks[].scyllaDB.volumes"),
+									},
+									ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+										Volumes: makeVolumesReferringSecret("racks[].scyllaDBManagerAgent.volumes"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{
+				"scylladb.volumes",
+				"scyllaDBManagerAgent.volumes",
+				"rackTemplate.scyllaDB.volumes",
+				"rackTemplate.scyllaDBManagerAgent.volumes",
+				"racks[].scyllaDB.volumes",
+				"racks[].scyllaDBManagerAgent.volumes",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := getSecretsToMirrorForAllDCs(tc.sc)
+
+			// Sort before comparison to ensure order does not affect the test.
+			sort.Strings(tc.expected)
+			sort.Strings(got)
+
+			if !slices.Equal(got, tc.expected) {
+				t.Errorf("expected and got secrets differ: %s", cmp.Diff(got, tc.expected))
+			}
+		})
+	}
+}
+
+func Test_getSecretsToMirrorForDC(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name     string
+		dc       *scyllav1alpha1.ScyllaDBClusterDatacenterTemplate
+		expected []string
+	}{
+		{
+			name:     "No secrets to mirror",
+			dc:       &scyllav1alpha1.ScyllaDBClusterDatacenterTemplate{},
+			expected: nil,
+		},
+		{
+			name: "All possible secrets from Volumes",
+			dc: &scyllav1alpha1.ScyllaDBClusterDatacenterTemplate{
+				ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+					Volumes: makeVolumesReferringSecret("scylladb.volumes"),
+				},
+				ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+					Volumes: makeVolumesReferringSecret("scyllaDBManagerAgent.volumes"),
+				},
+				RackTemplate: &scyllav1alpha1.RackTemplate{
+					ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+						Volumes: makeVolumesReferringSecret("rackTemplate.scyllaDB.volumes"),
+					},
+					ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+						Volumes: makeVolumesReferringSecret("rackTemplate.scyllaDBManagerAgent.volumes"),
+					},
+				},
+				Racks: []scyllav1alpha1.RackSpec{
+					{
+						RackTemplate: scyllav1alpha1.RackTemplate{
+							ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+								Volumes: makeVolumesReferringSecret("racks[].scyllaDB.volumes"),
+							},
+							ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+								Volumes: makeVolumesReferringSecret("racks[].scyllaDBManagerAgent.volumes"),
+							},
+						},
+					},
+				},
+			},
+			expected: []string{
+				"scylladb.volumes",
+				"scyllaDBManagerAgent.volumes",
+				"rackTemplate.scyllaDB.volumes",
+				"rackTemplate.scyllaDBManagerAgent.volumes",
+				"racks[].scyllaDB.volumes",
+				"racks[].scyllaDBManagerAgent.volumes",
+			},
+		},
+		{
+			name: "All possible secrets from CustomConfigSecretRef",
+			dc: &scyllav1alpha1.ScyllaDBClusterDatacenterTemplate{
+				ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+					CustomConfigSecretRef: pointer.Ptr("scyllaDBManagerAgent.customConfigSecretRef"),
+				},
+				RackTemplate: &scyllav1alpha1.RackTemplate{
+					ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+						CustomConfigSecretRef: pointer.Ptr("rackTemplate.scyllaDBManagerAgent.customConfigSecretRef"),
+					},
+				},
+				Racks: []scyllav1alpha1.RackSpec{
+					{
+						RackTemplate: scyllav1alpha1.RackTemplate{
+							ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgentTemplate{
+								CustomConfigSecretRef: pointer.Ptr("racks[].scyllaDBManagerAgent.customConfigSecretRef"),
+							},
+						},
+					},
+				},
+			},
+			expected: []string{
+				"scyllaDBManagerAgent.customConfigSecretRef",
+				"rackTemplate.scyllaDBManagerAgent.customConfigSecretRef",
+				"racks[].scyllaDBManagerAgent.customConfigSecretRef",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := getSecretsToMirrorForDC(tc.dc)
+
+			// Sort before comparison to ensure order does not affect the test.
+			sort.Strings(tc.expected)
+			sort.Strings(got)
+
+			if !slices.Equal(got, tc.expected) {
+				t.Errorf("expected and got secrets differ: %s", cmp.Diff(got, tc.expected))
+			}
+		})
+	}
+}
+
+func Test_collectSecretNamesFromVolumes(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name     string
+		volumes  []corev1.Volume
+		expected []string
+	}{
+		{
+			name:     "No volumes",
+			volumes:  []corev1.Volume{},
+			expected: []string{},
+		},
+		{
+			name: "Volumes with secret",
+			volumes: []corev1.Volume{
+				{
+					Name: "test-volume",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "s1",
+						},
+					},
+				},
+				{
+					Name: "test-volume",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "s2",
+						},
+					},
+				},
+			},
+			expected: []string{"s1", "s2"},
+		},
+		{
+			name: "Volume with no secret",
+			volumes: []corev1.Volume{
+				{
+					Name: "test-volume",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := collectSecretNamesFromVolumes(tc.volumes)
+
+			// Sort before comparison to ensure order does not affect the test.
+			sort.Strings(tc.expected)
+			sort.Strings(got)
+
+			if !slices.Equal(got, tc.expected) {
+				t.Errorf("expected and got secret names differ: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}
+
+func makeVolumesReferringSecret(secretName string) []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: "test-volume",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** 
Makes all Secrets referred from Volumes defined in ScyllaDBCluster to be mirrored to the respective DC's remote clusters.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2779.

/priority important-soon
/kind bug
