### PR TITLE
Fix variable substitutions for multiversion documentation 

### DIFF
--- a/docs/source/_ext/myst_multiversion_substitutions.py
+++ b/docs/source/_ext/myst_multiversion_substitutions.py
@@ -1,0 +1,32 @@
+from typing import Any
+from sphinx.application import Sphinx
+from sphinx.config import Config
+
+def config_inited(app: Sphinx, config: Config) -> None:
+    substitutions_by_version = getattr(config, 'myst_multiversion_substitutions', None)
+    if not substitutions_by_version:
+        return
+
+    current_version = config.myst_multiversion_substitutions_default_version
+    if config.smv_current_version is not None and config.smv_current_version != '':
+        current_version = config.smv_current_version
+    if not current_version:
+        raise AttributeError("'smv_current_version' is not set or is empty in config.")
+
+    try:
+        substitutions = substitutions_by_version[current_version]
+    except KeyError:
+        raise KeyError(f"Current version '{current_version}' not found in myst_multiversion_substitutions.")
+
+    config.myst_substitutions.update(substitutions)
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    app.add_config_value('myst_multiversion_substitutions_default_version', 'master', 'html')
+    app.add_config_value('myst_multiversion_substitutions', {}, 'html')
+    app.connect("config-inited", config_inited)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,12 @@ from datetime import date
 
 from sphinx_scylladb_theme.utils import multiversion_regex_builder
 
+import os
+import sys
+
+# Add custom extensions
+sys.path.append(os.path.abspath("./_ext"))
+
 # -- General configuration
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -18,6 +24,9 @@ extensions = [
     "sphinx_sitemap",
     "sphinx_design",
     "myst_parser",
+
+    # from ./_ext
+    "myst_multiversion_substitutions",
 ]
 
 # The suffix(es) of source filenames.
@@ -53,19 +62,40 @@ todo_include_todos = True
 myst_enable_extensions = ["colon_fence", "attrs_inline", "substitution"]
 myst_heading_anchors = 6
 
-# DEPRECATION NOTICE
-# MyST substitutions work counterintuitively with multiversion docs. Versions specified in the main branch are used for all versions.
-# These variables have no effect if set on branches other than master.
-# https://github.com/scylladb/scylla-operator/issues/2795
+# Global substitutions
 myst_substitutions = {
   "productName": "Scylla Operator",
   "repository": "scylladb/scylla-operator",
-  "revision": "master",
   "imageRepository": "docker.io/scylladb/scylla",
-  "imageTag": "2025.1.2",
   "enterpriseImageRepository": "docker.io/scylladb/scylla-enterprise",
-  "enterpriseImageTag": "2024.1.12",
-  "agentVersion": "3.5.0",
+}
+
+# Multiversion substitutions, merged with global substitutions but only when given documentation branch is being built.
+myst_multiversion_substitutions = {
+    "master": {
+        "revision": "master",
+        "agentVersion": "3.5.1",
+        "enterpriseImageTag": "2025.1.5",
+        "imageTag": "2025.1.5",
+    },
+    "v1.18": {
+        "revision": "v1.18",
+        "agentVersion": "3.5.1",
+        "enterpriseImageTag": "2025.1.5",
+        "imageTag": "2025.1.5",
+    },
+    "v1.17": {
+        "revision": "v1.17",
+        "agentVersion": "3.5.1",
+        "enterpriseImageTag": "2025.1.5",
+        "imageTag": "2025.1.5",
+    },
+    "v1.16": {
+        "revision": "v1.16",
+        "agentVersion": "3.4.2",
+        "enterpriseImageTag": "2025.1.5",
+        "imageTag": "2025.1.5",
+    },
 }
 
 # -- Options for not found extension

--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -20,12 +20,10 @@ In case you already have a supported version of each of these dependencies insta
 
 #### Cert Manager
 
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-kubectl apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/third-party/cert-manager.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+:::{code-block} shell
+:substitutions:
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/cert-manager.yaml
+:::
 
 :::{code-block} shell
 
@@ -45,12 +43,10 @@ done
 
 #### Prometheus Operator
 
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-kubectl -n=prometheus-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/third-party/prometheus-operator.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+:::{code-block} shell
+:substitutions:
+kubectl -n=prometheus-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/prometheus-operator.yaml
+:::
 
 :::{code-block} shell
 # Wait for CRDs to propagate to all apiservers.
@@ -64,12 +60,10 @@ kubectl -n=prometheus-operator rollout status --timeout=10m deployment.apps/prom
 
 Once you have the dependencies installed and available in your cluster, it is the time to install {{productName}}.
 
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/deploy/operator.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/operator.yaml
+:::
 
 ::::{caution}
 {{productName}} deployment references its own image that it later runs alongside each ScyllaDB instance. Therefore, you have to also replace the image in the environment variable called `SCYLLA_OPERATOR_IMAGE`:
