### PR TITLE
Add E2E verifying nodes cleanup after multi-node cluster provisioning

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -4,9 +4,11 @@ package scyllacluster
 
 import (
 	"context"
+	"fmt"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
@@ -29,139 +31,165 @@ var _ = g.Describe("ScyllaCluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		sc := f.GetDefaultScyllaCluster()
-		sc.Spec.Datacenter.Racks[0].Members = 1
-
-		jobListWatcher := &cache.ListWatch{
-			ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
-				return f.KubeClient().BatchV1().Jobs(f.Namespace()).List(ctx, options)
-			}),
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return f.KubeClient().BatchV1().Jobs(f.Namespace()).Watch(ctx, options)
-			},
-		}
-
-		framework.By("Creating a single node ScyllaCluster")
-
+		jobListWatcher := createJobListWatcher(ctx, f)
 		jobObserver := utils.ObserveObjects[*batchv1.Job](jobListWatcher)
 		err := jobObserver.Start(ctx)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		sc, err := createClusterAndWaitForRollout(ctx, f, 1)
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
-		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
-		defer waitCtx1Cancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 
 		framework.By("Validating no cleanup jobs were created")
 		jobEvents, err := jobObserver.Stop()
 		o.Expect(err).NotTo(o.HaveOccurred())
-
 		o.Expect(jobEvents).To(o.BeEmpty())
 
-		framework.By("Scaling the ScyllaCluster to 3 replicas")
+		jobObserver = utils.ObserveObjects[*batchv1.Job](jobListWatcher)
+		err = jobObserver.Start(ctx)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		sc, err = scaleClusterAndWaitForRollout(ctx, f, sc, 3)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		jobEvents, err = jobObserver.Stop()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		verifyCleanupJobsCreated(ctx, f, sc, jobEvents, []int32{0, 1})
 
 		jobObserver = utils.ObserveObjects[*batchv1.Job](jobListWatcher)
 		err = jobObserver.Start(ctx)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-			ctx,
-			sc.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 3}]`),
-			metav1.PatchOptions{},
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
-		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(3))
-
-		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
-		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, sc)
-		defer waitCtx2Cancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx2, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		sc, err = scaleClusterAndWaitForRollout(ctx, f, sc, 2)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-
-		framework.By("Validating cleanup jobs were created for all nodes except last one")
 		jobEvents, err = jobObserver.Stop()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		o.Expect(jobEvents).NotTo(o.BeEmpty())
+		verifyCleanupJobsCreated(ctx, f, sc, jobEvents, []int32{0, 1})
+	})
 
-		tokenRingHash, err := utils.GetCurrentTokenRingHash(ctx, f.KubeClient().CoreV1(), sc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		framework.Infof("Current token ring hash is %q", tokenRingHash)
+	g.It("multi-node cluster nodes are cleaned up right after provisioning", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
 
-		nodeJobMatcher := func(nodeName string) func(utils.ObserverEvent[*batchv1.Job]) bool {
-			return func(e utils.ObserverEvent[*batchv1.Job]) bool {
-				return e.Obj.Labels[naming.NodeJobLabel] == nodeName
-			}
-		}
-
-		cleanupJobsCreated := oslices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
-			return e.Action == watch.Added &&
-				e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup) &&
-				e.Obj.Annotations[naming.CleanupJobTokenRingHashAnnotation] == tokenRingHash
-		})
-
-		o.Expect(cleanupJobsCreated).To(o.HaveLen(2))
-		o.Expect(cleanupJobsCreated).To(o.ConsistOf(
-			o.Satisfy(nodeJobMatcher(naming.MemberServiceNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, 0))),
-			o.Satisfy(nodeJobMatcher(naming.MemberServiceNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, 1))),
-		))
-
-		framework.By("Scaling down the ScyllaCluster to 2 replicas")
-
-		jobObserver = utils.ObserveObjects[*batchv1.Job](jobListWatcher)
-		err = jobObserver.Start(ctx)
+		jobListWatcher := createJobListWatcher(ctx, f)
+		jobObserver := utils.ObserveObjects[*batchv1.Job](jobListWatcher)
+		err := jobObserver.Start(ctx)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-			ctx,
-			sc.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": 2}]`),
-			metav1.PatchOptions{},
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
-		o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(2))
-
-		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
-		waitCtx3, waitCtx3Cancel := utils.ContextForRollout(ctx, sc)
-		defer waitCtx3Cancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		sc, err := createClusterAndWaitForRollout(ctx, f, 3)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-
-		tokenRingHash, err = utils.GetCurrentTokenRingHash(ctx, f.KubeClient().CoreV1(), sc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		framework.Infof("Current token ring hash is %q", tokenRingHash)
-
-		framework.By("Validating cleanup jobs were created for all nodes")
-		jobEvents, err = jobObserver.Stop()
+		jobEvents, err := jobObserver.Stop()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		o.Expect(jobEvents).NotTo(o.BeEmpty())
-
-		cleanupJobsCreated = oslices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
-			return e.Action == watch.Added &&
-				e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup) &&
-				e.Obj.Annotations[naming.CleanupJobTokenRingHashAnnotation] == tokenRingHash
-		})
-
-		o.Expect(cleanupJobsCreated).To(o.HaveLen(2))
-		o.Expect(cleanupJobsCreated).To(o.ConsistOf(
-			o.Satisfy(nodeJobMatcher(naming.MemberServiceNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, 0))),
-			o.Satisfy(nodeJobMatcher(naming.MemberServiceNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, 1))),
-		))
+		verifyCleanupJobsCreated(ctx, f, sc, jobEvents, []int32{0, 1})
 	})
 })
