### PR TITLE
Add operator-sdk dependency to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,9 @@ it's up to the developer to ensure they are available in the environment:
 - [jq](https://github.com/jqlang/jq)
 - [helm](https://github.com/helm/helm)
 - [golangci-lint](https://github.com/golangci/golangci-lint)
+- [operator-sdk](https://sdk.operatorframework.io/docs/installation/)
+  (**Note:** Until [#6978](https://github.com/operator-framework/operator-sdk/pull/6978) is merged and released, you
+  need to use `operator-sdk` from the PR branch; `quay.io/scylladb/scylla-operator-images:golang-1.24` image has it preinstalled)
 
 ## Coding convention
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** OLM bundle generation added in https://github.com/scylladb/scylla-operator/pull/2885 requires a custom build of operator-sdk. This PR documents that.