### PR TITLE
Explicitly set and unify the number of retries and backoff duration in ScyllaDB Manager tasks in E2E tests

### DIFF
--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -171,6 +171,12 @@ var _ = g.Describe("Scylla Manager integration", func() {
 		scCopy := sc.DeepCopy()
 		scCopy.Spec.Repairs = append(scCopy.Spec.Repairs, scyllav1.RepairTaskSpec{
 			TaskSpec: scyllav1.TaskSpec{
+				SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+					NumRetries: pointer.Ptr[int64](3),
+					RetryWait: &metav1.Duration{
+						Duration: 30 * time.Second,
+					},
+				},
 				Name: "repair",
 			},
 			Parallel: 2,
@@ -288,7 +294,7 @@ var _ = g.Describe("Scylla Manager integration", func() {
 		framework.By("Waiting for repair to finish")
 		o.Eventually(verification.VerifyScyllaDBManagerRepairTaskCompleted).
 			WithContext(ctx).
-			WithTimeout(10*time.Minute).
+			WithTimeout(utils.ScyllaDBManagerTaskCompletionTimeout).
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, managerClusterID, repairTask.ID).
 			Should(o.Succeed())

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -80,6 +80,12 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		sourceSCCopy := sourceSC.DeepCopy()
 		sourceSCCopy.Spec.Backups = append(sourceSCCopy.Spec.Backups, scyllav1.BackupTaskSpec{
 			TaskSpec: scyllav1.TaskSpec{
+				SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+					NumRetries: pointer.Ptr[int64](utils.ScyllaDBManagerTaskNumRetries),
+					RetryWait: &metav1.Duration{
+						Duration: utils.ScyllaDBManagerTaskRetryWait,
+					},
+				},
 				Name: "backup",
 			},
 			Location:  []string{objectStorageLocation},
@@ -200,7 +206,7 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		framework.By("Waiting for the backup task to finish")
 		o.Eventually(verification.VerifyScyllaDBManagerBackupTaskCompleted).
 			WithContext(ctx).
-			WithTimeout(3*time.Minute).
+			WithTimeout(utils.ScyllaDBManagerTaskCompletionTimeout).
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, sourceManagerClusterID, backupTask.ID).
 			Should(o.Succeed())
@@ -341,6 +347,8 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 				fmt.Sprintf("--location=%s", objectStorageLocation),
 				fmt.Sprintf("--snapshot-tag=%s", snapshotTag),
 				"--restore-schema",
+				fmt.Sprintf("--num-retries=%d", utils.ScyllaDBManagerTaskNumRetries),
+				fmt.Sprintf("--retry-wait=%s", utils.ScyllaDBManagerTaskRetryWait),
 			},
 			Namespace:     scyllaManagerPod.Namespace,
 			PodName:       scyllaManagerPod.Name,
@@ -356,7 +364,7 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		framework.By("Waiting for schema restore to finish")
 		o.Eventually(verification.VerifyScyllaDBManagerRestoreTaskCompleted).
 			WithContext(ctx).
-			WithTimeout(10*time.Minute).
+			WithTimeout(utils.ScyllaDBManagerTaskCompletionTimeout).
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, targetManagerClusterID, schemaRestoreTaskID.String()).
 			Should(o.Succeed())
@@ -374,6 +382,8 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 				fmt.Sprintf("--location=%s", objectStorageLocation),
 				fmt.Sprintf("--snapshot-tag=%s", snapshotTag),
 				"--restore-tables",
+				fmt.Sprintf("--num-retries=%d", utils.ScyllaDBManagerTaskNumRetries),
+				fmt.Sprintf("--retry-wait=%s", utils.ScyllaDBManagerTaskRetryWait),
 			},
 			Namespace:     scyllaManagerPod.Namespace,
 			PodName:       scyllaManagerPod.Name,
@@ -389,7 +399,7 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		framework.By("Waiting for tables restore to finish")
 		o.Eventually(verification.VerifyScyllaDBManagerRestoreTaskCompleted).
 			WithContext(ctx).
-			WithTimeout(10*time.Minute).
+			WithTimeout(utils.ScyllaDBManagerTaskCompletionTimeout).
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, targetManagerClusterID, tablesRestoreTaskID.String()).
 			Should(o.Succeed())
