### PR TITLE
Set default channel annotation in OLM bundle metadata and make the channel annotation overwritten during publishing

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,7 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: scylladb-operator
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: dev # Overwritten during publishing.
+  operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-unknown
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/bundle/patches/metadata/publishing.annotations.yaml
+++ b/bundle/patches/metadata/publishing.annotations.yaml
@@ -1,0 +1,2 @@
+annotations:
+  operators.operatorframework.io.bundle.channels.v1: dev # Overwritten during publishing.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** We decided to use `dev` and `stable` channels for OLM. This PR configures the default channel annotation to `stable` and adds a patch for the channel annotation to be overwritten during publishing. This should be addressed by https://github.com/scylladb/scylla-operator/pull/3131.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon