### PR TITLE
Include the `sha256:` prefix in Renovate's digest matcher

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
         "/^assets/config/config\\.yaml$/"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*\\S+:\\s*\"?(?<currentValue>[^@\"\\s]+)(?:@sha256:(?<currentDigest>[a-f0-9]+))?\"?"
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*\\S+:\\s*\"?(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\"?"
       ]
     }
   ]


### PR DESCRIPTION
Follow-up to #3159, resolves #3154

Renovate logs show that the `currentDigest` format should include the `sha256:` prefix:

```json
          {
            "currentDigest": "9718a9333f9337418be6d301521ccb49ef1449ea693bb178c4b5f5e8feedaf23",
            "updates": [
              {
                "updateType": "digest",
                "newDigest": "sha256:9718a9333f9337418be6d301521ccb49ef1449ea693bb178c4b5f5e8feedaf23",
              }
            ]
          },
```

This PR makes it happen.
Regex test: https://regex101.com/r/sJ4HmU/1

/kind machinery
/priority important-soon