### PR TITLE
Increase linkcheck timeout and retries to reduce flakiness

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -179,3 +179,7 @@ linkcheck_ignore = [
 linkcheck_anchors_ignore_for_url = [
     'https://github.com/prometheus-operator/prometheus-operator/blob/e4c727291acc543dab531bc4aaf16637067c1b86/pkg/apis/monitoring/v1/.*',
 ]
+
+# Linkcheck timeout and retry configuration to handle slow-responding external sites.
+linkcheck_timeout = 60  # Increase from default 30s to 60s for slow sites like docs.redhat.com.
+linkcheck_retries = 3   # Retry 3 times before failing to handle transient network issues.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR increases Sphinx linkcheck timeout to 60s (from 30s default) and adds 3 retries to reduce flaky failures when checking external documentation links, particularly docs.redhat.com which was timing out in the `make verify` target (see e.g. https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3224/pull-scylla-operator-master-verify-docs/2023344602047582208#1:build-log.txt%3A204)

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc @ylebi