### PR TITLE
Add sysctl configuration guide to documentation

### DIFF
--- a/docs/source/.internal/wait-for-status-conditions.nodeconfig.code-block.md
+++ b/docs/source/.internal/wait-for-status-conditions.nodeconfig.code-block.md
@@ -1,0 +1,5 @@
+:::{code-block} bash
+kubectl wait --timeout=10m --for='condition=Progressing=False' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
+kubectl wait --timeout=10m --for='condition=Degraded=False' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
+kubectl wait --timeout=10m --for='condition=Available=True' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
+:::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,6 +75,7 @@ myst_multiversion_substitutions = {
         "agentVersion": "3.5.1",
         "enterpriseImageTag": "2025.1.5",
         "imageTag": "2025.1.5",
+        "scyllaDBRepositoryTag": "scylla-2025.1.5",
     },
     "v1.18": {
         "revision": "v1.18",

--- a/docs/source/management/index.md
+++ b/docs/source/management/index.md
@@ -3,5 +3,6 @@
 :::{toctree}
 :maxdepth: 1
 
+sysctls
 upgrading/index
 :::

--- a/docs/source/management/sysctls.md
+++ b/docs/source/management/sysctls.md
@@ -1,0 +1,52 @@
+# Configuring kernel parameters (sysctls)
+
+This guide explains how to configure Linux kernel parameters (sysctls) for nodes running production-grade ScyllaDB deployments.
+
+{{productName}} enables you to manage sysctl settings in a Kubernetes-native way using the NodeConfig resource.
+
+:::{note}
+To configure sysctls for multi-datacenter ScyllaDB deployments, simply perform the steps outlined in this guide in each worker cluster.
+:::
+
+## Configuring the recommended sysctls for ScyllaDB nodes
+
+:::{caution}    
+The recommended sysctl for production-grade ScyllaDB deployments provided throughout our examples follow the recommendations from the upstream ScyllaDB repository.
+However, as we are not able to reliably keep them up to date at all times, always consult the {{ '[configuration files in the source branch of your ScyllaDB release](https://github.com/scylladb/scylladb/tree/{}/dist/common/sysctl.d)'.format(scyllaDBRepositoryTag) }} before you configure your cluster.
+:::
+
+:::{caution}
+The recommended sysctl values are provided with the assumption that your nodes are not shared between multiple ScyllaDB instances.
+If your nodes are shared, consider adjusting the values accordingly.
+:::
+
+The below NodeConfig manifest configures the sysctls recommended for production-grade ScyllaDB deployments. Use the placement criteria to target the nodes used for running ScyllaDB workloads in your cluster.
+
+:::{literalinclude} ../../../examples/common/configure-sysctls.nodeconfig.yaml
+:language: yaml
+:linenos:
+:emphasize-lines: 6-18
+:::
+
+:::{tip}
+You can learn more about the NodeConfig resource in the [NodeConfig tutorial](../resources/nodeconfigs.md) and the [generated API reference](../api-reference/groups/scylla.scylladb.com/nodeconfigs.rst).
+:::
+
+### Configuring sysctls via GitOps (kubectl)
+
+To configure kernel parameters on selected nodes in your cluster, simply apply the NodeConfig manifest.
+
+To apply the above example manifest with `kubectl`, run the following command:
+:::{code-block} console
+:substitutions:
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/configure-sysctls.nodeconfig.yaml
+:::
+
+After applying the manifest, wait for the NodeConfig to be reconciled.
+:::{include} ./../.internal/wait-for-status-conditions.nodeconfig.code-block.md
+:::
+
+### Configuring sysctls via Helm
+
+We do not currently provide Helm charts for NodeConfig configuration.
+In case you installed {{productName}} using Helm, you still need use the GitOps (kubectl) instructions for NodeConfig setup.

--- a/docs/source/resources/nodeconfigs.md
+++ b/docs/source/resources/nodeconfigs.md
@@ -62,10 +62,7 @@ scylladb-pool-1   True        False         False      37d
 
 or programmatically wait for it:
 
-:::{code-block}
-kubectl wait --timeout=10m --for='condition=Progressing=False' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
-kubectl wait --timeout=10m --for='condition=Degraded=False' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
-kubectl wait --timeout=10m --for='condition=Available=True' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
+:::{include} ./../.internal/wait-for-status-conditions.nodeconfig.code-block.md
 :::
 
 If the NodeConfig doesn't reach the expected state, look at the fine-grained conditions in its status to find the cause.

--- a/examples/common/configure-sysctls.nodeconfig.yaml
+++ b/examples/common/configure-sysctls.nodeconfig.yaml
@@ -1,0 +1,26 @@
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: NodeConfig
+metadata:
+  name: scylladb-nodepool-1
+spec:
+  sysctls:
+  - name: fs.aio-max-nr
+    value: "30000000"
+  - name: fs.file-max
+    value: "9223372036854775807"
+  - name: fs.nr_open
+    value: "1073741816"
+  - name: fs.inotify.max_user_instances
+    value: "1200"
+  - name: vm.swappiness
+    value: "1"
+  - name: vm.vfs_cache_pressure
+    value: "2000"
+  placement:
+    nodeSelector:
+      scylla.scylladb.com/node-type: scylla
+    tolerations:
+    - effect: NoSchedule
+      key: scylla-operator.scylladb.com/dedicated
+      operator: Equal
+      value: scyllaclusters


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR adds a how-to-guide for sysctl configuration with NodeConfig to our documentation. It covers the single and multi-datacenter deployments. 

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-soon