### PR TITLE
[v1.19] Use newer AWS AMI AL2023 in the eksctl example

### DIFF
--- a/examples/eks/clusterconfig.eksctl.yaml
+++ b/examples/eks/clusterconfig.eksctl.yaml
@@ -11,6 +11,7 @@ nodeGroups:
 - name: scylla-pool
   instanceType: i4i.2xlarge
   desiredCapacity: 3
+  amiFamily: AmazonLinux2023
   labels:
     scylla.scylladb.com/node-type: scylla
   taints:
@@ -24,6 +25,7 @@ nodeGroups:
 - name: infra-pool
   instanceType: i3.large
   desiredCapacity: 1
+  amiFamily: AmazonLinux2023
   labels:
     scylla.scylladb.com/node-type: infra
   ssh:


### PR DESCRIPTION
**Description of your changes:**
The previous default AL2 is outdated and unsupported by AWS
backport of https://github.com/scylladb/scylla-operator/pull/3106