### PR TITLE
Extend tagged union convention with options validation

### DIFF
--- a/API_CONVENTIONS.md
+++ b/API_CONVENTIONS.md
@@ -16,6 +16,7 @@ the options are mutually exclusive.
 - The configuration options fields should be pointers and marked as `+optional` in the comments, to allow them to be omitted when not used.
 - The configuration option fields should be marked with `omitempty` in the JSON tags, to avoid cluttering the serialized output.
 - The validating server should validate that the configuration options corresponding to the chosen type are provided.
+- The validating server should validate that no configuration options for other types are provided.
 
 **Example:**
 ```go


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Adds a point about a validation rule ensuring no other options are set than those specified via `type` field.

**Which issue is resolved by this Pull Request:**
Follow up from https://github.com/scylladb/scylla-operator/pull/2943#discussion_r2349394802
