### PR TITLE
Change the default ScyllaDBCluster topology used in E2E test to 3x3x1 to survive rollouts

### DIFF
--- a/test/e2e/fixture/scylla/scylladbcluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbcluster.yaml.tmpl
@@ -34,6 +34,8 @@ spec:
       nodes: 1
     racks:
     - name: a
+    - name: b
+    - name: c
     placement:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/test/e2e/utils/verification/scylladbcluster/verify.go
+++ b/test/e2e/utils/verification/scylladbcluster/verify.go
@@ -306,18 +306,24 @@ func Verify(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster, rkcClusterM
 					Port:     pointer.Ptr(int32(9142)),
 				},
 			}))
-			o.Expect(seedServiceEndpointSlice.Endpoints).To(o.HaveLen(1))
 
-			o.Expect(seedServiceEndpointSlice.Endpoints[0].Addresses).To(o.HaveLen(int(dcNodeCount)))
+			otherDCNodeCount := controllerhelpers.GetScyllaDBClusterDatacenterNodeCount(sc, otherDC)
+			o.Expect(seedServiceEndpointSlice.Endpoints).To(o.HaveLen(int(otherDCNodeCount)))
 
-			o.Expect(seedServiceEndpointSlice.Endpoints[0].Conditions.Ready).ToNot(o.BeNil())
-			o.Expect(*seedServiceEndpointSlice.Endpoints[0].Conditions.Ready).To(o.BeTrue())
+			for _, endpoint := range seedServiceEndpointSlice.Endpoints {
+				o.Expect(endpoint.Addresses).To(o.HaveLen(1))
 
-			o.Expect(seedServiceEndpointSlice.Endpoints[0].Conditions.Serving).ToNot(o.BeNil())
-			o.Expect(*seedServiceEndpointSlice.Endpoints[0].Conditions.Serving).To(o.BeTrue())
+				o.Expect(endpoint.Conditions).ToNot(o.BeNil())
 
-			o.Expect(seedServiceEndpointSlice.Endpoints[0].Conditions.Terminating).ToNot(o.BeNil())
-			o.Expect(*seedServiceEndpointSlice.Endpoints[0].Conditions.Terminating).To(o.BeFalse())
+				o.Expect(endpoint.Conditions.Ready).ToNot(o.BeNil())
+				o.Expect(*endpoint.Conditions.Ready).To(o.BeTrue())
+
+				o.Expect(endpoint.Conditions.Serving).ToNot(o.BeNil())
+				o.Expect(*endpoint.Conditions.Serving).To(o.BeTrue())
+
+				o.Expect(endpoint.Conditions.Terminating).ToNot(o.BeNil())
+				o.Expect(*endpoint.Conditions.Terminating).To(o.BeFalse())
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** The currently used topology: 3DCs, one rack and one node each, used in the default ScyllaDBCluster makes it impossible for clusters to survive rollouts.

Such case can be observed here: https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2780/pull-scylla-operator-master-e2e-gke-multi-datacenter-parallel/1947260066201604096.

Node 1 logs: https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2780/pull-scylla-operator-master-e2e-gke-multi-datacenter-parallel/1947260066201604096/artifacts/e2e/workers/europe-west1/namespaces/e2e-test-scylladbmanagertask-lwvz4-5m85v-1ytny/pods/basic-92tsd-europe-west1-europe-west1-a-0/scylla.current
Node 1 nodetool status: https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2780/pull-scylla-operator-master-e2e-gke-multi-datacenter-parallel/1947260066201604096/artifacts/e2e/workers/europe-west1/namespaces/e2e-test-scylladbmanagertask-lwvz4-5m85v-1ytny/pods/basic-92tsd-europe-west1-europe-west1-a-0/nodetool-status.log

Node 2 logs: https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2780/pull-scylla-operator-master-e2e-gke-multi-datacenter-parallel/1947260066201604096/artifacts/e2e/workers/europe-west3/namespaces/e2e-test-scylladbmanagertask-lwvz4-5m85v-6x8e8/pods/basic-92tsd-europe-west3-europe-west3-a-0/scylla.current
Node 2 nodetool status: https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2780/pull-scylla-operator-master-e2e-gke-multi-datacenter-parallel/1947260066201604096/artifacts/e2e/workers/europe-west3/namespaces/e2e-test-scylladbmanagertask-lwvz4-5m85v-6x8e8/pods/basic-92tsd-europe-west3-europe-west3-a-0/nodetool-status.log

Node 3 logs: https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2780/pull-scylla-operator-master-e2e-gke-multi-datacenter-parallel/1947260066201604096/artifacts/e2e/workers/europe-west4/namespaces/e2e-test-scylladbmanagertask-lwvz4-5m85v-20cfp/pods/basic-92tsd-europe-west4-europe-west4-a-0/scylla.current
Node 3 nodetool status: https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2780/pull-scylla-operator-master-e2e-gke-multi-datacenter-parallel/1947260066201604096/artifacts/e2e/workers/europe-west4/namespaces/e2e-test-scylladbmanagertask-lwvz4-5m85v-20cfp/pods/basic-92tsd-europe-west4-europe-west4-a-0/nodetool-status.log

When the cluster is rolled out, all ScyllaDBDatacenters are recreated simultaneously. This means that each node is restarted concurrently. By default, with PodIP as broadcast address, each node changes its broadcast address. With each node being restarted concurrently, the seeds can't be resolved either:
```
2025-07-21T12:11:37.932723921Z WARN  2025-07-21 12:11:37,932 [shard 0:main] init - Bad configuration: invalid value in 'seeds': 'basic-92tsd-europe-west1-seed.e2e-test-scylladbmanagertask-lwvz4-5m85v-6x8e8.svc': std::system_error (error C-Ares:4, basic-92tsd-europe-west1-seed.e2e-test-scylladbmanagertask-lwvz4-5m85v-6x8e8.svc: Not found). Node will continue booting since already bootstrapped.
2025-07-21T12:11:37.956387030Z WARN  2025-07-21 12:11:37,956 [shard 0:main] init - Bad configuration: invalid value in 'seeds': 'basic-92tsd-europe-west4-seed.e2e-test-scylladbmanagertask-lwvz4-5m85v-6x8e8.svc': std::system_error (error C-Ares:4, basic-92tsd-europe-west4-seed.e2e-test-scylladbmanagertask-lwvz4-5m85v-6x8e8.svc: Not found). Node will continue booting since already bootstrapped.
2025-07-21T12:11:37.956416390Z INFO  2025-07-21 12:11:37,956 [shard 0:main] init - seeds={127.0.0.1}, listen_address=0.0.0.0, broadcast_address=10.97.1.70
```
https://github.com/scylladb/scylladb/blob/7fd97e6a93e25aa4659a505bc629f81db88e5c03/init.cc#L33-L47

And so the node ends up with just itself as seed. It can't connect to other nodes either as it hasn't learned their new IP addresses yet. Therefore the cluster ends up with all nodes seeing all other nodes as DN and it can't recover from it without the nodes being restarted again sequentially.

This PR changes the topology of default ScyllaDBCluster definitions used in our E2E tests to avoid this issue.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind flake
/priority important-soon