### PR TITLE
Unify NodeConfig resource name in docs and examples

### DIFF
--- a/docs/source/.internal/wait-for-status-conditions.nodeconfig.code-block.md
+++ b/docs/source/.internal/wait-for-status-conditions.nodeconfig.code-block.md
@@ -1,5 +1,5 @@
 :::{code-block} bash
-kubectl wait --timeout=10m --for='condition=Progressing=False' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
-kubectl wait --timeout=10m --for='condition=Degraded=False' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
-kubectl wait --timeout=10m --for='condition=Available=True' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
+kubectl wait --timeout=10m --for='condition=Progressing=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
+kubectl wait --timeout=10m --for='condition=Degraded=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
+kubectl wait --timeout=10m --for='condition=Available=True' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
 :::

--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -155,9 +155,8 @@ kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.
 Performance tuning is enabled for all nodes that are selected by [NodeConfig](../resources/nodeconfigs.md) by default, unless opted-out.
 :::
 
-:::{code-block} shell
-# Wait for NodeConfig to apply changes to the Kubernetes nodes.
-kubectl wait --for='condition=Reconciled' --timeout=10m nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
+After applying the manifest, wait for the NodeConfig to apply changes to the Kubernetes nodes.
+:::{include} ./../.internal/wait-for-status-conditions.nodeconfig.code-block.md
 :::
 
 ### Local CSI driver

--- a/docs/source/resources/nodeconfigs.md
+++ b/docs/source/resources/nodeconfigs.md
@@ -8,7 +8,7 @@ NodeConfig is an API object that helps you set up and tune the nodes.
 apiVersion: scylla.scylladb.com/v1alpha1
 kind: NodeConfig
 metadata:
-  name: scylladb-pool-1
+  name: scylladb-nodepool-1
 spec:
   localDiskSetup:
     raids:
@@ -53,11 +53,11 @@ Given NodeConfig specification needs to reference local disk by names or that th
 NodeConfig have the standard aggregated conditions to easily check whether everything went fine:
 
 :::{code-block} bash
-kubectl get nodeconfigs.scylla.scylladb.com/scylladb-pool-1
+kubectl get nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
 :::
 :::{code-block} console
 NAME              AVAILABLE   PROGRESSING   DEGRADED   AGE
-scylladb-pool-1   True        False         False      37d
+scylladb-nodepool-1   True        False         False      37d
 :::
 
 or programmatically wait for it:

--- a/examples/common/nodeconfig-alpha.yaml
+++ b/examples/common/nodeconfig-alpha.yaml
@@ -1,7 +1,7 @@
 apiVersion: scylla.scylladb.com/v1alpha1
 kind: NodeConfig
 metadata:
-  name: cluster
+  name: scylladb-nodepool-1
 spec:
   placement:
     nodeSelector:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** NodeConfig examples and related commands in our docs use different resource names leading to potential errors on command execution.
```
kubectl wait --timeout=10m --for='condition=Progressing=False' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
kubectl wait --timeout=10m --for='condition=Degraded=False' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
kubectl wait --timeout=10m --for='condition=Available=True' nodeconfigs.scylla.scylladb.com/scylladb-pool-1
Error from server (NotFound): nodeconfigs.scylla.scylladb.com "scylladb-pool-1" not found
Error from server (NotFound): nodeconfigs.scylla.scylladb.com "scylladb-pool-1" not found
Error from server (NotFound): nodeconfigs.scylla.scylladb.com "scylladb-pool-1" not found
```

This PR unifies the names. It also replaces waiting for the deprecated `Reconciled` condition with the standard set of conditions.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-longterm