### PR TITLE
Add mflendrich to review autoassignees

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,6 +9,7 @@ aliases:
   operator-review-autoassignees:
   # Subset of operator-team that will be automatically requested for reviews in PRs.
   - czeslavo
+  - mflendrich
   - rzetelskik
   operator-approvers:
   # Subset of operator-team that has "approve" rights.


### PR DESCRIPTION
Updates `OWNERS_ALIASES` to include myself in automatic review assignment to distribute the load better.

/kind cleanup
/priority important-longterm