### PR TITLE
Configure renovate to update Dockerfile base images every weekday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -95,6 +95,18 @@
       "schedule": [
         "before 5am every weekday"
       ]
+    },
+    {
+      "description": "Dockerfile base images should be updated every weekday",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchFileNames": [
+        "Dockerfile"
+      ],
+      "schedule": [
+        "before 5am every weekday"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** As per the title, we should check for base image updates every weekday.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon