### PR TITLE
Update ScyllaDB version to 2025.3.4

### DIFF
--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -1,5 +1,5 @@
 operator:
-  scyllaDBVersion: "2025.3.3"
+  scyllaDBVersion: "2025.3.4"
   # scyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride sets enterprise version
   # that requires consistent_cluster_management workaround for restore.
   # In the future, enterprise versions should be run as a different config instance in its own run.
@@ -14,6 +14,6 @@ operator:
   prometheusVersion: "v3.6.0" # Tracks scylla-monitoring/versions.sh PROMETHEUS_VERSION
 operatorTests:
   scyllaDBVersions:
-    updateFrom: "2025.3.2" # One patch lower than .operator.scyllaDBVersion
+    updateFrom: "2025.3.3" # One patch lower than .operator.scyllaDBVersion
     upgradeFrom: "2025.2.3" # One minor lower than .operator.scyllaDBVersion
   nodeSetupImage: "quay.io/scylladb/scylla-operator-images:node-setup-v0.0.4@sha256:8d77b91db6cffb40337e3db9c9a2f73f190eda9f9e547a752f0beab8aea322ef"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,11 +58,11 @@ myst_substitutions = {
     "repository": "scylladb/scylla-operator",
     "revision": "master",
     "imageRepository": "docker.io/scylladb/scylla",
-    "imageTag": "2025.3.3",
+    "imageTag": "2025.3.4",
     "enterpriseImageRepository": "docker.io/scylladb/scylla-enterprise",
-    "enterpriseImageTag": "2025.3.3",
+    "enterpriseImageTag": "2025.3.4",
     "agentVersion": "3.7.0",
-    "scyllaDBRepositoryTag": "scylla-2025.3.3",
+    "scyllaDBRepositoryTag": "scylla-2025.3.4",
 }
 
 # -- Options for not found extension


### PR DESCRIPTION
Bumps ScyllaDB to the newest version.

Going forward, we should probably hook up Renovate to do this for us.

/kind cleanup
/priority important-longterm