### PR TITLE
Fix potential data races in RenderTemplate function

### DIFF
--- a/pkg/assets/template.go
+++ b/pkg/assets/template.go
@@ -85,12 +85,18 @@ func MakeMap(kvs ...any) (map[any]any, error) {
 	return m, nil
 }
 
-func RenderTemplate(tmpl *template.Template, inputs any) ([]byte, error) {
+func RenderTemplate(t *template.Template, inputs any) ([]byte, error) {
+	// Clone the template to avoid mutating the original one (it could lead to race conditions).
+	tmpl, err := t.Clone()
+	if err != nil {
+		return nil, fmt.Errorf("can't clone template %q: %w", t.Name(), err)
+	}
+
 	// We always want correctness. (Accidentally missing a key might have side effects.)
 	tmpl.Option("missingkey=error")
 
 	var buf bytes.Buffer
-	err := tmpl.Execute(&buf, inputs)
+	err = tmpl.Execute(&buf, inputs)
 	if err != nil {
 		return nil, fmt.Errorf("can't execute template %q: %w", tmpl.Name(), err)
 	}

--- a/pkg/assets/template_test.go
+++ b/pkg/assets/template_test.go
@@ -1,0 +1,54 @@
+package assets
+
+import (
+	"errors"
+	"testing"
+	"text/template"
+)
+
+func TestRenderTemplate(t *testing.T) {
+	t.Parallel()
+
+	tpl, err := template.New("test").Parse("Hello, {{.Name}}!")
+	if err != nil {
+		t.Fatalf("can't parse template: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		data    map[string]string
+		want    string
+		wantErr error
+	}{
+		{
+			name: "simple",
+			data: map[string]string{"Name": "World"},
+			want: "Hello, World!",
+		},
+		{
+			name:    "missing key",
+			data:    map[string]string{},
+			wantErr: errors.New(`can't execute template "test": template: test:1:9: executing "test" at <.Name>: map has no entry for key "Name"`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := RenderTemplate(tpl, tc.data)
+			if tc.wantErr != nil {
+				if err == nil || err.Error() != tc.wantErr.Error() {
+					t.Fatalf("expected error %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("can't render template: %v", err)
+			}
+			if string(out) != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, string(out))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Fixes potential data races in the `RenderTemplate` function. Instead of modifying the passed template, let's clone it before.

**Which issue is resolved by this Pull Request:**
Issue discovered in https://github.com/scylladb/scylla-operator/pull/2943.
