### PR TITLE
Set feature gates flag in Operator deployment in CI release deployment script

### DIFF
--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -128,6 +128,9 @@ patches:
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: "--crypto-key-buffer-delay=2s"
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--feature-gates=${SCYLLA_OPERATOR_FEATURE_GATES}"
   target:
       group: apps
       version: v1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** CI release deployment script is not propagating the configured feature gates to Scylla Operator deployment. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc czeslavo