@@ -582,6 +592,12 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		scCopy.Spec.Backups = []scyllav1.BackupTaskSpec{
 			{
 				TaskSpec: scyllav1.TaskSpec{
+					SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+						NumRetries: pointer.Ptr[int64](utils.ScyllaDBManagerTaskNumRetries),
+						RetryWait: &metav1.Duration{
+							Duration: utils.ScyllaDBManagerTaskRetryWait,
+						},
+					},
 					Name: "backup",
 				},
 				Location: []string{validObjectStorageLocation},
@@ -590,6 +606,12 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 		scCopy.Spec.Repairs = []scyllav1.RepairTaskSpec{
 			{
 				TaskSpec: scyllav1.TaskSpec{
+					SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+						NumRetries: pointer.Ptr[int64](utils.ScyllaDBManagerTaskNumRetries),
+						RetryWait: &metav1.Duration{
+							Duration: utils.ScyllaDBManagerTaskRetryWait,
+						},
+					},
 					Name: "repair",
 				},
 			},

--- a/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
+++ b/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
@@ -79,7 +79,10 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 				Type: scyllav1alpha1.ScyllaDBManagerTaskTypeRepair,
 				Repair: &scyllav1alpha1.ScyllaDBManagerRepairTaskOptions{
 					ScyllaDBManagerTaskSchedule: scyllav1alpha1.ScyllaDBManagerTaskSchedule{
-						NumRetries: pointer.Ptr[int64](1),
+						NumRetries: pointer.Ptr[int64](utils.ScyllaDBManagerTaskNumRetries),
+						RetryWait: &metav1.Duration{
+							Duration: utils.ScyllaDBManagerTaskRetryWait,
+						},
 					},
 					Parallel: pointer.Ptr[int64](2),
 				},
@@ -164,7 +167,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 		framework.By("Waiting for the repair task to finish")
 		o.Eventually(verification.VerifyScyllaDBManagerRepairTaskCompleted).
 			WithContext(ctx).
-			WithTimeout(5*time.Minute).
+			WithTimeout(utils.ScyllaDBManagerMultiDatacenterTaskCompletionTimeout).
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, managerClusterID, managerTask.ID).
 			Should(o.Succeed())

--- a/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
+++ b/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
@@ -89,7 +89,10 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 				Type: scyllav1alpha1.ScyllaDBManagerTaskTypeBackup,
 				Backup: &scyllav1alpha1.ScyllaDBManagerBackupTaskOptions{
 					ScyllaDBManagerTaskSchedule: scyllav1alpha1.ScyllaDBManagerTaskSchedule{
-						NumRetries: pointer.Ptr[int64](1),
+						NumRetries: pointer.Ptr[int64](utils.ScyllaDBManagerTaskNumRetries),
+						RetryWait: &metav1.Duration{
+							Duration: utils.ScyllaDBManagerTaskRetryWait,
+						},
 					},
 					Location: []string{
 						utils.LocationForScyllaManager(objectStorageSettings),
@@ -182,7 +185,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		framework.By("Waiting for the backup task to finish")
 		o.Eventually(verification.VerifyScyllaDBManagerBackupTaskCompleted).
 			WithContext(ctx).
-			WithTimeout(3*time.Minute).
+			WithTimeout(utils.ScyllaDBManagerTaskCompletionTimeout).
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, sourceManagerClusterID, managerTask.ID).
 			Should(o.Succeed())
@@ -329,6 +332,8 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 				fmt.Sprintf("--location=%s", utils.LocationForScyllaManager(objectStorageSettings)),
 				fmt.Sprintf("--snapshot-tag=%s", snapshotTag),
 				"--restore-schema",
+				fmt.Sprintf("--num-retries=%d", utils.ScyllaDBManagerTaskNumRetries),
+				fmt.Sprintf("--retry-wait=%s", utils.ScyllaDBManagerTaskRetryWait),
 			},
 			Namespace:     globalScyllaDBManagerInstancePod.Namespace,
 			PodName:       globalScyllaDBManagerInstancePod.Name,
