### PR TITLE
Add copilot instructions for commit messages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,4 +8,6 @@ The commit message should always (no exceptions) be an imperative sentence witho
 
 Prefer commit message length under 72 characters.
 
+The commit message should never include "@mentions" or hashtag ("#") references. The commit message should never include [keywords that close issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
+
 The PR title should follow the same rules as the commit message.


### PR DESCRIPTION
This PR introduces [custom instructions for Copilot](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions#enabling-or-disabling-repository-custom-instructions) in the repository.

The intention is to start with very minimal and very clear prompting targeted at a specific issue. This PR is an attempt at unconfusing Copilot wrt. our highly specific commit message format that was difficult to back out of in https://github.com/scylladb/scylla-operator/pull/3138.

Note: my intention with this PR is to gradually build a prompt roughly compatible with [CONTRIBUTING.md](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md) and other similar places, but with a different audience (and therefore format) in mind, focusing on prompt engineering techniques as opposed to verbatim feeding the non-prompt-engineered raw (and not as targeted and quite obsolete at times) rules.

/kind cleanup
/priority backlog