### PR TITLE
Increase linkcheck timeout to 180s to handle slow external sites

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -181,5 +181,5 @@ linkcheck_anchors_ignore_for_url = [
 ]
 
 # Linkcheck timeout and retry configuration to handle slow-responding external sites.
-linkcheck_timeout = 60  # Increase from default 30s to 60s for slow sites like docs.redhat.com.
+linkcheck_timeout = 180  # Increase from default for slow sites like docs.redhat.com.
 linkcheck_retries = 3   # Retry 3 times before failing to handle transient network issues.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR further increases Sphinx linkcheck timeout to 180s (from 60s) to prevent flaky timeouts when checking external documentation links, particularly docs.redhat.com which consistently times out at the 60s threshold in the `make verify` target.

Testing showed that docs.redhat.com URLs can take over 60 seconds to respond, causing false failures even with the previously increased timeout and retry configuration.

```
(management/monitoring/external-prometheus-on-openshift: line   75) timeout   https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/certificate-types-and-descriptions#cert-types-service-ca-certificates - HTTPSConnectionPool(host='docs.redhat.com', port=443): Read timed out. (read timeout=60)
```

https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3224/pull-scylla-operator-master-verify-docs/2023373658990317568#1:build-log.txt%3A204

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc @ylebi 