### PR TITLE
[WIP] Fix remaining loop devices manipulations in NodeSetup E2Es

### DIFF
--- a/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
@@ -647,15 +647,15 @@ var _ = g.Describe("Node Setup", framework.Serial, func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Overwriting the corrupted filesystem")
-		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mkfs", "-t", string(scyllav1alpha1.XFSFilesystem), "-b", fmt.Sprintf("size=%s", blockSize), "-K", "-f", hostDevicePath)
+		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "mkfs", "-t", string(scyllav1alpha1.XFSFilesystem), "-b", fmt.Sprintf("size=%s", blockSize), "-K", "-f", devicePathInContainer)
 		o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 		framework.By("Zeroing XFS log")
-		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-L", "-f", hostDevicePath)
+		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-L", "-f", devicePathInContainer)
 		o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 		framework.By("Verifying the filesystem's integrity")
-		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-o", "force_geometry", "-f", "-n", hostDevicePath)
+		stdout, stderr, err = executeInPod(ctx, f.ClientConfig(), f.KubeClient().CoreV1(), clientPod, "xfs_repair", "-o", "force_geometry", "-f", "-n", devicePathInContainer)
 		o.Expect(err).NotTo(o.HaveOccurred(), stdout, stderr)
 
 		framework.By("Waiting for NodeConfig to roll out")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** It appears that when fixing the problem described in https://github.com/scylladb/scylla-operator/pull/2743, I missed a couple of commands that still cause flakiness. This PR should solve it.

**Which issue is resolved by this Pull Request:**
Should fix https://github.com/scylladb/scylla-operator/issues/2550.
