### PR TITLE
[v1.18] Align myst_substitutions with master source

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,12 +60,12 @@ myst_heading_anchors = 6
 myst_substitutions = {
   "productName": "Scylla Operator",
   "repository": "scylladb/scylla-operator",
-  "revision": "master",
+  "revision": "v1.18",
   "imageRepository": "docker.io/scylladb/scylla",
-  "imageTag": "2025.1.2",
+  "imageTag": "2025.1.5",
   "enterpriseImageRepository": "docker.io/scylladb/scylla-enterprise",
-  "enterpriseImageTag": "2024.1.12",
-  "agentVersion": "3.5.0",
+  "enterpriseImageTag": "2025.1.5",
+  "agentVersion": "3.5.1",
 }
 
 # -- Options for not found extension


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Removing the workaround for variable substitution in multiversion documentation (https://github.com/scylladb/scylla-operator/pull/3083) means that the branch will be the source of the substitutions for the given version. For this reason, the substitutions need to be aligned with the values specified in master for this branch.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc czeslavo