### PR TITLE
Extend admission review with warning messages

### DIFF
--- a/pkg/admissionreview/handler.go
+++ b/pkg/admissionreview/handler.go
@@ -26,7 +26,8 @@ func init() {
 	codecs = serializer.NewCodecFactory(scheme)
 }
 
-type HandleFunc func(*admissionv1.AdmissionReview) error
+// HandleFunc is a function type that processes an AdmissionReview request and returns warnings and a validation error.
+type HandleFunc func(*admissionv1.AdmissionReview) ([]string, error)
 
 type handler struct {
 	f HandleFunc
@@ -79,7 +80,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		funcErr := h.f(requestedAdmissionReview)
+		funcWarnings, funcErr := h.f(requestedAdmissionReview)
 		if funcErr != nil {
 			klog.V(2).InfoS("Review failed", "Error", err)
 		}
@@ -105,6 +106,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 					}(),
 				}
 			}(),
+			Warnings: funcWarnings,
 		}
 		responseObj = responseAdmissionReview
 

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -501,3 +501,11 @@ func isRackStatusUpToDate(sc *scyllav1.ScyllaCluster, rack string) bool {
 		sc.Status.Racks[rack].Stale != nil &&
 		!*sc.Status.Racks[rack].Stale
 }
+
+func GetWarningsOnScyllaClusterCreate(sc *scyllav1.ScyllaCluster) []string {
+	return nil
+}
+
+func GetWarningsOnScyllaClusterUpdate(new, old *scyllav1.ScyllaCluster) []string {
+	return nil
+}

--- a/pkg/api/scylla/validation/nodeconfig_validation.go
+++ b/pkg/api/scylla/validation/nodeconfig_validation.go
@@ -110,3 +110,11 @@ func ValidateNodeConfigSpecUpdate(new, old *scyllav1alpha1.NodeConfig, fldPath *
 
 	return allErrs
 }
+
+func GetWarningsOnNodeConfigCreate(nc *scyllav1alpha1.NodeConfig) []string {
+	return nil
+}
+
+func GetWarningsOnNodeConfigUpdate(new, old *scyllav1alpha1.NodeConfig) []string {
+	return nil
+}

--- a/pkg/api/scylla/validation/scylladbcluster_validation.go
+++ b/pkg/api/scylla/validation/scylladbcluster_validation.go
@@ -422,3 +422,11 @@ func ValidateScyllaDBClusterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBCluster,
 
 	return allErrs
 }
+
+func GetWarningsOnScyllaDBClusterCreate(sc *scyllav1alpha1.ScyllaDBCluster) []string {
+	return nil
+}
+
+func GetWarningsOnScyllaDBClusterUpdate(new, old *scyllav1alpha1.ScyllaDBCluster) []string {
+	return nil
+}

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation.go
@@ -576,3 +576,11 @@ func validateEnum[E ~string](value E, supported []E, fldPath *field.Path) field.
 
 	return allErrs
 }
+
+func GetWarningsOnScyllaDBDatacenterCreate(sdc *scyllav1alpha1.ScyllaDBDatacenter) []string {
+	return nil
+}
+
+func GetWarningsOnScyllaDBDatacenterUpdate(new, old *scyllav1alpha1.ScyllaDBDatacenter) []string {
+	return nil
+}

--- a/pkg/api/scylla/validation/scylladbmanagerclusterregistration_validation.go
+++ b/pkg/api/scylla/validation/scylladbmanagerclusterregistration_validation.go
@@ -96,3 +96,11 @@ func ValidateScyllaDBManagerClusterRegistrationSpecUpdate(newSpec, oldSpec *scyl
 
 	return allErrs
 }
+
+func GetWarningsOnScyllaDBManagerClusterRegistrationCreate(smcr *scyllav1alpha1.ScyllaDBManagerClusterRegistration) []string {
+	return nil
+}
+
+func GetWarningsOnScyllaDBManagerClusterRegistrationUpdate(new, old *scyllav1alpha1.ScyllaDBManagerClusterRegistration) []string {
+	return nil
+}

