### PR TITLE
Collect logs of terminated containers

### DIFF
--- a/pkg/gather/collect/podcollector.go
+++ b/pkg/gather/collect/podcollector.go
@@ -182,6 +182,14 @@ func (c *PodCollector) collectContainerLogs(ctx context.Context, logsDir string,
 		}
 	}
 
+	if cs.State.Terminated != nil {
+		logOptions.Previous = false
+		err = writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".terminated"), podMeta.Name, logOptions)
+		if err != nil {
+			return fmt.Errorf("can't retrieve pod logs for terminated container %q in pod %q: %w", containerName, naming.ObjRef(podMeta), err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR expands the Pod collector, used in must-gather and our E2E framework, to also include logs from terminated containers. This is helpful for debugging init containers.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon