### PR TITLE
Allow opting out of v1.ScyllaCluster global manager registration

### DIFF
--- a/pkg/controller/scyllacluster/status.go
+++ b/pkg/controller/scyllacluster/status.go
@@ -59,6 +59,11 @@ func (scmc *Controller) calculateStatus(
 
 	migratedStatus := migrateV1Alpha1ScyllaDBDatacenterStatusToV1ScyllaClusterStatus(sdc, configMaps, services)
 
+	if isGlobalScyllaDBManagerIntegrationDisabled(sc) {
+		klog.V(4).InfoS("ScyllaDBManager integration is disabled, skipping migration of repair and backup tasks' statuses", "ScyllaCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(sdc))
+		return migratedStatus
+	}
+
 	smcr, ok, err := getScyllaDBManagerClusterRegistration(sdc, scyllaDBManagerClusterRegistrations)
 	if err != nil {
 		klog.ErrorS(err, "Can't get ScyllaDBManagerClusterRegistration for ScyllaDBDatacenter", "ScyllaCluster", klog.KObj(sc), "ScyllaDBDatacenter", klog.KObj(sdc))

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -262,6 +262,9 @@ const (
 	GlobalScyllaDBManagerRegistrationLabel = "scylla-operator.scylladb.com/register-with-global-scylladb-manager"
 	GlobalScyllaDBManagerLabel             = "internal.scylla-operator.scylladb.com/global-scylladb-manager"
 
+	// DisableGlobalScyllaDBManagerIntegrationAnnotation can be set to `true` to disable v1.ScyllaCluster integration with the global ScyllaDB Manager which is enabled by default.
+	DisableGlobalScyllaDBManagerIntegrationAnnotation = "scylla-operator.scylladb.com/disable-global-scylladb-manager-integration"
+
 	// ScyllaDBManagerAgentAuthTokenOverrideSecretRefAnnotation is used to override the auth tokens generated for specific ScyllaDBDatacenters with a shared one, common for the entire ScyllaDBCluster.
 	ScyllaDBManagerAgentAuthTokenOverrideSecretRefAnnotation = "internal.scylla-operator.scylladb.com/scylladb-manager-agent-auth-token-override-secret-ref"
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Allows opting out of `v1.ScyllaCluster` global ScyllaDB Manager integration by annotating it explicitly with `scylla-operator.scylladb.com/disable-global-scylladb-manager-integration: true`.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2788.

/kind feature
/priority important-soon