### PR TITLE
Remove default channel annotation from OLM bundle metadata

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: scylladb-operator
   operators.operatorframework.io.bundle.channels.v1: dev # Overwritten during publishing.
-  operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-unknown
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** The default channel annotation set in the OLM bundle metadata breaks the certification pipeline if the default channel is not among channels, as the temporary catalog created in the pipeline does not contain an entry for the default channel then. We circumvented it in our CI as we're building the scratch catalog ourselves, but it's not possible to override it in the pipeline.

I propose we remove this annotation as it's optional. 
**An alternative solution would be to only set it in the post-processing script iff the provided channel is `stable`.**

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc mflendrich