### PR TITLE
Propagate NodeTune DaemonSet's DisableOptimiziation flag to controllers and do not create perftune Jobs when set

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -492,9 +492,9 @@ spec:
               properties:
                 disableOptimizations:
                   description: |-
-                    disableOptimizations controls if nodes matching placement requirements
-                    are going to be optimized. Turning off optimizations on already optimized
-                    Nodes does not revert changes.
+                    disableOptimizations controls if nodes matching placement requirements are going to be optimized for performance.
+                    Turning off optimizations on already optimized Nodes does not revert changes.
+                    See https://operator.docs.scylladb.com/stable/architecture/tuning.html for details.
                   type: boolean
                 localDiskSetup:
                   description: localDiskSetup contains options of automatic local disk setup.

--- a/docs/source/api-reference/groups/scylla.scylladb.com/nodeconfigs.rst
+++ b/docs/source/api-reference/groups/scylla.scylladb.com/nodeconfigs.rst
@@ -77,7 +77,7 @@ object
      - Description
    * - disableOptimizations
      - boolean
-     - disableOptimizations controls if nodes matching placement requirements are going to be optimized. Turning off optimizations on already optimized Nodes does not revert changes.
+     - disableOptimizations controls if nodes matching placement requirements are going to be optimized for performance. Turning off optimizations on already optimized Nodes does not revert changes. See https://operator.docs.scylladb.com/stable/architecture/tuning.html for details.
    * - :ref:`localDiskSetup<api-scylla.scylladb.com-nodeconfigs-v1alpha1-.spec.localDiskSetup>`
      - object
      - localDiskSetup contains options of automatic local disk setup.

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_nodeconfigs.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_nodeconfigs.yaml
@@ -52,9 +52,9 @@ spec:
               properties:
                 disableOptimizations:
                   description: |-
-                    disableOptimizations controls if nodes matching placement requirements
-                    are going to be optimized. Turning off optimizations on already optimized
-                    Nodes does not revert changes.
+                    disableOptimizations controls if nodes matching placement requirements are going to be optimized for performance.
+                    Turning off optimizations on already optimized Nodes does not revert changes.
+                    See https://operator.docs.scylladb.com/stable/architecture/tuning.html for details.
                   type: boolean
                 localDiskSetup:
                   description: localDiskSetup contains options of automatic local disk setup.

