### PR TITLE
[1.18] Set the 1.19 release date

### DIFF
--- a/docs/source/support/releases.md
+++ b/docs/source/support/releases.md
@@ -6,7 +6,7 @@ We are aiming to ship a new release approximately every 2 months. The following 
 :::{table}
 | Release | Code freeze | General availability |
 |:-------:|:-----------:|:--------------------:|
-|  1.19   | 2025-09-29  |      2025-10-13      |
+|  1.19   | 2025-10-27  |      2025-11-05      |
 :::
 
 ## Supported releases


### PR DESCRIPTION
Backport of #2952 to the stable release branch.