### PR TITLE
Enable poetry manager in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "enabledManagers": [
     "custom.regex",
     "gomod",
-    "pep621"
+    "poetry"
   ],
   "schedule": [
     "before 5am every weekday"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** I made a mistake rebasing https://github.com/scylladb/scylla-operator/pull/3214 which resulted in not replacing pep621 manager with poetry. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon