### PR TITLE
Configure renovate to update monitoring dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "scylla-monitoring"]
 	path = submodules/github.com/scylladb/scylla-monitoring
 	url = https://github.com/scylladb/scylla-monitoring.git
+	branch = 4.12.1

--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -24,5 +24,6 @@ operatorTests:
   envTestKubernetesVersion: "v1.35.0"
 thirdParty:
   prometheusOperator:
+    # renovate: datasource=github-releases depName=prometheus-operator packageName=prometheus-operator/prometheus-operator versioning=semver
     version: "0.86.1" # Latest compatible with .operator.prometheusVersion (https://prometheus-operator.dev/docs/getting-started/compatibility/)
     namespace: "prometheus-operator"

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,13 @@
   ],
   "enabledManagers": [
     "custom.regex",
+    "git-submodules",
     "gomod",
     "poetry"
   ],
+  "git-submodules": {
+    "enabled": true
+  },
   "schedule": [
     "before 5am on monday"
   ],
@@ -18,6 +22,9 @@
   "packageRules": [
     {
       "description": "Image references in assets/config/config.yaml should be updated every weekday",
+      "matchDatasources": [
+        "docker"
+      ],
       "matchFileNames": [
         "assets/config/config.yaml"
       ],
@@ -77,6 +84,17 @@
         "docs/pyproject.toml"
       ],
       "enabled": false
+    },
+    {
+      "description": "Monitoring dependencies should be grouped and updated every weekday",
+      "matchDepNames": [
+        "submodules/github.com/scylladb/scylla-monitoring",
+        "prometheus-operator"
+      ],
+      "groupName": "monitoring",
+      "schedule": [
+        "before 5am every weekday"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR configures renovate to update monitoring dependencies.
With the recent PRs, this will only require manually triggering the `make update` target. The existing unit tests and verify make targets should ensure the versions are aligned. 

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/hold for https://github.com/scylladb/scylla-operator/pull/3243