### PR TITLE
Add GKE (Ubuntu) >= 1.32 to unsupported platforms

### DIFF
--- a/docs/source/support/releases.md
+++ b/docs/source/support/releases.md
@@ -98,7 +98,8 @@ The following platforms are known **not to work correctly** at this time.
 :::{table}
 | Platform         | OS Image     | Details |
 |:-----------------|:-------------| :------ |
-| GKE              | Container OS |         |
+| GKE              | Container OS | Lack of XFS support |
+| GKE >= 1.32      | Ubuntu       | See [#2579](https://github.com/scylladb/scylla-operator/issues/2579) |
 | EKS              | Bottlerocket | Suspected kernel/cgroups issue that breaks available memory detection for ScyllaDB |
 :::
 :::


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Adds GKE >= 1.32 with Ubuntu OS image to unsupported platforms due to #2579.