--- a/pkg/api/scylla/validation/scylladbmanagertask_validation.go
+++ b/pkg/api/scylla/validation/scylladbmanagertask_validation.go
@@ -446,3 +446,11 @@ func validateDCLimit(s string, fldPath *field.Path) field.ErrorList {
 
 	return allErrs
 }
+
+func GetWarningsOnScyllaDBManagerTaskCreate(smt *scyllav1alpha1.ScyllaDBManagerTask) []string {
+	return nil
+}
+
+func GetWarningsOnScyllaDBManagerTaskUpdate(new, old *scyllav1alpha1.ScyllaDBManagerTask) []string {
+	return nil
+}

--- a/pkg/api/scylla/validation/scyllaoperatorconfig.go
+++ b/pkg/api/scylla/validation/scyllaoperatorconfig.go
@@ -79,3 +79,11 @@ func ValidateScyllaOperatorConfigUpdate(new, old *scyllav1alpha1.ScyllaOperatorC
 
 	return allErrs
 }
+
+func GetWarningsOnScyllaOperatorConfigCreate(soc *scyllav1alpha1.ScyllaOperatorConfig) []string {
+	return nil
+}
+
+func GetWarningsOnScyllaOperatorConfigUpdate(new, old *scyllav1alpha1.ScyllaOperatorConfig) []string {
+	return nil
+}

