### PR TITLE
Set E2E suites' parallelism to match their test cases count

### DIFF
--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -26,7 +26,7 @@ var Suites = ginkgotest.TestSuites{
 		Description: templates.LongDesc(`
 		Runs all tests.`,
 		),
-		DefaultParallelism: 42,
+		DefaultParallelism: 100,
 	},
 	{
 		Name: "scylla-operator/conformance/parallel",
@@ -40,7 +40,7 @@ var Suites = ginkgotest.TestSuites{
 			framework.SupportedOnlyOnOpenShiftLabelName,
 			framework.IPv6LabelName,
 		),
-		DefaultParallelism: 42,
+		DefaultParallelism: 70,
 	},
 	{
 		Name: "scylla-operator/conformance/parallel/openshift",
@@ -54,7 +54,7 @@ var Suites = ginkgotest.TestSuites{
 			framework.NotSupportedOnOpenShiftLabelName,
 			framework.IPv6LabelName,
 		),
-		DefaultParallelism: 42,
+		DefaultParallelism: 70,
 	},
 	{
 		Name: "scylla-operator/conformance/serial",
@@ -78,7 +78,7 @@ var Suites = ginkgotest.TestSuites{
 			framework.MultiDatacenterLabelName,
 			framework.SupportedOnlyOnOpenShiftLabelName,
 		),
-		DefaultParallelism: 42,
+		DefaultParallelism: 10,
 	},
 	{
 		Name: "scylla-operator/conformance/parallel-ipv6",
@@ -86,7 +86,7 @@ var Suites = ginkgotest.TestSuites{
 		Tests that ensure Scylla Operator is working properly with IPv6 and dual-stack networking.
 		`),
 		LabelFilter:        fmt.Sprintf("%s", framework.IPv6LabelName),
-		DefaultParallelism: 42,
+		DefaultParallelism: 10,
 	},
 	{
 		Name: "kind-fast",
@@ -103,7 +103,7 @@ var Suites = ginkgotest.TestSuites{
 			framework.SupportedOnlyOnOpenShiftLabelName,
 			framework.IPv6LabelName,
 		),
-		DefaultParallelism: 42,
+		DefaultParallelism: 60,
 	},
 }
 


### PR DESCRIPTION
**Description of your changes:** Sets the default parallelism for all E2E test suites to match their total test cases count (rounded up to 10s) so that all of them can run in a separate Ginkgo process.
