### PR TITLE
Configure Renovate for Dockerfile base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# renovate: datasource=docker depName=golang packageName=quay.io/scylladb/scylla-operator-images versioning=regex:^golang-(?<major>\d+)\.(?<minor>\d+)$
 FROM quay.io/scylladb/scylla-operator-images:golang-1.25 AS builder
 
 RUN groupadd -g 1001 scylla && \
@@ -12,6 +13,7 @@ RUN --mount=type=cache,target=/home/scylla/.cache/go-build,uid=1001,gid=1001 \
     --mount=type=cache,target=/go/pkg/mod,uid=1001,gid=1001 \
     make build --warn-undefined-variables
 
+# renovate: datasource=docker depName=base-ubi-minimal packageName=quay.io/scylladb/scylla-operator-images versioning=regex:^base-ubi-(?<major>\d+)\.(?<minor>\d+)-minimal$
 FROM quay.io/scylladb/scylla-operator-images:base-ubi-9.6-minimal
 
 LABEL org.opencontainers.image.title="Scylla Operator" \

--- a/renovate.json
+++ b/renovate.json
@@ -89,6 +89,16 @@
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*\\S+:\\s*\"?(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\"?"
       ]
+    },
+    {
+      "description": "Custom manager for Dockerfile with Renovate annotations matching the regex.",
+      "customType": "regex",
+      "fileMatch": [
+        "^Dockerfile$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\nFROM\\s+\\S+:(?<currentValue>\\S+)"
+      ]
     }
   ],
   "customDatasources": {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR sets up Renovate to update the container image's base images. Not very useful now as we're still creating these images manually, but saves as from a bit of busywork. 

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-longterm
/cc czeslavo