### PR TITLE
Fix renovate's depName matcher in scylla-manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   "packageRules": [
     {
       "description": "scylla-manager and scylla-manager-agent must be updated together",
-      "matchPackageNames": ["scylla-manager", "scylla-manager-agent"],
+      "matchDepNames": ["scylla-manager", "scylla-manager-agent"],
       "groupName": "scylla-manager"
     },
     {


### PR DESCRIPTION
I've noticed the likely reason for Renovate refusing to group `scylla-manager` and `scylla-manager-agent` updates together: we intended to match by `depName`, not by `packageName`.

This PR fixes that by switching the matcher used to the correct one.

The respective depNames and packageNames are defined like this:
https://github.com/scylladb/scylla-operator/blob/443331c02e86368773856361c64c77a42da529bd/assets/config/config.yaml#L10-L13

/kind machinery
/priority important-soon