@@ -120,21 +114,21 @@ Please review the [NodeConfig](../resources/nodeconfigs.md) and adjust it for yo
 :::::{tab-set}
 
 ::::{tab-item} GKE (NVMe)
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/gke/nodeconfig-alpha.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/gke/nodeconfig-alpha.yaml
+:::
+
 ::::
 
 ::::{tab-item} EKS (NVMe)
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/eks/nodeconfig-alpha.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/eks/nodeconfig-alpha.yaml
+:::
+
 ::::
 
 ::::{tab-item} Any platform (Loop devices)
@@ -143,12 +137,11 @@ This NodeConfig sets up loop devices instead of NVMe disks and is only intended 
 Do not expect meaningful performance with this setup.
 :::
 
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/generic/nodeconfig-alpha.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/generic/nodeconfig-alpha.yaml
+:::
+
 ::::
 
 :::::
@@ -164,12 +157,10 @@ kubectl wait --for='condition=Reconciled' --timeout=10m nodeconfigs.scylla.scyll
 
 ### Local CSI driver
 
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+:::{code-block} shell
+:substitutions:
+kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
+:::
 
 :::{code-block} shell
 # Wait for it to deploy.
@@ -185,23 +176,19 @@ kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-cs
 
 ::::{tab-item} Production (sized)
 
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/deploy/manager-prod.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/manager-prod.yaml
+:::
 
 ::::
 
 ::::{tab-item} Development (sized)
 
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/REPO/BRANCH/deploy/manager-dev.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} shell").replace("END_CODE_BLOCK", ":::")}}
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/manager-dev.yaml
+:::
 
 ::::
 

--- a/docs/source/installation/helm.md
+++ b/docs/source/installation/helm.md
@@ -139,11 +139,11 @@ Versions of images used in the cluster can be set via `scyllaImage` and `agentIm
 ```yaml
 scyllaImage:
   repository: scylladb/scylla
-  tag: 4.3.0
+  tag: {{ imageTag }}
 
 agentImage:
   repository: scylladb/scylla-manager-agent
-  tag: 2.2.1
+  tag: {{agentVersion}}
 ```
 
 A minimal Scylla cluster can be expressed as:
@@ -192,7 +192,7 @@ To set version of used Scylla Manager you can use `image` field:
 image:
   repository: scylladb
   pullPolicy: IfNotPresent
-  tag: 2.2.1
+  tag: {{agentVersion}}
 ```
 To control how many resources are allocated for Scylla Manager use `resource` field:
 ```yaml

--- a/docs/source/quickstarts/eks.md
+++ b/docs/source/quickstarts/eks.md
@@ -15,12 +15,10 @@ If you don't have those already, or are not available through your package manag
 ## Creating an EKS cluster
 
 First, let's create a declarative config to used with eksctl
-% The form of this code block is a workaround to allow resolution of smv_current_version - https://github.com/scylladb/scylla-operator/issues/2752
-{{"""
-BEGIN_CODE_BLOCK
-curl --fail --retry 5 --retry-all-errors -o 'clusterconfig.eksctl.yaml' -L https://raw.githubusercontent.com/REPO/BRANCH/examples/eks/clusterconfig.eksctl.yaml
-END_CODE_BLOCK
-""".replace("REPO", repository).replace("BRANCH", env.config.smv_current_version).replace("BEGIN_CODE_BLOCK", ":::{code-block} bash").replace("END_CODE_BLOCK", ":::")}}
+:::{code-block} shell
+:substitutions:
+curl --fail --retry 5 --retry-all-errors -o 'clusterconfig.eksctl.yaml' -L https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/eks/clusterconfig.eksctl.yaml
+:::
 
 With the config ready, we can easily create an EKS cluster by running
 

--- a/docs/source/resources/scyllaclusters/basics.md
+++ b/docs/source/resources/scyllaclusters/basics.md
@@ -61,7 +61,7 @@ metadata:
 spec:
   repository: {{imageRepository}}
   version: {{imageTag}}
-  agentVersion: 3.5.1
+  agentVersion: {{agentVersion}}
   developerMode: false
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/docs/source/resources/scyllaclusters/multidc/multidc.md
+++ b/docs/source/resources/scyllaclusters/multidc/multidc.md
@@ -103,15 +103,16 @@ For more information see [Create a ScyllaDB Cluster - Multi Data Centers (DC)](h
 :::
 
 Save the ScyllaCluster manifest in `dc1.yaml`:
-```yaml
+:::{code-block} yaml
+:substitutions:
 apiVersion: scylla.scylladb.com/v1
 kind: ScyllaCluster
 metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.5.1