--- a/pkg/cmd/operator/webhooks.go
+++ b/pkg/cmd/operator/webhooks.go
@@ -38,32 +38,46 @@ import (
 var (
 	DefaultValidators = map[schema.GroupVersionResource]Validator{
 		scyllav1.GroupVersion.WithResource("scyllaclusters"): &GenericValidator[*scyllav1.ScyllaCluster]{
-			ValidateCreateFunc: validation.ValidateScyllaCluster,
-			ValidateUpdateFunc: validation.ValidateScyllaClusterUpdate,
+			ValidateCreateFunc:      validation.ValidateScyllaCluster,
+			ValidateUpdateFunc:      validation.ValidateScyllaClusterUpdate,
+			GetWarningsOnCreateFunc: validation.GetWarningsOnScyllaClusterCreate,
+			GetWarningsOnUpdateFunc: validation.GetWarningsOnScyllaClusterUpdate,
 		},
 		scyllav1alpha1.GroupVersion.WithResource("nodeconfigs"): &GenericValidator[*scyllav1alpha1.NodeConfig]{
-			ValidateCreateFunc: validation.ValidateNodeConfig,
-			ValidateUpdateFunc: validation.ValidateNodeConfigUpdate,
+			ValidateCreateFunc:      validation.ValidateNodeConfig,
+			ValidateUpdateFunc:      validation.ValidateNodeConfigUpdate,
+			GetWarningsOnCreateFunc: validation.GetWarningsOnNodeConfigCreate,
+			GetWarningsOnUpdateFunc: validation.GetWarningsOnNodeConfigUpdate,
 		},
 		scyllav1alpha1.GroupVersion.WithResource("scyllaoperatorconfigs"): &GenericValidator[*scyllav1alpha1.ScyllaOperatorConfig]{
-			ValidateCreateFunc: validation.ValidateScyllaOperatorConfig,
-			ValidateUpdateFunc: validation.ValidateScyllaOperatorConfigUpdate,
+			ValidateCreateFunc:      validation.ValidateScyllaOperatorConfig,
+			ValidateUpdateFunc:      validation.ValidateScyllaOperatorConfigUpdate,
+			GetWarningsOnCreateFunc: validation.GetWarningsOnScyllaOperatorConfigCreate,
+			GetWarningsOnUpdateFunc: validation.GetWarningsOnScyllaOperatorConfigUpdate,
 		},
 		scyllav1alpha1.GroupVersion.WithResource("scylladbdatacenters"): &GenericValidator[*scyllav1alpha1.ScyllaDBDatacenter]{
-			ValidateCreateFunc: validation.ValidateScyllaDBDatacenter,
-			ValidateUpdateFunc: validation.ValidateScyllaDBDatacenterUpdate,
+			ValidateCreateFunc:      validation.ValidateScyllaDBDatacenter,
+			ValidateUpdateFunc:      validation.ValidateScyllaDBDatacenterUpdate,
+			GetWarningsOnCreateFunc: validation.GetWarningsOnScyllaDBDatacenterCreate,
+			GetWarningsOnUpdateFunc: validation.GetWarningsOnScyllaDBDatacenterUpdate,
 		},
 		scyllav1alpha1.GroupVersion.WithResource("scylladbclusters"): &GenericValidator[*scyllav1alpha1.ScyllaDBCluster]{
-			ValidateCreateFunc: validation.ValidateScyllaDBCluster,
-			ValidateUpdateFunc: validation.ValidateScyllaDBClusterUpdate,
+			ValidateCreateFunc:      validation.ValidateScyllaDBCluster,
+			ValidateUpdateFunc:      validation.ValidateScyllaDBClusterUpdate,
+			GetWarningsOnCreateFunc: validation.GetWarningsOnScyllaDBClusterCreate,
+			GetWarningsOnUpdateFunc: validation.GetWarningsOnScyllaDBClusterUpdate,
 		},
 		scyllav1alpha1.GroupVersion.WithResource("scylladbmanagerclusterregistrations"): &GenericValidator[*scyllav1alpha1.ScyllaDBManagerClusterRegistration]{
-			ValidateCreateFunc: validation.ValidateScyllaDBManagerClusterRegistration,
-			ValidateUpdateFunc: validation.ValidateScyllaDBManagerClusterRegistrationUpdate,
+			ValidateCreateFunc:      validation.ValidateScyllaDBManagerClusterRegistration,
+			ValidateUpdateFunc:      validation.ValidateScyllaDBManagerClusterRegistrationUpdate,
+			GetWarningsOnCreateFunc: validation.GetWarningsOnScyllaDBManagerClusterRegistrationCreate,
+			GetWarningsOnUpdateFunc: validation.GetWarningsOnScyllaDBManagerClusterRegistrationUpdate,
 		},
 		scyllav1alpha1.GroupVersion.WithResource("scylladbmanagertasks"): &GenericValidator[*scyllav1alpha1.ScyllaDBManagerTask]{
-			ValidateCreateFunc: validation.ValidateScyllaDBManagerTask,
-			ValidateUpdateFunc: validation.ValidateScyllaDBManagerTaskUpdate,
+			ValidateCreateFunc:      validation.ValidateScyllaDBManagerTask,
+			ValidateUpdateFunc:      validation.ValidateScyllaDBManagerTaskUpdate,
+			GetWarningsOnCreateFunc: validation.GetWarningsOnScyllaDBManagerTaskCreate,
+			GetWarningsOnUpdateFunc: validation.GetWarningsOnScyllaDBManagerTaskUpdate,
 		},
 	}
 )
@@ -73,6 +87,8 @@ type Validator interface {
 	ValidateUpdate(obj, oldObj runtime.Object) field.ErrorList
 	GetGroupKind(obj runtime.Object) schema.GroupKind
 	GetName(obj runtime.Object) string
+	GetWarningsOnCreate(obj runtime.Object) []string
+	GetWarningsOnUpdate(obj, oldObj runtime.Object) []string
 }
 
 type WebhookOptions struct {
@@ -248,7 +264,7 @@ func (o *WebhookOptions) run(ctx context.Context, streams genericclioptions.IOSt
 			klog.Error(err)
 		}
 	})
