### PR TITLE
Sync prom-operator go.mod versions with metadata.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,36 +187,33 @@ gofmt:
 # We need to force locale so different envs sort files the same way for recursive traversals
 diff :=LC_COLLATE=C diff --no-dereference -N
 
+# setup-deps-verification sets up two copies of the project for dependency verification:
+# 1. A symbolic link to the current directory (as-is)
+# 2. A copy with freshly processed dependencies (updated go.mod replace directives, tidied go.mod and go.sum, and recreated vendor/)
+# This allows comparing go.mod, go.sum, and vendor/ contents to ensure they are correct.
 # $1 - temporary directory
-define restore-deps
+define setup-deps-verification
 	ln -s $(abspath ./) "$(1)"/current
 	cp -R -H ./ "$(1)"/updated
 	$(RM) -r "$(1)"/updated/vendor
-	cd "$(1)"/updated && $(GO) mod tidy && $(GO) mod vendor && $(GO) mod verify
-	cd "$(1)" && $(diff) -r {current,updated}/vendor/ > updated/deps.diff || true
+	cd "$(1)"/updated && \
+		./hack/update-go-mod-replace.sh && \
+		$(GO) mod tidy && \
+		$(GO) mod vendor && \
+		$(GO) mod verify
 endef
 
 verify-deps: tmp_dir:=$(shell mktemp -d)
 verify-deps:
-	$(call restore-deps,$(tmp_dir))
+	$(call setup-deps-verification,$(tmp_dir))
 	@echo $(diff) "$(tmp_dir)"/{current,updated}/go.mod
-	@     $(diff) "$(tmp_dir)"/{current,updated}/go.mod || ( echo '`go.mod` content is incorrect - did you run `go mod tidy`?' && false )
+	@     $(diff) "$(tmp_dir)"/{current,updated}/go.mod || ( echo '`go.mod` content is incorrect - did you run `make update-go-mod-replace` and `go mod tidy`?' && false )
 	@echo $(diff) "$(tmp_dir)"/{current,updated}/go.sum
 	@     $(diff) "$(tmp_dir)"/{current,updated}/go.sum || ( echo '`go.sum` content is incorrect - did you run `go mod tidy`?' && false )
-	@echo $(diff) '$(tmp_dir)'/{current,updated}/deps.diff
-	@     $(diff) '$(tmp_dir)'/{current,updated}/deps.diff || ( \
-		echo "ERROR: Content of 'vendor/' directory doesn't match 'go.mod' configuration and the overrides in 'deps.diff'!" && \
-		echo 'Did you run `go mod vendor`?' && \
-		echo "If this is an intentional change (a carry patch) please update the 'deps.diff' using 'make update-deps-overrides'." && \
-		false \
-	)
+	@echo $(diff) -r "$(tmp_dir)"/{current,updated}/vendor
+	@     $(diff) -r "$(tmp_dir)"/{current,updated}/vendor || ( echo '`vendor/` content is incorrect - did you run `go mod vendor`?' && false )
+	$(RM) -r "$(tmp_dir)"
 .PHONY: verify-deps
-
-update-deps-overrides: tmp_dir:=$(shell mktemp -d)
-update-deps-overrides:
-	$(call restore-deps,$(tmp_dir))
-	cp "$(tmp_dir)"/{updated,current}/deps.diff
-.PHONY: update-deps-overrides
 
 verify-helm-lint:
 	@$(foreach chart,$(HELM_CHARTS),$(call lint-helm,$(chart)))
@@ -710,10 +707,14 @@ verify-bundle:
 	$(diff) -r '$(tmp_dir)'/ ./bundle
 .PHONY: verify-bundle
 
+update-go-mod-replace:
+	./hack/update-go-mod-replace.sh
+.PHONY: update-go-mod-replace
+
 verify: verify-codegen verify-crds verify-helm-schemas verify-helm-charts verify-deploy verify-lint verify-helm-lint verify-links verify-examples verify-docs-api verify-monitoring verify-bundle
 .PHONY: verify
 
-update: update-codegen update-crds update-helm-schemas update-helm-charts update-deploy update-examples update-docs-api update-monitoring update-bundle
+update: update-codegen update-crds update-helm-schemas update-helm-charts update-deploy update-examples update-docs-api update-monitoring update-bundle update-go-mod-replace
 .PHONY: update
 
 test-unit:

--- a/go.mod
+++ b/go.mod
@@ -231,3 +231,10 @@ tool (
 	k8s.io/code-generator
 	sigs.k8s.io/controller-tools/cmd/controller-gen
 )
+
+// prometheus-operator modules are intentionally kept in sync with the version defined in `assets/metadata/metadata.yaml`.
+// Synchronization is performed automatically by the `make update-go-mod-replace` target, do not edit manually.
+replace (
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring => github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.1
+	github.com/prometheus-operator/prometheus-operator/pkg/client => github.com/prometheus-operator/prometheus-operator/pkg/client v0.86.1
+)

