### PR TITLE
chore: Update example operator tag in gitops.md to 1.18

### DIFF
--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -85,11 +85,11 @@ spec:
       containers:
       - name: scylla-operator
         # ...
-        image: docker.io/scylladb/scylla-operator:1.14.0@sha256:8c75c5780e2283f0a8f9734925352716f37e0e7f41007e50ce9b1d9924046fa1
+        image: docker.io/scylladb/scylla-operator:1.18
         env:
           # ...
         - name: SCYLLA_OPERATOR_IMAGE
-          value: docker.io/scylladb/scylla-operator:1.14.0@sha256:8c75c5780e2283f0a8f9734925352716f37e0e7f41007e50ce9b1d9924046fa1
+          value: docker.io/scylladb/scylla-operator:1.18
 :::
 The {{productName}} image value and the `SCYLLA_OPERATOR_IMAGE` shall always match.
 Be careful not to use a rolling tag for any of them to avoid an accidental skew!


### PR DESCRIPTION
**Description of your changes:**
Update the example operator YAML to use the current Operator release version

**Which issue is resolved by this Pull Request:**
-
