### PR TITLE
Bump patch version of third-party haproxy-ingress example

### DIFF
--- a/examples/third-party/haproxy-ingress.yaml
+++ b/examples/third-party/haproxy-ingress.yaml
@@ -12,6 +12,9 @@ metadata:
   name: haproxy-ingress
 
 ---
+# Sources:
+# https://github.com/haproxytech/kubernetes-ingress/blob/v1.10.16/deploy/haproxy-ingress.yaml
+# https://github.com/haproxytech/kubernetes-ingress/blob/v1.10.16/documentation/gateway-api.md
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -65,6 +68,23 @@ rules:
   - core.haproxy.org
   resources:
   - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - "discovery.k8s.io"
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
   verbs:
   - get
   - list
@@ -337,7 +357,7 @@ spec:
       serviceAccountName: haproxy-ingress
       containers:
       - name: haproxy-ingress
-        image: docker.io/haproxytech/kubernetes-ingress:1.10.1@sha256:39eb1a1443e42dc4dc9883bbc764b21f7c7d507af277656551af39ff3faf7635
+        image: docker.io/haproxytech/kubernetes-ingress:1.10.16@sha256:30a51796be80f987a59b5dfc520b7955fe30eee9a411a05daff3157a1c137a25
         args:
         - --disable-ipv6
         - --ipv4-bind-address=0.0.0.0

--- a/examples/third-party/haproxy-ingress/10_clusterrole.yaml
+++ b/examples/third-party/haproxy-ingress/10_clusterrole.yaml
@@ -1,3 +1,6 @@
+# Sources:
+# https://github.com/haproxytech/kubernetes-ingress/blob/v1.10.16/deploy/haproxy-ingress.yaml
+# https://github.com/haproxytech/kubernetes-ingress/blob/v1.10.16/documentation/gateway-api.md
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -51,6 +54,23 @@ rules:
   - core.haproxy.org
   resources:
   - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - "discovery.k8s.io"
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
   verbs:
   - get
   - list

--- a/examples/third-party/haproxy-ingress/50_haproxy-ingress.deploy.yaml
+++ b/examples/third-party/haproxy-ingress/50_haproxy-ingress.deploy.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: haproxy-ingress
       containers:
       - name: haproxy-ingress
-        image: docker.io/haproxytech/kubernetes-ingress:1.10.1@sha256:39eb1a1443e42dc4dc9883bbc764b21f7c7d507af277656551af39ff3faf7635
+        image: docker.io/haproxytech/kubernetes-ingress:1.10.16@sha256:30a51796be80f987a59b5dfc520b7955fe30eee9a411a05daff3157a1c137a25
         args:
         - --disable-ipv6
         - --ipv4-bind-address=0.0.0.0


### PR DESCRIPTION
Version we used didn't have proper check if gateway API is available. It checked whether one particular resource is installed, but it hasn't validated whether given Gateway API spec is supported, nor whether other resources are in expected apiVersions. Latest patch release contains the fix for this logic which should solve issues we observe on Openshift. Only patch release is bumped because there're a lot of new major versions avaiable, doing a big step may uncover more gaps and I would like to do smaller steps eliminating one issue at a time.

/cc @czeslavo 