### PR TITLE
Remove reference to ScyllaDBMonitorings from Resources box in docs overview

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -90,7 +90,7 @@ Manage your ScyllaDB clusters using {{productName}}.
 :anchor: Learn more »
 :class: large-4
 
-Learn about the APIs that {{productName}} provides. ScyllaClusters, ScyllaDBMonitorings and more.
+Learn about the APIs that {{productName}} provides.
 ```
 
 ```{topic-box}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** 'Resources' section of the documentation no longer contains ScyllaDBMonitorings and overall we're heading towards clearing it up. This PR removes references to specific APIs from the box on the overview page.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-longterm
/cc czeslavo