-  version: 2025.1.2
+  agentVersion: {{agentVersion}}
+  version: {{imageTag}}
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"
@@ -259,7 +260,7 @@ spec:
           key: scylla-operator.scylladb.com/dedicated
           operator: Equal
           value: scyllaclusters
-```
+:::
 
 Apply the manifest:
 ```shell
@@ -357,15 +358,17 @@ For this guide, let's assume that the second cluster is running in `us-east-2` r
 :::
 
 Having configured it, save the manifest as `dc2.yaml`:
-```yaml
+:::{code-block} yaml
+:substitutions:
+
 apiVersion: scylla.scylladb.com/v1
 kind: ScyllaCluster
 metadata:
   name: scylla-cluster
   namespace: scylla
 spec:
-  agentVersion: 3.5.1
-  version: 2025.1.2
+  agentVersion: {{ agentVersion }}
+  version: {{ imageTag }}
   cpuset: true
   sysctls:
   - "fs.aio-max-nr=2097152"
@@ -517,7 +520,7 @@ spec:
           key: scylla-operator.scylladb.com/dedicated
           operator: Equal
           value: scyllaclusters
-```
+:::
 
 To apply the manifest, run:
 ```shell

--- a/docs/source/resources/scyllaclusters/nodeoperations/restore.md
+++ b/docs/source/resources/scyllaclusters/nodeoperations/restore.md
@@ -13,16 +13,17 @@ When following the steps for schema restore, ensure you follow the additional st
 
 In the following example, the ScyllaCluster, which was used to take the backup, is called `source`. Backup will be restored into the ScyllaCluster named `target`.
 
-::::{tab-set}
-:::{tab-item} Source ScyllaCluster
-```yaml
+:::::{tab-set}
+::::{tab-item} Source ScyllaCluster
+:::{code-block} yaml
+:substitutions:
 apiVersion: scylla.scylladb.com/v1
 kind: ScyllaCluster
 metadata:
   name: source
 spec:
-  agentVersion: 3.5.1
-  version: 2025.1.2
+  agentVersion: {{agentVersion}}
+  version: {{imageTag}}
   developerMode: true
   backups:
   - name: foo
@@ -41,17 +42,18 @@ spec:
         limits:
           cpu: 1
           memory: 1Gi
-```
 :::
-:::{tab-item} Target ScyllaCluster
-```yaml
+::::
+::::{tab-item} Target ScyllaCluster
+:::{code-block} yaml
+:substitutions:
 apiVersion: scylla.scylladb.com/v1
 kind: ScyllaCluster
 metadata:
   name: target
 spec:
-  agentVersion: 3.5.1
-  version: 2025.1.2
+  agentVersion: {{agentVersion}}
+  version: {{imageTag}}
   developerMode: true
   datacenter:
     name: us-east-1
@@ -64,9 +66,9 @@ spec:
         limits:
           cpu: 1
           memory: 1Gi
-```
-:::
+:::{code-block}
 ::::
+:::::
 
 Make sure your target cluster is already registered in Scylla Manager. To get a list of all registered clusters, execute the following command:
 ```console

--- a/docs/source/resources/scylladbclusters/scylladbclusters.md
+++ b/docs/source/resources/scylladbclusters/scylladbclusters.md
@@ -115,7 +115,7 @@ spec:
   scyllaDB:
     image: {{imageRepository}}:{{imageTag}}
   scyllaDBManagerAgent:
-    image: docker.io/scylladb/scylla-manager-agent:3.5.1
+    image: docker.io/scylladb/scylla-manager-agent:{{agentVersion}}
   datacenterTemplate:
     placement:
       nodeAffinity:


### PR DESCRIPTION
Introduces a custom Sphinx extension that allows `myst_substitutions` to be overridden with values specific to each version.
The extension hooks into Sphinx before myst loads its configuration.
Since each branch build runs as a separate execution with a different `smv_current_version`, this enables us to override `myst_substitutions` using values defined in our `myst_multiversion_substitutions`.

By specifying different variables per different version we are now able to specify values only on master, which are correctly resolved by each version.
With:
```
myst_multiversion_substitutions = {
    "master": {
        "agentVersion": "master-agentVersion",
        "imageTag": "master-imageTag",
        [...]
    },
    "v1.17": {
        "agentVersion": "v1.17-agentVersion",
        "imageTag": "v1.17-imageTag",
        [...]
    },
}
```
We get:
<img width="707" height="260" alt="Screenshot From 2025-07-25 13-14-48" src="https://github.com/user-attachments/assets/6b55b1aa-d951-4ca8-a7a8-400d04bfe277" />
<img width="707" height="260" alt="Screenshot From 2025-07-25 13-14-36" src="https://github.com/user-attachments/assets/c62424a7-1ec3-464a-85a9-309869d13f01" />


Fixes #2795 
Fixes #2644