### PR TITLE
Add a script for OLM bundle postprocessing

### DIFF
--- a/hack/olm/postprocess-bundle.sh
+++ b/hack/olm/postprocess-bundle.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright (C) 2025 ScyllaDB
+#
+# This script applies post-processing to an OLM bundle located at the specified target directory.
+
+set -euxEo pipefail
+shopt -s inherit_errexit
+
+if [[ "$#" -ne 2 ]]; then
+    echo -e "Missing arguments.\nUsage: ${0} <target> <operator_image_ref>" >&2
+    exit 1
+fi
+
+target="${1}"
+operator_image_ref="${2}"
+
+# set_metadata_annotation_without_line_comment sets a metadata annotation without a line comment in the specified YAML file.
+# $1 - target file
+# $2 - annotation key
+# $3 - annotation value
+function set_metadata_annotation_without_line_comment() {
+    local target_file="${1}"
+    local key="${2}"
+    local value="${3}"
+
+    key="${key}" value="${value}" yq -e -i '
+      .metadata.annotations[env(key)] = env(value) |
+      .metadata.annotations[env(key)] line_comment= ""
+    ' "${target_file}"
+}
+
+# Update the bundle's scylla-operator deployment spec to use the specified operator image reference as it can't be done in build time.
+operator_image_ref="${operator_image_ref}" yq -e -i '
+  (.spec.install.spec.deployments[]
+    | select(.name == "scylla-operator").spec.template.spec.containers[]
+    | select(.name == "scylla-operator")
+  ) |= with(
+    .;
+    .image = env(operator_image_ref) |
+    .env[] |= select(.name == "SCYLLA_OPERATOR_IMAGE").value = env(operator_image_ref)
+  )
+' "${target}/manifests/scylladb-operator.clusterserviceversion.yaml"
+
+# Update the bundle's webhook-server deployment spec to use the specified operator image reference as it can't be done in build time.
+operator_image_ref="${operator_image_ref}" yq -e -i '
+  (.spec.install.spec.deployments[]
+    | select(.name == "webhook-server").spec.template.spec.containers[]
+    | select(.name == "webhook-server")
+  ).image = env(operator_image_ref)
+' "${target}/manifests/scylladb-operator.clusterserviceversion.yaml"
+
+# Update the CSV annotations with the creation timestamp and operator image reference.
+# Note: this is only required for publishing.
+
+set_metadata_annotation_without_line_comment \
+    "${target}/manifests/scylladb-operator.clusterserviceversion.yaml" \
+    "createdAt" \
+    "$( date -u '+%Y-%m-%dT%H:%M:%S' )"
+
+set_metadata_annotation_without_line_comment \
+    "${target}/manifests/scylladb-operator.clusterserviceversion.yaml" \
+    "containerImage" \
+    "${operator_image_ref}"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** 
This PR adds a script for postprocessing the OLM bundle. It replaces the operator image references with a specified image reference. This can't be done in build time and is expected to happen in the CI job responsible for building the bundle image.
In presubmits, this is required to build the OLM bundle with the actual operator image being tested (instead of whatever placeholder is in the bundle manifests).

The script also updates `createdAt` and `containerImage` annotations in the CSV. It is not required as part of testing, but I'm hoping it can be used in the publishing procedure. 

**Which issue is resolved by this Pull Request:**
Partially addresses https://github.com/scylladb/scylla-operator-release/issues/519.

Please review together with https://github.com/scylladb/scylla-operator-release/pull/523.

/kind machinery
/priority important-soon