### PR TITLE
[v1.18] Don't provision 2025.3 and 2025.3.0 Grafana platform dashboards

### DIFF
--- a/assets/monitoring/grafana/v1alpha1/grafanadashboards.go
+++ b/assets/monitoring/grafana/v1alpha1/grafanadashboards.go
@@ -9,10 +9,18 @@ import (
 	"io/fs"
 	"path/filepath"
 	"regexp"
+	"slices"
 )
 
 var (
 	grafanaDashboardsFileRegex = regexp.MustCompile(`^[^/]+\.json$`)
+
+	// FIXME: remove the exclusions and fix https://github.com/scylladb/scylla-operator/issues/2822
+	// before supporting ScyllaDB 2025.3.
+	platformDashboardsToExclude = []string{
+		"scylladb-2025.3.0",
+		"scylladb-2025.3",
+	}
 )
 
 func gzipMapData(uncompressedMap map[string]string) (map[string]string, error) {
@@ -60,6 +68,13 @@ func NewGrafanaDashboardsFromFS(filesystem embed.FS, root string) (GrafanaDashbo
 	grafanaDashboardsFoldersMap := GrafanaDashboardsFoldersMap{}
 	for _, e := range topEntries {
 		if !e.IsDir() {
+			continue
+		}
+
+		// Exclude platform dashboards that are known to cause https://github.com/scylladb/scylla-operator/issues/2822.
+		// TODO: get rid of this exclusion once the root cause is fixed.
+		directoryName := filepath.Base(e.Name())
+		if slices.Contains(platformDashboardsToExclude, directoryName) {
 			continue
 		}
 

--- a/assets/monitoring/grafana/v1alpha1/grafanadashboards_test.go
+++ b/assets/monitoring/grafana/v1alpha1/grafanadashboards_test.go
@@ -23,6 +23,13 @@ func TestNewGrafanaDashboardsFromFS(t *testing.T) {
 			validateFunc: func(t *testing.T, dfs GrafanaDashboardsFoldersMap) {
 				t.Helper()
 
+				// TODO: get rid of this once the root cause is fixed (https://github.com/scylladb/scylla-operator/issues/2822).
+				for _, v := range platformDashboardsToExclude {
+					if _, ok := dfs[v]; ok {
+						t.Errorf("expected to not find %s platform dashboards as we explicitly exclude them", v)
+					}
+				}
+
 				if len(dfs) == 0 {
 					t.Errorf("no platform dashboards found")
 				}


### PR DESCRIPTION
Backport of https://github.com/scylladb/scylla-operator/pull/2823.