-	handler.Handle("/validate", admissionreview.NewHandler(func(review *admissionv1.AdmissionReview) error {
+	handler.Handle("/validate", admissionreview.NewHandler(func(review *admissionv1.AdmissionReview) ([]string, error) {
 		return validate(review, o.Validators)
 	}))
 
@@ -302,8 +318,10 @@ type ValidatableObject interface {
 }
 
 type GenericValidator[T ValidatableObject] struct {
-	ValidateCreateFunc func(obj T) field.ErrorList
-	ValidateUpdateFunc func(obj, oldObj T) field.ErrorList
+	ValidateCreateFunc      func(obj T) field.ErrorList
+	ValidateUpdateFunc      func(obj, oldObj T) field.ErrorList
+	GetWarningsOnCreateFunc func(obj T) []string
+	GetWarningsOnUpdateFunc func(obj, oldObj T) []string
 }
 
 func (v *GenericValidator[T]) ValidateCreate(obj runtime.Object) field.ErrorList {
@@ -322,7 +340,15 @@ func (v *GenericValidator[T]) GetName(obj runtime.Object) string {
 	return obj.(T).GetName()
 }
 
-func validate(ar *admissionv1.AdmissionReview, validators map[schema.GroupVersionResource]Validator) error {
+func (v *GenericValidator[T]) GetWarningsOnCreate(obj runtime.Object) []string {
+	return v.GetWarningsOnCreateFunc(obj.(T))
+}
+
+func (v *GenericValidator[T]) GetWarningsOnUpdate(obj, oldObj runtime.Object) []string {
+	return v.GetWarningsOnUpdateFunc(obj.(T), oldObj.(T))
+}
+
+func validate(ar *admissionv1.AdmissionReview, validators map[schema.GroupVersionResource]Validator) ([]string, error) {
 	gvr := schema.GroupVersionResource{
 		Group:    ar.Request.Resource.Group,
 		Version:  ar.Request.Resource.Version,
@@ -336,33 +362,40 @@ func validate(ar *admissionv1.AdmissionReview, validators map[schema.GroupVersio
 	if ar.Request.Object.Raw != nil {
 		obj, _, err = deserializer.Decode(ar.Request.Object.Raw, nil, nil)
 		if err != nil {
-			return fmt.Errorf("can't decode object %q: %w", gvr, err)
+			return nil, fmt.Errorf("can't decode object %q: %w", gvr, err)
 		}
 	}
 	if ar.Request.OldObject.Raw != nil {
 		oldObj, _, err = deserializer.Decode(ar.Request.OldObject.Raw, nil, nil)
 		if err != nil {
-			return fmt.Errorf("can't decode old object %q: %w", gvr, err)
+			return nil, fmt.Errorf("can't decode old object %q: %w", gvr, err)
 		}
 	}
 
 	validator, ok := validators[gvr]
 	if !ok {
-		return fmt.Errorf("unsupported GVR %q", gvr)
+		return nil, fmt.Errorf("unsupported GVR %q", gvr)
 	}
 
 	var errList field.ErrorList
+	var warnings []string
 	switch ar.Request.Operation {
 	case admissionv1.Create:
 		errList = validator.ValidateCreate(obj)
+		warnings = validator.GetWarningsOnCreate(obj)
+
 	case admissionv1.Update:
 		errList = validator.ValidateUpdate(obj, oldObj)
+		warnings = validator.GetWarningsOnUpdate(obj, oldObj)
+
 	default:
-		return fmt.Errorf("unsupported operation %q", ar.Request.Operation)
+		return nil, fmt.Errorf("unsupported operation %q", ar.Request.Operation)
+
 	}
 
 	if len(errList) > 0 {
-		return apierrors.NewInvalid(validator.GetGroupKind(obj), validator.GetName(obj), errList)
+		return warnings, apierrors.NewInvalid(validator.GetGroupKind(obj), validator.GetName(obj), errList)
 	}
-	return nil
+
+	return warnings, nil
 }

--- a/pkg/cmd/operator/webhooks_test.go
+++ b/pkg/cmd/operator/webhooks_test.go
@@ -21,7 +21,17 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 )
@@ -325,4 +335,353 @@ func createFileWithContent(path string, data []byte) error {
 	}
 
 	return nil
+}
+
+func Test_validate(t *testing.T) {
+	t.Parallel()
+
+	testScheme := runtime.NewScheme()
+
+	err := corev1.AddToScheme(testScheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	codecs := serializer.NewCodecFactory(testScheme)
+	encoder := unstructured.NewJSONFallbackEncoder(codecs.LegacyCodec(testScheme.PrioritizedVersionsAllGroups()...))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "test",
+		},
+	}
+	podRaw, err := runtime.Encode(encoder, pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tt := []struct {
+		name             string
+		ar               *admissionv1.AdmissionReview
+		validators       map[schema.GroupVersionResource]Validator
+		expectedWarnings []string
+		expectedError    error
+	}{
+		{
+			name: "create, no errors, no warnings",
+			ar: func() *admissionv1.AdmissionReview {
+				return &admissionv1.AdmissionReview{
+					Request: &admissionv1.AdmissionRequest{
+						UID: "uid",
+						Resource: metav1.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Operation: "CREATE",
+						Object:    runtime.RawExtension{Raw: podRaw},
+					},
+				}
+			}(),
+			validators: map[schema.GroupVersionResource]Validator{
+				corev1.SchemeGroupVersion.WithResource("pods"): &GenericValidator[*corev1.Pod]{
+					ValidateCreateFunc: func(_ *corev1.Pod) field.ErrorList {
+						return nil
+					},
+					ValidateUpdateFunc: func(_, _ *corev1.Pod) field.ErrorList {
+						panic("unexpected call to ValidateUpdateFunc")
+					},
+					GetWarningsOnCreateFunc: func(_ *corev1.Pod) []string {
+						return nil
+					},
+					GetWarningsOnUpdateFunc: func(_, _ *corev1.Pod) []string {
+						panic("unexpected call to GetWarningsOnUpdateFunc")
+					},
+				},
+			},
+			expectedWarnings: nil,
+			expectedError:    nil,
+		},
+		{
+			name: "create, error, no warnings",
+			ar: func() *admissionv1.AdmissionReview {
+				return &admissionv1.AdmissionReview{
+					Request: &admissionv1.AdmissionRequest{
+						UID: "uid",
+						Resource: metav1.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Operation: "CREATE",
+						Object:    runtime.RawExtension{Raw: podRaw},
+					},
+				}
+			}(),
+			validators: map[schema.GroupVersionResource]Validator{
+				corev1.SchemeGroupVersion.WithResource("pods"): &GenericValidator[*corev1.Pod]{
+					ValidateCreateFunc: func(_ *corev1.Pod) field.ErrorList {
+						return field.ErrorList{
+							field.Invalid(field.NewPath("spec"), "value", "error"),
+						}
+					},
+					ValidateUpdateFunc: func(_, _ *corev1.Pod) field.ErrorList {
+						panic("unexpected call to ValidateUpdateFunc")
+					},
+					GetWarningsOnCreateFunc: func(_ *corev1.Pod) []string {
+						return nil
+					},
+					GetWarningsOnUpdateFunc: func(_, _ *corev1.Pod) []string {
+						panic("unexpected call to GetWarningsOnUpdateFunc")
+					},
+				},
+			},
+			expectedWarnings: nil,
+			expectedError: apierrors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Pod").GroupKind(), "pod", field.ErrorList{
+				field.Invalid(field.NewPath("spec"), "value", "error"),
+			}),
+		},
+		{
+			name: "create, no errors, warnings",
+			ar: func() *admissionv1.AdmissionReview {
+				return &admissionv1.AdmissionReview{
+					Request: &admissionv1.AdmissionRequest{
+						UID: "uid",
+						Resource: metav1.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Operation: "CREATE",
+						Object:    runtime.RawExtension{Raw: podRaw},
+					},
+				}
+			}(),
+			validators: map[schema.GroupVersionResource]Validator{
+				corev1.SchemeGroupVersion.WithResource("pods"): &GenericValidator[*corev1.Pod]{
+					ValidateCreateFunc: func(_ *corev1.Pod) field.ErrorList {
+						return nil
+					},
+					ValidateUpdateFunc: func(_, _ *corev1.Pod) field.ErrorList {
+						panic("unexpected call to ValidateUpdateFunc")
+					},
+					GetWarningsOnCreateFunc: func(_ *corev1.Pod) []string {
+						return []string{"warning"}
+					},
+					GetWarningsOnUpdateFunc: func(_, _ *corev1.Pod) []string {
+						panic("unexpected call to GetWarningsOnUpdateFunc")
+					},
+				},
+			},
+			expectedWarnings: []string{"warning"},
+			expectedError:    nil,
+		},
+		{
+			name: "create, errors, warnings",
+			ar: func() *admissionv1.AdmissionReview {
+				return &admissionv1.AdmissionReview{
+					Request: &admissionv1.AdmissionRequest{
+						UID: "uid",
+						Resource: metav1.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Operation: "CREATE",
+						Object:    runtime.RawExtension{Raw: podRaw},
+					},
+				}
+			}(),
+			validators: map[schema.GroupVersionResource]Validator{
+				corev1.SchemeGroupVersion.WithResource("pods"): &GenericValidator[*corev1.Pod]{
+					ValidateCreateFunc: func(_ *corev1.Pod) field.ErrorList {
+						return field.ErrorList{
+							field.Invalid(field.NewPath("spec"), "value", "error"),
+						}
+					},
+					ValidateUpdateFunc: func(_, _ *corev1.Pod) field.ErrorList {
+						panic("unexpected call to ValidateUpdateFunc")
+					},
+					GetWarningsOnCreateFunc: func(_ *corev1.Pod) []string {
+						return []string{"warning"}
+					},
+					GetWarningsOnUpdateFunc: func(_, _ *corev1.Pod) []string {
+						panic("unexpected call to GetWarningsOnUpdateFunc")
+					},
+				},
+			},
+			expectedWarnings: []string{"warning"},
+			expectedError: apierrors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Pod").GroupKind(), "pod", field.ErrorList{
+				field.Invalid(field.NewPath("spec"), "value", "error"),
+			}),
+		},
+		{
+			name: "update, no errors, no warnings",
+			ar: func() *admissionv1.AdmissionReview {
+				return &admissionv1.AdmissionReview{
+					Request: &admissionv1.AdmissionRequest{
+						UID: "uid",
+						Resource: metav1.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Operation: "UPDATE",
+						Object:    runtime.RawExtension{Raw: podRaw},
+						OldObject: runtime.RawExtension{Raw: podRaw},
+					},
+				}
+			}(),
+			validators: map[schema.GroupVersionResource]Validator{
+				corev1.SchemeGroupVersion.WithResource("pods"): &GenericValidator[*corev1.Pod]{
+					ValidateCreateFunc: func(_ *corev1.Pod) field.ErrorList {
+						panic("unexpected call to ValidateCreateFunc")
+					},
+					ValidateUpdateFunc: func(_, _ *corev1.Pod) field.ErrorList {
+						return nil
+					},
+					GetWarningsOnCreateFunc: func(_ *corev1.Pod) []string {
+						panic("unexpected call to GetWarningsOnCreateFunc")
+					},
+					GetWarningsOnUpdateFunc: func(_, _ *corev1.Pod) []string {
+						return nil
+					},
+				},
+			},
+			expectedWarnings: nil,
+			expectedError:    nil,
+		},
+		{
+			name: "update, error, no warnings",
+			ar: func() *admissionv1.AdmissionReview {
+				return &admissionv1.AdmissionReview{
+					Request: &admissionv1.AdmissionRequest{
+						UID: "uid",
+						Resource: metav1.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Operation: "UPDATE",
+						Object:    runtime.RawExtension{Raw: podRaw},
+						OldObject: runtime.RawExtension{Raw: podRaw},
+					},
+				}
+			}(),
+			validators: map[schema.GroupVersionResource]Validator{
+				corev1.SchemeGroupVersion.WithResource("pods"): &GenericValidator[*corev1.Pod]{
+					ValidateCreateFunc: func(_ *corev1.Pod) field.ErrorList {
+						panic("unexpected call to ValidateCreateFunc")
+					},
+					ValidateUpdateFunc: func(_, _ *corev1.Pod) field.ErrorList {
+						return field.ErrorList{
+							field.Invalid(field.NewPath("spec"), "value", "error"),
+						}
+					},
+					GetWarningsOnCreateFunc: func(_ *corev1.Pod) []string {
+						panic("unexpected call to GetWarningsOnCreateFunc")
+					},
+					GetWarningsOnUpdateFunc: func(_, _ *corev1.Pod) []string {
+						return nil
+					},
+				},
+			},
+			expectedWarnings: nil,
+			expectedError: apierrors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Pod").GroupKind(), "pod", field.ErrorList{
+				field.Invalid(field.NewPath("spec"), "value", "error"),
+			}),
+		},
+		{
+			name: "update, no errors, warnings",
+			ar: func() *admissionv1.AdmissionReview {
+				return &admissionv1.AdmissionReview{
+					Request: &admissionv1.AdmissionRequest{
+						UID: "uid",
+						Resource: metav1.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Operation: "UPDATE",
+						Object:    runtime.RawExtension{Raw: podRaw},
+						OldObject: runtime.RawExtension{Raw: podRaw},
+					},
+				}
+			}(),
+			validators: map[schema.GroupVersionResource]Validator{
+				corev1.SchemeGroupVersion.WithResource("pods"): &GenericValidator[*corev1.Pod]{
+					ValidateCreateFunc: func(_ *corev1.Pod) field.ErrorList {
+						panic("unexpected call to ValidateCreateFunc")
+					},
+					ValidateUpdateFunc: func(_, _ *corev1.Pod) field.ErrorList {
+						return nil
+					},
+					GetWarningsOnCreateFunc: func(_ *corev1.Pod) []string {
+						panic("unexpected call to GetWarningsOnCreateFunc")
+					},
+					GetWarningsOnUpdateFunc: func(_, _ *corev1.Pod) []string {
+						return []string{"warning"}
+					},
+				},
+			},
+			expectedWarnings: []string{"warning"},
+			expectedError:    nil,
+		},
+		{
+			name: "update, errors, warnings",
+			ar: func() *admissionv1.AdmissionReview {
+				return &admissionv1.AdmissionReview{
+					Request: &admissionv1.AdmissionRequest{
+						UID: "uid",
+						Resource: metav1.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Operation: "UPDATE",
+						Object:    runtime.RawExtension{Raw: podRaw},
+						OldObject: runtime.RawExtension{Raw: podRaw},
+					},
+				}
+			}(),
+			validators: map[schema.GroupVersionResource]Validator{
+				corev1.SchemeGroupVersion.WithResource("pods"): &GenericValidator[*corev1.Pod]{
+					ValidateCreateFunc: func(_ *corev1.Pod) field.ErrorList {
+						panic("unexpected call to ValidateCreateFunc")
+					},
+					ValidateUpdateFunc: func(_, _ *corev1.Pod) field.ErrorList {
+						return field.ErrorList{
+							field.Invalid(field.NewPath("spec"), "value", "error"),
+						}
+					},
+					GetWarningsOnCreateFunc: func(_ *corev1.Pod) []string {
+						panic("unexpected call to GetWarningsOnCreateFunc")
+					},
+					GetWarningsOnUpdateFunc: func(_, _ *corev1.Pod) []string {
+						return []string{"warning"}
+					},
+				},
+			},
+			expectedWarnings: []string{"warning"},
+			expectedError: apierrors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Pod").GroupKind(), "pod", field.ErrorList{
+				field.Invalid(field.NewPath("spec"), "value", "error"),
+			}),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			warnings, err := validate(tc.ar, tc.validators)
+			if !reflect.DeepEqual(tc.expectedError, err) {
+				t.Fatalf("expected and actual errors differ: %s", cmp.Diff(tc.expectedError, err, cmpopts.EquateErrors()))
+			}
+
+			if !reflect.DeepEqual(tc.expectedWarnings, warnings) {
+				t.Errorf("expected and actual warnings differ: %s", cmp.Diff(tc.expectedWarnings, warnings))
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR extends our validation with the capability of returning warning messages and wires it in the admission webhook.

As discussed internally with @czeslavo (and described by him in https://github.com/scylladb/scylla-operator/issues/2895, thanks!), there is no appropriate test coverage checking whether all correct validation/warnings functions are wired correctly. This will be handled separately.

An E2E for webhook validation will be extended with warning propagation verification once there is a warning to check - this will be implemented as part of https://github.com/scylladb/scylla-operator/issues/2457.

Required by https://github.com/scylladb/scylla-operator/issues/2457, as described in the [enhancement proposal](https://github.com/scylladb/scylla-operator/blob/1a8361eb998f8ac7b4350e8ba05abc3676f6715a/enhancements/proposals/2457-nodeconfig-sysctls/README.md).

**Which issue is resolved by this Pull Request:**
Resolves #

/kind feature
/priority important-soon