### PR TITLE
Set supported ScyllaDB Manager version range to 3.7 - 3.8 for v1.20

### DIFF
--- a/docs/source/support/releases.md
+++ b/docs/source/support/releases.md
@@ -159,7 +159,7 @@ The support matrix table shows version requirements for a particular **ScyllaDB 
   - 2024.1, 2025.1 - 2025.3
 * - ScyllaDB Manager
   - 3.7 - 3.8
-  - 3.5, 3.7
+  - 3.7 - 3.8
   - 3.5, 3.7
 * - ScyllaDB Monitoring
   - (CRD)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** The supported ScyllaDB Manager version range hasn't been updated for v1.20. This PR fixes it.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind documentation
/priority important-longterm
