### PR TITLE
Allow for setting additional arguments for Scylla Operator containers through Helm

### DIFF
--- a/helm/scylla-operator/templates/operator.deployment.yaml
+++ b/helm/scylla-operator/templates/operator.deployment.yaml
@@ -39,6 +39,9 @@ spec:
         args:
         - operator
         - --loglevel={{ .Values.logLevel }}
+        {{- range $arg := .Values.additionalArgs }}
+        - {{ $arg }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -12,6 +12,8 @@ image:
 
 # Scylla Operator log level, 0-9 (higher number means more detailed logs)
 logLevel: 2
+# Additional arguments to pass to Scylla Operator container.
+additionalArgs: [ ]
 # Resources allocated to Scylla Operator pods
 resources:
   requests:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** We currently have no way of providing additional arguments to Scylla Operator when deploying via Helm. This PR fixes it. The existing `logLevel` option remains, but `additionalArguments` take precedence.

This also allows for enabling/disabling feature gates. For this reason we'll also have to backport it to 1.19.


**Which issue is resolved by this Pull Request:**
Resolves #

/kind bug
/priority critical-urgent
/cc czeslavo