### PR TITLE
Exclude `vendor/` from `.gitattributes` generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,7 +16,6 @@ examples/haproxy-ingress.yaml linguist-generated=true
 values.schema.json linguist-generated=true
 
 # Path prefixes
-vendor/** linguist-generated=true
 docs/source/reference/api/** linguist-generated=true
 pkg/client/** linguist-generated=true
 pkg/externalclient/** linguist-generated=true


### PR DESCRIPTION
This PR proposes that we remove `vendor/**` from the list of "generated" files in `.gitattributes`.

As for the "why": reviewing dependency bump PRs, I want the possibility to skim through the code changes (to see the most basic of issues).

Rationale:
- vendored code is not "generated" - it is real code that we are checking into the project, and therefore subject to (at least the most basic) review
- vendored code can contain changes (like licensing) that require review (and therefore hiding them is counterproductive)
- 99% of the time, edits to vendor happen in a dependency bump PR, so there's no advantage in hiding the diff in those PRs -- there is literally nothing else in them than the dependency diff

Cons:
- it makes vendored code count into "repository language statistics" as per [docs](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)

/cc czeslavo
/kind machinery
/priority backlog