### PR TITLE
Remove line numbers from example manifest in sysctl guide

### DIFF
--- a/docs/source/management/sysctls.md
+++ b/docs/source/management/sysctls.md
@@ -24,7 +24,6 @@ The below NodeConfig manifest configures the sysctls recommended for production-
 
 :::{literalinclude} ../../../examples/common/configure-sysctls.nodeconfig.yaml
 :language: yaml
-:linenos:
 :emphasize-lines: 6-18
 :::
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Line numbers in inlined manifest examples make it harder for the readers to copy their contents.
This PR removes them from the example manifest in sysctl guide.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-longterm