### PR TITLE
Fix Prometheus Operator installation instructions in docs

### DIFF
--- a/docs/source/management/monitoring/setup.md
+++ b/docs/source/management/monitoring/setup.md
@@ -18,7 +18,7 @@ Deploy Prometheus Operator using kubectl:
 
 :::{code-block} shell
 :substitutions:
-kubectl apply -n prometheus-operator --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/prometheus-operator
+kubectl apply -n prometheus-operator --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/prometheus-operator.yaml
 :::
 
 #### Wait for Prometheus Operator to roll out


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Prometheus Operator deployment instructions in our docs are invalid: https://operator.docs.scylladb.com/master/management/monitoring/setup.html#deploy-prometheus-operator.

```sh
$ kubectl apply -n prometheus-operator --server-side -f=https://raw.githubusercontent.com/scylladb/scylla-operator/master/examples/third-party/prometheus-operator

error: unable to read URL "https://raw.githubusercontent.com/scylladb/scylla-operator/master/examples/third-party/prometheus-operator", server reported 404 Not Found, status code=404
```

This PR fixes it.

```sh
$ kubectl apply -n prometheus-operator --server-side -f=https://raw.githubusercontent.com/scylladb/scylla-operator/master/examples/third-party/prometheus-operator.yaml

customresourcedefinition.apiextensions.k8s.io/alertmanagerconfigs.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheusagents.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/scrapeconfigs.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com serverside-applied
namespace/prometheus-operator serverside-applied
clusterrole.rbac.authorization.k8s.io/prometheus-operator serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator serverside-applied
serviceaccount/prometheus-operator serverside-applied
service/prometheus-operator serverside-applied
deployment.apps/prometheus-operator serverside-applied
```

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-soon