### PR TITLE
Add verify-docs to root Makefile's verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -618,6 +618,10 @@ verify-monitoring: submodules
 	$(diff) -r '$(tmp_dir)'/ ./assets/monitoring
 .PHONY: verify-monitoring
 
+verify-docs:
+	@$(MAKE) -C ./docs verify
+.PHONY: verify-docs
+
 # $1 - extra flags
 define run-update-docs
 	$(GO) run ./cmd/gen-api-reference/ --templates-dir ./docs/source/api-reference/templates $(1) $(CRD_FILES)
@@ -643,7 +647,7 @@ verify-links:
 	fi;
 .PHONY: verify-links
 
-verify: verify-codegen verify-crds verify-helm-schemas verify-helm-charts verify-deploy verify-lint verify-helm-lint verify-links verify-examples verify-docs-api verify-monitoring
+verify: verify-codegen verify-crds verify-helm-schemas verify-helm-charts verify-deploy verify-lint verify-helm-lint verify-links verify-examples verify-docs-api verify-monitoring verify-docs
 .PHONY: verify
 
 update: update-codegen update-crds update-helm-schemas update-helm-charts update-deploy update-examples update-docs-api update-monitoring


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Add docs' Makefile `verify` target to the root's Makefile `verify` to have a single target verifying both the code and the docs.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-longterm