### PR TITLE
Fix Grafana container image reference to use a multi-arch index

### DIFF
--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -8,7 +8,7 @@ operator:
   scyllaDBManagerVersion: "3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816"
   scyllaDBManagerAgentVersion: "3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc"
   bashToolsImage: "registry.access.redhat.com/ubi9/ubi:9.5-1745854298@sha256:f4ebd46d3ba96feb016d798009e1cc2404c3a4ebdac8b2479a2ac053e59f41b4"
-  grafanaImage: "docker.io/grafana/grafana:12.0.2-security-01@sha256:40e468f95e84cfcb68b1de2e0638f73377b59c3ac566283c8c973697f48deaca" # Tracks scylla-monitoring/versions.sh GRAFANA_VERSION
+  grafanaImage: "docker.io/grafana/grafana:12.0.2-security-01@sha256:9047b1d7ec7bfad6a7e6542e7f1782b2337e18af8ebf4f21cf5327e903dac830" # Tracks scylla-monitoring/versions.sh GRAFANA_VERSION
   grafanaDefaultPlatformDashboard: "scylladb-2025.1/scylla-overview.2025.1.json"
   prometheusVersion: "v3.5.0" # Tracks scylla-monitoring/versions.sh PROMETHEUS_VERSION
 operatorTests:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Grafana container image reference was incorrectly configured to use an amd64 image instead of the multi-arch image index (https://hub.docker.com/layers/grafana/grafana/12.0.2-security-01/images/sha256-40e468f95e84cfcb68b1de2e0638f73377b59c3ac566283c8c973697f48deaca). This PR fixes it.

```
$ skopeo inspect --raw docker://docker.io/grafana/grafana@sha256:9047b1d7ec7bfad6a7e6542e7f1782b2337e18af8ebf4f21cf5327e903dac830
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2417,
         "digest": "sha256:40e468f95e84cfcb68b1de2e0638f73377b59c3ac566283c8c973697f48deaca",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2412,
         "digest": "sha256:8844925b9866ef585c963518cef93541a8cdbf6a1451012649a0a267ba156b72",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2411,
         "digest": "sha256:9e5e94758675c8675a1e351f3fa6c4174f7e9883de95b0fd2684427f5afae0e3",
         "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
         }
      }
   ]
}
```

**Which issue is resolved by this Pull Request:**
Resolves #

/priority critical-urgent
/kind bug