### PR TITLE
Set up dependabot for docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,11 @@ updates:
   labels:
   - priority/important-longterm
   - kind/dependency-bump
+- package-ecosystem: pip
+  directory: /docs
+  schedule:
+    interval: daily
+    time: '05:00' # UTC
+  allow:
+  - dependency-name: sphinx-scylladb-theme
+  - dependency-name: sphinx-multiversion-scylla


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR configures dependabot for poetry used in our docs. I'm following https://github.com/scylladb/scylladb/blob/master/.github/dependabot.yml. ~I suspect this won't work too well with poetry v1.* (https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-) or version pinning (https://github.com/dependabot/dependabot-core/issues/1556), but let's give this a go.~ edit: bumped poetry to v2, hopefully that suffices.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-longterm
