### PR TITLE
Allow configuring Scylla reactor backend in E2E tests

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -359,6 +359,7 @@ function run-e2e {
     "--scyllacluster-nodes-broadcast-address-type=${SO_SCYLLACLUSTER_NODES_BROADCAST_ADDRESS_TYPE}"
     "--scyllacluster-clients-broadcast-address-type=${SO_SCYLLACLUSTER_CLIENTS_BROADCAST_ADDRESS_TYPE}"
     "--scyllacluster-storageclass-name=${SO_SCYLLACLUSTER_STORAGECLASS_NAME}"
+    "--scyllacluster-reactor-backend=${SO_SCYLLACLUSTER_REACTOR_BACKEND:-}"
     "--object-storage-bucket=${SO_BUCKET_NAME}"
     "--gcs-service-account-key-path=${gcs_sa_in_container_path}"
     "--s3-credentials-file-path=${s3_credentials_in_container_path}"

--- a/pkg/assets/template.go
+++ b/pkg/assets/template.go
@@ -21,6 +21,7 @@ var TemplateFuncs template.FuncMap = template.FuncMap{
 	"repeat":               Repeat,
 	"isTrue":               IsTrue,
 	"sanitizeDNSSubdomain": SanitizeDNSSubdomain,
+	"join":                 strings.Join,
 }
 
 func MarshalYAML(v any) (string, error) {

--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -10,6 +10,9 @@ spec:
   agentVersion: "{{ .scyllaDBManagerVersion }}"
   version: "{{ .scyllaDBVersion }}"
   developerMode: true
+  {{- if .scyllaArgs }}
+  scyllaArgs: "{{ join .scyllaArgs " " }}"
+  {{- end }}
   exposeOptions:
     nodeService:
       type: {{ .nodeServiceType }}

--- a/test/e2e/fixture/scylla/scylladbcluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbcluster.yaml.tmpl
@@ -14,6 +14,13 @@ spec:
   scyllaDB:
     image: "{{ .scyllaDBRepository }}:{{ .scyllaDBVersion }}"
     enableDeveloperMode: true
+    {{- if .scyllaArgs }}
+    additionalScyllaDBArguments: [
+        {{- range .scyllaArgs }}
+        "{{ . }}",
+        {{- end }}
+    ]
+    {{- end }}
   scyllaDBManagerAgent:
     image: "{{ .scyllaDBManagerAgentRepository }}:{{ .scyllaDBManagerVersion }}"
   datacenterTemplate:

--- a/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
@@ -12,6 +12,13 @@ spec:
   scyllaDB:
     image: "{{ .scyllaDBRepository }}:{{ .scyllaDBVersion }}"
     enableDeveloperMode: true
+    {{- if .scyllaArgs }}
+    additionalScyllaDBArguments: [
+        {{- range .scyllaArgs }}
+        "{{ . }}",
+        {{- end }}
+    ]
+    {{- end }}
   scyllaDBManagerAgent:
     image: "{{ .scyllaDBManagerAgentRepository }}:{{ .scyllaDBManagerVersion }}"
   exposeOptions:

--- a/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
@@ -10,6 +10,9 @@ spec:
   agentVersion: "{{ .scyllaDBManagerVersion }}"
   version: "{{ .scyllaDBVersion }}"
   developerMode: true
+  {{- if .scyllaArgs }}
+  scyllaArgs: "{{ join .scyllaArgs " " }}"
+  {{- end }}
   exposeOptions:
     nodeService:
       type: {{ .nodeServiceType }}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -167,6 +167,7 @@ func (f *Framework) GetDefaultScyllaCluster() *scyllav1.ScyllaCluster {
 		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
 		"storageClassName":            TestContext.ScyllaClusterOptions.StorageClassName,
+		"scyllaArgs":                  TestContext.ScyllaClusterOptions.ScyllaArgs(),
 	}
 
 	sc, _, err := scyllafixture.ScyllaClusterTemplate.RenderObject(renderArgs)
@@ -183,6 +184,7 @@ func (f *Framework) GetDefaultZonalScyllaClusterWithThreeRacks() *scyllav1.Scyll
 		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
 		"storageClassName":            TestContext.ScyllaClusterOptions.StorageClassName,
+		"scyllaArgs":                  TestContext.ScyllaClusterOptions.ScyllaArgs(),
 		"rackNames":                   []string{"a", "b", "c"},
 	}
 
@@ -200,6 +202,7 @@ func (f *Framework) GetDefaultScyllaDBDatacenter() *scyllav1alpha1.ScyllaDBDatac
 		"nodesBroadcastAddressType":      TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType":    TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
 		"storageClassName":               TestContext.ScyllaClusterOptions.StorageClassName,
+		"scyllaArgs":                     TestContext.ScyllaClusterOptions.ScyllaArgs(),
 		"scyllaDBRepository":             configassets.ScyllaDBImageRepository,
 		"scyllaDBManagerAgentRepository": configassets.ScyllaDBManagerAgentImageRepository,
 	}
