### PR TITLE
Pin prometheus-operator modules to a pre-v0.86.0 commit (6958a7c)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,10 @@ require (
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.85.0
-	github.com/prometheus-operator/prometheus-operator/pkg/client v0.85.0
+	// Pinned to a commit fixing https://github.com/scylladb/scylla-operator/issues/2963. Update to proper release once it's available.
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.85.1-0.20250908125250-6958a7c31c4a
+	// Pinned to a commit fixing https://github.com/scylladb/scylla-operator/issues/2963. Update to proper release once it's available.
+	github.com/prometheus-operator/prometheus-operator/pkg/client v0.85.1-0.20250908125250-6958a7c31c4a
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/scylladb/go-set v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -313,10 +313,10 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.85.0 h1:oY+F5FZFmCjCyzkHWPjVQpzvnvEB/0FP+iyzDUUlqFc=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.85.0/go.mod h1:VB7wtBmDT6W2RJHzsvPZlBId+EnmeQA0d33fFTXvraM=
-github.com/prometheus-operator/prometheus-operator/pkg/client v0.85.0 h1:OdW3Vnmoa2pM5PfRyQaSEO+UN5yamEUS1MuhwE0PxbY=
-github.com/prometheus-operator/prometheus-operator/pkg/client v0.85.0/go.mod h1:5ctipSFkXKeXig01Or0aXKNaaBQFWZAAK1zzYWz9YZY=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.85.1-0.20250908125250-6958a7c31c4a h1:xkEI8pyPBHDksJLbnTfzXUrP381ALzdkvFyFYTEzmak=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.85.1-0.20250908125250-6958a7c31c4a/go.mod h1:k94oCBI0HYfPrYJQtmuDIVOVC+2Tv1n5sdwfq6QLX6E=
+github.com/prometheus-operator/prometheus-operator/pkg/client v0.85.1-0.20250908125250-6958a7c31c4a h1:1qiK7cRgB3v3Mu8ec7B8nxiKmtA+cTTuQ0JIMyQB9WE=
+github.com/prometheus-operator/prometheus-operator/pkg/client v0.85.1-0.20250908125250-6958a7c31c4a/go.mod h1:oKQxfOEQRyUzsktM+6dxb6Ux5gNL461vSTnSz7Rx18Q=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -48,14 +48,17 @@ const (
 //
 // The resource defines via label and namespace selectors which `AlertmanagerConfig` objects should be associated to the deployed Alertmanager instances.
 type Alertmanager struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the desired behavior of the Alertmanager cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +required
 	Spec AlertmanagerSpec `json:"spec"`
 	// Most recent observed status of the Alertmanager cluster. Read-only.
 	// More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +optional
 	Status AlertmanagerStatus `json:"status,omitempty"`
 }
 
@@ -77,43 +80,53 @@ type AlertmanagerSpec struct {
 	// * "app.kubernetes.io/name" label, set to "alertmanager".
 	// * "app.kubernetes.io/version" label, set to the Alertmanager version.
 	// * "kubectl.kubernetes.io/default-container" annotation, set to "alertmanager".
+	// +optional
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 	// Image if specified has precedence over baseImage, tag and sha
 	// combinations. Specifying the version is still necessary to ensure the
 	// Prometheus Operator knows what version of Alertmanager is being
 	// configured.
+	// +optional
 	Image *string `json:"image,omitempty"`
 	// Image pull policy for the 'alertmanager', 'init-config-reloader' and 'config-reloader' containers.
 	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
 	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
+	// +optional
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// Version the cluster should be on.
+	// +optional
 	Version string `json:"version,omitempty"`
 	// Tag of Alertmanager container image to be deployed. Defaults to the value of `version`.
 	// Version is ignored if Tag is set.
 	// Deprecated: use 'image' instead. The image tag can be specified as part of the image URL.
+	// +optional
 	Tag string `json:"tag,omitempty"`
 	// SHA of Alertmanager container image to be deployed. Defaults to the value of `version`.
 	// Similar to a tag, but the SHA explicitly deploys an immutable container image.
 	// Version and Tag are ignored if SHA is set.
 	// Deprecated: use 'image' instead. The image digest can be specified as part of the image URL.
+	// +optional
 	SHA string `json:"sha,omitempty"`
 	// Base image that is used to deploy pods, without tag.
 	// Deprecated: use 'image' instead.
+	// +optional
 	BaseImage string `json:"baseImage,omitempty"`
 	// An optional list of references to secrets in the same namespace
 	// to use for pulling prometheus and alertmanager images from registries
 	// see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+	// +optional
 	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// Secrets is a list of Secrets in the same namespace as the Alertmanager
 	// object, which shall be mounted into the Alertmanager Pods.
 	// Each Secret is added to the StatefulSet definition as a volume named `secret-<secret-name>`.
 	// The Secrets are mounted into `/etc/alertmanager/secrets/<secret-name>` in the 'alertmanager' container.
+	// +optional
 	Secrets []string `json:"secrets,omitempty"`
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the Alertmanager
 	// object, which shall be mounted into the Alertmanager Pods.
 	// Each ConfigMap is added to the StatefulSet definition as a volume named `configmap-<configmap-name>`.
 	// The ConfigMaps are mounted into `/etc/alertmanager/configmaps/<configmap-name>` in the 'alertmanager' container.
+	// +optional
 	ConfigMaps []string `json:"configMaps,omitempty"`
 	// ConfigSecret is the name of a Kubernetes Secret in the same namespace as the
 	// Alertmanager object, which contains the configuration for this Alertmanager
@@ -127,31 +140,39 @@ type AlertmanagerSpec struct {
 	// If either the secret or the `alertmanager.yaml` key is missing, the
 	// operator provisions a minimal Alertmanager configuration with one empty
 	// receiver (effectively dropping alert notifications).
+	// +optional
 	ConfigSecret string `json:"configSecret,omitempty"`
 	// Log level for Alertmanager to be configured with.
 	// +kubebuilder:validation:Enum="";debug;info;warn;error
+	// +optional
 	LogLevel string `json:"logLevel,omitempty"`
 	// Log format for Alertmanager to be configured with.
 	// +kubebuilder:validation:Enum="";logfmt;json
+	// +optional
 	LogFormat string `json:"logFormat,omitempty"`
 	// Size is the expected size of the alertmanager cluster. The controller will
 	// eventually make the size of the running cluster equal to the expected
 	// size.
+	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Time duration Alertmanager shall retain data for. Default is '120h',
 	// and must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds seconds minutes hours).
 	// +kubebuilder:default:="120h"
+	// +optional
 	Retention GoDuration `json:"retention,omitempty"`
 	// Storage is the definition of how storage will be used by the Alertmanager
 	// instances.
+	// +optional
 	Storage *StorageSpec `json:"storage,omitempty"`
 	// Volumes allows configuration of additional volumes on the output StatefulSet definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of
 	// StorageSpec objects.
+	// +optional
 	Volumes []v1.Volume `json:"volumes,omitempty"`
 	// VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition.
 	// VolumeMounts specified will be appended to other VolumeMounts in the alertmanager container,
 	// that are generated as a result of StorageSpec objects.
+	// +optional
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 	// The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
 	// The default behavior is all PVCs are retained.
@@ -163,27 +184,36 @@ type AlertmanagerSpec struct {
 	// The external URL the Alertmanager instances will be available under. This is
 	// necessary to generate correct URLs. This is necessary if Alertmanager is not
 	// served from root of a DNS name.
+	// +optional
 	ExternalURL string `json:"externalUrl,omitempty"`
 	// The route prefix Alertmanager registers HTTP handlers for. This is useful,
 	// if using ExternalURL and a proxy is rewriting HTTP routes of a request,
 	// and the actual ExternalURL is still true, but the server serves requests
 	// under a different route prefix. For example for use with `kubectl proxy`.
+	// +optional
 	RoutePrefix string `json:"routePrefix,omitempty"`
 	// If set to true all actions on the underlying managed objects are not
 	// going to be performed, except for delete actions.
+	// +optional
 	Paused bool `json:"paused,omitempty"`
 	// Define which Nodes the Pods are scheduled on.
+	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Define resources requests and limits for single Pods.
+	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`
 	// If specified, the pod's scheduling constraints.
+	// +optional
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// If specified, the pod's tolerations.
+	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// If specified, the pod's topology spread constraints.
+	// +optional
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// SecurityContext holds pod-level security attributes and common container settings.
 	// This defaults to the default PodSecurityContext.
+	// +optional
 	SecurityContext *v1.PodSecurityContext `json:"securityContext,omitempty"`
 	// Defines the DNS policy for the pods.
 	//
@@ -206,10 +236,12 @@ type AlertmanagerSpec struct {
 	ServiceName *string `json:"serviceName,omitempty"`
 	// ServiceAccountName is the name of the ServiceAccount to use to run the
 	// Prometheus Pods.
+	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 	// ListenLocal makes the Alertmanager server listen on loopback, so that it
 	// does not bind against the Pod IP. Note this is only for the Alertmanager
 	// UI, not the gossip communication.
+	// +optional
 	ListenLocal bool `json:"listenLocal,omitempty"`
 	// Containers allows injecting additional containers. This is meant to
 	// allow adding an authentication proxy to an Alertmanager pod.
@@ -219,6 +251,7 @@ type AlertmanagerSpec struct {
 	// `config-reloader`. Overriding containers is entirely outside the scope
 	// of what the maintainers will support and by doing so, you accept that
 	// this behaviour may break at any time without notice.
+	// +optional
 	Containers []v1.Container `json:"containers,omitempty"`
 	// InitContainers allows adding initContainers to the pod definition. Those can be used to e.g.
 	// fetch secrets for injection into the Alertmanager configuration from external sources. Any
@@ -229,39 +262,52 @@ type AlertmanagerSpec struct {
 	// `init-config-reloader`. Overriding init containers is entirely outside the
 	// scope of what the maintainers will support and by doing so, you accept that
 	// this behaviour may break at any time without notice.
+	// +optional
 	InitContainers []v1.Container `json:"initContainers,omitempty"`
 	// Priority class assigned to the Pods
+	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
+	// +optional
 	AdditionalPeers []string `json:"additionalPeers,omitempty"`
 	// ClusterAdvertiseAddress is the explicit address to advertise in cluster.
 	// Needs to be provided for non RFC1918 [1] (public) addresses.
 	// [1] RFC1918: https://tools.ietf.org/html/rfc1918
+	// +optional
 	ClusterAdvertiseAddress string `json:"clusterAdvertiseAddress,omitempty"`
 	// Interval between gossip attempts.
+	// +optional
 	ClusterGossipInterval GoDuration `json:"clusterGossipInterval,omitempty"`
 	// Defines the identifier that uniquely identifies the Alertmanager cluster.
 	// You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the `.spec.additionalPeers` field.
+	// +optional
 	ClusterLabel *string `json:"clusterLabel,omitempty"`
 	// Interval between pushpull attempts.
+	// +optional
 	ClusterPushpullInterval GoDuration `json:"clusterPushpullInterval,omitempty"`
 	// Timeout for cluster peering.
+	// +optional
 	ClusterPeerTimeout GoDuration `json:"clusterPeerTimeout,omitempty"`
 	// Port name used for the pods and governing service.
 	// Defaults to `web`.
 	// +kubebuilder:default:="web"
+	// +optional
 	PortName string `json:"portName,omitempty"`
 	// ForceEnableClusterMode ensures Alertmanager does not deactivate the cluster mode when running with a single replica.
 	// Use case is e.g. spanning an Alertmanager cluster across Kubernetes clusters with a single replica in each.
+	// +optional
 	ForceEnableClusterMode bool `json:"forceEnableClusterMode,omitempty"`
 	// AlertmanagerConfigs to be selected for to merge and configure Alertmanager with.
+	// +optional
 	AlertmanagerConfigSelector *metav1.LabelSelector `json:"alertmanagerConfigSelector,omitempty"`
 	// Namespaces to be selected for AlertmanagerConfig discovery. If nil, only
 	// check own namespace.
+	// +optional
 	AlertmanagerConfigNamespaceSelector *metav1.LabelSelector `json:"alertmanagerConfigNamespaceSelector,omitempty"`
 
 	// AlertmanagerConfigMatcherStrategy defines how AlertmanagerConfig objects
 	// process incoming alerts.
+	// +optional
 	AlertmanagerConfigMatcherStrategy AlertmanagerConfigMatcherStrategy `json:"alertmanagerConfigMatcherStrategy,omitempty"`
 
 	// Minimum number of seconds for which a newly created pod should be ready
@@ -275,15 +321,18 @@ type AlertmanagerSpec struct {
 	// Pods' hostAliases configuration
 	// +listType=map
 	// +listMapKey=ip
+	// +optional
 	HostAliases []HostAlias `json:"hostAliases,omitempty"`
 	// Defines the web command line flags when starting Alertmanager.
+	// +optional
 	Web *AlertmanagerWebSpec `json:"web,omitempty"`
 	// Defines the limits command line flags when starting Alertmanager.
+	// +optional
 	Limits *AlertmanagerLimitsSpec `json:"limits,omitempty"`
 	// Configures the mutual TLS configuration for the Alertmanager cluster's gossip protocol.
 	//
 	// It requires Alertmanager >= 0.24.0.
-	//+optional
+	// +optional
 	ClusterTLS *ClusterTLSConfig `json:"clusterTLS,omitempty"`
 	// alertmanagerConfiguration specifies the configuration of Alertmanager.
 	//
@@ -292,7 +341,7 @@ type AlertmanagerSpec struct {
 	// This is an *experimental feature*, it may change in any upcoming release
 	// in a breaking way.
 	//
-	//+optional
+	// +optional
 	AlertmanagerConfiguration *AlertmanagerConfiguration `json:"alertmanagerConfiguration,omitempty"`
 	// AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
 	// If the service account has `automountServiceAccountToken: true`, set the field to `false` to opt out of automounting API credentials.
@@ -345,6 +394,7 @@ type AlertmanagerConfigMatcherStrategy struct {
 	//
 	// +kubebuilder:validation:Enum="OnNamespace";"OnNamespaceExceptForAlertmanagerNamespace";"None"
 	// +kubebuilder:default:="OnNamespace"
+	// +optional
 	Type AlertmanagerConfigMatcherStrategyType `json:"type,omitempty"`
 }
 
@@ -374,6 +424,7 @@ type AlertmanagerConfiguration struct {
 	// It must be defined in the same namespace as the Alertmanager object.
 	// The operator will not enforce a `namespace` label for routes and inhibition rules.
 	// +kubebuilder:validation:MinLength=1
+	// +optional
 	Name string `json:"name,omitempty"`
 	// Defines the global parameters of the Alertmanager configuration.
 	// +optional
@@ -393,36 +444,47 @@ type AlertmanagerGlobalConfig struct {
 	// ResolveTimeout is the default value used by alertmanager if the alert does
 	// not include EndsAt, after this time passes it can declare the alert as resolved if it has not been updated.
 	// This has no impact on alerts from Prometheus, as they always include EndsAt.
+	// +optional
 	ResolveTimeout Duration `json:"resolveTimeout,omitempty"`
 
 	// HTTP client configuration.
+	// +optional
 	HTTPConfig *HTTPConfig `json:"httpConfig,omitempty"`
 
 	// The default Slack API URL.
+	// +optional
 	SlackAPIURL *v1.SecretKeySelector `json:"slackApiUrl,omitempty"`
 
 	// The default OpsGenie API URL.
+	// +optional
 	OpsGenieAPIURL *v1.SecretKeySelector `json:"opsGenieApiUrl,omitempty"`
 
 	// The default OpsGenie API Key.
+	// +optional
 	OpsGenieAPIKey *v1.SecretKeySelector `json:"opsGenieApiKey,omitempty"`
 
 	// The default Pagerduty URL.
+	// +optional
 	PagerdutyURL *string `json:"pagerdutyUrl,omitempty"`
 
 	// The default Telegram config
+	// +optional
 	TelegramConfig *GlobalTelegramConfig `json:"telegram,omitempty"`
 
 	// The default configuration for Jira.
+	// +optional
 	JiraConfig *GlobalJiraConfig `json:"jira,omitempty"`
 
 	// The default configuration for VictorOps.
+	// +optional
 	VictorOpsConfig *GlobalVictorOpsConfig `json:"victorops,omitempty"`
 
 	// The default configuration for Rocket Chat.
+	// +optional
 	RocketChatConfig *GlobalRocketChatConfig `json:"rocketChat,omitempty"`
 
 	// The default configuration for Jira.
+	// +optional
 	WebexConfig *GlobalWebexConfig `json:"webex,omitempty"`
 
 	// The default WeChat Config
@@ -437,19 +499,25 @@ type AlertmanagerGlobalConfig struct {
 type AlertmanagerStatus struct {
 	// Represents whether any actions on the underlying managed objects are
 	// being performed. Only delete actions will be performed.
+	// +required
 	Paused bool `json:"paused"`
 	// Total number of non-terminated pods targeted by this Alertmanager
 	// object (their labels match the selector).
+	// +required
 	Replicas int32 `json:"replicas"`
 	// Total number of non-terminated pods targeted by this Alertmanager
 	// object that have the desired version spec.
+	// +required
 	UpdatedReplicas int32 `json:"updatedReplicas"`
 	// Total number of available pods (ready for at least minReadySeconds)
 	// targeted by this Alertmanager cluster.
+	// +required
 	AvailableReplicas int32 `json:"availableReplicas"`
 	// Total number of unavailable pods targeted by this Alertmanager object.
+	// +required
 	UnavailableReplicas int32 `json:"unavailableReplicas"`
 	// The selector used to match the pods targeted by this Alertmanager object.
+	// +optional
 	Selector string `json:"selector,omitempty"`
 	// The current state of the Alertmanager object.
 	// +listType=map
@@ -629,9 +697,11 @@ type GlobalVictorOpsConfig struct {
 type HostPort struct {
 	// Defines the host's address, it can be a DNS name or a literal IP address.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Host string `json:"host"`
 	// Defines the host's port, it can be a literal port number or a port name.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Port string `json:"port"`
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/dns_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/dns_types.go
@@ -18,14 +18,14 @@ package v1
 type PodDNSConfig struct {
 	// A list of DNS name server IP addresses.
 	// This will be appended to the base nameservers generated from DNSPolicy.
-	// +kubebuilder:validation:Optional
+	// +optional
 	// +listType:=set
 	// +kubebuilder:validation:items:MinLength:=1
 	Nameservers []string `json:"nameservers,omitempty"`
 
 	// A list of DNS search domains for host-name lookup.
 	// This will be appended to the base search paths generated from DNSPolicy.
-	// +kubebuilder:validation:Optional
+	// +optional
 	// +listType:=set
 	// +kubebuilder:validation:items:MinLength:=1
 	Searches []string `json:"searches,omitempty"`
@@ -34,7 +34,7 @@ type PodDNSConfig struct {
 	// This will be merged with the base options generated from DNSPolicy.
 	// Resolution options given in Options
 	// will override those that appear in the base DNSPolicy.
-	// +kubebuilder:validation:Optional
+	// +optional
 	// +listType=map
 	// +listMapKey=name
 	Options []PodDNSConfigOption `json:"options,omitempty"`
@@ -44,10 +44,11 @@ type PodDNSConfig struct {
 type PodDNSConfigOption struct {
 	// Name is required and must be unique.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 
 	// Value is optional.
-	// +kubebuilder:validation:Optional
+	// +optional
 	Value *string `json:"value,omitempty"`
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/podmonitor_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/podmonitor_types.go
@@ -40,9 +40,11 @@ const (
 //
 // `Prometheus` and `PrometheusAgent` objects select `PodMonitor` objects using label and namespace selectors.
 type PodMonitor struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of desired Pod selection for target discovery by Prometheus.
+	// +required
 	Spec PodMonitorSpec `json:"spec"`
 }
 
@@ -64,11 +66,13 @@ type PodMonitorSpec struct {
 	//
 	// If the value of this field is empty, the `job` label of the metrics
 	// defaults to the namespace and name of the PodMonitor object (e.g. `<namespace>/<name>`).
+	// +optional
 	JobLabel string `json:"jobLabel,omitempty"`
 
 	// `podTargetLabels` defines the labels which are transferred from the
 	// associated Kubernetes `Pod` object onto the ingested metrics.
 	//
+	// +optional
 	PodTargetLabels []string `json:"podTargetLabels,omitempty"`
 
 	// Defines how to scrape metrics from the selected pods.
@@ -77,6 +81,7 @@ type PodMonitorSpec struct {
 	PodMetricsEndpoints []PodMetricsEndpoint `json:"podMetricsEndpoints"`
 
 	// Label selector to select the Kubernetes `Pod` objects to scrape metrics from.
+	// +required
 	Selector metav1.LabelSelector `json:"selector"`
 
 	// Mechanism used to select the endpoints to scrape.
@@ -91,6 +96,7 @@ type PodMonitorSpec struct {
 
 	// `namespaceSelector` defines in which namespace(s) Prometheus should discover the pods.
 	// By default, the pods are discovered in the same namespace as the `PodMonitor` object but it is possible to select pods across different/all namespaces.
+	// +optional
 	NamespaceSelector NamespaceSelector `json:"namespaceSelector,omitempty"`
 
 	// `sampleLimit` defines a per-scrape limit on the number of scraped samples
@@ -210,11 +216,13 @@ type PodMetricsEndpoint struct {
 	// port must be specified with container port property.
 	//
 	// Deprecated: use 'port' or 'portNumber' instead.
+	// +optional
 	TargetPort *intstr.IntOrString `json:"targetPort,omitempty"`
 
 	// HTTP path from which to scrape for metrics.
 	//
 	// If empty, Prometheus uses the default value (e.g. `/metrics`).
+	// +optional
 	Path string `json:"path,omitempty"`
 
 	// HTTP scheme to use for scraping.
@@ -225,14 +233,17 @@ type PodMetricsEndpoint struct {
 	// If empty, Prometheus uses the default value `http`.
 	//
 	// +kubebuilder:validation:Enum=http;https
+	// +optional
 	Scheme string `json:"scheme,omitempty"`
 
 	// `params` define optional HTTP URL parameters.
+	// +optional
 	Params map[string][]string `json:"params,omitempty"`
 
 	// Interval at which Prometheus scrapes the metrics from the target.
 	//
 	// If empty, Prometheus uses the global scrape interval.
+	// +optional
 	Interval Duration `json:"interval,omitempty"`
 
 	// Timeout after which Prometheus considers the scrape to be failed.
@@ -240,6 +251,7 @@ type PodMetricsEndpoint struct {
 	// If empty, Prometheus uses the global scrape timeout unless it is less
 	// than the target's scrape interval value in which the latter is used.
 	// The value cannot be greater than the scrape interval otherwise the operator will reject the resource.
+	// +optional
 	ScrapeTimeout Duration `json:"scrapeTimeout,omitempty"`
 
 	// TLS configuration to use when scraping the target.
@@ -258,6 +270,7 @@ type PodMetricsEndpoint struct {
 
 	// When true, `honorLabels` preserves the metric's labels when they collide
 	// with the target's labels.
+	// +optional
 	HonorLabels bool `json:"honorLabels,omitempty"`
 
 	// `honorTimestamps` controls whether Prometheus preserves the timestamps

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/prometheus_types.go
@@ -102,7 +102,7 @@ type CoreV1TopologySpreadConstraint v1.TopologySpreadConstraint
 type TopologySpreadConstraint struct {
 	CoreV1TopologySpreadConstraint `json:",inline"`
 
-	//+optional
+	// +optional
 	// Defines what Prometheus Operator managed labels should be added to labelSelector on the topologySpreadConstraint.
 	AdditionalLabelSelectors *AdditionalLabelSelectors `json:"additionalLabelSelectors,omitempty"`
 }
@@ -124,6 +124,7 @@ type CommonPrometheusFields struct {
 	// * "operator.prometheus.io/name" label, set to the name of the Prometheus object.
 	// * "operator.prometheus.io/shard" label, set to the shard number of the Prometheus object.
 	// * "kubectl.kubernetes.io/default-container" annotation, set to "prometheus".
+	// +optional
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 
 	// ServiceMonitors to be selected for target discovery. An empty label
@@ -137,10 +138,12 @@ type CommonPrometheusFields struct {
 	// This behavior is *deprecated* and will be removed in the next major version
 	// of the custom resource definition. It is recommended to use
 	// `spec.additionalScrapeConfigs` instead.
+	// +optional
 	ServiceMonitorSelector *metav1.LabelSelector `json:"serviceMonitorSelector,omitempty"`
 	// Namespaces to match for ServicedMonitors discovery. An empty label selector
 	// matches all namespaces. A null label selector (default value) matches the current
 	// namespace only.
+	// +optional
 	ServiceMonitorNamespaceSelector *metav1.LabelSelector `json:"serviceMonitorNamespaceSelector,omitempty"`
 
 	// PodMonitors to be selected for target discovery. An empty label selector
@@ -154,10 +157,12 @@ type CommonPrometheusFields struct {
 	// This behavior is *deprecated* and will be removed in the next major version
 	// of the custom resource definition. It is recommended to use
 	// `spec.additionalScrapeConfigs` instead.
+	// +optional
 	PodMonitorSelector *metav1.LabelSelector `json:"podMonitorSelector,omitempty"`
 	// Namespaces to match for PodMonitors discovery. An empty label selector
 	// matches all namespaces. A null label selector (default value) matches the current
 	// namespace only.
+	// +optional
 	PodMonitorNamespaceSelector *metav1.LabelSelector `json:"podMonitorNamespaceSelector,omitempty"`
 
 	// Probes to be selected for target discovery. An empty label selector
@@ -171,10 +176,12 @@ type CommonPrometheusFields struct {
 	// This behavior is *deprecated* and will be removed in the next major version
 	// of the custom resource definition. It is recommended to use
 	// `spec.additionalScrapeConfigs` instead.
+	// +optional
 	ProbeSelector *metav1.LabelSelector `json:"probeSelector,omitempty"`
 	// Namespaces to match for Probe discovery. An empty label
 	// selector matches all namespaces. A null label selector matches the
 	// current namespace only.
+	// +optional
 	ProbeNamespaceSelector *metav1.LabelSelector `json:"probeNamespaceSelector,omitempty"`
 
 	// ScrapeConfigs to be selected for target discovery. An empty label
@@ -208,10 +215,12 @@ type CommonPrometheusFields struct {
 	// If not specified, the operator assumes the latest upstream version of
 	// Prometheus available at the time when the version of the operator was
 	// released.
+	// +optional
 	Version string `json:"version,omitempty"`
 
 	// When a Prometheus deployment is paused, no actions except for deletion
 	// will be performed on the underlying objects.
+	// +optional
 	Paused bool `json:"paused,omitempty"`
 
 	// Container image name for Prometheus. If specified, it takes precedence
@@ -229,10 +238,12 @@ type CommonPrometheusFields struct {
 	// Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers.
 	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
 	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
+	// +optional
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// An optional list of references to Secrets in the same namespace
 	// to use for pulling images from registries.
 	// See http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+	// +optional
 	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// Number of replicas of each shard to deploy for a Prometheus deployment.
@@ -269,6 +280,7 @@ type CommonPrometheusFields struct {
 	// You can also disable sharding on a specific target by setting the
 	// `__tmp_disable_sharding` label with relabeling configuration. When
 	// the label value isn't empty, all Prometheus shards will scrape the target.
+	// +optional
 	Shards *int32 `json:"shards,omitempty"`
 
 	// Name of Prometheus external label used to denote the replica name.
@@ -288,18 +300,22 @@ type CommonPrometheusFields struct {
 
 	// Log level for Prometheus and the config-reloader sidecar.
 	// +kubebuilder:validation:Enum="";debug;info;warn;error
+	// +optional
 	LogLevel string `json:"logLevel,omitempty"`
 	// Log format for Log level for Prometheus and the config-reloader sidecar.
 	// +kubebuilder:validation:Enum="";logfmt;json
+	// +optional
 	LogFormat string `json:"logFormat,omitempty"`
 
 	// Interval between consecutive scrapes.
 	//
 	// Default: "30s"
 	// +kubebuilder:default:="30s"
+	// +optional
 	ScrapeInterval Duration `json:"scrapeInterval,omitempty"`
 	// Number of seconds to wait until a scrape request times out.
 	// The value cannot be greater than the scrape interval otherwise the operator will reject the resource.
+	// +optional
 	ScrapeTimeout Duration `json:"scrapeTimeout,omitempty"`
 
 	// The protocols to negotiate during a scrape. It tells clients the
@@ -319,6 +335,7 @@ type CommonPrometheusFields struct {
 	// external systems (federation, remote storage, Alertmanager).
 	// Labels defined by `spec.replicaExternalLabelName` and
 	// `spec.prometheusExternalLabelName` take precedence over this list.
+	// +optional
 	ExternalLabels map[string]string `json:"externalLabels,omitempty"`
 
 	// Enable Prometheus to be used as a receiver for the Prometheus remote
@@ -331,6 +348,7 @@ type CommonPrometheusFields struct {
 	// For more information see https://prometheus.io/docs/prometheus/latest/querying/api/#remote-write-receiver
 	//
 	// It requires Prometheus >= v2.33.0.
+	// +optional
 	EnableRemoteWriteReceiver bool `json:"enableRemoteWriteReceiver,omitempty"`
 
 	// Enable Prometheus to be used as a receiver for the OTLP Metrics protocol.
@@ -366,6 +384,7 @@ type CommonPrometheusFields struct {
 	// The external URL under which the Prometheus service is externally
 	// available. This is necessary to generate correct URLs (for instance if
 	// Prometheus is accessible behind an Ingress resource).
+	// +optional
 	ExternalURL string `json:"externalUrl,omitempty"`
 	// The route prefix Prometheus registers HTTP handlers for.
 	//
@@ -373,19 +392,23 @@ type CommonPrometheusFields struct {
 	// HTTP routes of a request, and the actual ExternalURL is still true, but
 	// the server serves requests under a different route prefix. For example
 	// for use with `kubectl proxy`.
+	// +optional
 	RoutePrefix string `json:"routePrefix,omitempty"`
 
 	// Storage defines the storage used by Prometheus.
+	// +optional
 	Storage *StorageSpec `json:"storage,omitempty"`
 
 	// Volumes allows the configuration of additional volumes on the output
 	// StatefulSet definition. Volumes specified will be appended to other
 	// volumes that are generated as a result of StorageSpec objects.
+	// +optional
 	Volumes []v1.Volume `json:"volumes,omitempty"`
 	// VolumeMounts allows the configuration of additional VolumeMounts.
 	//
 	// VolumeMounts will be appended to other VolumeMounts in the 'prometheus'
 	// container, that are generated as a result of StorageSpec objects.
+	// +optional
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
@@ -397,16 +420,20 @@ type CommonPrometheusFields struct {
 	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
 
 	// Defines the configuration of the Prometheus web server.
+	// +optional
 	Web *PrometheusWebSpec `json:"web,omitempty"`
 
 	// Defines the resources requests and limits of the 'prometheus' container.
+	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Defines on which Nodes the Pods are scheduled.
+	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run the
 	// Prometheus Pods.
+	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
@@ -422,11 +449,13 @@ type CommonPrometheusFields struct {
 	// Each Secret is added to the StatefulSet definition as a volume named `secret-<secret-name>`.
 	// The Secrets are mounted into /etc/prometheus/secrets/<secret-name> in the 'prometheus' container.
 	// +listType:=set
+	// +optional
 	Secrets []string `json:"secrets,omitempty"`
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the Prometheus
 	// object, which shall be mounted into the Prometheus Pods.
 	// Each ConfigMap is added to the StatefulSet definition as a volume named `configmap-<configmap-name>`.
 	// The ConfigMaps are mounted into /etc/prometheus/configmaps/<configmap-name> in the 'prometheus' container.
+	// +optional
 	ConfigMaps []string `json:"configMaps,omitempty"`
 
 	// Defines the Pods' affinity scheduling rules if specified.
@@ -437,7 +466,7 @@ type CommonPrometheusFields struct {
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 
 	// Defines the pod's topology spread constraints if specified.
-	//+optional
+	// +optional
 	TopologySpreadConstraints []TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
 	// Defines the list of remote write configurations.
@@ -465,6 +494,8 @@ type CommonPrometheusFields struct {
 	DNSConfig *PodDNSConfig `json:"dnsConfig,omitempty"`
 	// When true, the Prometheus server listens on the loopback address
 	// instead of the Pod IP's address.
+	//
+	// +optional
 	ListenLocal bool `json:"listenLocal,omitempty"`
 
 	// Indicates whether information about services should be injected into pod's environment variables
@@ -529,10 +560,12 @@ type CommonPrometheusFields struct {
 	APIServerConfig *APIServerConfig `json:"apiserverConfig,omitempty"`
 
 	// Priority class assigned to the Pods.
+	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// Port name used for the pods and governing service.
 	// Default: "web"
 	// +kubebuilder:default:="web"
+	// +optional
 	PortName string `json:"portName,omitempty"`
 
 	// When true, ServiceMonitor, PodMonitor and Probe object are forbidden to
@@ -545,6 +578,7 @@ type CommonPrometheusFields struct {
 	// `spec.arbitraryFSAccessThroughSM` to 'true' would prevent the attack.
 	// Users should instead provide the credentials using the
 	// `spec.bearerTokenSecret` field.
+	// +optional
 	ArbitraryFSAccessThroughSMs ArbitraryFSAccessThroughSMsConfig `json:"arbitraryFSAccessThroughSMs,omitempty"`
 
 	// When true, Prometheus resolves label conflicts by renaming the labels in the scraped data
@@ -552,16 +586,19 @@ type CommonPrometheusFields struct {
 	// ScrapeConfig objects. Otherwise the HonorLabels field of the service or pod monitor applies.
 	// In practice,`overrideHonorLaels:true` enforces `honorLabels:false`
 	// for all ServiceMonitor, PodMonitor and ScrapeConfig objects.
+	// +optional
 	OverrideHonorLabels bool `json:"overrideHonorLabels,omitempty"`
 	// When true, Prometheus ignores the timestamps for all the targets created
 	// from service and pod monitors.
 	// Otherwise the HonorTimestamps field of the service or pod monitor applies.
+	// +optional
 	OverrideHonorTimestamps bool `json:"overrideHonorTimestamps,omitempty"`
 
 	// When true, `spec.namespaceSelector` from all PodMonitor, ServiceMonitor
 	// and Probe objects will be ignored. They will only discover targets
 	// within the namespace of the PodMonitor, ServiceMonitor and Probe
 	// object.
+	// +optional
 	IgnoreNamespaceSelectors bool `json:"ignoreNamespaceSelectors,omitempty"`
 
 	// When not empty, a label will be added to:
@@ -576,6 +613,7 @@ type CommonPrometheusFields struct {
 	// The label's name is this field's value.
 	// The label's value is the namespace of the `ServiceMonitor`,
 	// `PodMonitor`, `Probe`, `PrometheusRule` or `ScrapeConfig` object.
+	// +optional
 	EnforcedNamespaceLabel string `json:"enforcedNamespaceLabel,omitempty"`
 
 	// When defined, enforcedSampleLimit specifies a global limit on the number
@@ -691,6 +729,7 @@ type CommonPrometheusFields struct {
 	// * Scrape objects with a bodySizeLimit value less than or equal to enforcedBodySizeLimit keep their specific value.
 	// * Scrape objects with a bodySizeLimit value greater than enforcedBodySizeLimit are set to enforcedBodySizeLimit.
 	//
+	// +optional
 	EnforcedBodySizeLimit ByteSize `json:"enforcedBodySizeLimit,omitempty"`
 
 	// Specifies the validation scheme for metric and label names.
@@ -782,6 +821,8 @@ type CommonPrometheusFields struct {
 	// When hostNetwork is enabled, this will set the DNS policy to
 	// `ClusterFirstWithHostNet` automatically (unless `.spec.DNSPolicy` is set
 	// to a different value).
+	//
+	// +optional
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 
 	// PodTargetLabels are appended to the `spec.podTargetLabels` field of all
@@ -875,6 +916,7 @@ type CommonPrometheusFields struct {
 	//
 	// +listType=map
 	// +listMapKey=name
+	// +optional
 	ScrapeClasses []ScrapeClass `json:"scrapeClasses,omitempty"`
 
 	// Defines the service discovery role used to discover targets from
@@ -1040,14 +1082,17 @@ func (cpf *CommonPrometheusFields) WebRoutePrefix() string {
 //
 // The Operator continuously reconciles the scrape and rules configuration and a sidecar container running in the Prometheus pods triggers a reload of the configuration when needed.
 type Prometheus struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the desired behavior of the Prometheus cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +required
 	Spec PrometheusSpec `json:"spec"`
 	// Most recent observed status of the Prometheus cluster. Read-only.
 	// More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +optional
 	Status PrometheusStatus `json:"status,omitempty"`
 }
 
@@ -1062,6 +1107,7 @@ type PrometheusList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// List of Prometheuses
 	Items []Prometheus `json:"items"`
@@ -1076,20 +1122,26 @@ func (l *PrometheusList) DeepCopyObject() runtime.Object {
 // https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 // +k8s:openapi-gen=true
 type PrometheusSpec struct {
+	// +optional
 	CommonPrometheusFields `json:",inline"`
 
 	// Deprecated: use 'spec.image' instead.
+	// +optional
 	BaseImage string `json:"baseImage,omitempty"`
 	// Deprecated: use 'spec.image' instead. The image's tag can be specified as part of the image name.
+	// +optional
 	Tag string `json:"tag,omitempty"`
 	// Deprecated: use 'spec.image' instead. The image's digest can be specified as part of the image name.
+	// +optional
 	SHA string `json:"sha,omitempty"`
 
 	// How long to retain the Prometheus data.
 	//
 	// Default: "24h" if `spec.retention` and `spec.retentionSize` are empty.
+	// +optional
 	Retention Duration `json:"retention,omitempty"`
 	// Maximum number of bytes used by the Prometheus data.
+	// +optional
 	RetentionSize ByteSize `json:"retentionSize,omitempty"`
 
 	// ShardRetentionPolicy defines the retention policy for the Prometheus shards.
@@ -1105,9 +1157,11 @@ type PrometheusSpec struct {
 	// When true, the Prometheus compaction is disabled.
 	// When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
 	// disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
+	// +optional
 	DisableCompaction bool `json:"disableCompaction,omitempty"`
 
 	// Defines the configuration of the Prometheus rules' engine.
+	// +optional
 	Rules Rules `json:"rules,omitempty"`
 	// Defines the list of PrometheusRule objects to which the namespace label
 	// enforcement doesn't apply.
@@ -1186,12 +1240,14 @@ type PrometheusSpec struct {
 	// Alternatively, the location can be set to a standard I/O stream, e.g.
 	// `/dev/stdout`, to log query information to the default Prometheus log
 	// stream.
+	// +optional
 	QueryLogFile string `json:"queryLogFile,omitempty"`
 
 	// AllowOverlappingBlocks enables vertical compaction and vertical query
 	// merge in Prometheus.
 	//
 	// Deprecated: this flag has no effect for Prometheus >= 2.39.0 where overlapping blocks are enabled by default.
+	// +optional
 	AllowOverlappingBlocks bool `json:"allowOverlappingBlocks,omitempty"`
 
 	// Exemplars related settings that are runtime reloadable.
@@ -1202,6 +1258,7 @@ type PrometheusSpec struct {
 	// Interval between rule evaluations.
 	// Default: "30s"
 	// +kubebuilder:default:="30s"
+	// +optional
 	EvaluationInterval Duration `json:"evaluationInterval,omitempty"`
 
 	// Defines the offset the rule evaluation timestamp of this particular group by the specified duration into the past.
@@ -1218,6 +1275,7 @@ type PrometheusSpec struct {
 	//
 	// For more information:
 	// https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis
+	// +optional
 	EnableAdminAPI bool `json:"enableAdminAPI,omitempty"`
 }
 
@@ -1292,17 +1350,22 @@ type PrometheusTracingConfig struct {
 type PrometheusStatus struct {
 	// Represents whether any actions on the underlying managed objects are
 	// being performed. Only delete actions will be performed.
+	// +required
 	Paused bool `json:"paused"`
 	// Total number of non-terminated pods targeted by this Prometheus deployment
 	// (their labels match the selector).
+	// +required
 	Replicas int32 `json:"replicas"`
 	// Total number of non-terminated pods targeted by this Prometheus deployment
 	// that have the desired version spec.
+	// +required
 	UpdatedReplicas int32 `json:"updatedReplicas"`
 	// Total number of available pods (ready for at least minReadySeconds)
 	// targeted by this Prometheus deployment.
+	// +required
 	AvailableReplicas int32 `json:"availableReplicas"`
 	// Total number of unavailable pods targeted by this Prometheus deployment.
+	// +required
 	UnavailableReplicas int32 `json:"unavailableReplicas"`
 	// The current state of the Prometheus deployment.
 	// +listType=map
@@ -1315,8 +1378,10 @@ type PrometheusStatus struct {
 	// +optional
 	ShardStatuses []ShardStatus `json:"shardStatuses,omitempty"`
 	// Shards is the most recently observed number of shards.
+	// +optional
 	Shards int32 `json:"shards,omitempty"`
 	// The selector used to match the pods targeted by this Prometheus resource.
+	// +optional
 	Selector string `json:"selector,omitempty"`
 }
 
@@ -1324,6 +1389,7 @@ type PrometheusStatus struct {
 // +k8s:openapi-gen=true
 type AlertingSpec struct {
 	// Alertmanager endpoints where Prometheus should send alerts to.
+	// +required
 	Alertmanagers []AlertmanagerEndpoints `json:"alertmanagers"`
 }
 
@@ -1338,19 +1404,23 @@ type AlertingSpec struct {
 // +k8s:openapi-gen=true
 type StorageSpec struct {
 	// Deprecated: subPath usage will be removed in a future release.
+	// +optional
 	DisableMountSubPath bool `json:"disableMountSubPath,omitempty"`
 	// EmptyDirVolumeSource to be used by the StatefulSet.
 	// If specified, it takes precedence over `ephemeral` and `volumeClaimTemplate`.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
+	// +optional
 	EmptyDir *v1.EmptyDirVolumeSource `json:"emptyDir,omitempty"`
 	// EphemeralVolumeSource to be used by the StatefulSet.
 	// This is a beta field in k8s 1.21 and GA in 1.15.
 	// For lower versions, starting with k8s 1.19, it requires enabling the GenericEphemeralVolume feature gate.
 	// More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+	// +optional
 	Ephemeral *v1.EphemeralVolumeSource `json:"ephemeral,omitempty"`
 	// Defines the PVC spec to be used by the Prometheus StatefulSets.
 	// The easiest way to use a volume that cannot be automatically provisioned
 	// is to use a label selector alongside manually created PersistentVolumes.
+	// +optional
 	VolumeClaimTemplate EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate,omitempty"`
 }
 
@@ -1377,6 +1447,7 @@ type QuerySpec struct {
 // PrometheusWebSpec defines the configuration of the Prometheus web server.
 // +k8s:openapi-gen=true
 type PrometheusWebSpec struct {
+	// +optional
 	WebConfigFileFields `json:",inline"`
 
 	// The prometheus web page title.
@@ -1428,6 +1499,7 @@ type ThanosSpec struct {
 	BaseImage *string `json:"baseImage,omitempty"`
 
 	// Defines the resources requests and limits of the Thanos sidecar.
+	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Defines the Thanos sidecar's configuration to upload TSDB blocks to object storage.
@@ -1446,18 +1518,21 @@ type ThanosSpec struct {
 	ObjectStorageConfigFile *string `json:"objectStorageConfigFile,omitempty"`
 
 	// Deprecated: use `grpcListenLocal` and `httpListenLocal` instead.
+	// +optional
 	ListenLocal bool `json:"listenLocal,omitempty"`
 
 	// When true, the Thanos sidecar listens on the loopback interface instead
 	// of the Pod IP's address for the gRPC endpoints.
 	//
 	// It has no effect if `listenLocal` is true.
+	// +optional
 	GRPCListenLocal bool `json:"grpcListenLocal,omitempty"`
 
 	// When true, the Thanos sidecar listens on the loopback interface instead
 	// of the Pod IP's address for the HTTP endpoints.
 	//
 	// It has no effect if `listenLocal` is true.
+	// +optional
 	HTTPListenLocal bool `json:"httpListenLocal,omitempty"`
 
 	// Defines the tracing configuration for the Thanos sidecar.
@@ -1479,6 +1554,7 @@ type ThanosSpec struct {
 	//
 	// This is an *experimental feature*, it may change in any upcoming release
 	// in a breaking way.
+	// +optional
 	TracingConfigFile string `json:"tracingConfigFile,omitempty"`
 
 	// Configures the TLS parameters for the gRPC server providing the StoreAPI.
@@ -1490,15 +1566,18 @@ type ThanosSpec struct {
 
 	// Log level for the Thanos sidecar.
 	// +kubebuilder:validation:Enum="";debug;info;warn;error
+	// +optional
 	LogLevel string `json:"logLevel,omitempty"`
 	// Log format for the Thanos sidecar.
 	// +kubebuilder:validation:Enum="";logfmt;json
+	// +optional
 	LogFormat string `json:"logFormat,omitempty"`
 
 	// Defines the start of time range limit served by the Thanos sidecar's StoreAPI.
 	// The field's value should be a constant time in RFC3339 format or a time
 	// duration relative to current time, such as -1d or 2h45m. Valid duration
 	// units are ms, s, m, h, d, w, y.
+	// +optional
 	MinTime string `json:"minTime,omitempty"`
 
 	// BlockDuration controls the size of TSDB blocks produced by Prometheus.
@@ -1511,14 +1590,18 @@ type ThanosSpec struct {
 	// example, 30s * 120 = 1h.
 	//
 	// +kubebuilder:default:="2h"
+	// +optional
 	BlockDuration Duration `json:"blockSize,omitempty"`
 
 	// ReadyTimeout is the maximum time that the Thanos sidecar will wait for
 	// Prometheus to start.
+	// +optional
 	ReadyTimeout Duration `json:"readyTimeout,omitempty"`
 	// How often to retrieve the Prometheus configuration.
+	// +optional
 	GetConfigInterval Duration `json:"getConfigInterval,omitempty"`
 	// Maximum time to wait when retrieving the Prometheus configuration.
+	// +optional
 	GetConfigTimeout Duration `json:"getConfigTimeout,omitempty"`
 
 	// VolumeMounts allows configuration of additional VolumeMounts for Thanos.
@@ -1551,7 +1634,7 @@ type RemoteWriteSpec struct {
 	//
 	// It requires Prometheus >= v2.15.0 or Thanos >= 0.24.0.
 	//
-	//+optional
+	// +optional
 	Name *string `json:"name,omitempty"`
 
 	// The Remote Write message's version to use when writing to the endpoint.
@@ -1621,6 +1704,7 @@ type RemoteWriteSpec struct {
 	// File from which to read bearer token for the URL.
 	//
 	// Deprecated: this will be removed in a future release. Prefer using `authorization`.
+	// +optional
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 
 	// Authorization section for the URL.
@@ -1654,6 +1738,7 @@ type RemoteWriteSpec struct {
 	// in clear-text. Prefer using `authorization`.*
 	//
 	// Deprecated: this will be removed in a future release.
+	// +optional
 	BearerToken string `json:"bearerToken,omitempty"`
 
 	// TLS Config to use for the URL.
@@ -1716,17 +1801,22 @@ const (
 type QueueConfig struct {
 	// Capacity is the number of samples to buffer per shard before we start
 	// dropping them.
+	// +optional
 	Capacity int `json:"capacity,omitempty"`
+	// +optional
 	// MinShards is the minimum number of shards, i.e. amount of concurrency.
 	MinShards int `json:"minShards,omitempty"`
 	// MaxShards is the maximum number of shards, i.e. amount of concurrency.
+	// +optional
 	MaxShards int `json:"maxShards,omitempty"`
 	// MaxSamplesPerSend is the maximum number of samples per send.
+	// +optional
 	MaxSamplesPerSend int `json:"maxSamplesPerSend,omitempty"`
 	// BatchSendDeadline is the maximum time a sample will wait in buffer.
 	// +optional
 	BatchSendDeadline *Duration `json:"batchSendDeadline,omitempty"`
 	// MaxRetries is the maximum number of times to retry a batch on recoverable errors.
+	// +optional
 	MaxRetries int `json:"maxRetries,omitempty"`
 	// MinBackoff is the initial retry delay. Gets doubled for every retry.
 	// +optional
@@ -1738,6 +1828,7 @@ type QueueConfig struct {
 	//
 	// This is an *experimental feature*, it may change in any upcoming release
 	// in a breaking way.
+	// +optional
 	RetryOnRateLimit bool `json:"retryOnRateLimit,omitempty"`
 	// SampleAgeLimit drops samples older than the limit.
 	// It requires Prometheus >= v2.50.0 or Thanos >= v0.32.0.
@@ -1751,6 +1842,7 @@ type QueueConfig struct {
 // +k8s:openapi-gen=true
 type Sigv4 struct {
 	// Region is the AWS region. If blank, the region from the default credentials chain used.
+	// +optional
 	Region string `json:"region,omitempty"`
 	// AccessKey is the AWS API key. If not specified, the environment variable
 	// `AWS_ACCESS_KEY_ID` is used.
@@ -1761,8 +1853,10 @@ type Sigv4 struct {
 	// +optional
 	SecretKey *v1.SecretKeySelector `json:"secretKey,omitempty"`
 	// Profile is the named AWS profile used to authenticate.
+	// +optional
 	Profile string `json:"profile,omitempty"`
 	// RoleArn is the named AWS profile used to authenticate.
+	// +optional
 	RoleArn string `json:"roleArn,omitempty"`
 }
 
@@ -1831,6 +1925,7 @@ type AzureSDK struct {
 // +k8s:openapi-gen=true
 type RemoteReadSpec struct {
 	// The URL of the endpoint to query from.
+	// +required
 	URL string `json:"url"`
 
 	// The name of the remote read queue, it must be unique if specified. The
@@ -1839,6 +1934,7 @@ type RemoteReadSpec struct {
 	//
 	// It requires Prometheus >= v2.15.0.
 	//
+	// +optional
 	Name string `json:"name,omitempty"`
 
 	// An optional list of equality matchers which have to be present
@@ -1858,6 +1954,7 @@ type RemoteReadSpec struct {
 
 	// Whether reads should be made for queries for time ranges that
 	// the local storage should have complete data for.
+	// +optional
 	ReadRecent bool `json:"readRecent,omitempty"`
 
 	// OAuth2 configuration for the URL.
@@ -1877,6 +1974,7 @@ type RemoteReadSpec struct {
 	// File from which to read the bearer token for the URL.
 	//
 	// Deprecated: this will be removed in a future release. Prefer using `authorization`.
+	// +optional
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 	// Authorization section for the URL.
 	//
@@ -1891,6 +1989,7 @@ type RemoteReadSpec struct {
 	// in clear-text. Prefer using `authorization`.*
 	//
 	// Deprecated: this will be removed in a future release.
+	// +optional
 	BearerToken string `json:"bearerToken,omitempty"`
 
 	// TLS Config to use for the URL.
@@ -1931,6 +2030,7 @@ type RelabelConfig struct {
 	SourceLabels []LabelName `json:"sourceLabels,omitempty"`
 
 	// Separator is the string between concatenated SourceLabels.
+	// +optional
 	Separator *string `json:"separator,omitempty"`
 
 	// Label to which the resulting string is written in a replacement.
@@ -1939,14 +2039,17 @@ type RelabelConfig struct {
 	// `KeepEqual` and `DropEqual` actions.
 	//
 	// Regex capture groups are available.
+	// +optional
 	TargetLabel string `json:"targetLabel,omitempty"`
 
 	// Regular expression against which the extracted value is matched.
+	// +optional
 	Regex string `json:"regex,omitempty"`
 
 	// Modulus to take of the hash of the source label values.
 	//
 	// Only applicable when the action is `HashMod`.
+	// +optional
 	Modulus uint64 `json:"modulus,omitempty"`
 
 	// Replacement value against which a Replace action is performed if the
@@ -1954,7 +2057,7 @@ type RelabelConfig struct {
 	//
 	// Regex capture groups are available.
 	//
-	//+optional
+	// +optional
 	Replacement *string `json:"replacement,omitempty"`
 
 	// Action to perform based on the regex matching.
@@ -1966,6 +2069,7 @@ type RelabelConfig struct {
 	//
 	// +kubebuilder:validation:Enum=replace;Replace;keep;Keep;drop;Drop;hashmod;HashMod;labelmap;LabelMap;labeldrop;LabelDrop;labelkeep;LabelKeep;lowercase;Lowercase;uppercase;Uppercase;keepequal;KeepEqual;dropequal;DropEqual
 	// +kubebuilder:default=replace
+	// +optional
 	Action string `json:"action,omitempty"`
 }
 
@@ -1977,6 +2081,7 @@ type RelabelConfig struct {
 type APIServerConfig struct {
 	// Kubernetes API address consisting of a hostname or IP address followed
 	// by an optional port number.
+	// +required
 	Host string `json:"host"`
 
 	// BasicAuth configuration for the API server.
@@ -1992,6 +2097,7 @@ type APIServerConfig struct {
 	// Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`.
 	//
 	// Deprecated: this will be removed in a future release. Prefer using `authorization`.
+	// +optional
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 
 	// TLS Config to use for the API server.
@@ -2011,6 +2117,7 @@ type APIServerConfig struct {
 	// in clear-text. Prefer using `authorization`.*
 	//
 	// Deprecated: this will be removed in a future release.
+	// +optional
 	BearerToken string `json:"bearerToken,omitempty"`
 
 	// Optional ProxyConfig.
@@ -2046,12 +2153,15 @@ type AlertmanagerEndpoints struct {
 	Name string `json:"name"`
 
 	// Port on which the Alertmanager API is exposed.
+	// +required
 	Port intstr.IntOrString `json:"port"`
 
 	// Scheme to use when firing alerts.
+	// +optional
 	Scheme string `json:"scheme,omitempty"`
 
 	// Prefix for the HTTP path alerts are pushed to.
+	// +optional
 	PathPrefix string `json:"pathPrefix,omitempty"`
 
 	// TLS Config to use for Alertmanager.
@@ -2071,6 +2181,7 @@ type AlertmanagerEndpoints struct {
 	// Cannot be set at the same time as `basicAuth`, `authorization`, or `sigv4`.
 	//
 	// Deprecated: this will be removed in a future release. Prefer using `authorization`.
+	// +optional
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 
 	// Authorization section for Alertmanager.
@@ -2090,6 +2201,7 @@ type AlertmanagerEndpoints struct {
 	Sigv4 *Sigv4 `json:"sigv4,omitempty"`
 
 	// ProxyConfig
+	// +optional
 	ProxyConfig `json:",inline"`
 
 	// Version of the Alertmanager API that Prometheus uses to send alerts.
@@ -2126,6 +2238,7 @@ type Rules struct {
 	// Defines the parameters of the Prometheus rules' engine.
 	//
 	// Any update to these parameters trigger a restart of the pods.
+	// +optional
 	Alert RulesAlert `json:"alert,omitempty"`
 }
 
@@ -2133,16 +2246,19 @@ type Rules struct {
 type RulesAlert struct {
 	// Max time to tolerate prometheus outage for restoring 'for' state of
 	// alert.
+	// +optional
 	ForOutageTolerance string `json:"forOutageTolerance,omitempty"`
 
 	// Minimum duration between alert and restored 'for' state.
 	//
 	// This is maintained only for alerts with a configured 'for' time greater
 	// than the grace period.
+	// +optional
 	ForGracePeriod string `json:"forGracePeriod,omitempty"`
 
 	// Minimum amount of time to wait before resending an alert to
 	// Alertmanager.
+	// +optional
 	ResendDelay string `json:"resendDelay,omitempty"`
 }
 
@@ -2151,9 +2267,11 @@ type RulesAlert struct {
 // +k8s:openapi-gen=true
 type MetadataConfig struct {
 	// Defines whether metric metadata is sent to the remote storage or not.
+	// +optional
 	Send bool `json:"send,omitempty"`
 
 	// Defines how frequently metric metadata is sent to the remote storage.
+	// +optional
 	SendInterval Duration `json:"sendInterval,omitempty"`
 
 	// MaxSamplesPerSend is the maximum number of metadata samples per send.
@@ -2170,14 +2288,18 @@ type ShardStatus struct {
 	// +required
 	ShardID string `json:"shardID"`
 	// Total number of pods targeted by this shard.
+	// +required
 	Replicas int32 `json:"replicas"`
 	// Total number of non-terminated pods targeted by this shard
 	// that have the desired spec.
+	// +required
 	UpdatedReplicas int32 `json:"updatedReplicas"`
 	// Total number of available pods (ready for at least minReadySeconds)
 	// targeted by this shard.
+	// +required
 	AvailableReplicas int32 `json:"availableReplicas"`
 	// Total number of unavailable pods targeted by this shard.
+	// +required
 	UnavailableReplicas int32 `json:"unavailableReplicas"`
 }
 
@@ -2220,9 +2342,11 @@ type SafeAuthorization struct {
 	// "Basic" is not a supported value.
 	//
 	// Default: "Bearer"
+	// +optional
 	Type string `json:"type,omitempty"`
 
 	// Selects a key of a Secret in the namespace that contains the credentials for authentication.
+	// +optional
 	Credentials *v1.SecretKeySelector `json:"credentials,omitempty"`
 }
 
@@ -2244,9 +2368,11 @@ func (c *SafeAuthorization) Validate() error {
 }
 
 type Authorization struct {
+	// +optional
 	SafeAuthorization `json:",inline"`
 
 	// File to read a secret from, mutually exclusive with `credentials`.
+	// +optional
 	CredentialsFile string `json:"credentialsFile,omitempty"`
 }
 
@@ -2271,6 +2397,7 @@ func (c *Authorization) Validate() error {
 // on semantically invalid configurations.
 // +k8s:openapi-gen=false
 type AuthorizationValidationError struct {
+	// +optional
 	err string
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/prometheusrule_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/prometheusrule_types.go
@@ -34,9 +34,11 @@ const (
 //
 // `Prometheus` and `ThanosRuler` objects select `PrometheusRule` objects using label and namespace selectors.
 type PrometheusRule struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of desired alerting rule definitions for Prometheus.
+	// +required
 	Spec PrometheusRuleSpec `json:"spec"`
 }
 
@@ -51,6 +53,7 @@ type PrometheusRuleSpec struct {
 	// Content of Prometheus rule file
 	// +listType=map
 	// +listMapKey=name
+	// +optional
 	Groups []RuleGroup `json:"groups,omitempty"`
 }
 
@@ -62,6 +65,7 @@ type PrometheusRuleSpec struct {
 type RuleGroup struct {
 	// Name of the rule group.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// Labels to add or overwrite before storing the result for its rules.
 	// The labels defined at the rule level take precedence.
@@ -86,6 +90,7 @@ type RuleGroup struct {
 	// be ignored by Prometheus instances.
 	// More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response
 	// +kubebuilder:validation:Pattern="^(?i)(abort|warn)?$"
+	// +optional
 	PartialResponseStrategy string `json:"partial_response_strategy,omitempty"`
 	// Limit the number of alerts an alerting rule and series a recording
 	// rule can produce.
@@ -97,14 +102,18 @@ type RuleGroup struct {
 // Rule describes an alerting or recording rule
 // See Prometheus documentation: [alerting](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) or [recording](https://www.prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules) rule
 // +k8s:openapi-gen=true
+// +kubebuilder:validation:OneOf=Record,Alert
 type Rule struct {
 	// Name of the time series to output to. Must be a valid metric name.
 	// Only one of `record` and `alert` must be set.
+	// +optional
 	Record string `json:"record,omitempty"`
 	// Name of the alert. Must be a valid label value.
 	// Only one of `record` and `alert` must be set.
+	// +optional
 	Alert string `json:"alert,omitempty"`
 	// PromQL expression to evaluate.
+	// +required
 	Expr intstr.IntOrString `json:"expr"`
 	// Alerts are considered firing once they have been returned for this long.
 	// +optional
@@ -113,9 +122,11 @@ type Rule struct {
 	// +optional
 	KeepFiringFor *NonEmptyDuration `json:"keep_firing_for,omitempty"`
 	// Labels to add or overwrite.
+	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 	// Annotations to add to each alert.
 	// Only valid for alerting rules.
+	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
@@ -125,8 +136,10 @@ type PrometheusRuleList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// List of Rules
+	// +required
 	Items []PrometheusRule `json:"items"`
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/servicemonitor_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/servicemonitor_types.go
@@ -39,10 +39,12 @@ const (
 //
 // `Prometheus` and `PrometheusAgent` objects select `ServiceMonitor` objects using label and namespace selectors.
 type ServiceMonitor struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of desired Service selection for target discovery by
 	// Prometheus.
+	// +required
 	Spec ServiceMonitorSpec `json:"spec"`
 	// This Status subresource is under active development and is updated only when the
 	// "StatusForConfigurationResources" feature gate is enabled.
@@ -51,7 +53,7 @@ type ServiceMonitor struct {
 	// More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
-	Status ConfigResourceStatus `json:"status,omitempty"`
+	Status ConfigResourceStatus `json:"status,omitempty,omitzero"`
 }
 
 // DeepCopyObject implements the runtime.Object interface.
@@ -72,6 +74,7 @@ type ServiceMonitorSpec struct {
 	// If the value of this field is empty or if the label doesn't exist for
 	// the given Service, the `job` label of the metrics defaults to the name
 	// of the associated Kubernetes `Service`.
+	// +optional
 	JobLabel string `json:"jobLabel,omitempty"`
 
 	// `targetLabels` defines the labels which are transferred from the
@@ -88,9 +91,11 @@ type ServiceMonitorSpec struct {
 	// List of endpoints part of this ServiceMonitor.
 	// Defines how to scrape metrics from Kubernetes [Endpoints](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) objects.
 	// In most cases, an Endpoints object is backed by a Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/) object with the same name and labels.
+	// +required
 	Endpoints []Endpoint `json:"endpoints"`
 
 	// Label selector to select the Kubernetes `Endpoints` objects to scrape metrics from.
+	// +required
 	Selector metav1.LabelSelector `json:"selector"`
 
 	// Mechanism used to select the endpoints to scrape.
@@ -105,6 +110,7 @@ type ServiceMonitorSpec struct {
 
 	// `namespaceSelector` defines in which namespace(s) Prometheus should discover the services.
 	// By default, the services are discovered in the same namespace as the `ServiceMonitor` object but it is possible to select pods across different/all namespaces.
+	// +optional
 	NamespaceSelector NamespaceSelector `json:"namespaceSelector,omitempty"`
 
 	// `sampleLimit` defines a per-scrape limit on the number of scraped samples
@@ -155,6 +161,7 @@ type ServiceMonitorSpec struct {
 	// +optional
 	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
 
+	// +optional
 	NativeHistogramConfig `json:",inline"`
 
 	// Per-scrape limit on the number of targets dropped by relabeling
@@ -193,8 +200,10 @@ type ServiceMonitorList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// List of ServiceMonitors
+	// +required
 	Items []ServiceMonitor `json:"items"`
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/thanos_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/thanos_types.go
@@ -44,14 +44,17 @@ const (
 //
 // The resource defines via label and namespace selectors which `PrometheusRule` objects should be associated to the deployed Thanos Ruler instances.
 type ThanosRuler struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the desired behavior of the ThanosRuler cluster. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +required
 	Spec ThanosRulerSpec `json:"spec"`
 	// Most recent observed status of the ThanosRuler cluster. Read-only.
 	// More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +optional
 	Status ThanosRulerStatus `json:"status,omitempty"`
 }
 
@@ -61,8 +64,10 @@ type ThanosRulerList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// List of Prometheuses
+	// +required
 	Items []ThanosRuler `json:"items"`
 }
 
@@ -86,11 +91,13 @@ type ThanosRulerSpec struct {
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 
 	// Thanos container image URL.
+	// +optional
 	Image string `json:"image,omitempty"`
 
 	// Image pull policy for the 'thanos', 'init-config-reloader' and 'config-reloader' containers.
 	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
 	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
+	// +optional
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// An optional list of references to secrets in the same namespace
@@ -101,6 +108,7 @@ type ThanosRulerSpec struct {
 
 	// When a ThanosRuler deployment is paused, no actions except for deletion
 	// will be performed on the underlying objects.
+	// +optional
 	Paused bool `json:"paused,omitempty"`
 
 	// Number of thanos ruler instances to deploy.
@@ -113,6 +121,7 @@ type ThanosRulerSpec struct {
 
 	// Resources defines the resource requirements for single Pods.
 	// If not provided, no requests/limits will be set
+	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`
 
 	// If specified, the pod's scheduling constraints.
@@ -146,6 +155,7 @@ type ThanosRulerSpec struct {
 	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty"`
 
 	// Priority class assigned to the Pods
+	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
 	// The name of the service name used by the underlying StatefulSet(s) as the governing service.
@@ -159,6 +169,7 @@ type ThanosRulerSpec struct {
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run the
 	// Thanos Ruler Pods.
+	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Storage spec to specify how storage shall be used.
@@ -198,6 +209,7 @@ type ThanosRulerSpec struct {
 
 	// ListenLocal makes the Thanos ruler listen on loopback, so that it
 	// does not bind against the Pod IP.
+	// +optional
 	ListenLocal bool `json:"listenLocal,omitempty"`
 
 	// Configures the list of Thanos Query endpoints from which to query metrics.
@@ -258,6 +270,7 @@ type ThanosRulerSpec struct {
 	// EnforcedNamespaceLabel enforces adding a namespace label of origin for each alert
 	// and metric that is user created. The label value will always be the namespace of the object that is
 	// being created.
+	// +optional
 	EnforcedNamespaceLabel string `json:"enforcedNamespaceLabel,omitempty"`
 	// List of references to PrometheusRule objects
 	// to be excluded from enforcing a namespace label of origin.
@@ -273,18 +286,22 @@ type ThanosRulerSpec struct {
 
 	// Log level for ThanosRuler to be configured with.
 	// +kubebuilder:validation:Enum="";debug;info;warn;error
+	// +optional
 	LogLevel string `json:"logLevel,omitempty"`
 	// Log format for ThanosRuler to be configured with.
 	// +kubebuilder:validation:Enum="";logfmt;json
+	// +optional
 	LogFormat string `json:"logFormat,omitempty"`
 
 	// Port name used for the pods and governing service.
 	// Defaults to `web`.
 	// +kubebuilder:default:="web"
+	// +optional
 	PortName string `json:"portName,omitempty"`
 
 	// Interval between consecutive evaluations.
 	// +kubebuilder:default:="15s"
+	// +optional
 	EvaluationInterval Duration `json:"evaluationInterval,omitempty"`
 
 	// Minimum amount of time to wait before resending an alert to Alertmanager.
@@ -323,6 +340,7 @@ type ThanosRulerSpec struct {
 	// operates in stateless mode.
 	//
 	// +kubebuilder:default:="24h"
+	// +optional
 	Retention Duration `json:"retention,omitempty"`
 
 	// Containers allows injecting additional containers or modifying operator generated
@@ -355,7 +373,7 @@ type ThanosRulerSpec struct {
 	//
 	// `tracingConfigFile` takes precedence over this field.
 	//
-	//+optional
+	// +optional
 	TracingConfig *v1.SecretKeySelector `json:"tracingConfig,omitempty"`
 	// Configures the path of the tracing configuration file.
 	//
@@ -368,7 +386,7 @@ type ThanosRulerSpec struct {
 	//
 	// This field takes precedence over `tracingConfig`.
 	//
-	//+optional
+	// +optional
 	TracingConfigFile string `json:"tracingConfigFile,omitempty"`
 
 	// Configures the external label pairs of the ThanosRuler resource.
@@ -390,8 +408,10 @@ type ThanosRulerSpec struct {
 	// The external URL the Thanos Ruler instances will be available under. This is
 	// necessary to generate correct URLs. This is necessary if Thanos Ruler is not
 	// served from root of a DNS name.
+	// +optional
 	ExternalPrefix string `json:"externalPrefix,omitempty"`
 	// The route prefix ThanosRuler registers HTTP handlers for. This allows thanos UI to be served on a sub-path.
+	// +optional
 	RoutePrefix string `json:"routePrefix,omitempty"`
 
 	// GRPCServerTLSConfig configures the gRPC server from which Thanos Querier reads
@@ -404,6 +424,7 @@ type ThanosRulerSpec struct {
 	// The external Query URL the Thanos Ruler will set in the 'Source' field
 	// of all alerts.
 	// Maps to the '--alert.query-url' CLI arg.
+	// +optional
 	AlertQueryURL string `json:"alertQueryUrl,omitempty"`
 
 	// Minimum number of seconds for which a newly created pod should be ready
@@ -443,6 +464,7 @@ type ThanosRulerSpec struct {
 	// Pods' hostAliases configuration
 	// +listType=map
 	// +listMapKey=ip
+	// +optional
 	HostAliases []HostAlias `json:"hostAliases,omitempty"`
 
 	// AdditionalArgs allows setting additional arguments for the ThanosRuler container.
@@ -507,6 +529,7 @@ type ThanosRulerSpec struct {
 // ThanosRulerWebSpec defines the configuration of the ThanosRuler web server.
 // +k8s:openapi-gen=true
 type ThanosRulerWebSpec struct {
+	// +optional
 	WebConfigFileFields `json:",inline"`
 }
 
@@ -517,17 +540,22 @@ type ThanosRulerWebSpec struct {
 type ThanosRulerStatus struct {
 	// Represents whether any actions on the underlying managed objects are
 	// being performed. Only delete actions will be performed.
+	// +required
 	Paused bool `json:"paused"`
 	// Total number of non-terminated pods targeted by this ThanosRuler deployment
 	// (their labels match the selector).
+	// +required
 	Replicas int32 `json:"replicas"`
 	// Total number of non-terminated pods targeted by this ThanosRuler deployment
 	// that have the desired version spec.
+	// +required
 	UpdatedReplicas int32 `json:"updatedReplicas"`
 	// Total number of available pods (ready for at least minReadySeconds)
 	// targeted by this ThanosRuler deployment.
+	// +required
 	AvailableReplicas int32 `json:"availableReplicas"`
 	// Total number of unavailable pods targeted by this ThanosRuler deployment.
+	// +required
 	UnavailableReplicas int32 `json:"unavailableReplicas"`
 	// The current state of the ThanosRuler object.
 	// +listType=map

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1/types.go
@@ -73,10 +73,10 @@ type GoDuration string
 // pod's hosts file.
 type HostAlias struct {
 	// IP address of the host file entry.
-	// +kubebuilder:validation:Required
+	// +required
 	IP string `json:"ip"`
 	// Hostnames for the above IP address.
-	// +kubebuilder:validation:Required
+	// +required
 	Hostnames []string `json:"hostnames"`
 }
 
@@ -85,8 +85,10 @@ type HostAlias struct {
 // namespace label for alerts and metrics.
 type PrometheusRuleExcludeConfig struct {
 	// Namespace of the excluded PrometheusRule object.
+	// +required
 	RuleNamespace string `json:"ruleNamespace"`
 	// Name of the excluded PrometheusRule object.
+	// +required
 	RuleName string `json:"ruleName"`
 }
 
@@ -174,12 +176,12 @@ type ObjectReference struct {
 	// +kubebuilder:validation:Enum=monitoring.coreos.com
 	Group string `json:"group"`
 	// Resource of the referent.
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:validation:Enum=prometheusrules;servicemonitors;podmonitors;probes;scrapeconfigs
 	Resource string `json:"resource"`
 	// Namespace of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:validation:MinLength=1
 	Namespace string `json:"namespace"`
 	// Name of the referent. When not set, all resources in the namespace are matched.
@@ -219,6 +221,7 @@ func (obj *ObjectReference) getGroup() string {
 // request by Prometheus to a malicious target. Denying the above would prevent the
 // attack, users can instead use the BearerTokenSecret field.
 type ArbitraryFSAccessThroughSMsConfig struct {
+	// +optional
 	Deny bool `json:"deny,omitempty"`
 }
 
@@ -246,6 +249,7 @@ type Condition struct {
 	// currently 12, but the `.status.conditions[].observedGeneration` is 9, the
 	// condition is out of date with respect to the current state of the
 	// instance.
+	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
@@ -293,6 +297,7 @@ type EmbeddedPersistentVolumeClaim struct {
 	metav1.TypeMeta `json:",inline"`
 
 	// EmbeddedMetadata contains metadata relevant to an EmbeddedResource.
+	// +optional
 	EmbeddedObjectMetadata `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Defines the desired characteristics of a volume requested by a pod author.
@@ -336,8 +341,10 @@ type EmbeddedObjectMetadata struct {
 // +k8s:deepcopy-gen=true
 type WebConfigFileFields struct {
 	// Defines the TLS parameters for HTTPS.
+	// +optional
 	TLSConfig *WebTLSConfig `json:"tlsConfig,omitempty"`
 	// Defines HTTP parameters for web server.
+	// +optional
 	HTTPConfig *WebHTTPConfig `json:"httpConfig,omitempty"`
 }
 
@@ -347,8 +354,10 @@ type WebHTTPConfig struct {
 	// Enable HTTP/2 support. Note that HTTP/2 is only supported with TLS.
 	// When TLSConfig is not configured, HTTP/2 will be disabled.
 	// Whenever the value of the field changes, a rolling update will be triggered.
+	// +optional
 	HTTP2 *bool `json:"http2,omitempty"`
 	// List of headers that can be added to HTTP responses.
+	// +optional
 	Headers *WebHTTPHeaders `json:"headers,omitempty"`
 }
 
@@ -357,20 +366,24 @@ type WebHTTPConfig struct {
 type WebHTTPHeaders struct {
 	// Set the Content-Security-Policy header to HTTP responses.
 	// Unset if blank.
+	// +optional
 	ContentSecurityPolicy string `json:"contentSecurityPolicy,omitempty"`
 	// Set the X-Frame-Options header to HTTP responses.
 	// Unset if blank. Accepted values are deny and sameorigin.
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-	//+kubebuilder:validation:Enum="";Deny;SameOrigin
+	// +kubebuilder:validation:Enum="";Deny;SameOrigin
+	// +optional
 	XFrameOptions string `json:"xFrameOptions,omitempty"`
 	// Set the X-Content-Type-Options header to HTTP responses.
 	// Unset if blank. Accepted value is nosniff.
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
-	//+kubebuilder:validation:Enum="";NoSniff
+	// +kubebuilder:validation:Enum="";NoSniff
+	// +optional
 	XContentTypeOptions string `json:"xContentTypeOptions,omitempty"`
 	// Set the X-XSS-Protection header to all responses.
 	// Unset if blank.
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+	// +optional
 	XXSSProtection string `json:"xXSSProtection,omitempty"`
 	// Set the Strict-Transport-Security header to HTTP responses.
 	// Unset if blank.
@@ -378,6 +391,7 @@ type WebHTTPHeaders struct {
 	// browsers to load Prometheus and the other applications hosted on the same
 	// domain and subdomains over HTTPS.
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+	// +optional
 	StrictTransportSecurity string `json:"strictTransportSecurity,omitempty"`
 }
 
@@ -533,6 +547,7 @@ type Endpoint struct {
 	// Name of the Service port which this endpoint refers to.
 	//
 	// It takes precedence over `targetPort`.
+	// +optional
 	Port string `json:"port,omitempty"`
 
 	// Name or number of the target port of the `Pod` object behind the
@@ -544,6 +559,7 @@ type Endpoint struct {
 	// HTTP path from which to scrape for metrics.
 	//
 	// If empty, Prometheus uses the default value (e.g. `/metrics`).
+	// +optional
 	Path string `json:"path,omitempty"`
 
 	// HTTP scheme to use for scraping.
@@ -554,14 +570,17 @@ type Endpoint struct {
 	// If empty, Prometheus uses the default value `http`.
 	//
 	// +kubebuilder:validation:Enum=http;https
+	// +optional
 	Scheme string `json:"scheme,omitempty"`
 
 	// params define optional HTTP URL parameters.
+	// +optional
 	Params map[string][]string `json:"params,omitempty"`
 
 	// Interval at which Prometheus scrapes the metrics from the target.
 	//
 	// If empty, Prometheus uses the global scrape interval.
+	// +optional
 	Interval Duration `json:"interval,omitempty"`
 
 	// Timeout after which Prometheus considers the scrape to be failed.
@@ -569,6 +588,7 @@ type Endpoint struct {
 	// If empty, Prometheus uses the global scrape timeout unless it is less
 	// than the target's scrape interval value in which the latter is used.
 	// The value cannot be greater than the scrape interval otherwise the operator will reject the resource.
+	// +optional
 	ScrapeTimeout Duration `json:"scrapeTimeout,omitempty"`
 
 	// TLS configuration to use when scraping the target.
@@ -579,6 +599,7 @@ type Endpoint struct {
 	// File to read bearer token for scraping the target.
 	//
 	// Deprecated: use `authorization` instead.
+	// +optional
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 
 	// `bearerTokenSecret` specifies a key of a Secret containing the bearer
@@ -600,6 +621,7 @@ type Endpoint struct {
 
 	// When true, `honorLabels` preserves the metric's labels when they collide
 	// with the target's labels.
+	// +optional
 	HonorLabels bool `json:"honorLabels,omitempty"`
 
 	// `honorTimestamps` controls whether Prometheus preserves the timestamps
@@ -694,15 +716,18 @@ type AttachMetadata struct {
 type OAuth2 struct {
 	// `clientId` specifies a key of a Secret or ConfigMap containing the
 	// OAuth2 client's ID.
+	// +required
 	ClientID SecretOrConfigMap `json:"clientId"`
 
 	// `clientSecret` specifies a key of a Secret containing the OAuth2
 	// client's secret.
+	// +required
 	ClientSecret v1.SecretKeySelector `json:"clientSecret"`
 
 	// `tokenURL` configures the URL to fetch the token from.
 	//
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	TokenURL string `json:"tokenUrl"`
 
 	// `scopes` defines the OAuth2 scopes used for the token request.
@@ -730,6 +755,7 @@ type OAuth2 struct {
 }
 
 type OAuth2ValidationError struct {
+	// +optional
 	err string
 }
 
@@ -767,18 +793,22 @@ func (o *OAuth2) Validate() error {
 type BasicAuth struct {
 	// `username` specifies a key of a Secret containing the username for
 	// authentication.
+	// +optional
 	Username v1.SecretKeySelector `json:"username,omitempty"`
 
 	// `password` specifies a key of a Secret containing the password for
 	// authentication.
+	// +optional
 	Password v1.SecretKeySelector `json:"password,omitempty"`
 }
 
 // SecretOrConfigMap allows to specify data as a Secret or ConfigMap. Fields are mutually exclusive.
 type SecretOrConfigMap struct {
 	// Secret containing data to use for the targets.
+	// +optional
 	Secret *v1.SecretKeySelector `json:"secret,omitempty"`
 	// ConfigMap containing data to use for the targets.
+	// +optional
 	ConfigMap *v1.ConfigMapKeySelector `json:"configMap,omitempty"`
 }
 
@@ -824,12 +854,15 @@ const (
 // +k8s:openapi-gen=true
 type SafeTLSConfig struct {
 	// Certificate authority used when verifying server certificates.
+	// +optional
 	CA SecretOrConfigMap `json:"ca,omitempty"`
 
 	// Client certificate to present when doing client-authentication.
+	// +optional
 	Cert SecretOrConfigMap `json:"cert,omitempty"`
 
 	// Secret containing the client key file for the targets.
+	// +optional
 	KeySecret *v1.SecretKeySelector `json:"keySecret,omitempty"`
 
 	// Used to verify the hostname for the targets.
@@ -889,12 +922,16 @@ func (c *SafeTLSConfig) Validate() error {
 // TLSConfig extends the safe TLS configuration with file parameters.
 // +k8s:openapi-gen=true
 type TLSConfig struct {
+	// +optional
 	SafeTLSConfig `json:",inline"`
 	// Path to the CA cert in the Prometheus container to use for the targets.
+	// +optional
 	CAFile string `json:"caFile,omitempty"`
 	// Path to the client cert file in the Prometheus container for the targets.
+	// +optional
 	CertFile string `json:"certFile,omitempty"`
 	// Path to the client key file in the Prometheus container for the targets.
+	// +optional
 	KeyFile string `json:"keyFile,omitempty"`
 }
 
@@ -953,8 +990,10 @@ func (c *TLSConfig) Validate() error {
 type NamespaceSelector struct {
 	// Boolean describing whether all namespaces are selected in contrast to a
 	// list restricting them.
+	// +optional
 	Any bool `json:"any,omitempty"`
 	// List of namespace names to select from.
+	// +optional
 	MatchNames []string `json:"matchNames,omitempty"`
 
 	// TODO(fabxc): this should embed metav1.LabelSelector eventually.
@@ -967,8 +1006,10 @@ type NamespaceSelector struct {
 type Argument struct {
 	// Name of the argument, e.g. "scrape.discovery-reload-interval".
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// Argument value, e.g. 30s. Can be empty for name-only arguments (e.g. --storage.tsdb.no-lockfile)
+	// +optional
 	Value string `json:"value,omitempty"`
 }
 
@@ -1028,6 +1069,11 @@ const (
 // +k8s:openapi-gen=true
 type ConfigResourceStatus struct {
 	// The list of workload resources (Prometheus or PrometheusAgent) which select the configuration resource.
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=resource
+	// +listMapKey=name
+	// +listMapKey=namespace
 	// +optional
 	Bindings []WorkloadBinding `json:"bindings,omitempty"`
 }
@@ -1082,5 +1128,6 @@ type ConfigResourceCondition struct {
 	// condition was set based upon. For instance, if `.metadata.generation` is
 	// currently 12, but the `.status.conditions[].observedGeneration` is 9, the
 	// condition is out of date with respect to the current state of the object.
+	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -47,9 +47,10 @@ const (
 // AlertmanagerConfig configures the Prometheus Alertmanager,
 // specifying how alerts should be grouped, inhibited and notified to external systems.
 type AlertmanagerConfig struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// +required
 	Spec AlertmanagerConfigSpec `json:"spec"`
 }
 
@@ -126,6 +127,7 @@ type Route struct {
 	// +optional
 	Continue bool `json:"continue,omitempty"`
 	// Child routes.
+	// +optional
 	Routes []apiextensionsv1.JSON `json:"routes,omitempty"`
 	// Note: this comment applies to the field definition above but appears
 	// below otherwise it gets included in the generated manifest.
@@ -161,40 +163,55 @@ func (r *Route) ChildRoutes() ([]Route, error) {
 type Receiver struct {
 	// Name of the receiver. Must be unique across all items from the list.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// List of OpsGenie configurations.
+	// +optional
 	OpsGenieConfigs []OpsGenieConfig `json:"opsgenieConfigs,omitempty"`
 	// List of PagerDuty configurations.
+	// +optional
 	PagerDutyConfigs []PagerDutyConfig `json:"pagerdutyConfigs,omitempty"`
 	// List of Discord configurations.
 	// +optional
 	DiscordConfigs []DiscordConfig `json:"discordConfigs,omitempty"`
 	// List of Slack configurations.
+	// +optional
 	SlackConfigs []SlackConfig `json:"slackConfigs,omitempty"`
 	// List of webhook configurations.
+	// +optional
 	WebhookConfigs []WebhookConfig `json:"webhookConfigs,omitempty"`
 	// List of WeChat configurations.
+	// +optional
 	WeChatConfigs []WeChatConfig `json:"wechatConfigs,omitempty"`
 	// List of Email configurations.
+	// +optional
 	EmailConfigs []EmailConfig `json:"emailConfigs,omitempty"`
 	// List of VictorOps configurations.
+	// +optional
 	VictorOpsConfigs []VictorOpsConfig `json:"victoropsConfigs,omitempty"`
 	// List of Pushover configurations.
+	// +optional
 	PushoverConfigs []PushoverConfig `json:"pushoverConfigs,omitempty"`
 	// List of SNS configurations
+	// +optional
 	SNSConfigs []SNSConfig `json:"snsConfigs,omitempty"`
 	// List of Telegram configurations.
+	// +optional
 	TelegramConfigs []TelegramConfig `json:"telegramConfigs,omitempty"`
 	// List of Webex configurations.
+	// +optional
 	WebexConfigs []WebexConfig `json:"webexConfigs,omitempty"`
 	// List of MSTeams configurations.
 	// It requires Alertmanager >= 0.26.0.
+	// +optional
 	MSTeamsConfigs []MSTeamsConfig `json:"msteamsConfigs,omitempty"`
 	// List of MSTeamsV2 configurations.
 	// It requires Alertmanager >= 0.28.0.
+	// +optional
 	MSTeamsV2Configs []MSTeamsV2Config `json:"msteamsv2Configs,omitempty"`
 	// List of RocketChat configurations.
 	// It requires Alertmanager >= 0.28.0.
+	// +optional
 	RocketChatConfigs []RocketChatConfig `json:"rocketchatConfigs,omitempty"`
 }
 
@@ -394,8 +411,10 @@ func (sc *SlackConfig) Validate() error {
 // https://api.slack.com/docs/message-buttons for more information.
 type SlackAction struct {
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Type string `json:"type"`
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Text string `json:"text"`
 	// +optional
 	URL string `json:"url,omitempty"`
@@ -439,6 +458,7 @@ func (sa *SlackAction) Validate() error {
 // for more information.
 type SlackConfirmationField struct {
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Text string `json:"text"`
 	// +optional
 	Title string `json:"title,omitempty"`
@@ -462,8 +482,10 @@ func (scf *SlackConfirmationField) Validate() error {
 // See https://api.slack.com/docs/message-attachments#fields for more information.
 type SlackField struct {
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Title string `json:"title"`
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Value string `json:"value"`
 	// +optional
 	Short *bool `json:"short,omitempty"`
@@ -590,6 +612,7 @@ type OpsGenieConfigResponder struct {
 	Username string `json:"username,omitempty"`
 	// Type of responder.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Type string `json:"type"`
 }
 
@@ -708,6 +731,7 @@ type WeChatConfig struct {
 	// +optional
 	ToTag string `json:"toTag,omitempty"`
 	// API request data as defined by the WeChat API.
+	// +optional
 	Message string `json:"message,omitempty"`
 	// +optional
 	MessageType string `json:"messageType,omitempty"`
@@ -739,16 +763,19 @@ type EmailConfig struct {
 	// The secret's key that contains the password to use for authentication.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
+	// +optional
 	AuthPassword *v1.SecretKeySelector `json:"authPassword,omitempty"`
 	// The secret's key that contains the CRAM-MD5 secret.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
+	// +optional
 	AuthSecret *v1.SecretKeySelector `json:"authSecret,omitempty"`
 	// The identity to use for authentication.
 	// +optional
 	AuthIdentity string `json:"authIdentity,omitempty"`
 	// Further headers email header key/value pairs. Overrides any headers
 	// previously set by the notification implementation.
+	// +optional
 	Headers []KeyValue `json:"headers,omitempty"`
 	// The HTML body of the email notification.
 	// +optional
@@ -927,7 +954,7 @@ type TelegramConfig struct {
 	//
 	// Either `botToken` or `botTokenFile` is required.
 	//
-	//+optional
+	// +optional
 	BotToken *v1.SecretKeySelector `json:"botToken,omitempty"`
 	// File to read the Telegram bot token from. It is mutually exclusive with `botToken`.
 	// Either `botToken` or `botTokenFile` is required.
@@ -965,7 +992,7 @@ type MSTeamsConfig struct {
 	// +optional
 	SendResolved *bool `json:"sendResolved,omitempty"`
 	// MSTeams webhook URL.
-	// +kubebuilder:validation:Required
+	// +required
 	WebhookURL v1.SecretKeySelector `json:"webhookUrl"`
 	// Message title template.
 	// +optional
@@ -1109,13 +1136,16 @@ type RocketChatActionConfig struct {
 type InhibitRule struct {
 	// Matchers that have to be fulfilled in the alerts to be muted. The
 	// operator enforces that the alert matches the resource's namespace.
+	// +optional
 	TargetMatch []Matcher `json:"targetMatch,omitempty"`
 	// Matchers for which one or more alerts have to exist for the inhibition
 	// to take effect. The operator enforces that the alert matches the
 	// resource's namespace.
+	// +optional
 	SourceMatch []Matcher `json:"sourceMatch,omitempty"`
 	// Labels that must have an equal value in the source and target alert for
 	// the inhibition to take effect.
+	// +optional
 	Equal []string `json:"equal,omitempty"`
 }
 
@@ -1123,8 +1153,10 @@ type InhibitRule struct {
 type KeyValue struct {
 	// Key of the tuple.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Key string `json:"key"`
 	// Value of the tuple.
+	// +required
 	Value string `json:"value"`
 }
 
@@ -1132,6 +1164,7 @@ type KeyValue struct {
 type Matcher struct {
 	// Label to match.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// Label value to match.
 	// +optional
@@ -1222,9 +1255,10 @@ func openMetricsEscape(s string) string {
 // MuteTimeInterval specifies the periods in time when notifications will be muted
 type MuteTimeInterval struct {
 	// Name of the time interval
-	// +kubebuilder:validation:Required
+	// +required
 	Name string `json:"name,omitempty"`
 	// TimeIntervals is a list of TimeInterval
+	// +optional
 	TimeIntervals []TimeInterval `json:"timeIntervals,omitempty"`
 }
 
@@ -1254,8 +1288,10 @@ type Time string
 // TimeRange defines a start and end time in 24hr format
 type TimeRange struct {
 	// StartTime is the start time in 24hr format.
+	// +optional
 	StartTime Time `json:"startTime,omitempty"`
 	// EndTime is the end time in 24hr format.
+	// +optional
 	EndTime Time `json:"endTime,omitempty"`
 }
 
@@ -1269,10 +1305,12 @@ type DayOfMonthRange struct {
 	// Start of the inclusive range
 	// +kubebuilder:validation:Minimum=-31
 	// +kubebuilder:validation:Maximum=31
+	// +optional
 	Start int `json:"start,omitempty"`
 	// End of the inclusive range
 	// +kubebuilder:validation:Minimum=-31
 	// +kubebuilder:validation:Maximum=31
+	// +optional
 	End int `json:"end,omitempty"`
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
@@ -57,14 +57,17 @@ func (l *PrometheusAgent) GetStatus() monitoringv1.PrometheusStatus {
 //
 // The CRD is very similar to the `Prometheus` CRD except for features which aren't available in agent mode like rule evaluation, persistent storage and Thanos sidecar.
 type PrometheusAgent struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the desired behavior of the Prometheus agent. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +required
 	Spec PrometheusAgentSpec `json:"spec"`
 	// Most recent observed status of the Prometheus cluster. Read-only.
 	// More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +optional
 	Status monitoringv1.PrometheusStatus `json:"status,omitempty"`
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -115,9 +115,10 @@ type K8SSelectorConfig struct {
 // ScrapeConfig defines a namespaced Prometheus scrape_config to be aggregated across
 // multiple namespaces into the Prometheus configuration.
 type ScrapeConfig struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// +required
 	Spec ScrapeConfigSpec `json:"spec"`
 }
 
@@ -132,8 +133,10 @@ type ScrapeConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// List of ScrapeConfigs
+	// +required
 	Items []ScrapeConfig `json:"items"`
 }
 
@@ -973,6 +976,7 @@ type KumaSDConfig struct {
 // +k8s:openapi-gen=true
 type EurekaSDConfig struct {
 	// The URL to connect to the Eureka server.
+	// +kubebuilder:validation:Pattern:="^http(s)?://.+$"
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	Server string `json:"server"`
@@ -1093,8 +1097,10 @@ type HetznerSDConfig struct {
 	// +optional
 	TLSConfig *v1.SafeTLSConfig `json:"tlsConfig,omitempty"`
 	// The port to scrape metrics from.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int32 `json:"port,omitempty"`
 	// The time after which the servers are refreshed.
 	// +optional
 	RefreshInterval *v1.Duration `json:"refreshInterval,omitempty"`
@@ -1170,7 +1176,6 @@ type OVHCloudSDConfig struct {
 	// +required
 	ConsumerKey corev1.SecretKeySelector `json:"consumerKey"`
 	// Service of the targets to retrieve. Must be `VPS` or `DedicatedServer`.
-	// +kubebuilder:validation:Enum=VPS;DedicatedServer
 	// +required
 	Service OVHService `json:"service"`
 	// Custom endpoint to be used.
@@ -1296,6 +1301,7 @@ type PuppetDBSDConfig struct {
 	// Port to scrape the metrics from.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
+	// +optional
 	Port *int32 `json:"port,omitempty"`
 	// Optional HTTP basic authentication information.
 	// Cannot be set at the same time as `authorization`, or `oauth2`.
@@ -1349,6 +1355,7 @@ type LightSailSDConfig struct {
 	// If using the public IP address, this must instead be specified in the relabeling rule.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
+	// +optional
 	Port *int32 `json:"port,omitempty"`
 	// Optional HTTP basic authentication information.
 	// Cannot be set at the same time as `authorization`, or `oauth2`.

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/validation.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/validation.go
@@ -305,8 +305,10 @@ func (mr MonthRange) Parse() (*ParsedRange, error) {
 // +kubebuilder:object:generate:=false
 type ParsedRange struct {
 	// Start is the beginning of the range
+	// +optional
 	Start int `json:"start,omitempty"`
 	// End of the range
+	// +optional
 	End int `json:"end,omitempty"`
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -1027,7 +1027,7 @@ func (in *HetznerSDConfig) DeepCopyInto(out *HetznerSDConfig) {
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.RefreshInterval != nil {

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -47,9 +47,10 @@ const (
 //
 // `Alertmanager` objects select `AlertmanagerConfig` objects using label and namespace selectors.
 type AlertmanagerConfig struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// +required
 	Spec AlertmanagerConfigSpec `json:"spec"`
 }
 
@@ -123,6 +124,7 @@ type Route struct {
 	// +optional
 	Continue bool `json:"continue,omitempty"`
 	// Child routes.
+	// +optional
 	Routes []apiextensionsv1.JSON `json:"routes,omitempty"`
 	// Note: this comment applies to the field definition above but appears
 	// below otherwise it gets included in the generated manifest.
@@ -158,39 +160,55 @@ func (r *Route) ChildRoutes() ([]Route, error) {
 type Receiver struct {
 	// Name of the receiver. Must be unique across all items from the list.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// List of OpsGenie configurations.
+	// +optional
 	OpsGenieConfigs []OpsGenieConfig `json:"opsgenieConfigs,omitempty"`
 	// List of PagerDuty configurations.
+	// +optional
 	PagerDutyConfigs []PagerDutyConfig `json:"pagerdutyConfigs,omitempty"`
 	// List of Slack configurations.
+	// +optional
 	DiscordConfigs []DiscordConfig `json:"discordConfigs,omitempty"`
 	// List of Slack configurations.
+	// +optional
 	SlackConfigs []SlackConfig `json:"slackConfigs,omitempty"`
 	// List of webhook configurations.
+	// +optional
 	WebhookConfigs []WebhookConfig `json:"webhookConfigs,omitempty"`
 	// List of WeChat configurations.
+	// +optional
 	WeChatConfigs []WeChatConfig `json:"wechatConfigs,omitempty"`
 	// List of Email configurations.
+	// +optional
 	EmailConfigs []EmailConfig `json:"emailConfigs,omitempty"`
 	// List of VictorOps configurations.
+	// +optional
 	VictorOpsConfigs []VictorOpsConfig `json:"victoropsConfigs,omitempty"`
 	// List of Pushover configurations.
+	// +optional
 	PushoverConfigs []PushoverConfig `json:"pushoverConfigs,omitempty"`
 	// List of SNS configurations
+	// +optional
 	SNSConfigs []SNSConfig `json:"snsConfigs,omitempty"`
 	// List of Telegram configurations.
+	// +optional
 	TelegramConfigs []TelegramConfig `json:"telegramConfigs,omitempty"`
 	// List of Webex configurations.
+	// +optional
 	WebexConfigs []WebexConfig `json:"webexConfigs,omitempty"`
 	// List of MSTeams configurations.
 	// It requires Alertmanager >= 0.26.0.
+	// +optional
 	MSTeamsConfigs []MSTeamsConfig `json:"msteamsConfigs,omitempty"`
 	// List of MSTeamsV2 configurations.
 	// It requires Alertmanager >= 0.28.0.
+	// +optional
 	MSTeamsV2Configs []MSTeamsV2Config `json:"msteamsv2Configs,omitempty"`
 	// List of RocketChat configurations.
 	// It requires Alertmanager >= 0.28.0.
+	// +optional
 	RocketChatConfigs []RocketChatConfig `json:"rocketchatConfigs,omitempty"`
 }
 
@@ -390,8 +408,10 @@ func (sc *SlackConfig) Validate() error {
 // https://api.slack.com/docs/message-buttons for more information.
 type SlackAction struct {
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Type string `json:"type"`
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Text string `json:"text"`
 	// +optional
 	URL string `json:"url,omitempty"`
@@ -435,6 +455,7 @@ func (sa *SlackAction) Validate() error {
 // for more information.
 type SlackConfirmationField struct {
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Text string `json:"text"`
 	// +optional
 	Title string `json:"title,omitempty"`
@@ -458,8 +479,10 @@ func (scf *SlackConfirmationField) Validate() error {
 // See https://api.slack.com/docs/message-attachments#fields for more information.
 type SlackField struct {
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Title string `json:"title"`
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Value string `json:"value"`
 	// +optional
 	Short *bool `json:"short,omitempty"`
@@ -570,6 +593,7 @@ func (o *OpsGenieConfig) Validate() error {
 
 // OpsGenieConfigResponder defines a responder to an incident.
 // One of `id`, `name` or `username` has to be defined.
+// +kubebuilder:validation:OneOf=ID,Name,Username
 type OpsGenieConfigResponder struct {
 	// ID of the responder.
 	// +optional
@@ -583,6 +607,7 @@ type OpsGenieConfigResponder struct {
 	// Type of responder.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Enum=team;teams;user;escalation;schedule
+	// +required
 	Type string `json:"type"`
 }
 
@@ -661,6 +686,7 @@ type WebexConfig struct {
 
 	// The HTTP client's configuration.
 	// You must use this configuration to supply the bot token as part of the HTTP `Authorization` header.
+	// +optional
 	HTTPConfig *HTTPConfig `json:"httpConfig,omitempty"`
 
 	// Message template
@@ -699,6 +725,7 @@ type WeChatConfig struct {
 	// +optional
 	ToTag string `json:"toTag,omitempty"`
 	// API request data as defined by the WeChat API.
+	// +optional
 	Message string `json:"message,omitempty"`
 	// +optional
 	MessageType string `json:"messageType,omitempty"`
@@ -730,16 +757,19 @@ type EmailConfig struct {
 	// The secret's key that contains the password to use for authentication.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
+	// +optional
 	AuthPassword *SecretKeySelector `json:"authPassword,omitempty"`
 	// The secret's key that contains the CRAM-MD5 secret.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
+	// +optional
 	AuthSecret *SecretKeySelector `json:"authSecret,omitempty"`
 	// The identity to use for authentication.
 	// +optional
 	AuthIdentity string `json:"authIdentity,omitempty"`
 	// Further headers email header key/value pairs. Overrides any headers
 	// previously set by the notification implementation.
+	// +optional
 	Headers []KeyValue `json:"headers,omitempty"`
 	// The HTML body of the email notification.
 	// +optional
@@ -918,7 +948,7 @@ type TelegramConfig struct {
 	//
 	// Either `botToken` or `botTokenFile` is required.
 	//
-	//+optional
+	// +optional
 	BotToken *SecretKeySelector `json:"botToken,omitempty"`
 	// File to read the Telegram bot token from. It is mutually exclusive with `botToken`.
 	// Either `botToken` or `botTokenFile` is required.
@@ -956,7 +986,7 @@ type MSTeamsConfig struct {
 	// +optional
 	SendResolved *bool `json:"sendResolved,omitempty"`
 	// MSTeams webhook URL.
-	// +kubebuilder:validation:Required
+	// +required
 	WebhookURL v1.SecretKeySelector `json:"webhookUrl"`
 	// Message title template.
 	// +optional
@@ -1100,13 +1130,16 @@ type RocketChatActionConfig struct {
 type InhibitRule struct {
 	// Matchers that have to be fulfilled in the alerts to be muted. The
 	// operator enforces that the alert matches the resource's namespace.
+	// +optional
 	TargetMatch []Matcher `json:"targetMatch,omitempty"`
 	// Matchers for which one or more alerts have to exist for the inhibition
 	// to take effect. The operator enforces that the alert matches the
 	// resource's namespace.
+	// +optional
 	SourceMatch []Matcher `json:"sourceMatch,omitempty"`
 	// Labels that must have an equal value in the source and target alert for
 	// the inhibition to take effect.
+	// +optional
 	Equal []string `json:"equal,omitempty"`
 }
 
@@ -1114,8 +1147,10 @@ type InhibitRule struct {
 type KeyValue struct {
 	// Key of the tuple.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Key string `json:"key"`
 	// Value of the tuple.
+	// +required
 	Value string `json:"value"`
 }
 
@@ -1123,6 +1158,7 @@ type KeyValue struct {
 type Matcher struct {
 	// Label to match.
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// Label value to match.
 	// +optional
@@ -1131,6 +1167,7 @@ type Matcher struct {
 	// match) or `!~` (not regex match).
 	// Negative operators (`!=` and `!~`) require Alertmanager >= v0.22.0.
 	// +kubebuilder:validation:Enum=!=;=;=~;!~
+	// +optional
 	MatchType MatchType `json:"matchType,omitempty"`
 }
 
@@ -1172,11 +1209,11 @@ func (mt MatchType) Valid() bool {
 type SecretKeySelector struct {
 	// The name of the secret in the object's namespace to select from.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Required
+	// +required
 	Name string `json:"name"`
 	// The key of the secret to select from.  Must be a valid secret key.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Required
+	// +required
 	Key string `json:"key"`
 }
 
@@ -1221,9 +1258,10 @@ func openMetricsEscape(s string) string {
 // TimeInterval specifies the periods in time when notifications will be muted or active.
 type TimeInterval struct {
 	// Name of the time interval.
-	// +kubebuilder:validation:Required
+	// +required
 	Name string `json:"name,omitempty"`
 	// TimeIntervals is a list of TimePeriod.
+	// +optional
 	TimeIntervals []TimePeriod `json:"timeIntervals,omitempty"`
 }
 
@@ -1253,8 +1291,10 @@ type Time string
 // TimeRange defines a start and end time in 24hr format
 type TimeRange struct {
 	// StartTime is the start time in 24hr format.
+	// +optional
 	StartTime Time `json:"startTime,omitempty"`
 	// EndTime is the end time in 24hr format.
+	// +optional
 	EndTime Time `json:"endTime,omitempty"`
 }
 
@@ -1268,10 +1308,12 @@ type DayOfMonthRange struct {
 	// Start of the inclusive range
 	// +kubebuilder:validation:Minimum=-31
 	// +kubebuilder:validation:Maximum=31
+	// +optional
 	Start int `json:"start,omitempty"`
 	// End of the inclusive range
 	// +kubebuilder:validation:Minimum=-31
 	// +kubebuilder:validation:Maximum=31
+	// +optional
 	End int `json:"end,omitempty"`
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1/validation.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1/validation.go
@@ -304,8 +304,10 @@ func (mr MonthRange) Parse() (*ParsedRange, error) {
 // +kubebuilder:object:generate:=false
 type ParsedRange struct {
 	// Start is the beginning of the range
+	// +optional
 	Start int `json:"start,omitempty"`
 	// End of the range
+	// +optional
 	End int `json:"end,omitempty"`
 }
 

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/alertmanager.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/alertmanager.go
@@ -41,6 +41,7 @@ func Alertmanager(name, namespace string) *AlertmanagerApplyConfiguration {
 	b.WithAPIVersion("monitoring.coreos.com/v1")
 	return b
 }
+func (b AlertmanagerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -216,8 +217,24 @@ func (b *AlertmanagerApplyConfiguration) WithStatus(value *AlertmanagerStatusApp
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *AlertmanagerApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *AlertmanagerApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *AlertmanagerApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *AlertmanagerApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/embeddedpersistentvolumeclaim.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/embeddedpersistentvolumeclaim.go
@@ -38,6 +38,7 @@ func EmbeddedPersistentVolumeClaim() *EmbeddedPersistentVolumeClaimApplyConfigur
 	b.WithAPIVersion("monitoring.coreos.com/v1")
 	return b
 }
+func (b EmbeddedPersistentVolumeClaimApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -114,4 +115,14 @@ func (b *EmbeddedPersistentVolumeClaimApplyConfiguration) WithSpec(value corev1.
 func (b *EmbeddedPersistentVolumeClaimApplyConfiguration) WithStatus(value corev1.PersistentVolumeClaimStatus) *EmbeddedPersistentVolumeClaimApplyConfiguration {
 	b.Status = &value
 	return b
+}
+
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *EmbeddedPersistentVolumeClaimApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *EmbeddedPersistentVolumeClaimApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/podmonitor.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/podmonitor.go
@@ -40,6 +40,7 @@ func PodMonitor(name, namespace string) *PodMonitorApplyConfiguration {
 	b.WithAPIVersion("monitoring.coreos.com/v1")
 	return b
 }
+func (b PodMonitorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -207,8 +208,24 @@ func (b *PodMonitorApplyConfiguration) WithSpec(value *PodMonitorSpecApplyConfig
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *PodMonitorApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *PodMonitorApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *PodMonitorApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *PodMonitorApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/probe.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/probe.go
@@ -40,6 +40,7 @@ func Probe(name, namespace string) *ProbeApplyConfiguration {
 	b.WithAPIVersion("monitoring.coreos.com/v1")
 	return b
 }
+func (b ProbeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -207,8 +208,24 @@ func (b *ProbeApplyConfiguration) WithSpec(value *ProbeSpecApplyConfiguration) *
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *ProbeApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *ProbeApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *ProbeApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *ProbeApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/prometheus.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/prometheus.go
@@ -41,6 +41,7 @@ func Prometheus(name, namespace string) *PrometheusApplyConfiguration {
 	b.WithAPIVersion("monitoring.coreos.com/v1")
 	return b
 }
+func (b PrometheusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -216,8 +217,24 @@ func (b *PrometheusApplyConfiguration) WithStatus(value *PrometheusStatusApplyCo
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *PrometheusApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *PrometheusApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *PrometheusApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *PrometheusApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/prometheusrule.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/prometheusrule.go
@@ -40,6 +40,7 @@ func PrometheusRule(name, namespace string) *PrometheusRuleApplyConfiguration {
 	b.WithAPIVersion("monitoring.coreos.com/v1")
 	return b
 }
+func (b PrometheusRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -207,8 +208,24 @@ func (b *PrometheusRuleApplyConfiguration) WithSpec(value *PrometheusRuleSpecApp
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *PrometheusRuleApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *PrometheusRuleApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *PrometheusRuleApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *PrometheusRuleApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/servicemonitor.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/servicemonitor.go
@@ -41,6 +41,7 @@ func ServiceMonitor(name, namespace string) *ServiceMonitorApplyConfiguration {
 	b.WithAPIVersion("monitoring.coreos.com/v1")
 	return b
 }
+func (b ServiceMonitorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -216,8 +217,24 @@ func (b *ServiceMonitorApplyConfiguration) WithStatus(value *ConfigResourceStatu
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *ServiceMonitorApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *ServiceMonitorApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *ServiceMonitorApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *ServiceMonitorApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/thanosruler.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1/thanosruler.go
@@ -41,6 +41,7 @@ func ThanosRuler(name, namespace string) *ThanosRulerApplyConfiguration {
 	b.WithAPIVersion("monitoring.coreos.com/v1")
 	return b
 }
+func (b ThanosRulerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -216,8 +217,24 @@ func (b *ThanosRulerApplyConfiguration) WithStatus(value *ThanosRulerStatusApply
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *ThanosRulerApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *ThanosRulerApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *ThanosRulerApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *ThanosRulerApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1/alertmanagerconfig.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1/alertmanagerconfig.go
@@ -40,6 +40,7 @@ func AlertmanagerConfig(name, namespace string) *AlertmanagerConfigApplyConfigur
 	b.WithAPIVersion("monitoring.coreos.com/v1alpha1")
 	return b
 }
+func (b AlertmanagerConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -207,8 +208,24 @@ func (b *AlertmanagerConfigApplyConfiguration) WithSpec(value *AlertmanagerConfi
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *AlertmanagerConfigApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *AlertmanagerConfigApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *AlertmanagerConfigApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *AlertmanagerConfigApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1/hetznersdconfig.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1/hetznersdconfig.go
@@ -33,7 +33,7 @@ type HetznerSDConfigApplyConfiguration struct {
 	FollowRedirects                  *bool                               `json:"followRedirects,omitempty"`
 	EnableHTTP2                      *bool                               `json:"enableHTTP2,omitempty"`
 	TLSConfig                        *v1.SafeTLSConfigApplyConfiguration `json:"tlsConfig,omitempty"`
-	Port                             *int                                `json:"port,omitempty"`
+	Port                             *int32                              `json:"port,omitempty"`
 	RefreshInterval                  *monitoringv1.Duration              `json:"refreshInterval,omitempty"`
 	LabelSelector                    *string                             `json:"labelSelector,omitempty"`
 }
@@ -141,7 +141,7 @@ func (b *HetznerSDConfigApplyConfiguration) WithTLSConfig(value *v1.SafeTLSConfi
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *HetznerSDConfigApplyConfiguration) WithPort(value int) *HetznerSDConfigApplyConfiguration {
+func (b *HetznerSDConfigApplyConfiguration) WithPort(value int32) *HetznerSDConfigApplyConfiguration {
 	b.Port = &value
 	return b
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagent.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagent.go
@@ -42,6 +42,7 @@ func PrometheusAgent(name, namespace string) *PrometheusAgentApplyConfiguration 
 	b.WithAPIVersion("monitoring.coreos.com/v1alpha1")
 	return b
 }
+func (b PrometheusAgentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -217,8 +218,24 @@ func (b *PrometheusAgentApplyConfiguration) WithStatus(value *monitoringv1.Prome
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *PrometheusAgentApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *PrometheusAgentApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *PrometheusAgentApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *PrometheusAgentApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfig.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfig.go
@@ -40,6 +40,7 @@ func ScrapeConfig(name, namespace string) *ScrapeConfigApplyConfiguration {
 	b.WithAPIVersion("monitoring.coreos.com/v1alpha1")
 	return b
 }
+func (b ScrapeConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -207,8 +208,24 @@ func (b *ScrapeConfigApplyConfiguration) WithSpec(value *ScrapeConfigSpecApplyCo
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *ScrapeConfigApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *ScrapeConfigApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *ScrapeConfigApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *ScrapeConfigApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1beta1/alertmanagerconfig.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1beta1/alertmanagerconfig.go
@@ -40,6 +40,7 @@ func AlertmanagerConfig(name, namespace string) *AlertmanagerConfigApplyConfigur
 	b.WithAPIVersion("monitoring.coreos.com/v1beta1")
 	return b
 }
+func (b AlertmanagerConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
@@ -207,8 +208,24 @@ func (b *AlertmanagerConfigApplyConfiguration) WithSpec(value *AlertmanagerConfi
 	return b
 }
 
+// GetKind retrieves the value of the Kind field in the declarative configuration.
+func (b *AlertmanagerConfigApplyConfiguration) GetKind() *string {
+	return b.TypeMetaApplyConfiguration.Kind
+}
+
+// GetAPIVersion retrieves the value of the APIVersion field in the declarative configuration.
+func (b *AlertmanagerConfigApplyConfiguration) GetAPIVersion() *string {
+	return b.TypeMetaApplyConfiguration.APIVersion
+}
+
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *AlertmanagerConfigApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
 	return b.ObjectMetaApplyConfiguration.Name
+}
+
+// GetNamespace retrieves the value of the Namespace field in the declarative configuration.
+func (b *AlertmanagerConfigApplyConfiguration) GetNamespace() *string {
+	b.ensureObjectMetaApplyConfigurationExists()
+	return b.ObjectMetaApplyConfiguration.Namespace
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -682,13 +682,13 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.85.0
+# github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.85.1-0.20250908125250-6958a7c31c4a
 ## explicit; go 1.24.0
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1
-# github.com/prometheus-operator/prometheus-operator/pkg/client v0.85.0
+# github.com/prometheus-operator/prometheus-operator/pkg/client v0.85.1-0.20250908125250-6958a7c31c4a
 ## explicit; go 1.24.0
 github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1
 github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1


### PR DESCRIPTION
The commit we're pinning to is a fix for missing `omitzero` tag on a recently added `ServiceMonitor.status` field.

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Pins proemtheus-operator Go modules to https://github.com/prometheus-operator/prometheus-operator/commit/6958a7c31c4ad05b6e7f51172edc26bd3cd059be commit to fix the issue with `status` field in `ServiceMonitor` not being omitted when it's empty and breaking the operator when running in a cluster with `ServiceMonitor` that doesn't include the `status` field.

**Which issue is resolved by this Pull Request:**
Fixes https://github.com/scylladb/scylla-operator/issues/2963.
