### PR TITLE
[v1.18] Update ScyllaDB to 2025.1.5

### DIFF
--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -1,10 +1,10 @@
 operator:
-  scyllaDBVersion: "2025.1.2"
+  scyllaDBVersion: "2025.1.5"
   # scyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride sets enterprise version
   # that requires consistent_cluster_management workaround for restore.
   # In the future, enterprise versions should be run as a different config instance in its own run.
   scyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride: "2024.1.11"
-  scyllaDBUtilsImage: "docker.io/scylladb/scylla:2025.1.2@sha256:84e914792c61a7703ff616bf6ee6d4becbcf68845221bd2458fcab10ef64302c"
+  scyllaDBUtilsImage: "docker.io/scylladb/scylla:2025.1.5@sha256:acd61debf250089e926db5c6a0d4675d42324feadec3965c04f9b6a7f7679216"
   scyllaDBManagerVersion: "3.5.1@sha256:6986ecfc8c925c3d59b65bbcb9763d62f7591a00bb30242842aada115929e816"
   scyllaDBManagerAgentVersion: "3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc"
   bashToolsImage: "registry.access.redhat.com/ubi9/ubi:9.5-1745854298@sha256:f4ebd46d3ba96feb016d798009e1cc2404c3a4ebdac8b2479a2ac053e59f41b4"
@@ -13,6 +13,6 @@ operator:
   prometheusVersion: "v3.5.0" # Tracks scylla-monitoring/versions.sh PROMETHEUS_VERSION
 operatorTests:
   scyllaDBVersions:
-    updateFrom: "2025.1.1" # One patch lower than .operator.scyllaDBVersion
+    updateFrom: "2025.1.4" # One patch lower than .operator.scyllaDBVersion
     upgradeFrom: "6.2.3" # One minor lower than .operator.scyllaDBVersion
   nodeSetupImage: "quay.io/scylladb/scylla-operator-images:node-setup-v0.0.4@sha256:8d77b91db6cffb40337e3db9c9a2f73f190eda9f9e547a752f0beab8aea322ef"

--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -127,7 +127,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 2025.1.2
+  version: 2025.1.5
   agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -127,7 +127,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 2025.1.2
+  version: 2025.1.5
   agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/dev/50_scyllacluster.yaml
+++ b/deploy/manager/dev/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 2025.1.2
+  version: 2025.1.5
   agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/deploy/manager/prod/50_scyllacluster.yaml
+++ b/deploy/manager/prod/50_scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla-manager-cluster
   namespace: scylla-manager
 spec:
-  version: 2025.1.2
+  version: 2025.1.5
   agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   repository: docker.io/scylladb/scylla
   agentRepository: docker.io/scylladb/scylla-manager-agent

--- a/examples/helm/values.cluster.yaml
+++ b/examples/helm/values.cluster.yaml
@@ -1,6 +1,6 @@
 # Version information
 scyllaImage:
-  tag: 2025.1.2
+  tag: 2025.1.5
 agentImage:
   tag: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
 # Cluster information

--- a/examples/helm/values.manager.yaml
+++ b/examples/helm/values.manager.yaml
@@ -13,7 +13,7 @@ resources:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 2025.1.2
+    tag: 2025.1.5
   agentImage:
     tag: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   datacenter: manager-dc

--- a/examples/scylladb/scylla.scyllacluster.yaml
+++ b/examples/scylladb/scylla.scyllacluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scylla
 spec:
   agentVersion: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
-  version: 2025.1.2
+  version: 2025.1.5
   developerMode: true
   automaticOrphanedNodeCleanup: true
   sysctls:

--- a/helm/deploy/manager_prod.yaml
+++ b/helm/deploy/manager_prod.yaml
@@ -20,7 +20,7 @@ scylla:
   fullnameOverride: scylla-manager-cluster
   scyllaImage:
     repository: docker.io/scylladb/scylla
-    tag: 2025.1.2
+    tag: 2025.1.5
   agentImage:
     tag: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
     repository: docker.io/scylladb/scylla-manager-agent

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -33,7 +33,7 @@ serviceAccount:
 scylla:
   developerMode: true
   scyllaImage:
-    tag: 2025.1.2
+    tag: 2025.1.5
   agentImage:
     tag: 3.5.1@sha256:d1b57d08b9949c8faad2048fdf4dc7c502dae81da856c3c6b3a77dd347d5c7fc
   datacenter: manager-dc

--- a/helm/scylla/values.yaml
+++ b/helm/scylla/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 scyllaImage:
   repository: scylladb/scylla
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 2025.1.2
+  tag: 2025.1.5
 # Allows to customize Scylla image
 agentImage:
   repository: scylladb/scylla-manager-agent


### PR DESCRIPTION
Backport of https://github.com/scylladb/scylla-operator/pull/2844. 

Part of https://github.com/scylladb/scylla-operator/issues/2792.

/kind dependency-bump
/priority critical-urgent