### PR TITLE
Use provided SSH identity and accept new host when cloning target repository in OLM certification script

### DIFF
--- a/hack/.ci/olm/certify-bundle.sh
+++ b/hack/.ci/olm/certify-bundle.sh
@@ -92,6 +92,8 @@ cp -r "${script_dir}/../../../bundle/"{manifests,metadata} "${target_dir}/"
 
 (
   cd "${repo_target_dir}"
+  git config user.name "ScyllaDB Operator Continuous Delivery Bot"
+  git config user.email "251034767+scylladb-operator-cd-bot@users.noreply.github.com"
   git checkout -B "${TARGET_BRANCH}"
   git add .
   # https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#pull-request-title


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** The certification job fails due to the target repository host being unknown: https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/post-scylla-operator-olm-bundle-certification/2011405952661590016#1:build-log.txt%3A36-39.

This PR fixes it. It also configures the author identity.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc czeslavo