@@ -344,7 +349,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		framework.By("Waiting for the schema restore task to finish")
 		o.Eventually(verification.VerifyScyllaDBManagerRestoreTaskCompleted).
 			WithContext(ctx).
-			WithTimeout(10*time.Minute).
+			WithTimeout(utils.ScyllaDBManagerTaskCompletionTimeout).
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, targetManagerClusterID, schemaRestoreTaskID.String()).
 			Should(o.Succeed())
@@ -364,6 +369,8 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 				fmt.Sprintf("--location=%s", utils.LocationForScyllaManager(objectStorageSettings)),
 				fmt.Sprintf("--snapshot-tag=%s", snapshotTag),
 				"--restore-tables",
+				fmt.Sprintf("--num-retries=%d", utils.ScyllaDBManagerTaskNumRetries),
+				fmt.Sprintf("--retry-wait=%s", utils.ScyllaDBManagerTaskRetryWait),
 			},
 			Namespace:     globalScyllaDBManagerInstancePod.Namespace,
 			PodName:       globalScyllaDBManagerInstancePod.Name,
@@ -379,7 +386,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		framework.By("Waiting for the tables restore task to finish")
 		o.Eventually(verification.VerifyScyllaDBManagerRestoreTaskCompleted).
 			WithContext(ctx).
-			WithTimeout(10*time.Minute).
+			WithTimeout(utils.ScyllaDBManagerTaskCompletionTimeout).
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, targetManagerClusterID, tablesRestoreTaskID.String()).
 			Should(o.Succeed())

--- a/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdataceter_globalmanager.go
+++ b/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdataceter_globalmanager.go
@@ -67,7 +67,10 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 				Type: scyllav1alpha1.ScyllaDBManagerTaskTypeRepair,
 				Repair: &scyllav1alpha1.ScyllaDBManagerRepairTaskOptions{
 					ScyllaDBManagerTaskSchedule: scyllav1alpha1.ScyllaDBManagerTaskSchedule{
-						NumRetries: pointer.Ptr[int64](1),
+						NumRetries: pointer.Ptr[int64](3),
+						RetryWait: &metav1.Duration{
+							Duration: 30 * time.Second,
+						},
 					},
 					Parallel: pointer.Ptr[int64](2),
 				},
@@ -156,7 +159,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		framework.By("Waiting for the repair task to finish")
 		o.Eventually(verification.VerifyScyllaDBManagerRepairTaskCompleted).
 			WithContext(ctx).
-			WithTimeout(10*time.Minute).
+			WithTimeout(utils.ScyllaDBManagerTaskCompletionTimeout).
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, managerClusterID, managerTask.ID).
 			Should(o.Succeed())

--- a/test/e2e/utils/config.go
+++ b/test/e2e/utils/config.go
@@ -26,4 +26,10 @@ const (
 
 	baseManagerSyncTimeout = 3 * time.Minute
 	managerTaskSyncTimeout = 30 * time.Second
+
+	ScyllaDBManagerTaskNumRetries = 3
+	ScyllaDBManagerTaskRetryWait  = 30 * time.Second
+
+	ScyllaDBManagerTaskCompletionTimeout                = 10 * time.Minute
+	ScyllaDBManagerMultiDatacenterTaskCompletionTimeout = 15 * time.Minute
 )


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR explicitly sets and unifies `NumRetries` and `RetryWait` parameters in ScyllaDB Manager tasks created in our e2e tests. The default value for the latter is 10m, which results in transitive failures in task scheduling causing our test suites to fail, as the value is often larger than the corresponding timeouts, as can be observed in https://github.com/scylladb/scylla-operator/issues/2816.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2816

/kind flake
/priority important-soon
