### PR TITLE
Improve debugging info for failed must-gather in CI

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -131,7 +131,9 @@ spec:
   - name: artifacts
     emptyDir: {}
 EOF
-  kubectl -n=gather-artifacts wait --for=condition=Ready pod/must-gather
+  kubectl -n=gather-artifacts wait --timeout=300s --for=condition=Ready pod/must-gather ||
+    kubectl -n gather-artifacts describe pod must-gather && \
+    kubectl -n gather-artifacts logs pod/must-gather --all-containers=true
 
   exit_code="$( wait-for-container-exit-with-logs gather-artifacts must-gather must-gather )"
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Bumps the timeout from default 30s to 300s and enables debugging in case of a failure by adding pod describe output and dumping its logs. 

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2817.
