### PR TITLE
Fix missing namespace for SA creation in Setting up monitoring on OpenShift guide

### DIFF
--- a/docs/source/management/monitoring/external-prometheus-on-openshift.md
+++ b/docs/source/management/monitoring/external-prometheus-on-openshift.md
@@ -43,7 +43,7 @@ We assume you have `ScyllaCluster` deployed in `scylla` namespace/project. Repla
 You can create the `ServiceAccount` and `ClusterRoleBinding` using the following commands:
 
 ```shell
-oc create serviceaccount scylla-grafana-monitoring-viewer
+oc create -n=scylla serviceaccount scylla-grafana-monitoring-viewer
 oc create clusterrolebinding scylla-monitoring-grafana-cluster-monitoring-view --clusterrole=cluster-monitoring-view --serviceaccount=scylla:scylla-grafana-monitoring-viewer
 ```
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** A command creating the SA for OpenShift UWM was missing a namespace which was breaking the workflow. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-longterm
/cc @czeslavo 