### PR TITLE
Update ScyllaDB Manager to 3.5.1

### DIFF
--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -5,8 +5,8 @@ operator:
   # In the future, enterprise versions should be run as a different config instance in its own run.
   scyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride: "2024.1.11"
   scyllaDBUtilsImage: "docker.io/scylladb/scylla:2025.1.2@sha256:84e914792c61a7703ff616bf6ee6d4becbcf68845221bd2458fcab10ef64302c"
-  scyllaDBManagerVersion: "3.5.0@sha256:c38c7f741e46ba5da3914eec9113b615bab779586ba4767605f0a3ebd494bcd2"
-  scyllaDBManagerAgentVersion: "3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16"
+  scyllaDBManagerVersion: "3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816"
+  scyllaDBManagerAgentVersion: "3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc"
   bashToolsImage: "registry.access.redhat.com/ubi9/ubi:9.5-1745854298@sha256:f4ebd46d3ba96feb016d798009e1cc2404c3a4ebdac8b2479a2ac053e59f41b4"
   grafanaImage: "docker.io/grafana/grafana:11.4.3@sha256:95eb8900c1e40e89b3e907094383b1c76c0c166ad5ec85e635de86f114aa7184" # Tracks scylla-monitoring/versions.sh GRAFANA_VERSION
   grafanaDefaultPlatformDashboard: "scylladb-2025.1/scylla-overview.2025.1.json"

--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.5.0@sha256:c38c7f741e46ba5da3914eec9113b615bab779586ba4767605f0a3ebd494bcd2
+        image: docker.io/scylladb/scylla-manager:3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager
@@ -128,7 +128,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 2025.1.2
-  agentVersion: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+  agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.5.0@sha256:c38c7f741e46ba5da3914eec9113b615bab779586ba4767605f0a3ebd494bcd2
+        image: docker.io/scylladb/scylla-manager:3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager
@@ -128,7 +128,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 2025.1.2
-  agentVersion: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+  agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager/dev/50_manager_deployment.yaml
+++ b/deploy/manager/dev/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.5.0@sha256:c38c7f741e46ba5da3914eec9113b615bab779586ba4767605f0a3ebd494bcd2
+        image: docker.io/scylladb/scylla-manager:3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 2025.1.2
-  agentVersion: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+  agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/deploy/manager/prod/50_manager_deployment.yaml
+++ b/deploy/manager/prod/50_manager_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: scylla-manager
       containers:
       - name: scylla-manager
-        image: docker.io/scylladb/scylla-manager:3.5.0@sha256:c38c7f741e46ba5da3914eec9113b615bab779586ba4767605f0a3ebd494bcd2
+        image: docker.io/scylladb/scylla-manager:3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/scylla-manager

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: scylla-manager
 spec:
   version: 2025.1.2
-  agentVersion: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+  agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent
   developerMode: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,9 @@ todo_include_todos = True
 
 myst_enable_extensions = ["colon_fence", "attrs_inline", "substitution"]
 myst_heading_anchors = 6
