### PR TITLE
Await schema agreement after keyspace creation by E2E's data inserter

### DIFF
--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -108,7 +108,7 @@ func (di *DataInserter) SetClientEndpoints(hosts []string) error {
 	return nil
 }
 
-func (di *DataInserter) Insert() error {
+func (di *DataInserter) Insert(ctx context.Context) error {
 	ss := make([]string, 0, len(di.replicationFactor))
 	for dc, rf := range di.replicationFactor {
 		ss = append(ss, fmt.Sprintf("'%s': %d", dc, rf))
@@ -132,6 +132,12 @@ func (di *DataInserter) Insert() error {
 	))
 	if err != nil {
 		return fmt.Errorf("can't create table: %w", err)
+	}
+
+	framework.Infof("Awaiting schema agreement")
+	err = di.session.AwaitSchemaAgreement(ctx)
+	if err != nil {
+		return fmt.Errorf("can't await schema agreement: %w", err)
 	}
 
 	framework.Infof("Inserting data into table %s", di.table.Name())

--- a/test/e2e/utils/verification/cql.go
+++ b/test/e2e/utils/verification/cql.go
@@ -29,7 +29,7 @@ func InsertAndVerifyCQLDataByDC(ctx context.Context, hosts map[string][]string) 
 
 func InsertAndVerifyCQLDataUsingDataInserter(ctx context.Context, di *utils.DataInserter) *utils.DataInserter {
 	framework.By("Inserting data")
-	err := di.Insert()
+	err := di.Insert(ctx)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	VerifyCQLData(ctx, di)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Schema agreement should be awaited after schema-altering statements. This PR adds it after keyspace and table creation in E2E's data inserter.

**Which issue is resolved by this Pull Request:**
I'm taking a stab at minimising instability in https://github.com/scylladb/scylla-operator/issues/2827 here, although I'm not expecting it to be a root cause.

/kind failing-test
/priority important-soon