### PR TITLE
Replace the DaemonSet workaround for setting fs.aio-max-nr with NodeConfig's sysctls

### DIFF
--- a/hack/.ci/manifests/cluster/nodeconfig-gke-arm64.yaml
+++ b/hack/.ci/manifests/cluster/nodeconfig-gke-arm64.yaml
@@ -16,6 +16,19 @@ spec:
       mountPoint: /var/lib/persistent-volumes
       unsupportedOptions:
       - prjquota
+  sysctls:
+  - name: fs.aio-max-nr
+    value: "4294967295" # Allow for high parallelism in CI.
+  - name: fs.file-max
+    value: "9223372036854775807"
+  - name: fs.nr_open
+    value: "1073741816"
+  - name: fs.inotify.max_user_instances
+    value: "1200"
+  - name: vm.swappiness
+    value: "1"
+  - name: vm.vfs_cache_pressure
+    value: "2000"
   placement:
     nodeSelector:
       scylla.scylladb.com/node-type: scylla

--- a/hack/.ci/manifests/cluster/nodeconfig-openshift-aws.yaml
+++ b/hack/.ci/manifests/cluster/nodeconfig-openshift-aws.yaml
@@ -19,6 +19,19 @@ spec:
         devices:
           modelRegex: Amazon EC2 NVMe Instance Storage
           nameRegex: ^/dev/nvme\d+n\d+$
+  sysctls:
+  - name: fs.aio-max-nr
+    value: "4294967295" # Allow for high parallelism in CI.
+  - name: fs.file-max
+    value: "9223372036854775807"
+  - name: fs.nr_open
+    value: "1073741816"
+  - name: fs.inotify.max_user_instances
+    value: "1200"
+  - name: vm.swappiness
+    value: "1"
+  - name: vm.vfs_cache_pressure
+    value: "2000"
   placement:
     nodeSelector:
       scylla.scylladb.com/node-type: scylla

--- a/hack/.ci/manifests/cluster/nodeconfig.yaml
+++ b/hack/.ci/manifests/cluster/nodeconfig.yaml
@@ -18,6 +18,19 @@ spec:
       RAID0:
         devices:
           nameRegex: ^/dev/nvme0n[1-9]\d*$
+  sysctls:
+  - name: fs.aio-max-nr
+    value: "4294967295" # Allow for high parallelism in CI.
+  - name: fs.file-max
+    value: "9223372036854775807"
+  - name: fs.nr_open
+    value: "1073741816"
+  - name: fs.inotify.max_user_instances
+    value: "1200"
+  - name: vm.swappiness
+    value: "1"
+  - name: vm.vfs_cache_pressure
+    value: "2000"
   placement:
     nodeSelector:
       scylla.scylladb.com/node-type: scylla


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR replaces the workaround introduced in https://github.com/scylladb/scylla-operator/issues/1385 with NodeConfig's functionality.

Requires https://github.com/scylladb/scylla-operator/pull/2901.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/1385 https://github.com/scylladb/scylla-operator/issues/2860

/kind cleanup
/priority important-soon