@@ -218,6 +221,7 @@ func (f *Framework) GetDefaultScyllaDBCluster(rkcMap map[string]*scyllav1alpha1.
 		"nodesBroadcastAddressType":      TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
 		"clientsBroadcastAddressType":    TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
 		"storageClassName":               TestContext.ScyllaClusterOptions.StorageClassName,
+		"scyllaArgs":                     TestContext.ScyllaClusterOptions.ScyllaArgs(),
 		"remoteKubernetesClusterMap":     rkcMap,
 		"scyllaDBRepository":             configassets.ScyllaDBImageRepository,
 		"scyllaDBManagerAgentRepository": configassets.ScyllaDBManagerAgentImageRepository,

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -26,6 +26,17 @@ type IngressController struct {
 type ScyllaClusterOptions struct {
 	ExposeOptions    ExposeOptions
 	StorageClassName string
+	ReactorBackend   string
+}
+
+func (o *ScyllaClusterOptions) ScyllaArgs() []string {
+	var args []string
+
+	if o.ReactorBackend != "" {
+		args = append(args, "--reactor-backend="+o.ReactorBackend)
+	}
+
+	return args
 }
 
 type ExposeOptions struct {

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -420,7 +420,10 @@ var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage
 			scyllaRepository: configassets.ScyllaDBEnterpriseImageRepository,
 			scyllaVersion:    configassets.Project.Operator.ScyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride,
 			preTargetClusterCreateHook: func(targetCluster *scyllav1.ScyllaCluster) {
-				targetCluster.Spec.ScyllaArgs = "--consistent-cluster-management=false"
+				if targetCluster.Spec.ScyllaArgs != "" {
+					targetCluster.Spec.ScyllaArgs += " "
+				}
+				targetCluster.Spec.ScyllaArgs += "--consistent-cluster-management=false"
 			},
 			postSchemaRestoreHook: func(ctx context.Context, f *framework.Framework, targetSC *scyllav1.ScyllaCluster) {
 				var err error

--- a/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
+++ b/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
@@ -406,7 +406,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		g.Entry("using a workaround for consistent_cluster_management for ScyllaDB Enterprise image", entry{
 			scyllaDBImage: fmt.Sprintf("%s:%s", configassets.ScyllaDBEnterpriseImageRepository, configassets.Project.Operator.ScyllaDBEnterpriseVersionNeedingConsistentClusterManagementOverride),
 			preTargetClusterCreateHook: func(targetSDC *scyllav1alpha1.ScyllaDBDatacenter) {
-				targetSDC.Spec.ScyllaDB.AdditionalScyllaDBArguments = []string{"--consistent-cluster-management=false"}
+				targetSDC.Spec.ScyllaDB.AdditionalScyllaDBArguments = append(targetSDC.Spec.ScyllaDB.AdditionalScyllaDBArguments, "--consistent-cluster-management=false")
 			},
 			postSchemaRestoreHook: func(ctx context.Context, ns string, nsClient framework.Client, targetSDC *scyllav1alpha1.ScyllaDBDatacenter) {
 				var err error


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**  Unlocks ability to set reactor backend to `io_uring` which, in contrast to `linux_aio`, doesn't require IO-related sysctls tweaking (which we wouldn't be able to tweak in KinD clusters). It also results in better performance in tests, reducing their total time to run.

**Which issue is resolved by this Pull Request:**
Prerequisite for: https://github.com/scylladb/scylla-operator/issues/3144
