### PR TITLE
Promote `czeslavo` to `operator-approvers`

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,5 +16,6 @@ aliases:
   # Rule for adding new members:
   # Demonstrated meaningful contributions to the majority of the codebase
   # over a period of at least 6 months, OR a team lead.
+  - czeslavo
   - mflendrich
   - rzetelskik


### PR DESCRIPTION
Adds @czeslavo to `operator-approvers`.

The criteria (`Demonstrated meaningful contributions to the majority of the codebase over a period of at least 6 months`) are met.

/kind cleanup
/priority important-longterm