### PR TITLE
Add gomodUpdateImportPaths to renovate postUpdateOptions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
   },
   "postUpdateOptions": [
     "gomodTidy",
-    "gomodVendor"
+    "gomodVendor",
+    "gomodUpdateImportPaths"
   ],
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Adds `gomodUpdateImportPaths` to the Renovate's `postUpdateOptions` to automatically update package paths when bumping majors (it's missing in https://github.com/scylladb/scylla-operator/pull/3181).

Source: https://docs.renovatebot.com/modules/manager/gomod/#major-upgrades-of-dependencies

**Which issue is resolved by this Pull Request:**
Related to https://github.com/scylladb/scylla-operator/pull/3181.
