### PR TITLE
Add Management section in docs and restructure operator upgrade guide

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -17,6 +17,7 @@ hide-post-content:
 
 architecture/index
 installation/index
+management/index
 resources/index
 quickstarts/index
 support/index
@@ -70,6 +71,16 @@ Learn about the components of Scylla Operator and how they fit together.
 :class: large-4
 
 Configure your Kubernetes platform, install prerequisites and all components of {{productName}}.
+```
+
+```{topic-box}
+:title: Management
+:icon: icon-operations
+:link: management/overview
+:anchor: Learn more »
+:class: large-4
+
+Manage your ScyllaDB clusters using {{productName}}. 
 ```
 
 ```{topic-box}

--- a/docs/source/installation/helm.md
+++ b/docs/source/installation/helm.md
@@ -308,7 +308,7 @@ Helm should notice the difference, install the ServiceMonitor, and then Promethe
 
 ## Upgrade
 
-Please refer to the [upgrade guide](./upgrade.md#upgrade-via-helm) to learn how to upgrade your Helm installations.
+Please refer to the [upgrade guide](./../management/upgrading/upgrade.md#upgrade-via-helm) to learn how to upgrade your Helm installations.
 
 ## Cleanup
 

--- a/docs/source/installation/index.md
+++ b/docs/source/installation/index.md
@@ -7,5 +7,4 @@ overview
 kubernetes/index
 gitops
 helm
-upgrade
 :::

--- a/docs/source/installation/overview.md
+++ b/docs/source/installation/overview.md
@@ -102,4 +102,4 @@ For details, please see the [dedicated section describing the deployment using H
 
 ## Upgrades
 
-Please see the [dedicated section describing the upgrade process](./upgrade.md).
+Please see the [dedicated section describing the upgrade process](./../management/upgrading/upgrade.md).

--- a/docs/source/management/index.md
+++ b/docs/source/management/index.md
@@ -1,0 +1,7 @@
+# Management
+
+:::{toctree}
+:maxdepth: 1
+
+upgrading/index
+:::

--- a/docs/source/management/upgrading/index.md
+++ b/docs/source/management/upgrading/index.md
@@ -1,0 +1,7 @@
+# Upgrading
+
+:::{toctree}
+:maxdepth: 1
+
+upgrade
+:::

--- a/docs/source/management/upgrading/upgrade.md
+++ b/docs/source/management/upgrading/upgrade.md
@@ -1,4 +1,4 @@
-# Upgrade
+# Upgrading {{productName}}
 
 {{productName}} supports N+1 upgrades only.
 That means to you can only update by 1 minor version at the time and wait for it to successfully roll out and then update
@@ -13,7 +13,7 @@ If any additional steps are required for a specific version upgrade, they will b
 ## Upgrade via GitOps (kubectl)
 
 A typical upgrade flow using GitOps (kubectl) requires re-applying the manifests using ones from the release you want to upgrade to.
-Please refer to the [GitOps installation instructions](./gitops.md) for details.
+Please refer to the [GitOps installation instructions](./../../installation/gitops.md) for details.
 
 ## Upgrade via Helm
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** I'm sending this PR in an effort to nudge us towards the restructuring and framework changes proposed in https://github.com/scylladb/scylla-operator/issues/2787. However, the structure proposed in the issue lacks a more general section for "regular" management tasks related to configuration or day-2 operations. This PR adds a generic "Management" section and moves the operator upgrade guide there. This is not meant to be set in stone, but more a disruptive change to promote discussions around the docs structure.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-longterm
