### PR TITLE
Don't emit FilesystemCreated when device already formatted

### DIFF
--- a/pkg/disks/fs.go
+++ b/pkg/disks/fs.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/utils/exec"
 )
 
+// MakeFS creates a filesystem of type fsType on the given device with the specified block size.
+// It returns a boolean indicating whether there were any changes made (i.e., if the filesystem was created).
 func MakeFS(ctx context.Context, executor exec.Interface, device string, blockSize int, fsType string) (bool, error) {
 	existingFs, err := blkutils.GetFilesystemType(ctx, executor, device)
 	if err != nil {
@@ -19,7 +21,7 @@ func MakeFS(ctx context.Context, executor exec.Interface, device string, blockSi
 	}
 
 	if existingFs == fsType {
-		return true, nil
+		return false, nil
 	}
 	if len(existingFs) > 0 {
 		return false, fmt.Errorf("can't format device %q with filesystem %q: already formatted with conflicting filesystem %q", device, fsType, existingFs)

--- a/pkg/disks/fs_test.go
+++ b/pkg/disks/fs_test.go
@@ -20,7 +20,7 @@ func TestMakeFS(t *testing.T) {
 		blockSize        int
 		fsType           string
 		expectedCommands []exectest.Command
-		expectedFinished bool
+		expectedChanged  bool
 		expectedErr      error
 	}{
 		{
@@ -37,8 +37,8 @@ func TestMakeFS(t *testing.T) {
 					Err:    nil,
 				},
 			},
-			expectedFinished: true,
-			expectedErr:      nil,
+			expectedChanged: false,
+			expectedErr:     nil,
 		},
 		{
 			name:      "fail if there's already a different filesystem",
@@ -54,8 +54,8 @@ func TestMakeFS(t *testing.T) {
 					Err:    nil,
 				},
 			},
-			expectedFinished: false,
-			expectedErr:      fmt.Errorf(`can't format device "/dev/md0" with filesystem "xfs": already formatted with conflicting filesystem "ext4"`),
+			expectedChanged: false,
+			expectedErr:     fmt.Errorf(`can't format device "/dev/md0" with filesystem "xfs": already formatted with conflicting filesystem "ext4"`),
 		},
 		{
 			name:      "format the device if existing disk filesystem is empty",
@@ -78,8 +78,8 @@ func TestMakeFS(t *testing.T) {
 					Err:    nil,
 				},
 			},
-			expectedFinished: true,
-			expectedErr:      nil,
+			expectedChanged: true,
+			expectedErr:     nil,
 		},
 	}
 
@@ -96,8 +96,8 @@ func TestMakeFS(t *testing.T) {
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Fatalf("expected %v error, got %v", tc.expectedErr, err)
 			}
-			if !reflect.DeepEqual(finished, tc.expectedFinished) {
-				t.Fatalf("expected finished %v, got %v", tc.expectedFinished, finished)
+			if !reflect.DeepEqual(finished, tc.expectedChanged) {
+				t.Fatalf("expected finished %v, got %v", tc.expectedChanged, finished)
 			}
 			if executor.CommandCalls != len(tc.expectedCommands) {
 				t.Fatalf("expected %d command calls, got %d", len(tc.expectedCommands), executor.CommandCalls)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** It fixes a bug that caused the emission of `FilesystemCreated` events even when a device was already formatted.

[Here](https://github.com/scylladb/scylla-operator/blob/6d673e2aaba4070a21460f8534cf69d632d67508/pkg/controller/nodesetup/sync_filesystems.go#L38) is the only production call of `MakeFS` - it treats the returned boolean as "changed", not "completed".

