### PR TITLE
Add initial Renovate configuration for updating Scylla

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,3 +83,12 @@ Refer to [The Standard of Code Review](https://github.com/golang/go/wiki/CodeRev
 ### Submitting
 
 After addressing the review feedback, squash your changes into the original commits. Avoid adding new commits. Your PR should always be in a mergeable state.
+
+## Maintenance
+
+### Configuring Renovate
+
+We're using [Renovate](https://docs.renovatebot.com/) for automatic dependency updates of some components.
+If you want to modify Renovate's configuration, edit the `renovate.json` file in the repository root. You can verify
+your changes by running Renovate locally using the following command: `./hack/check-renovate.sh`. If there are any
+updates that you expect Renovate to make, but the script does not report them, please adjust your configuration accordingly.

--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -1,4 +1,5 @@
 operator:
+  # renovate: datasource=docker depName=scylladb packageName=docker.io/scylladb/scylla versioning=semver
   scyllaDBVersion: "2025.3.5"
   # scyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride sets enterprise version
   # that requires consistent_cluster_management workaround for restore.

--- a/hack/check-renovate.sh
+++ b/hack/check-renovate.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This scripts runs renovate in dry-run mode against the local config.
+# It can be used to check if changes to the config result in the expected updates.
+
+# Note: Renovate CLI output is quote verbose, so it's recommended to redirect it to a file for easier analysis.
+
+set -euxEo pipefail
+shopt -s inherit_errexit
+
+npx --yes renovate --platform=local --dry-run=full --print-config=true

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["custom.regex"],
+  "schedule": ["before 5am every weekday"],
+  "labels": [
+    "kind/dependency-bump",
+    "priority/important-longterm"
+  ],
+  "customManagers": [
+    {
+      "description": "Custom manager for dependencies defined in assets/config/config.yaml with Renovate annotations matching the regex.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^assets/config/config\\.yaml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*\\S+:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Adds initial Renovate configuration that will make sure anytime a minor/patch release of ScyllaDB is released, we'll get it automatically updated the morning after. 

Note: It will still require a manual step of running `make update` and committing changes, but we can get to automating this as well: either by adding an automation that will be triggered on these automatic version updates relying on a GH label (e.g., `requires-regenerating`), or by offloading this to Copilot. Still, I believe that getting the automatic PRs is a step forward compared to current manual approach.

I've verified this config on my fork. Renovate created the following PR: https://github.com/czeslavo/scylla-operator/pull/11