### PR TITLE
Increase CPU requests in E2E's ScyllaDBCluster template

### DIFF
--- a/test/e2e/fixture/scylla/scylladbcluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbcluster.yaml.tmpl
@@ -20,7 +20,7 @@ spec:
     scyllaDB:
       resources:
         requests:
-          cpu: 10m
+          cpu: 100m
           memory: 100Mi
         limits:
           cpu: 1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** After a deep dive into one of the cases of  [#2827](https://github.com/scylladb/scylla-operator/issues/2827)'s flakiness returned no obvious issues, we concluded with @zimnx that the cluster is most likely underprovisioned. We have no way of confirming this in our CI, so this PR takes a stab at improving the situation. Let's start with giving it more CPU requests to see if Scylla will be able to handle queries in the default timeout. 

**Which issue is resolved by this Pull Request:**
Potentially resolves https://github.com/scylladb/scylla-operator/issues/2827.

/kind failing-test
/priority important-soon