### PR TITLE
Exit with pipeline run error in RH certification script

### DIFF
--- a/hack/.ci/olm/certify-bundle.sh
+++ b/hack/.ci/olm/certify-bundle.sh
@@ -128,4 +128,5 @@ tkn pipeline start operator-ci-pipeline \
   --param upstream_repo_name=redhat-openshift-ecosystem/certified-operators \
   --param submit="${SUBMIT}" \
   --use-param-defaults \
-  --showlog
+  --showlog \
+  --exit-with-pipelinerun-error


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Currently, an error in certification pipeline run does not lead to the job failure, leading to the job passing successfully despite any errors. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc czeslavo