### PR TITLE
Fix optional description formatting in ScyllaDBManager task completion verification

### DIFF
--- a/test/e2e/utils/verification/scylladbmanager.go
+++ b/test/e2e/utils/verification/scylladbmanager.go
@@ -15,7 +15,7 @@ func VerifyScyllaDBManagerRestoreTaskCompleted(eo o.Gomega, ctx context.Context,
 
 	eo.Expect(restoreProgress.Errors).To(o.BeEmpty())
 	eo.Expect(restoreProgress.Run).NotTo(o.BeNil())
-	eo.Expect(restoreProgress.Run.Status).To(o.Equal(managerclient.TaskStatusDone), "Restore task is not done, status: %q, cause: %q.", taskID, restoreProgress.Run.Status, restoreProgress.Run.Cause)
+	eo.Expect(restoreProgress.Run.Status).To(o.Equal(managerclient.TaskStatusDone), "Restore task %q is not done, status: %q, cause: %q.", taskID, restoreProgress.Run.Status, restoreProgress.Run.Cause)
 }
 
 func VerifyScyllaDBManagerRepairTaskCompleted(eo o.Gomega, ctx context.Context, managerClient *managerclient.Client, clusterID, taskID string) {
@@ -23,7 +23,7 @@ func VerifyScyllaDBManagerRepairTaskCompleted(eo o.Gomega, ctx context.Context, 
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	eo.Expect(repairProgress.Run).NotTo(o.BeNil())
-	eo.Expect(repairProgress.Run.Status).To(o.Equal(managerclient.TaskStatusDone), "Repair task is not done, status: %q, cause: %q.", taskID, repairProgress.Run.Status, repairProgress.Run.Cause)
+	eo.Expect(repairProgress.Run.Status).To(o.Equal(managerclient.TaskStatusDone), "Repair task %q is not done, status: %q, cause: %q.", taskID, repairProgress.Run.Status, repairProgress.Run.Cause)
 }
 
 func VerifyScyllaDBManagerBackupTaskCompleted(eo o.Gomega, ctx context.Context, managerClient *managerclient.Client, clusterID, taskID string) {
@@ -31,5 +31,5 @@ func VerifyScyllaDBManagerBackupTaskCompleted(eo o.Gomega, ctx context.Context, 
 	eo.Expect(err).NotTo(o.HaveOccurred())
 
 	eo.Expect(backupProgress.Run).NotTo(o.BeNil())
-	eo.Expect(backupProgress.Run.Status).To(o.Equal(managerclient.TaskStatusDone), "Backup task is not done, status: %q, cause: %q.", taskID, backupProgress.Run.Status, backupProgress.Run.Cause)
+	eo.Expect(backupProgress.Run.Status).To(o.Equal(managerclient.TaskStatusDone), "Backup task %q is not done, status: %q, cause: %q.", taskID, backupProgress.Run.Status, backupProgress.Run.Cause)
 }


### PR DESCRIPTION
**Description of your changes:** This PR fixes string formatting in e2e helpers verifying ScyllaDB Manager task completion.
Example: https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/2811/pull-scylla-operator-master-e2e-gke-parallel-clusterip/1947984117425508352#1:test-build-log.txt%3A3315. 

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-longterm