### PR TITLE
Fix address source paths in ServiceLoadBalancerIngress exposure type documentation

### DIFF
--- a/docs/source/resources/common/exposing.md
+++ b/docs/source/resources/common/exposing.md
@@ -299,7 +299,7 @@ spec:
 
 #### ServiceLoadBalancerIngress Type
 
-Address broadcasted to clients/nodes is taken from the node dedicated Service, from `status.ingress[0].ipAddress` or `status.ingress[0].hostname` field.
+Address broadcasted to clients/nodes is taken from the node dedicated Service, from `.status.loadBalancer.ingress[0].ip` or `.status.loadBalancer.ingress[0].hostname` field.
 
 In order to configure it, the `nodeService` template must specify the LoadBalancer Service.
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** During an issue investigation we noticed that the documented address source paths for ServiceLoadBalancerIngress exposure type are incorrect and do not match the actual behaviour. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-soon