### PR TITLE
[v1.19] Bring prom-operator back as dependency in installation guide

### DIFF
--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -43,6 +43,31 @@ for i in {1..30}; do
 done
 :::
 
+#### Prometheus Operator
+
+:::{note}
+{{productName}} currently relies on the Prometheus Operator CRDs being present in the cluster even if you do not use the
+monitoring stack (`ScyllaDBMonitoring` CRD).
+
+If the CRDs are not installed, {{productName}} may report errors about missing Prometheus types. These errors do
+not affect the core functionality of {{productName}}.
+
+Support for making Prometheus Operator installation fully optional is being tracked in issue [#3075](https://github.com/scylladb/scylla-operator/issues/3075).
+:::
+
+:::{code-block} shell
+:substitutions:
+kubectl apply -n prometheus-operator --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/prometheus-operator.yaml
+:::
+
+```shell
+# Wait for CRDs to propagate to all apiservers.
+kubectl wait --for='condition=established' crd/prometheuses.monitoring.coreos.com crd/prometheusrules.monitoring.coreos.com crd/servicemonitors.monitoring.coreos.com
+
+# Wait for prometheus operator deployment.
+kubectl -n=prometheus-operator rollout status --timeout=10m deployment.apps/prometheus-operator
+```
+
 ### {{productName}}
 
 Once you have the dependencies installed and available in your cluster, it is the time to install {{productName}}.

--- a/docs/source/management/monitoring/setup.md
+++ b/docs/source/management/monitoring/setup.md
@@ -9,29 +9,8 @@ see the [`ScyllaDBMonitoring` API reference](../../api-reference/groups/scylla.s
 
 ## Requirements
 
-Before you can set up your ScyllaDB monitoring, you need {{productName}} and a `ScyllaCluster` already installed in your Kubernetes cluster.
-For more information on how to deploy {{productName}}, see [the installation guide](../../installation/overview.md).
-
-### Deploy Prometheus Operator
-
-:::{note}
-`ScyllaDBMonitoring` relies on the Prometheus Operator for managing Prometheus-related resources.
-You can deploy it in your Kubernetes cluster using the provided third-party examples. If you already have it deployed
-in your cluster, you can skip this step.
-:::
-
-Deploy Prometheus Operator using kubectl:
-
-:::{code-block} shell
-:substitutions:
-kubectl apply -n prometheus-operator --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/prometheus-operator.yaml
-:::
-
-#### Wait for Prometheus Operator to roll out
-
-```console
-kubectl -n prometheus-operator rollout status --timeout=5m deployments.apps/prometheus-operator
-```
+Before you can set up your ScyllaDB monitoring, you need {{productName}} (along with the Prometheus Operator) and a `ScyllaCluster`
+already installed in your Kubernetes cluster. For more information on how to deploy {{productName}}, see [the installation guide](../../installation/overview.md).
 
 ## Deploy external Prometheus
 


### PR DESCRIPTION
Backports https://github.com/scylladb/scylla-operator/pull/3073 to v1.19

/hold for master