### PR TITLE
Describe potential env-specific requirements for kind-fast

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,11 @@ it's up to the developer to ensure they are available in the environment:
 
 ### Running E2E tests locally
 
-We use [Kind](https://kind.sigs.k8s.io/) for basic local testing. There's a Makefile target to create a Kind cluster with a local registry configured
-so we can use locally built images. To set up the Kind cluster, run:
+We use [Kind](https://kind.sigs.k8s.io/) for basic local testing. We rely on a kind with rootless Podman setup, so before
+proceeding, make sure your host system is configured accordingly to [Kind Podman rootless guide](https://kind.sigs.k8s.io/docs/user/rootless/).
+
+There's a Makefile target to create a Kind cluster with a local registry configured so we can use locally built images.
+To set up the Kind cluster, run:
 
 ```bash
 make kind-setup

--- a/hack/kind/run-e2e-tests.sh
+++ b/hack/kind/run-e2e-tests.sh
@@ -40,7 +40,7 @@ trap gracefully-shutdown-e2es INT
 if [ -z "${SO_IMAGE:-}" ]; then
   SO_IMAGE="localhost:5001/scylladb/scylla-operator:e2e-$( date +%Y%m%d%H%M%S )"
   export SO_IMAGE
-  podman build -t "${SO_IMAGE}" -f "${parent_dir}/../../Dockerfile" "${parent_dir}/../.."
+  podman build --format docker -t "${SO_IMAGE}" -f "${parent_dir}/../../Dockerfile" "${parent_dir}/../.."
 
   # Push the image to the local registry. Use --tls-verify=false as we're running local registry without TLS.
   podman push --tls-verify=false "${SO_IMAGE}"


### PR DESCRIPTION
**Description of your changes:** The PR addresses gaps discovered by @mflendrich during his test run of the kind-fast machinery:

- documents the rootless podman requirements by linking to the kind guide
- adds `systemd-run --scope --user -p "Delegate=yes"` to `kind create ...` for compatibility with development hosts with systemd older than 252
- changes the local image format to `docker` to avoid noisy warnings