### PR TITLE
Adjusts monitoring diagram to external Prometheus

### DIFF
--- a/docs/source/management/monitoring/diagrams/monitoring-overview.mmd
+++ b/docs/source/management/monitoring/diagrams/monitoring-overview.mmd
@@ -31,26 +31,28 @@ class OtherGrafanaResources grafanaVibe
 PrometheusOperator(Prometheus Operator)
 class PrometheusOperator prometheusVibe
 
+Operator(👷 Human Operator)
+
 %% Grouping
 subgraph K8sCluster[Kubernetes Cluster]
-    direction TB
-    MS
-    SC
-    PrometheusOperator
+direction TB
+MS
+SC
+PrometheusOperator
+Prometheus
 end
 subgraph MS[Monitoring Stack]
-    SDM
-    subgraph PrometheusStack[Prometheus]
-        ServiceMonitor
-        PrometheusRule
-        Prometheus["Prometheus"]
-    end
+SDM
+subgraph PrometheusStack[Prometheus]
+ServiceMonitor
+PrometheusRule
+end
 
-    subgraph GrafanaStack[Grafana]
-        direction LR
-        GrafanaDeployment[Deployment]
-        OtherGrafanaResources["`_Other objects..._`"]
-    end
+subgraph GrafanaStack[Grafana]
+direction LR
+GrafanaDeployment[Deployment]
+OtherGrafanaResources["`_Other objects..._`"]
+end
 end
 
 %% Relationships between nodes
@@ -59,5 +61,9 @@ SDM -->|creates| PrometheusStack
 SDM -->|creates| GrafanaStack
 Prometheus -->|scrapes| SC
 
+Operator -->|creates| Prometheus
+Operator -->|creates| SDM
+
 PrometheusOperator -->|reconciles| PrometheusStack
+PrometheusOperator -->|reconciles| Prometheus
 :::


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Adjusts the monitoring diagram so it depicts the recommended `External` Prometheus mode.

**Before**

<img width="1180" height="678" alt="image" src="https://github.com/user-attachments/assets/17ac8406-33e1-484a-a53a-30e3d1a2628c" />


**After**

<img width="1180" height="588" alt="image" src="https://github.com/user-attachments/assets/dd777a54-ddfe-4299-8466-823a251d0b41" />
