### PR TITLE
Fix for Unused import

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 from datetime import date
-import sys
+
 
 from sphinx_scylladb_theme.utils import multiversion_regex_builder
 


### PR DESCRIPTION
The best way to fix this issue is to simply remove the unused import statement `import sys` from line 4 of `docs/source/conf.py`. This does not affect the existing functionality, as the module is not referenced elsewhere in the provided snippet. No other imports or code need to be altered. The only change is to delete or comment out the line containing `import sys`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._