### PR TITLE
Remove redundant checkout steps from release-notes composite action

### DIFF
--- a/.github/actions/release-notes/action.yaml
+++ b/.github/actions/release-notes/action.yaml
@@ -13,9 +13,6 @@ inputs:
   goVersion:
     description: "Version of Go"
     required: true
-  genReleaseNotesVersionRef:
-    description: "Version ref of gen-release-notes"
-    required: true
   containerImageName:
     description: "Full name of the container image"
     required: true
@@ -26,31 +23,18 @@ runs:
     uses: actions/setup-go@v3
     with:
       go-version: ${{ inputs.goVersion }}
-  
-  - uses: actions/checkout@v3
-    with:
-      ref: ${{ inputs.genReleaseNotesVersionRef }}
-      repository: scylladb/scylla-operator
-      path: ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator
-      fetch-depth: 0
-  
+
   - name: Install release notes generator
     shell: bash
     run: |
       set -euExo pipefail
       shopt -s inherit_errexit
       
-      cd ${{ github.workspace }}/go/src/github.com/scylladb/scylla-operator
+      cd ${{ github.workspace }}/go/src/github.com/${{ inputs.githubRepository }}
       make build GO_BUILD_PACKAGES=./cmd/gen-release-notes --warn-undefined-variables
       
       sudo mv ./gen-release-notes /usr/local/bin/gen-release-notes
-  
-  - uses: actions/checkout@v3
-    with:
-      repository: ${{ inputs.githubRepository }}
-      path: ${{ github.workspace }}/go/src/github.com/${{ inputs.githubRepository }}
-      fetch-depth: 0
-  
+
   - name: Create release
     working-directory: ${{ github.workspace }}/go/src/github.com/${{ inputs.githubRepository }}
     shell: bash

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -53,5 +53,4 @@ jobs:
         githubRef: ${{ env.current_tag }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         goVersion: ${{ env.go_version }}
-        genReleaseNotesVersionRef: ${{ env.current_tag }}
         containerImageName: docker.io/scylladb/scylla-operator


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This PR fixes the "Duplicate header: 'Authorization'" error in the release-notes workflow by removing redundant checkout steps from the composite action that were causing authentication conflicts.

After the releases workflow was upgraded to use actions/checkout@v6, the release-notes job started failing with:
```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/scylladb/scylla-operator/': The requested URL returned error: 400
```
https://github.com/scylladb/scylla-operator/actions/runs/21901321999/job/63230718464

The composite action contained two redundant checkout steps that were re-checking out the repository that the workflow had already checked out. I assume the intent was that the gen-release-notes binary is built from the target branch, but I don't see any benefits here.
The version mismatch created conflicting authentication mechanisms that resulted in duplicate Authorization headers.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc czeslavo