### PR TITLE
Fix makeCertificate test race causing panic

### DIFF
--- a/pkg/kubecrypto/certs_test.go
+++ b/pkg/kubecrypto/certs_test.go
@@ -806,8 +806,17 @@ func Test_makeCertificate_certStability(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer keygen.Close()
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	ctx, ctxCancel := context.WithCancel(t.Context())
+	defer ctxCancel()
+
+	wg.Add(1)
 	go func() {
-		keygen.Run(t.Context())
+		defer wg.Done()
+		keygen.Run(ctx)
 	}()
 
 	controller := &metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** `Test_makeCertificate_certStability` proved to be unstable in https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3196/pull-scylla-operator-master-unit/2012176084010799104. This PR aims to fix it by ensuring the key generator is torn down before the end of the test.
