### PR TITLE
Make example ScyllaCluster nodes to be considered tunable

### DIFF
--- a/docs/source/resources/scyllaclusters/basics.md
+++ b/docs/source/resources/scyllaclusters/basics.md
@@ -50,7 +50,6 @@ Now we can create a simple ScyllaCluster to get ScyllaDB running.
 :::
 
 :::{code-block} bash
-:linenos:
 :substitutions:
 
 kubectl apply --server-side -f=- <<EOF
@@ -80,6 +79,13 @@ spec:
         limits:
           cpu: 1
           memory: 8Gi
+      agentResources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+        limits:
+          cpu: 100m
+          memory: 100Mi
       placement:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -111,6 +117,13 @@ spec:
         limits:
           cpu: 1
           memory: 8Gi
+      agentResources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+        limits:
+          cpu: 100m
+          memory: 100Mi
       placement:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -142,6 +155,13 @@ spec:
         limits:
           cpu: 1
           memory: 8Gi
+      agentResources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+        limits:
+          cpu: 100m
+          memory: 100Mi
       placement:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Make the example `ScyllaCluster` in the [ScyllaCluster basics](https://operator.docs.scylladb.com/stable/resources/scyllaclusters/basics.html) article tunable from the Operator perspective by adding `agentResources` with limits and requests matching (so Scylla pods get `QoS=Guaranteed`).