--- a/pkg/api/scylla/v1alpha1/types_nodeconfig.go
+++ b/pkg/api/scylla/v1alpha1/types_nodeconfig.go
@@ -229,9 +229,9 @@ type NodeConfigSpec struct {
 	// +kubebuilder:validation:Required
 	Placement NodeConfigPlacement `json:"placement"`
 
-	// disableOptimizations controls if nodes matching placement requirements
-	// are going to be optimized. Turning off optimizations on already optimized
-	// Nodes does not revert changes.
+	// disableOptimizations controls if nodes matching placement requirements are going to be optimized for performance.
+	// Turning off optimizations on already optimized Nodes does not revert changes.
+	// See https://operator.docs.scylladb.com/stable/architecture/tuning.html for details.
 	DisableOptimizations bool `json:"disableOptimizations"`
 
 	// localDiskSetup contains options of automatic local disk setup.

--- a/pkg/cmd/operator/nodesetupdaemon.go
+++ b/pkg/cmd/operator/nodesetupdaemon.go
@@ -255,6 +255,7 @@ func (o *NodeSetupDaemonOptions) Run(streams genericclioptions.IOStreams, cmd *c
 		types.UID(o.NodeConfigUID),
 		o.ScyllaImage,
 		o.OperatorImage,
+		o.DisableOptimizations,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create node config instance controller: %w", err)

--- a/pkg/controller/nodetune/controller.go
+++ b/pkg/controller/nodetune/controller.go
@@ -67,14 +67,15 @@ type Controller struct {
 	namespacedJobLister       batchv1listers.JobLister
 	selfPodLister             corev1listers.PodLister
 
-	namespace      string
-	podName        string
-	nodeName       string
-	nodeUID        types.UID
-	nodeConfigName string
-	nodeConfigUID  types.UID
-	scyllaImage    string
-	operatorImage  string
+	namespace            string
+	podName              string
+	nodeName             string
+	nodeUID              types.UID
+	nodeConfigName       string
+	nodeConfigUID        types.UID
+	scyllaImage          string
+	operatorImage        string
+	disableOptimizations bool
 
 	cachesToSync []cache.InformerSynced
 
@@ -101,6 +102,7 @@ func NewController(
 	nodeConfigUID types.UID,
 	scyllaImage string,
 	operatorImage string,
+	disableOptimizations bool,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -118,14 +120,15 @@ func NewController(
 		namespacedJobLister:       namespacedJobInformer.Lister(),
 		selfPodLister:             selfPodInformer.Lister(),
 
-		namespace:      namespace,
-		podName:        podName,
-		nodeName:       nodeName,
-		nodeUID:        nodeUID,
-		nodeConfigName: nodeConfigName,
-		nodeConfigUID:  nodeConfigUID,
-		scyllaImage:    scyllaImage,
-		operatorImage:  operatorImage,
+		namespace:            namespace,
+		podName:              podName,
+		nodeName:             nodeName,
+		nodeUID:              nodeUID,
+		nodeConfigName:       nodeConfigName,
+		nodeConfigUID:        nodeConfigUID,
+		scyllaImage:          scyllaImage,
+		operatorImage:        operatorImage,
+		disableOptimizations: disableOptimizations,
 
 		cachesToSync: []cache.InformerSynced{
 			nodeConfigInformer.Informer().HasSynced,

--- a/pkg/controller/nodetune/sync_jobs.go
+++ b/pkg/controller/nodetune/sync_jobs.go
@@ -28,12 +28,17 @@ import (
 )
 
 func (ncdc *Controller) makeJobsForNode(ctx context.Context) ([]*batchv1.Job, error) {
+	var jobs []*batchv1.Job
+
+	if ncdc.disableOptimizations {
+		klog.V(2).InfoS("NodeConfig's optimizations are disabled, skipping perftune Job creation for node")
+		return jobs, nil
+	}
+
 	pod, err := ncdc.selfPodLister.Pods(ncdc.namespace).Get(ncdc.podName)
 	if err != nil {
 		return nil, fmt.Errorf("can't get self Pod %q: %w", naming.ManualRef(ncdc.namespace, ncdc.podName), err)
 	}
-
-	var jobs []*batchv1.Job
 
 	cr, err := ncdc.newOwningDSControllerRef()
 	if err != nil {
@@ -214,6 +219,11 @@ func (ncdc *Controller) makeJobsForContainers(ctx context.Context) ([]*batchv1.J
 
 		runningScyllaPods = append(runningScyllaPods, scyllaPod)
 
+		if ncdc.disableOptimizations {
+			klog.V(4).Infof("NodeConfig's optimizations are disabled, Pod %q isn't considered for optimizations", naming.ObjRef(scyllaPod))
+			continue
+		}
+
 		if !controllerhelpers.IsPodTunable(scyllaPod) {
 			klog.V(4).Infof("Pod %q isn't a subject for optimizations", naming.ObjRef(scyllaPod))
 			continue
@@ -229,9 +239,14 @@ func (ncdc *Controller) makeJobsForContainers(ctx context.Context) ([]*batchv1.J
 		return nil, fmt.Errorf("can't get Pod %q: %w", naming.ManualRef(ncdc.namespace, ncdc.podName), err)
 	}
 
-	perftuneJob, err := ncdc.makePerftuneJobForContainers(ctx, &selfPod.Spec, optimizablePods, optimizableScyllaContainerIDs)
-	if err != nil {
-		return nil, fmt.Errorf("can't make perftune jobs: %w", err)
+	var perftuneJob *batchv1.Job
+	if ncdc.disableOptimizations {
+		klog.V(2).InfoS("NodeConfig's optimizations are disabled, skipping perftune Job creation for containers")
+	} else {
+		perftuneJob, err = ncdc.makePerftuneJobForContainers(ctx, &selfPod.Spec, optimizablePods, optimizableScyllaContainerIDs)
+		if err != nil {
+			return nil, fmt.Errorf("can't make perftune jobs: %w", err)
+		}
 	}
 
 	resourceLimitsJobs, err := ncdc.makeResourceLimitJobsForContainers(ctx, &selfPod.Spec, runningScyllaPods)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Although [NodeConfig's DisableOptimizations](https://github.com/scylladb/scylla-operator/blob/001128a8d05330567d33ef89b1591a347d0de8ec/pkg/api/scylla/v1alpha1/types_nodeconfig.go#L235) is propagated to the respective DaemonSets, [the flag is unused](https://github.com/scylladb/scylla-operator/blob/001128a8d05330567d33ef89b1591a347d0de8ec/pkg/cmd/operator/nodesetupdaemon.go#L44) and so it is not respected by the actual controllers. The pertfune Jobs are created for respective nodes and containers regardless. Therefore it is only possible to disable perftune [if LocalDiskSetup is not configured](https://github.com/scylladb/scylla-operator/blob/001128a8d05330567d33ef89b1591a347d0de8ec/pkg/controller/nodeconfig/resource.go#L244).
This PR stops perftune Jobs creation when DisableOptimizations is set.
It also extend the API field's comment to specify it only refers to performance optimizations.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2874

/kind bug
/priority important-soon