--- a/go.sum
+++ b/go.sum
@@ -351,10 +351,10 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.2 h1:VRXUgbGmpmjZgFYiUnTwlC+JjfCUs5KKFsorJhI1ZKQ=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.2/go.mod h1:nPk0OteXBkbT0CRCa2oZQL1jRLW6RJ2fuIijHypeJdk=
-github.com/prometheus-operator/prometheus-operator/pkg/client v0.86.2 h1:aD+r5a/96ZVT11Uo6Jpt3gO2Hutq3NROB8lXYKMZlOI=
-github.com/prometheus-operator/prometheus-operator/pkg/client v0.86.2/go.mod h1:fXZB2vXirMxIjFEIggDrFirYJQh7GkHCZRwm8aKD0e8=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.1 h1:j/GvU9UxlK5nuUKOWYOY0LRqcfHZl1ffTOa46+00Cys=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.1/go.mod h1:nPk0OteXBkbT0CRCa2oZQL1jRLW6RJ2fuIijHypeJdk=
+github.com/prometheus-operator/prometheus-operator/pkg/client v0.86.1 h1:IqbpBVUahr2978vI6GkoCeaaugklgtq0M0FRJ5Ytdkk=
+github.com/prometheus-operator/prometheus-operator/pkg/client v0.86.1/go.mod h1:dquFiWkRGsMzjxckZAOFSsqqhUYQ9UZtwBeqaOsrWCk=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/hack/lib/metadata.sh
+++ b/hack/lib/metadata.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+readonly metadata_file="assets/metadata/metadata.yaml"
+
+# get-metadata retrieves a value from the metadata YAML file.
+# Usage: get-metadata <yaml-key>
+function get-metadata() {
+    local key="${1}"
+    yq -e "$key" "${metadata_file}" || {
+        echo "Failed to get key ${key} from ${metadata_file}" >&2
+        exit 1
+    }
+}

--- a/hack/third-party/build-prometheus-operator-manifest.sh
+++ b/hack/third-party/build-prometheus-operator-manifest.sh
@@ -8,6 +8,8 @@
 set -euxEo pipefail
 shopt -s inherit_errexit
 
+source "$( dirname "${BASH_SOURCE[0]}" )/../lib/metadata.sh"
+
 if [[ -n "${1+x}" ]]; then
     target="${1}"
 else
@@ -15,15 +17,6 @@ else
     exit 1
 fi
 
-readonly metadata_file="assets/metadata/metadata.yaml"
-
-function get-metadata() {
-    local key="${1}"
-    yq -e "$key" "${metadata_file}" || {
-        echo "Failed to get key ${key} from ${metadata_file}" >&2
-        exit 1
-    }
-}
 
 function get-url() {
     local version="${1}"

--- a/hack/update-go-mod-replace.sh
+++ b/hack/update-go-mod-replace.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euxEo pipefail
+shopt -s inherit_errexit
+
+# This script updates the 'replace' directives in go.mod for dependencies that we want to keep in sync with their versions
+# defined in `assets/metadata/metadata.yaml`.
+
+source "$( dirname "${BASH_SOURCE[0]}" )/lib/metadata.sh"
+
+function update_replace_directive() {
+    local module=$1
+    local version=$2
+
+    go mod edit -replace=${module}=${module}@${version}
+}
+
+# Update prometheus-operator modules.
+PROMETHEUS_OPERATOR_VERSION="v$( get-metadata ".thirdParty.prometheusOperator.version" )"
+update_replace_directive "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring" "${PROMETHEUS_OPERATOR_VERSION}"
+update_replace_directive "github.com/prometheus-operator/prometheus-operator/pkg/client" "${PROMETHEUS_OPERATOR_VERSION}"
+
+go mod tidy && go mod vendor

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -773,13 +773,13 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.2
+# github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.2 => github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.1
 ## explicit; go 1.24.0
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1
-# github.com/prometheus-operator/prometheus-operator/pkg/client v0.86.2
+# github.com/prometheus-operator/prometheus-operator/pkg/client v0.86.2 => github.com/prometheus-operator/prometheus-operator/pkg/client v0.86.1
 ## explicit; go 1.24.0
 github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1
 github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1
@@ -1909,3 +1909,5 @@ sigs.k8s.io/structured-merge-diff/v6/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/kyaml
 # github.com/gocql/gocql => github.com/scylladb/gocql v1.14.5
+# github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring => github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.1
+# github.com/prometheus-operator/prometheus-operator/pkg/client => github.com/prometheus-operator/prometheus-operator/pkg/client v0.86.1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** To make sure we always keep Prometheus Operator dependencies versions in sync (to avoid issues like https://github.com/scylladb/scylla-operator/issues/2949#issuecomment-3274003808), let's make the version in `go.mod` sync with the one defined in `metadata.yaml`.

Note adjustments in Makefile reflect `local-csi-driver` changes we made recently: https://github.com/scylladb/local-csi-driver/pull/106

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/2813.
