### PR TITLE
Always set rack name in ScyllaDBDatacenter rack status

### DIFF
--- a/pkg/controller/scylladbdatacenter/status.go
+++ b/pkg/controller/scylladbdatacenter/status.go
@@ -58,8 +58,9 @@ func (sdcc *Controller) getScyllaVersion(sts *appsv1.StatefulSet) (string, error
 
 // calculateRackStatus calculates a status for the rack.
 // sts and old status may be nil.
-func (sdcc *Controller) calculateRackStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, sts *appsv1.StatefulSet) *scyllav1alpha1.RackStatus {
+func (sdcc *Controller) calculateRackStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, sts *appsv1.StatefulSet) *scyllav1alpha1.RackStatus {
 	status := &scyllav1alpha1.RackStatus{
+		Name:           rackName,
 		Nodes:          pointer.Ptr(int32(0)),
 		CurrentNodes:   pointer.Ptr(int32(0)),
 		UpdatedNodes:   pointer.Ptr(int32(0)),
@@ -72,7 +73,6 @@ func (sdcc *Controller) calculateRackStatus(sdc *scyllav1alpha1.ScyllaDBDatacent
 		return status
 	}
 
-	status.Name = sts.Labels[naming.RackNameLabel]
 	status.Nodes = pointer.Ptr(*sts.Spec.Replicas)
 	status.ReadyNodes = pointer.Ptr(sts.Status.ReadyReplicas)
 	status.AvailableNodes = pointer.Ptr(sts.Status.AvailableReplicas)
@@ -129,7 +129,7 @@ func (sdcc *Controller) calculateStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, 
 	// Calculate the status for racks.
 	for _, rack := range sdc.Spec.Racks {
 		stsName := naming.StatefulSetNameForRack(rack, sdc)
-		status.Racks = append(status.Racks, *sdcc.calculateRackStatus(sdc, statefulSetMap[stsName]))
+		status.Racks = append(status.Racks, *sdcc.calculateRackStatus(sdc, rack.Name, statefulSetMap[stsName]))
 	}
 
 	updateAggregatedStatusFields(status)

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -430,7 +430,7 @@ func (sdcc *Controller) createMissingStatefulSets(
 					continue
 				}
 
-				updatedRackStatus := *sdcc.calculateRackStatus(sdc, sts)
+				updatedRackStatus := *sdcc.calculateRackStatus(sdc, rackName, sts)
 				_, idx, ok := oslices.Find(status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
 					return rackStatus.Name == rackName
 				})
@@ -782,7 +782,7 @@ func (sdcc *Controller) syncStatefulSets(
 						continue
 					}
 
-					status.Racks[idx] = *sdcc.calculateRackStatus(sdc, updatedSts)
+					status.Racks[idx] = *sdcc.calculateRackStatus(sdc, rackName, updatedSts)
 				}
 			}
 			if anyStsChanged {
@@ -1050,7 +1050,7 @@ func (sdcc *Controller) syncStatefulSets(
 				return progressingConditions, fmt.Errorf("can't find rack %q status in %q ScyllaDBDatacenter", rackName, naming.ObjRef(sdc))
 			}
 
-			status.Racks[idx] = *sdcc.calculateRackStatus(sdc, updatedSts)
+			status.Racks[idx] = *sdcc.calculateRackStatus(sdc, rackName, updatedSts)
 		}
 
 		// Wait for the StatefulSet to roll out.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** When an STS doesn't exist, SDC controller creates an unidentifiable status entry missing the name of the rack that it's supposed to reflect. This PR fixes it so that the rack name is always set, regardless of STS' existence.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority important-soon