### PR TITLE
[v1.19] Make 'make_latest' parameter in github release API call data a string

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -113,7 +113,7 @@ runs:
         --arg release_name "${release_name}" \
         --arg prerelease "${prerelease}" \
         --arg body "$( cat ~/release_notes.md )" \
-        --argjson make_latest ${make_latest} \
+        --arg make_latest "${make_latest}" \
         '{
           "tag_name": $current_tag,
           "name": $current_tag,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Backport of https://github.com/scylladb/scylla-operator/pull/3058.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc mflendrich