### PR TITLE
[v1.18] Remove number-lines directive from all help files

### DIFF
--- a/docs/source/installation/kubernetes-prerequisites.md
+++ b/docs/source/installation/kubernetes-prerequisites.md
@@ -23,7 +23,7 @@ We provide a few examples for the major ones in this section, otherwise please c
 
 GKE allows you to set static CPU policy using a [node system configuration](https://cloud.google.com/kubernetes-engine/docs/how-to/node-system-config):
 :::{code} yaml
-:number-lines:
+
 kubeletConfig:
   cpuManagerPolicy: static
 :::
@@ -34,7 +34,7 @@ kubeletConfig:
 `eksctl` allows you to set static CPU policy for each node pool like:
 
 :::{code} yaml
-:number-lines:
+
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 # ...

--- a/docs/source/quickstarts/gke.md
+++ b/docs/source/quickstarts/gke.md
@@ -9,7 +9,7 @@ This is by no means a complete guide, and you should always consult your Kuberne
 
 First, we need to create a kubelet config to configure [static CPU policy](../installation/kubernetes-prerequisites.md#static-cpu-policy):
 :::{code} bash
-:number-lines:
+
 
 cat > systemconfig.yaml <<EOF
 kubeletConfig:


### PR DESCRIPTION
**Description of your changes:**
Removes unnecessary line-numbers directive in all help files (same as https://github.com/scylladb/scylla-operator/pull/2957, just for v1.18)