### PR TITLE
Await for previous DCs to finish progressing before creating next DC

### DIFF
--- a/pkg/controller/scylladbcluster/sync.go
+++ b/pkg/controller/scylladbcluster/sync.go
@@ -419,7 +419,7 @@ func (scc *Controller) sync(ctx context.Context, key string) error {
 				progressingCondition: makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(dc.Name),
 				degradedCondition:    makeRemoteScyllaDBDatacenterControllerDatacenterDegradedCondition(dc.Name),
 				syncFn: func(remoteNamespace *corev1.Namespace, remoteController metav1.Object) ([]metav1.Condition, error) {
-					return scc.syncRemoteScyllaDBDatacenters(ctx, sc, &dc, remoteNamespace, remoteController, remoteScyllaDBDatacenterMap, managingClusterDomain)
+					return scc.syncRemoteScyllaDBDatacenters(ctx, sc, &dc, status, remoteNamespace, remoteController, remoteScyllaDBDatacenterMap, managingClusterDomain)
 				},
 			},
 		}

--- a/pkg/controller/scylladbcluster/sync_scylladbdatacenter.go
+++ b/pkg/controller/scylladbcluster/sync_scylladbdatacenter.go
@@ -20,6 +20,7 @@ func (scc *Controller) syncRemoteScyllaDBDatacenters(
 	ctx context.Context,
 	sc *scyllav1alpha1.ScyllaDBCluster,
 	dc *scyllav1alpha1.ScyllaDBClusterDatacenter,
+	status *scyllav1alpha1.ScyllaDBClusterStatus,
 	remoteNamespace *corev1.Namespace,
 	remoteController metav1.Object,
 	remoteScyllaDBDatacenters map[string]map[string]*scyllav1alpha1.ScyllaDBDatacenter,
@@ -53,7 +54,7 @@ func (scc *Controller) syncRemoteScyllaDBDatacenters(
 		return progressingConditions, fmt.Errorf("can't prune scylladbdatacenter(s) in %q Datacenter of %q ScyllaDBCluster: %w", dc.Name, naming.ObjRef(sc), err)
 	}
 
-	_, sdcExists := remoteScyllaDBDatacenters[dc.RemoteKubernetesClusterName][requiredScyllaDBDatacenter.Name]
+	existingSDC, sdcExists := remoteScyllaDBDatacenters[dc.RemoteKubernetesClusterName][requiredScyllaDBDatacenter.Name]
 	if !sdcExists {
 		klog.V(4).InfoS("Required ScyllaDBDatacenter doesn't exists, awaiting all previous DC to finish bootstrapping", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(requiredScyllaDBDatacenter))
 		for i := range sc.Spec.Datacenters {
@@ -61,47 +62,29 @@ func (scc *Controller) syncRemoteScyllaDBDatacenters(
 				break
 			}
 			previousDCSpec := sc.Spec.Datacenters[i]
-			previousDCSDCName := naming.ScyllaDBDatacenterName(sc, &previousDCSpec)
-			previousDCSDC, ok := remoteScyllaDBDatacenters[previousDCSpec.RemoteKubernetesClusterName][previousDCSDCName]
-			if !ok {
-				klog.V(4).InfoS("Waiting for datacenter to be created", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(requiredScyllaDBDatacenter), "Datacenter", previousDCSpec.Name)
+			isScyllaDBDatacenterControllerProgressing := meta.IsStatusConditionTrue(status.Conditions, makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(previousDCSpec.Name))
+			if isScyllaDBDatacenterControllerProgressing {
+				klog.V(4).InfoS("Waiting for ScyllaDBDatacenter controller for previous datacenter to finish progressing", "ScyllaDBCluster", klog.KObj(sc), "Datacenter", dc.Name, "PreviousDatacenter", previousDCSpec.Name)
 				progressingConditions = append(progressingConditions, metav1.Condition{
 					Type:               makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(dc.Name),
 					Status:             metav1.ConditionTrue,
-					Reason:             "WaitingForScyllaDBDatacenterCreation",
-					Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to be created.", previousDCSDCName),
-					ObservedGeneration: sc.Generation,
-				})
-
-				return progressingConditions, nil
-			}
-
-			rolledOut, err := controllerhelpers.IsScyllaDBDatacenterRolledOut(previousDCSDC)
-			if err != nil {
-				return progressingConditions, fmt.Errorf("can't check if scylladbdatacenter %q is rolled out: %w", naming.ObjRef(previousDCSDC), err)
-			}
-			if !rolledOut {
-				klog.V(4).InfoS("Waiting for datacenter to roll out", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(requiredScyllaDBDatacenter), "Datacenter", previousDCSpec.Name)
-				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(dc.Name),
-					Status:             metav1.ConditionTrue,
-					Reason:             "WaitingForScyllaDBDatacenterRollout",
-					Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to roll out.", naming.ObjRef(previousDCSDC)),
+					Reason:             "WaitingForScyllaDBDatacenterController",
+					Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter controller for %q datacenter to finish progressing", previousDCSpec.Name),
 					ObservedGeneration: sc.Generation,
 				})
 			}
 		}
 
 		// Scylla cannot start without connecting to seeds. Before we create new DC, make sure seed service and endpoints behind it are already reconciled.
-		isEndpointSliceControllerProgressing := meta.IsStatusConditionTrue(sc.Status.Conditions, makeRemoteEndpointSliceControllerDatacenterProgressingCondition(dc.Name))
-		isServiceControllerProgressing := meta.IsStatusConditionTrue(sc.Status.Conditions, makeRemoteServiceControllerDatacenterProgressingCondition(dc.Name))
+		isEndpointSliceControllerProgressing := meta.IsStatusConditionTrue(status.Conditions, makeRemoteEndpointSliceControllerDatacenterProgressingCondition(dc.Name))
+		isServiceControllerProgressing := meta.IsStatusConditionTrue(status.Conditions, makeRemoteServiceControllerDatacenterProgressingCondition(dc.Name))
 		if isEndpointSliceControllerProgressing || isServiceControllerProgressing {
 			klog.V(4).InfoS("Waiting until EndpointSlice and Service controllers are no longer progressing", "ScyllaDBCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(requiredScyllaDBDatacenter), "Datacenter", dc.Name)
 			progressingConditions = append(progressingConditions, metav1.Condition{
 				Type:               makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(dc.Name),
 				Status:             metav1.ConditionTrue,
 				Reason:             "WaitingForEndpointSliceServiceController",
-				Message:            fmt.Sprintf("Waiting for EndpointSlice and Service controller to finish progressing"),
+				Message:            fmt.Sprintf("Waiting for EndpointSlice and Service controller for %q datacenter to finish progressing", dc.Name),
 				ObservedGeneration: sc.Generation,
 			})
 		}
@@ -120,7 +103,14 @@ func (scc *Controller) syncRemoteScyllaDBDatacenters(
 		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, makeRemoteScyllaDBDatacenterControllerDatacenterProgressingCondition(dc.Name), sdc, "apply", sc.Generation)
 	}
 
-	rolledOut, err := controllerhelpers.IsScyllaDBDatacenterRolledOut(sdc)
+	// Use existingSDC coming from cache to validate the rollout state instead of a freshly fetched SDC,
+	// because the state of the required object depends on the state of other DCs (e.g., seed calculation).
+	// Using a fresh SDC could result in evaluating different state than an outdated state due to cache staleness,
+	// leading us to incorrectly mark the ScyllaCluster as fully rolled out while pending changes still exist.
+	if !sdcExists {
+		existingSDC = sdc
+	}
+	rolledOut, err := controllerhelpers.IsScyllaDBDatacenterRolledOut(existingSDC)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't check if scylladbdatacenter is rolled out: %w", err)
 	}
@@ -134,8 +124,6 @@ func (scc *Controller) syncRemoteScyllaDBDatacenters(
 			Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenter %q to roll out.", naming.ObjRef(sdc)),
 			ObservedGeneration: sc.Generation,
 		})
-
-		return progressingConditions, nil
 	}
 
 	return progressingConditions, nil


### PR DESCRIPTION
Instead awaiting only for previous DC SDC rollout, we await until entire DC finished progressing before proceeding to create new one. In addition it fixes an issue where stale status and wrong object was considered for other conditions we await for.
