### PR TITLE
Add a ScyllaDB Operator installation guide in Red Hat OpenShift

### DIFF
--- a/docs/source/.internal/node-tuning.note.md
+++ b/docs/source/.internal/node-tuning.note.md
@@ -1,0 +1,3 @@
+:::{note}
+Performance tuning is enabled for all nodes that are selected by `NodeConfig` by default, unless explicitly opted-out of.
+:::

--- a/docs/source/.internal/operator-namespace.warning.md
+++ b/docs/source/.internal/operator-namespace.warning.md
@@ -1,0 +1,3 @@
+:::{warning}
+ScyllaDB Operator must run in a reserved `scylla-operator` namespace. [It is not currently possible](https://github.com/scylladb/scylla-operator/issues/2563) to run it in a different namespace.
+:::

--- a/docs/source/.internal/verify-operator-installation-gitops.md
+++ b/docs/source/.internal/verify-operator-installation-gitops.md
@@ -1,0 +1,24 @@
+Wait for CRDs to propagate to all apiservers:
+:::{code-block} shell
+kubectl wait --for='condition=established' crd/scyllaclusters.scylla.scylladb.com crd/nodeconfigs.scylla.scylladb.com crd/scyllaoperatorconfigs.scylla.scylladb.com crd/scylladbmonitorings.scylla.scylladb.com
+:::
+
+**Expected output**:
+:::{code-block} console
+customresourcedefinition.apiextensions.k8s.io/scyllaclusters.scylla.scylladb.com condition met
+customresourcedefinition.apiextensions.k8s.io/nodeconfigs.scylla.scylladb.com condition met
+customresourcedefinition.apiextensions.k8s.io/scyllaoperatorconfigs.scylla.scylladb.com condition met
+customresourcedefinition.apiextensions.k8s.io/scylladbmonitorings.scylla.scylladb.com condition met
+:::
+
+Wait for the components to roll out:
+:::{code-block} shell
+kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/{scylla-operator,webhook-server}
+:::
+
+**Expected output**:
+:::{code-block} console
+deployment "scylla-operator" successfully rolled out
+deployment "webhook-server" successfully rolled out
+:::
+

--- a/docs/source/installation/gitops.md
+++ b/docs/source/installation/gitops.md
@@ -108,12 +108,9 @@ The ScyllaDB Operator image value and the `SCYLLA_OPERATOR_IMAGE` shall always m
 Be careful not to use a rolling tag for any of them to avoid an accidental skew!
 ::::
 
-:::{code-block} shell
-# Wait for CRDs to propagate to all apiservers.
-kubectl wait --for='condition=established' crd/scyllaclusters.scylla.scylladb.com crd/nodeconfigs.scylla.scylladb.com crd/scyllaoperatorconfigs.scylla.scylladb.com crd/scylladbmonitorings.scylla.scylladb.com
+### Verify the ScyllaDB Operator installation
 
-# Wait for the components to deploy.
-kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/{scylla-operator,webhook-server}
+:::{include} ./../.internal/verify-operator-installation-gitops.md
 :::
 
 ### Setting up local storage on nodes and enabling tuning
@@ -164,8 +161,7 @@ kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.
 
 :::::
 
-:::{note}
-Performance tuning is enabled for all nodes that are selected by [NodeConfig](../resources/nodeconfigs.md) by default, unless opted-out.
+:::{include} ../.internal/node-tuning.note.md
 :::
 
 After applying the manifest, wait for the NodeConfig to apply changes to the Kubernetes nodes.

--- a/docs/source/installation/index.md
+++ b/docs/source/installation/index.md
@@ -7,4 +7,5 @@ overview
 kubernetes-prerequisites
 gitops
 helm
+OpenShift <openshift>
 :::

--- a/docs/source/installation/kubernetes-prerequisites.md
+++ b/docs/source/installation/kubernetes-prerequisites.md
@@ -46,6 +46,13 @@ nodeGroups:
 
 ::::
 
+::::{group-tab} OpenShift
+
+In Red Hat OpenShift, you can configure CPU Manager policy to `static` by creating a `KubeletConfig` resource and configuring it to select the `MachineConfigPool` dedicated to your ScyllaDB nodes.
+Please follow the steps outlined in the Red Hat documentation: [Setting up CPU Manager](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/scalability_and_performance/using-cpu-manager#setting_up_cpu_manager_using-cpu-manager-and-topology-manager).
+
+::::
+
 :::::
 
 ## Nodes

--- a/docs/source/installation/openshift.md
+++ b/docs/source/installation/openshift.md
@@ -1,0 +1,310 @@
+# Install ScyllaDB Operator in Red Hat OpenShift
+
+ScyllaDB Operator is a Red Hat OpenShift Certified Operator available for installation through the embedded software catalog, 
+a user interface for discovering Operators working in conjunction with Operator Lifecycle Manager (OLM), which installs and manages Operators in a cluster.
+This guide describes how to install ScyllaDB Operator from the software catalog in a Red Hat OpenShift cluster.
+
+## Prerequisites
+
+This guide requires you to have access to an OpenShift Container Platform cluster using an account with `cluster-admin` permissions.
+
+Ensure that your OpenShift cluster meets the [general prerequisites](./kubernetes-prerequisites.md) for ScyllaDB Operator installation.
+
+Additionally, ensure that you have `kubectl` or OpenShift CLI (`oc`) installed.
+
+:::{tip}
+Commands in this guide can be executed using the OpenShift CLI (`oc`) in place of `kubectl`.
+:::
+
+## Install ScyllaDB Operator
+
+ScyllaDB Operator can be installed in a Red Hat OpenShift cluster from the software catalog through one of the below methods: OpenShift Container Platform web console or CLI. 
+
+:::::{tabs}
+
+::::{group-tab} Web Console
+
+This procedure describes how to install and subscribe to ScyllaDB Operator from software catalog by using the OpenShift Container Platform web console.
+
+:::{note}
+This procedure aims to follow the generic Operator installation steps outlined in the upstream documentation: [Installing from the software catalog by using the web console](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-installing-from-software-catalog-using-web-console_olm-adding-operators-to-a-cluster).
+You can refer to it for more detailed instructions, or follow the below steps for a more contained, ScyllaDB Operator specific guidance.
+:::
+
+### Procedure
+
+1. Navigate to `Ecosystem` -> `Software Catalog`.
+2. Search for ScyllaDB Operator and select the `Certified` version by setting the `Source` filter to `Certified` or ensuring that the ScyllaDB Operator tile has the `Certified` tag next to it.
+3. In the description dialog, read the information about the operator and click `Install`.
+4. In the `Install Operator` dialog, configure your ScyllaDB Operator installation:
+   * For clusters on cloud providers with token-based authentication:
+     - AWS Security Token Service (STS Mode in the web console): enter the Amazon Resource Name (ARN) of the AWS IAM role of your service account in the role ARN field.
+   * Select the `stable` Update Channel and version {{latestStableVersion}} from the list.
+   * Select the `All namespaces on the cluster` installation mode.
+   * Select the Operator recommended installed namespace: `scylla-operator`.
+     :::{include} ../.internal/operator-namespace.warning.md
+     :::
+   * Select the `Manual` update approval strategy to manually approve ScyllaDB Operator upgrades when new versions are available.
+     :::{caution}
+     Always review the [Upgrading ScyllaDB Operator](../management/upgrading/upgrade.md) guide and check for [additional steps for specific versions](../management/upgrading/upgrade.md#upgrade-steps-for-specific-versions) before starting the upgrade process.
+     :::
+5. Click `Install` to install and subscribe to ScyllaDB Operator.
+6. In the `Install Plan` dialog, review the manual install plan and click `Approve` to approve it.
+7. Log in to the OpenShift cluster in the terminal. Ensure that `kubectl` is configured to communicate with your OpenShift cluster.
+::::
+
+::::{group-tab} CLI
+
+This procedure describes how to install and subscribe to ScyllaDB Operator from software catalog by using the CLI.
+
+:::{note}
+This procedure aims to follow the generic Operator installation steps outlined in the upstream documentation: [Installing from the software catalog by using the CLI](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-installing-operator-from-software-catalog-using-cli_olm-adding-operators-to-a-cluster).
+You can refer to it for more detailed instructions, or follow the below steps for a more contained, ScyllaDB Operator specific guidance.
+:::
+
+### Procedure
+
+1. Log in to the OpenShift cluster in the terminal. Ensure that `kubectl` is configured to communicate with your OpenShift cluster.
+2. Ensure that the ScyllaDB Operator package is available:
+    :::{code-block} bash
+    kubectl get -n=openshift-marketplace packagemanifest scylladb-operator
+    :::
+
+    **Expected output**:
+    :::{code-block} console
+    NAME                CATALOG               AGE
+    scylladb-operator   Certified Operators   2d22h
+    :::
+
+3. Create the `scylla-operator` namespace:
+    :::{include} ../.internal/operator-namespace.warning.md
+    :::
+
+    :::{code-block} bash
+    kubectl create namespace scylla-operator
+    :::
+
+4. Create an `OperatorGroup` object in the `scylla-operator` namespace:
+    :::{code-block} bash
+    kubectl apply --server-side -n=scylla-operator -f=- <<EOF
+    apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: scylladb-operator
+      namespace: scylla-operator
+    EOF
+    :::
+
+5. Create a `Subscription` object to install and subscribe to ScyllaDB Operator:
+    
+    Clusters on cloud providers with token-based authentication require you to include relevant cloud-provider specific fields in the `Subscription` object’s config section.
+    Apply the appropriate manifest based on your environment. In the below table, manifests are provided for AWS STS mode and generic installations.
+    
+    :::::{tabs}
+    ::::{group-tab} AWS STS
+
+    If the cluster is in AWS STS mode, include the role ARN details in the `Subscription` manifest.
+
+    :::{code-block} bash
+    :substitutions:
+    kubectl apply --server-side -n=scylla-operator -f=- <<EOF
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: scylladb-operator
+      namespace: scylla-operator
+    spec:
+      channel: stable
+      installPlanApproval: Manual
+      name: scylladb-operator
+      source: certified-operators
+      sourceNamespace: openshift-marketplace
+      startingCSV: scylladb-operator.{{latestStableRelease}}
+      config:
+        env:
+        - name: ROLEARN
+          value: "<role_arn>"
+    EOF
+    :::
+
+    ::::
+
+    ::::{group-tab} Generic
+
+    :::{code-block} bash
+    :substitutions:
+    kubectl apply --server-side -n=scylla-operator -f=- <<EOF
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: scylladb-operator
+      namespace: scylla-operator
+    spec:
+      channel: stable
+      installPlanApproval: Manual
+      name: scylladb-operator
+      source: certified-operators
+      sourceNamespace: openshift-marketplace
+      startingCSV: scylladb-operator.{{latestStableRelease}}
+    EOF
+    :::
+    
+    ::::
+    
+    :::::
+
+6. Review and approve the generated `InstallPlan` to start the installation:
+   - Locate the generated `InstallPlan` object and note its name:
+     :::{code-block} bash
+     kubectl -n=scylla-operator get installplan -l=operators.coreos.com/scylladb-operator.scylla-operator=""
+     :::
+    
+     **Example expected output**:
+     :::{code-block}  console
+     NAME            CSV                         APPROVAL   APPROVED
+     install-tw6bv   scylladb-operator.v1.20.0   Manual     true
+     :::
+
+   - Describe the `InstallPlan` object and review the changes that will be applied:
+     :::{code-block} bash
+     kubectl -n=scylla-operator describe installplan <install-plan-name>
+     :::
+   
+   - Approve the reviewed `InstallPlan` to start the installation:
+     :::{code-block} bash
+     kubectl -n=scylla-operator patch installplan --type=merge -p='{"spec":{"approved":true}}' <install-plan-name>
+     :::
+    
+     **Example expected output**:
+     :::{code-block} console
+     installplan.operators.coreos.com/install-tw6bv patched
+     :::
+
+6. Wait for the ScyllaDB Operator to be installed:
+    
+    Wait for `ClusterServiceVersion` to be created:
+    :::{code-block} bash 
+    :substitutions:
+    kubectl -n=scylla-operator wait --for=create --timeout=10m csv/scylladb-operator.{{latestStableRelease}} 
+    :::
+    
+    **Expected output**:
+    :::{code-block} console
+    :substitutions:
+    clusterserviceversion.operators.coreos.com/scylladb-operator.{{latestStableRelease}} condition met
+    :::
+
+    Wait for `ClusterServiceVersion` to reach `Succeeded` phase:
+    :::{code-block} bash 
+    :substitutions:
+    kubectl wait -n=scylla-operator --timeout=5m --for=jsonpath='{.status.phase}'=Succeeded clusterserviceversions.operators.coreos.com/scylladb-operator.{{latestStableRelease}}
+    :::
+    
+    **Expected output**:
+    :::{code-block} console
+    :substitutions:
+    clusterserviceversion.operators.coreos.com/scylladb-operator.{{latestStableRelease}} condition met
+    :::
+::::
+:::::
+
+### Verify the ScyllaDB Operator installation
+
+:::{include} ./../.internal/verify-operator-installation-gitops.md
+:::
+
+## Set up local storage on dedicated nodes and enable tuning
+
+ScyllaDB Operator enables local storage configuration and performance tuning through the [`NodeConfig`](../resources/nodeconfigs.md) resource.
+The below table contains example `NodeConfig` manifests for a selected set of OpenShift deployment models and platforms:
+- A production-ready configuration for Red Hat OpenShift Service on AWS (ROSA) clusters with local NVMe storage.
+- A development-oriented configuration using loop devices intended for environments with no local disks available.
+
+:::{caution}
+Local storage configuration depends on the OpenShift deployment model and the underlying platform and infrastructure.
+Review the [`NodeConfig`](../resources/nodeconfigs.md) reference and adjust the manifest to your specific environment.
+:::
+
+:::{include} ../.internal/node-tuning.note.md
+:::
+
+:::::{tabs}
+::::{group-tab} ROSA (NVMe)
+
+The following manifest creates a RAID0 array from the available NVMe devices, formats it with the XFS filesystem, and enables performance tuning recommended for production-grade ScyllaDB deployments on the selected nodes.
+:::{literalinclude} ../../../examples/openshift/rosa/nodeconfig.yaml
+:language: yaml
+:::
+
+You can apply it using the following command:
+
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/openshift/rosa/nodeconfig.yaml
+:::
+::::
+
+::::{group-tab} Any platform (Loop devices)
+
+The following manifest creates a loop device, formats it with the XFS filesystem, and enables performance tuning on the selected nodes.
+
+:::{caution}
+This configuration is only intended for development purposes in environments with no local NVMe disks available.
+Expect performance to be significantly degraded with this setup.
+:::
+
+:::{literalinclude} ../../../examples/generic/nodeconfig-alpha.yaml
+:language: yaml
+:::
+
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-operator apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/generic/nodeconfig-alpha.yaml
+:::
+
+::::
+
+:::::
+
+Having applied the `NodeConfig` manifest, wait for it to apply changes to the selected Kubernetes nodes:
+:::{include} ./../.internal/wait-for-status-conditions.nodeconfig.code-block.md
+:::
+
+## Install Local CSI Driver
+
+Local CSI Driver dynamically provisions PersistentVolumes on local storage configured on the nodes using the `NodeConfig` resource.
+To install Local CSI Driver in a Red Hat OpenShift cluster, run the following command:
+
+:::{code-block} shell
+:substitutions:
+kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
+:::
+
+Having applied the manifests, wait for the Local CSI Driver `DaemonSet` to be deployed:
+:::{code-block} shell
+kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-csi-driver
+:::
+
+## Install ScyllaDB Manager
+
+ScyllaDB Manager enables you to schedule second-day operations tasks, such as backups and repairs.
+
+Run the following command to install a production-ready ScyllaDB Manager deployment:
+
+:::{warning}
+ScyllaDB Manager must run in a reserved `scylla-manager` namespace. It is [not currently possible](https://github.com/scylladb/scylla-operator/issues/2563) to use a different namespace for ScyllaDB Manager deployment.
+:::
+
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/manager-prod.yaml
+:::
+
+Having applied the manifest, wait for ScyllaDB Manager to deploy:
+:::{code-block} shell
+kubectl -n=scylla-manager rollout status --timeout=10m deployment.apps/scylla-manager
+:::
+
+## Next steps
+- Deploy a ScyllaDB cluster by following the [ScyllaCluster deployment guide](../resources/scyllaclusters/basics.md).
+- To set up ScyllaDB Monitoring, refer to [](../management/monitoring/external-prometheus-on-openshift.md). Visit the [ScyllaDB Monitoring overview](../management/monitoring/overview.md) for more information about the monitoring stack.

--- a/docs/source/installation/overview.md
+++ b/docs/source/installation/overview.md
@@ -58,17 +58,29 @@ ScyllaDB Manager uses a small ScyllaCluster instance internally and thus depends
 
 ScyllaDB provides you with a custom [Local CSI driver](../architecture/storage/local-csi-driver.md) that lets you dynamically provision PersistentVolumes, share the disk space but still track the capacity and use quotas.
 
-## Notes
+## Installation
 
-:::{note}
-Before reporting and issue, please see our [support page](../support/overview.md) and [troubleshooting installation issues](../support/troubleshooting/installation.md#troubleshooting-installation-issues)
-:::
+You can install ScyllaDB Operator on Red Hat OpenShift using OLM (Operator Lifecycle Manager), or on any Kubernetes cluster using GitOps manifests or Helm charts.
 
-## Installation modes
+### Red Hat OpenShift
 
-Depending on your preference, there is more than one way to install ScyllaDB Operator and there may be more to come / or provided by other parties or supply chains.
+ScyllaDB Operator is available as a Red Hat Certified Operator in the embedded OperatorHub. 
+You can install it using OLM (Operator Lifecycle Manager), which handles installation, upgrades, and management of operators and their dependencies, including CRDs.
 
-At this point, we provide 2 ways to install the operator - [GitOps/manifests](#gitops) and [Helm charts](#helm). Given we provide only a subset of helm charts for the main resources and because **Helm can't update CRDs** - you still have to resort to using the manifests or GitOps anyway. For a consistent experience we'd recommend using the [GitOps flow](#gitops) which will also give you a better idea about what you actually deploy and maintain.
+The following components need to be deployed and maintained using other deployment methods:
+- [Local CSI Driver](#local-csi-driver)
+- [ScyllaDB Manager](#scylladb-manager)
+
+We provide [GitOps](#gitops) manifests and installation instructions for these components.
+
+For details, please see the [dedicated section describing the deployment on Red Hat OpenShift](./openshift.md).
+
+### Generic Kubernetes
+
+For generic Kubernetes clusters, we provide [GitOps/manifests](#gitops) and [Helm charts](#helm).
+
+Given we provide only a subset of helm charts for the main resources and because **Helm can't update CRDs** - you still have to resort to using the manifests or GitOps anyway. 
+For a consistent experience we'd recommend using the [GitOps flow](#gitops) which will also give you a better idea about what you actually deploy and maintain.
 
 :::{caution}
 Do not use rolling tags (like `latest`, `1.14`) with our manifests in production.
@@ -81,11 +93,11 @@ To avoid races, when you create a CRD, you need to wait for it to be propagated 
 :::
 
 :::{note}
-When you create [ValidatingWebhookConfiguration](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#webhook-configuration) or [MutatingWebhookConfiguration](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#webhook-configuration), you have to wait for the corresponding webhook deployments to be available, or the kubernetes-apiserver will fail all requests for resources affected by these webhhok configurations.
+When you create [ValidatingWebhookConfiguration](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#webhook-configuration) or [MutatingWebhookConfiguration](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#webhook-configuration), you have to wait for the corresponding webhook deployments to be available, or the kubernetes-apiserver will fail all requests for resources affected by these webhook configurations.
 Also note that some platforms have non-conformant networking setups by default that prevents the kube-apiserver from talking to the webhooks - [see our troubleshooting guide for more info](../support/troubleshooting/installation.md#webhooks).
 ::: 
 
-### GitOps
+#### GitOps
 
 We provide a set of Kubernetes manifest that contain all necessary objects to apply to your Kubernetes cluster.
 Depending on your preference applying them may range from using `git` with a declarative CD to `git` and `kubectl`.
@@ -93,7 +105,7 @@ To keep the instructions clear for everyone we'll demonstrate applying the manif
 
 For details, please see the [dedicated section describing the deployment using GitOps (kubectl)](./gitops.md). 
 
-### Helm
+#### Helm
 
 :::{include} ../.internal/helm-crd-warning.md
 :::

--- a/examples/openshift/rosa/nodeconfig.yaml
+++ b/examples/openshift/rosa/nodeconfig.yaml
@@ -1,0 +1,42 @@
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: NodeConfig
+metadata:
+  name: scylladb-nodepool-1
+spec:
+  localDiskSetup:
+    filesystems:
+    - device: /dev/md/nvmes
+      type: xfs
+    mounts:
+    - device: /dev/md/nvmes
+      mountPoint: /var/lib/persistent-volumes
+      unsupportedOptions:
+      - prjquota
+    raids:
+    - name: nvmes
+      type: RAID0
+      RAID0:
+        devices:
+          modelRegex: Amazon EC2 NVMe Instance Storage
+          nameRegex: ^/dev/nvme\d+n\d+$
+  sysctls:
+  - name: fs.aio-max-nr
+    value: "30000000"
+  - name: fs.file-max
+    value: "9223372036854775807"
+  - name: fs.nr_open
+    value: "1073741816"
+  - name: fs.inotify.max_user_instances
+    value: "1200"
+  - name: vm.swappiness
+    value: "1"
+  - name: vm.vfs_cache_pressure
+    value: "2000"
+  placement:
+    nodeSelector:
+      scylla.scylladb.com/node-type: scylla
+    tolerations:
+    - effect: NoSchedule
+      key: scylla-operator.scylladb.com/dedicated
+      operator: Equal
+      value: scyllaclusters


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR introduces an installation guide for Red Hat OpenShift clusters.
Two installation methods are covered: OpenShift Container Platform web console and CLI.
The installation overview is modified to accommodate the new deployment method.

*Note*: this PR doesn't include upgrade steps for operator installed through OLM.

**Which issue is resolved by this Pull Request:**
Resolves #

/priority important-soon
/kind documentation