+
+// createJobListWatcher creates a ListWatch for observing Jobs in the framework's namespace.
+func createJobListWatcher(ctx context.Context, f *framework.Framework) *cache.ListWatch {
+	return &cache.ListWatch{
+		ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
+			return f.KubeClient().BatchV1().Jobs(f.Namespace()).List(ctx, options)
+		}),
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return f.KubeClient().BatchV1().Jobs(f.Namespace()).Watch(ctx, options)
+		},
+	}
+}
+
+// nodeJobMatcher returns a matcher function that checks if a job event is for the given node name.
+func nodeJobMatcher(nodeName string) func(utils.ObserverEvent[*batchv1.Job]) bool {
+	return func(e utils.ObserverEvent[*batchv1.Job]) bool {
+		return e.Obj.Labels[naming.NodeJobLabel] == nodeName
+	}
+}
+
+// verifyCleanupJobsCreated verifies that cleanup jobs were created for the expected nodes.
+func verifyCleanupJobsCreated(
+	ctx context.Context,
+	f *framework.Framework,
+	sc *scyllav1.ScyllaCluster,
+	jobEvents []utils.ObserverEvent[*batchv1.Job],
+	expectedNodeIndices []int32,
+) {
+	o.Expect(jobEvents).NotTo(o.BeEmpty())
+
+	tokenRingHash, err := utils.GetCurrentTokenRingHash(ctx, f.KubeClient().CoreV1(), sc)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	framework.Infof("Current token ring hash of the cluster is %q", tokenRingHash)
+
+	framework.Infof("Verifying cleanup jobs were created for nodes: %v", expectedNodeIndices)
+	cleanupJobsCreated := oslices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
+		return e.Action == watch.Added &&
+			e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup) &&
+			e.Obj.Annotations[naming.CleanupJobTokenRingHashAnnotation] == tokenRingHash
+	})
+
+	o.Expect(cleanupJobsCreated).To(o.HaveLen(len(expectedNodeIndices)))
+
+	expectedMatchers := make([]interface{}, len(expectedNodeIndices))
+	for i, nodeIndex := range expectedNodeIndices {
+		nodeName := naming.MemberServiceNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, int(nodeIndex))
+		expectedMatchers[i] = o.Satisfy(nodeJobMatcher(nodeName))
+	}
+	o.Expect(cleanupJobsCreated).To(o.ConsistOf(expectedMatchers...))
+}
+
+// createClusterAndWaitForRollout creates a ScyllaCluster with the specified number of members and waits for rollout.
+func createClusterAndWaitForRollout(
+	ctx context.Context,
+	f *framework.Framework,
+	members int32,
+) (*scyllav1.ScyllaCluster, error) {
+	sc := f.GetDefaultScyllaCluster()
+	sc.Spec.Datacenter.Racks[0].Members = members
+
+	framework.By("Creating a %d node ScyllaCluster", members)
+	sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
+	waitCtx, waitCtxCancel := utils.ContextForRollout(ctx, sc)
+	defer waitCtxCancel()
+	sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+
+	return sc, nil
+}
+
+// scaleClusterAndWaitForRollout scales the cluster to the given number of members and waits for rollout.
+func scaleClusterAndWaitForRollout(
+	ctx context.Context,
+	f *framework.Framework,
+	sc *scyllav1.ScyllaCluster,
+	members int32,
+) (*scyllav1.ScyllaCluster, error) {
+	patchData := []byte(fmt.Sprintf(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": %d}]`, members))
+
+	framework.By("Scaling the ScyllaCluster to %d members", members)
+	sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+		ctx,
+		sc.Name,
+		types.JSONPatchType,
+		patchData,
+		metav1.PatchOptions{},
+	)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
+	o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(members))
+
+	framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
+	waitCtx, waitCtxCancel := utils.ContextForRollout(ctx, sc)
+	defer waitCtxCancel()
+	sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+
+	return sc, nil
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Adds an E2E test that verifies that cleanup jobs are created for multi-node clusters after their provisioning (not only after scaling up).

**Which issue is resolved by this Pull Request:**
Related to https://github.com/scylladb/scylla-operator/issues/3102.
