### PR TITLE
Update the dockerfile to address image certifcation requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,6 @@ RUN microdnf install -y procps-ng && \
 COPY --from=builder /go/src/github.com/scylladb/scylla-operator/scylla-operator /usr/bin/
 COPY --from=builder /go/src/github.com/scylladb/scylla-operator/scylla-operator-tests /usr/bin/
 
+COPY /LICENSE /licenses/LICENSE
+
 ENTRYPOINT ["/usr/bin/scylla-operator"]


### PR DESCRIPTION
Address the [image content requirements](https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images) (specifically: _HasLicense_) and the [image metadata requirements](https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-metadata-requirements_openshift-sw-cert-policy-container-images) (specifically: _HasRequiredLabels_) of the Red Hat container certification requirements. See the respective commit messages for additional context.

This change dances around the fact that we don't know the package version at build time by setting `version` and `release` to a constant`"see-image-tag"` to maximize its usefulness. I think that it's desirable to have better wiring for version numbers, but it's infeasible with the current build system setup (or we'd otherwise sacrifice all immutability of deps pulled into the build image across the promotion process; it feels like a lesser evil to keep it this way).

Verified locally that this passes preflight.

/kind machinery
/priority important-soon