+
+# MyST substitutions are broken with multiversion docs. Versions specified in the main branch are used for all versions.
+# DO NOT USE OR CHANGE THESE VERSIONS!
 myst_substitutions = {
   "productName": "Scylla Operator",
   "repository": "scylladb/scylla-operator",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,8 +53,10 @@ todo_include_todos = True
 myst_enable_extensions = ["colon_fence", "attrs_inline", "substitution"]
 myst_heading_anchors = 6
 
-# MyST substitutions are broken with multiversion docs. Versions specified in the main branch are used for all versions.
-# DO NOT USE OR CHANGE THESE VERSIONS!
+# DEPRECATION NOTICE
+# MyST substitutions work counterintuitively with multiversion docs. Versions specified in the main branch are used for all versions.
+# These variables have no effect if set on branches other than master.
+# https://github.com/scylladb/scylla-operator/issues/2795
 myst_substitutions = {
   "productName": "Scylla Operator",
   "repository": "scylladb/scylla-operator",

--- a/docs/source/resources/scyllaclusters/basics.md
+++ b/docs/source/resources/scyllaclusters/basics.md
@@ -61,7 +61,7 @@ metadata:
 spec:
   repository: {{imageRepository}}
   version: {{imageTag}}
-  agentVersion: {{agentVersion}}
+  agentVersion: 3.5.1
   developerMode: false
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/docs/source/resources/scyllaclusters/multidc/multidc.md
+++ b/docs/source/resources/scyllaclusters/multidc/multidc.md
@@ -110,7 +110,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.5.0
+  agentVersion: 3.5.1
   version: 2025.1.2
   cpuset: true
   sysctls:
@@ -364,7 +364,7 @@ metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.5.0
+  agentVersion: 3.5.1
   version: 2025.1.2
   cpuset: true
   sysctls:

--- a/docs/source/resources/scyllaclusters/nodeoperations/restore.md
+++ b/docs/source/resources/scyllaclusters/nodeoperations/restore.md
@@ -21,7 +21,7 @@ kind: ScyllaCluster
 metadata:
   name: source
 spec:
-  agentVersion: 3.5.0
+  agentVersion: 3.5.1
   version: 2025.1.2
   developerMode: true
   backups:
@@ -50,7 +50,7 @@ kind: ScyllaCluster
 metadata:
   name: target
 spec:
-  agentVersion: 3.5.0
+  agentVersion: 3.5.1
   version: 2025.1.2
   developerMode: true
   datacenter:

--- a/docs/source/resources/scylladbclusters/scylladbclusters.md
+++ b/docs/source/resources/scylladbclusters/scylladbclusters.md
@@ -115,7 +115,7 @@ spec:
   scyllaDB:
     image: {{imageRepository}}:{{imageTag}}
   scyllaDBManagerAgent:
-    image: docker.io/scylladb/scylla-manager-agent:{{agentVersion}}
+    image: docker.io/scylladb/scylla-manager-agent:3.5.1
   datacenterTemplate:
     placement:
       nodeAffinity:

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -2,7 +2,7 @@
 scyllaImage:
   tag: 2025.1.2
 agentImage:
-  tag: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+  tag: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
 # Cluster information
 developerMode: true
 datacenter: us-east-1

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -1,6 +1,6 @@
 # Scylla Manager image
 image:
-  tag: 3.5.0@sha256:c38c7f741e46ba5da3914eec9113b615bab779586ba4767605f0a3ebd494bcd2
+  tag: 3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816
 # Resources allocated to Scylla Manager pods
 resources:
   limits:
@@ -15,7 +15,7 @@ scylla:
   scyllaImage:
     tag: 2025.1.2
   agentImage:
-    tag: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+    tag: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   datacenter: manager-dc
   racks:
     - name: manager-rack

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -3,7 +3,7 @@ kind: ScyllaCluster
 metadata:
   name: scylla
 spec:
-  agentVersion: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+  agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   version: 2025.1.2
   developerMode: true
   automaticOrphanedNodeCleanup: true

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -1,7 +1,7 @@
 # Scylla Manager image
 image:
   repository: docker.io/scylladb
-  tag: 3.5.0@sha256:c38c7f741e46ba5da3914eec9113b615bab779586ba4767605f0a3ebd494bcd2
+  tag: 3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816
 controllerImage:
   repository: docker.io/scylladb
 logLevel: info
@@ -22,7 +22,7 @@ scylla:
     repository: docker.io/scylladb/scylla
     tag: 2025.1.2
   agentImage:
-    tag: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+    tag: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
     repository: docker.io/scylladb/scylla-manager-agent
   developerMode: true
   cpuset: true

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 image:
   repository: scylladb
   pullPolicy: IfNotPresent
-  tag: 3.5.0@sha256:c38c7f741e46ba5da3914eec9113b615bab779586ba4767605f0a3ebd494bcd2
+  tag: 3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816
 # Scylla Manager log level, allowed values are: error, warn, info, debug, trace
 logLevel: info
 # Resources allocated to Scylla Manager pods
@@ -35,7 +35,7 @@ scylla:
   scyllaImage:
     tag: 2025.1.2
   agentImage:
-    tag: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+    tag: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   datacenter: manager-dc
   racks:
     - name: manager-rack

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -11,7 +11,7 @@ scyllaImage:
 agentImage:
   repository: scylladb/scylla-manager-agent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.5.0@sha256:12755969f1b3258572c520aa82c2f18db52287b3dc7055a977072284f234da16
+  tag: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR updates ScyllaDB Manager and ScyllaDB Manager agent container image references to 3.5.1. Most notably, this patch release brings a fix to frequent snapshot name collisions in a single Manager instance (https://github.com/scylladb/scylla-manager/issues/3873), which we've often hit in our CI (https://github.com/scylladb/scylla-operator/issues/2370).

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2370

/kind dependency-bump
/priority important-soon
