### PR TITLE
Promote v1.19 to latest stable version and deprecate v1.17 in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,12 +118,12 @@ smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
 BRANCHES = ['master', 'v1.17', 'v1.18', 'v1.19']
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", "v1.19"]
-DEPRECATED_VERSIONS = []
+UNSTABLE_VERSIONS = ["master"]
+DEPRECATED_VERSIONS = ['v1.17']
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.
-smv_latest_version = 'v1.18'
+smv_latest_version = 'v1.19'
 smv_rename_latest_version = 'stable'
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR updates the docs to promote v1.19 to latest stable and deprecate v1.17.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-soon
/hold for 1.19 GA
/cc
