### PR TITLE
Grant Gateway API RBAC to haproxy ingress controller

### DIFF
--- a/examples/third-party/haproxy-ingress.yaml
+++ b/examples/third-party/haproxy-ingress.yaml
@@ -78,6 +78,25 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "gateway.networking.k8s.io"
+  resources:
+  - referencegrants
+  - gateways
+  - gatewayclasses
+  - tcproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "gateway.networking.k8s.io"
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - tcproutes/status
+  verbs:
+  - update
 
 ---
 apiVersion: v1

--- a/examples/third-party/haproxy-ingress/10_clusterrole.yaml
+++ b/examples/third-party/haproxy-ingress/10_clusterrole.yaml
@@ -64,3 +64,22 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "gateway.networking.k8s.io"
+  resources:
+  - referencegrants
+  - gateways
+  - gatewayclasses
+  - tcproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "gateway.networking.k8s.io"
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - tcproutes/status
+  verbs:
+  - update


### PR DESCRIPTION
Example haproxy installation was extended with necessary Gateway API RBAC roles.

After bumping OKD version on Openshift jobs, Gateway API CRDs are installed by default which presence is verified by Haproxy Ingress Controller.
Because we haven't granted necessary RBAC, it's failing to bootstrap breaking our e2e setup.
There's no way to disable it explicitly, haproxy only checks CRD presence.
