### PR TITLE
Fix release workflow to not mark old patches as latest

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -87,6 +87,16 @@ runs:
       release_name="${current_tag#v}"
       previous_release_name="${previous_tag#v}"
       
+      # Determine if current tag is the latest version among proper releases (excluding pre-releases).
+      all_tags=$( git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' )
+      highest_tag=$( echo "${all_tags}" | tr ' ' '\n' | sort_semver_decs | head -n1 )
+      
+      # Set make_latest to true only if the current tag is the highest.
+      make_latest=false
+      if [[ "${current_tag}" == "${highest_tag}" ]]; then
+        make_latest=true
+      fi
+      
       gen-release-notes \
       --start-ref="$( git merge-base "${current_tag}" "${previous_tag}" )" \
       --end-ref="${current_tag}" \
@@ -103,12 +113,14 @@ runs:
         --arg release_name "${release_name}" \
         --arg prerelease "${prerelease}" \
         --arg body "$( cat ~/release_notes.md )" \
+        --argjson make_latest ${make_latest} \
         '{
           "tag_name": $current_tag,
           "name": $current_tag,
           "draft": false,
           "prerelease": $prerelease | test("^$") | not,
-          "body": $body
+          "body": $body,
+          "make_latest": $make_latest
       }' )"
       curl --fail -X POST \
       -H "Authorization: Bearer ${{ inputs.githubToken }}" \


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** 
Fixes GH release workflow to not mark releases as latest if they're not the newest in semver terms. `make_latest` is a parameter that's set to `true` ([API spec](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release)).

Tested locally, giving the following requests:

- v1.17.1 (current latest)
```json
{
  "tag_name": "v1.17.1",
  "name": "v1.17.1",
  "draft": false,
  "prerelease": false,
  "body": "Hardcoded release notes",
  "make_latest": true
}
```
- v1.16.3 (older patch)
```json
{
  "tag_name": "v1.16.3",
  "name": "v1.16.3",
  "draft": false,
  "prerelease": false,
  "body": "Hardcoded release notes",
  "make_latest": false
}
```

/kind machinery
/priority important-longterm