### PR TITLE
Update maintainers in the Helm charts

### DIFF
--- a/helm/scylla-manager/Chart.yaml
+++ b/helm/scylla-manager/Chart.yaml
@@ -17,6 +17,6 @@ home: https://www.scylladb.com/
 sources:
   - https://github.com/scylladb/scylla-operator
 maintainers:
-  - name: Maciej Zimnoch
-    email: maciej@scylladb.com
+  - name: ScyllaDB
+    email: support@scylladb.com
 icon: https://www.scylladb.com/wp-content/uploads/scylla-manager.png

--- a/helm/scylla-operator/Chart.yaml
+++ b/helm/scylla-operator/Chart.yaml
@@ -12,6 +12,6 @@ home: https://www.scylladb.com/
 sources:
   - https://github.com/scylladb/scylla-operator
 maintainers:
-  - name: Maciej Zimnoch
-    email: maciej@scylladb.com
+  - name: ScyllaDB
+    email: support@scylladb.com
 icon: https://github.com/scylladb/scylla-operator/raw/master/logo.svg

--- a/helm/scylla/Chart.yaml
+++ b/helm/scylla/Chart.yaml
@@ -13,6 +13,6 @@ sources:
   - https://github.com/scylladb/scylla-operator
   - https://github.com/scylladb/scylla
 maintainers:
-  - name: Maciej Zimnoch
-    email: maciej@scylladb.com
+  - name: ScyllaDB
+    email: support@scylladb.com
 icon: https://www.scylladb.com/wp-content/uploads/brand-logo-vert@2x.png


### PR DESCRIPTION
Fixes #3107 

Follows the pattern set in https://github.com/scylladb/scylla-operator/blob/9e63e5ac740b82e38b42a1a26cdd1e6007fc0392/bundle/manifests/scylladb-operator.clusterserviceversion.yaml#L516-L517 .

/kind cleanup
/priority important-longterm