### PR TITLE
Update ScyllaDB version in docs to 2025.3.2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,9 +73,9 @@ myst_multiversion_substitutions = {
     "master": {
         "revision": "master",
         "agentVersion": "3.5.1",
-        "enterpriseImageTag": "2025.1.5",
-        "imageTag": "2025.1.5",
-        "scyllaDBRepositoryTag": "scylla-2025.1.5",
+        "enterpriseImageTag": "2025.3.2",
+        "imageTag": "2025.3.2",
+        "scyllaDBRepositoryTag": "scylla-2025.3.2",
     },
     "v1.18": {
         "revision": "v1.18",


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** ScyllaDB version was updated in tests, but not in docs. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-soon
/cc czeslavo