### PR TITLE
Make timeouts more explicit and improve related error messages in ScyllaDB Manager E2Es

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_restarts.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_restarts.go
@@ -23,12 +23,8 @@ import (
 )
 
 const (
-	// terminationTimeout is the amount of time that the pod needs to terminate gracefully.
-	// In addition to process termination, this needs to account for kubelet sending signals, state propagation
-	// and generally being busy in the CI.
-	terminationTimeout = 5 * time.Minute
 	// A high enough grace period so it can never terminate gracefully in an e2e run.
-	gracePeriod = terminationTimeout + (7 * 24 * time.Hour)
+	gracePeriod = utils.ScyllaDBTerminationTimeout + (7 * 24 * time.Hour)
 )
 
 var _ = g.Describe("ScyllaCluster graceful termination", func() {
@@ -131,7 +127,7 @@ done
 		framework.By("Waiting for the ScyllaDB Pod to be deleted")
 		deletionCtx, deletionCtxCancel := context.WithTimeoutCause(
 			ctx,
-			terminationTimeout,
+			utils.ScyllaDBTerminationTimeout,
 			fmt.Errorf("pod %q has not finished termination in time", naming.ObjRef(pod)),
 		)
 		defer deletionCtxCancel()
@@ -197,7 +193,7 @@ done
 		framework.By("Waiting for the ScyllaDB Pod to be deleted")
 		deletionCtx, deletionCtxCancel := context.WithTimeoutCause(
 			ctx,
-			terminationTimeout,
+			utils.ScyllaDBTerminationTimeout,
 			fmt.Errorf("pod %q has not finished termination in time", naming.ObjRef(pod)),
 		)
 		defer deletionCtxCancel()

--- a/test/e2e/utils/config.go
+++ b/test/e2e/utils/config.go
@@ -14,6 +14,11 @@ const (
 	joinClusterTimeout = 3 * time.Minute
 	cleanupJobTimeout  = 1 * time.Minute
 
+	// ScyllaDBTerminationTimeout is the amount of time that a ScyllaDB Pod needs to terminate gracefully.
+	// In addition to process termination, this needs to account for kubelet sending signals, state propagation
+	// and generally being busy in the CI.
+	ScyllaDBTerminationTimeout = 5 * time.Minute
+
 	// memberRolloutTimeout is the maximum amount of time it takes to start a scylla pod and become ready.
 	// It includes the time to pull the images, copy the necessary files (sidecar), join the cluster and similar.
 	memberRolloutTimeout = 30*time.Second + imagePullTimeout + joinClusterTimeout
@@ -24,12 +29,13 @@ const (
 	multiDatacenterJoinClusterBuffer    = 15 * time.Minute
 	multiDatacenterMemberRolloutTimeout = memberRolloutTimeout + multiDatacenterJoinClusterBuffer
 
-	baseManagerSyncTimeout = 3 * time.Minute
-	managerTaskSyncTimeout = 30 * time.Second
-
 	ScyllaDBManagerTaskNumRetries = 3
 	ScyllaDBManagerTaskRetryWait  = 30 * time.Second
 
+	// ScyllaDBManagerClusterSyncTimeout is the maximum amount of time it should take for a ScyllaDB Manager Agent to register/update a cluster with ScyllaDB Manager.
+	ScyllaDBManagerClusterSyncTimeout = 3 * time.Minute
+	// ScyllaDBManagerTaskSyncTimeout is the maximum amount of time it should take for a ScyllaDB Manager Agent to register/update a task with ScyllaDB Manager.
+	ScyllaDBManagerTaskSyncTimeout                      = 3 * time.Minute
 	ScyllaDBManagerTaskCompletionTimeout                = 10 * time.Minute
 	ScyllaDBManagerMultiDatacenterTaskCompletionTimeout = 15 * time.Minute
 )

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -98,20 +98,19 @@ func GetMemberCount(sc *scyllav1.ScyllaCluster) int32 {
 }
 
 func ContextForRollout(parent context.Context, sc *scyllav1.ScyllaCluster) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(parent, RolloutTimeoutForScyllaCluster(sc))
+	return context.WithTimeoutCause(
+		parent,
+		RolloutTimeoutForScyllaCluster(sc),
+		fmt.Errorf("ScyllaCluster %q has not rolled out in time", naming.ObjRef(sc)),
+	)
 }
 
 func ContextForMultiDatacenterRollout(parent context.Context, sc *scyllav1.ScyllaCluster) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(parent, RolloutTimeoutForMultiDatacenterScyllaCluster(sc))
-}
-
-func SyncTimeoutForScyllaCluster(sc *scyllav1.ScyllaCluster) time.Duration {
-	tasks := int64(len(sc.Spec.Repairs) + len(sc.Spec.Backups))
-	return baseManagerSyncTimeout + time.Duration(tasks)*managerTaskSyncTimeout
-}
-
-func ContextForManagerSync(parent context.Context, sc *scyllav1.ScyllaCluster) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(parent, SyncTimeoutForScyllaCluster(sc))
+	return context.WithTimeoutCause(
+		parent,
+		RolloutTimeoutForMultiDatacenterScyllaCluster(sc),
+		fmt.Errorf("ScyllaCluster %q has not rolled out in time", naming.ObjRef(sc)),
+	)
 }
 
 func ContextForPodStartup(parent context.Context) (context.Context, context.CancelFunc) {
@@ -130,16 +129,16 @@ func ContextForRemoteKubernetesClusterRollout(ctx context.Context, rkc *scyllav1
 	return context.WithTimeout(ctx, RolloutTimeoutForRemoteKubernetesCluster(rkc))
 }
 
-func RolloutTimeoutForScyllaDBCluster(sc *scyllav1alpha1.ScyllaDBCluster) time.Duration {
-	return SyncTimeout + time.Duration(controllerhelpers.GetScyllaDBClusterNodeCount(sc))*memberRolloutTimeout
-}
-
 func RolloutTimeoutForMultiDatacenterScyllaDBCluster(sc *scyllav1alpha1.ScyllaDBCluster) time.Duration {
 	return SyncTimeout + time.Duration(controllerhelpers.GetScyllaDBClusterNodeCount(sc))*multiDatacenterMemberRolloutTimeout
 }
 
 func ContextForMultiDatacenterScyllaDBClusterRollout(ctx context.Context, sc *scyllav1alpha1.ScyllaDBCluster) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(ctx, RolloutTimeoutForMultiDatacenterScyllaDBCluster(sc))
+	return context.WithTimeoutCause(
+		ctx,
+		RolloutTimeoutForMultiDatacenterScyllaDBCluster(sc),
+		fmt.Errorf("ScyllaDBCluster %q has not rolled out in time", naming.ObjRef(sc)),
+	)
 }
 
 func IsScyllaClusterRolledOut(sc *scyllav1.ScyllaCluster) (bool, error) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Error messages coming from timeouts in ScyllaDB Manager E2Es are non-descriptive now and make it hard to debug causes of test failues. This PR improves it. It also makes the timeout for cluster deletion sufficiently high.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind failing-test
/priority important-soon
/cc czeslavo
