### PR TITLE
Set explicit PAT permissions for release GH Actions workflow

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -16,6 +16,9 @@ on:
         description: 'Tag for publishing a release, like `v1.3.0`. The old release must be deleted before this job.'
         required: true
 
+permissions:
+  contents: write
+
 env:
   go_version: '1.22'
 


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-operator/security/code-scanning/1](https://github.com/scylladb/scylla-operator/security/code-scanning/1)

In general, the fix is to explicitly declare `permissions` for the `GITHUB_TOKEN` in the workflow, rather than relying on repository/organization defaults. This is done by adding a `permissions:` block either at the top workflow level (so it applies to all jobs without their own `permissions`) or within the specific job. The least-privilege baseline recommended by the alert is `contents: read`, which is sufficient for checking out code and many read-only operations.

For this workflow, the simplest and least intrusive change is to add a top-level `permissions:` block just after the `on:` section (before `env:`). This will apply to the single `release-notes` job and any future jobs unless they override it. We will set:
```yaml
permissions:
  contents: read
```
No imports or additional methods are needed—this is purely a YAML configuration change within `.github/workflows/releases.yaml`. Functionality should remain unchanged for operations that only need read access to repository contents; if the custom `release-notes` action requires more, those can be added later, but that is outside the scope of the current static-analysis fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
