### PR TITLE
Change scylla-monitoring renovate to rely on GH release instead of git-refs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "scylla-monitoring"]
 	path = submodules/github.com/scylladb/scylla-monitoring
 	url = https://github.com/scylladb/scylla-monitoring.git
+	# renovate: datasource=github-releases depName=scylladb/scylla-monitoring
 	branch = 4.14.0

--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,9 @@
   ],
   "enabledManagers": [
     "custom.regex",
-    "git-submodules",
     "gomod",
     "poetry"
   ],
-  "git-submodules": {
-    "enabled": true
-  },
   "schedule": [
     "before 5am on monday"
   ],
@@ -88,7 +84,7 @@
     {
       "description": "Monitoring dependencies should be grouped and updated every weekday",
       "matchDepNames": [
-        "submodules/github.com/scylladb/scylla-monitoring",
+        "scylladb/scylla-monitoring",
         "prometheus-operator"
       ],
       "groupName": "monitoring",
@@ -106,6 +102,36 @@
       ],
       "schedule": [
         "before 5am every weekday"
+      ]
+    },
+    {
+      "matchManagers": [
+        "regex"
+      ],
+      "matchDepNames": [
+        "scylladb/scylla-monitoring"
+      ],
+      "addLabels": [
+        "do-not-merge/hold"
+      ],
+      "prBodyNotes": [
+        "### ⚠️ Manual Action Required",
+        "Renovate has detected a new GitHub Release for `scylla-monitoring`, but cannot automatically update the Git submodule's commit and update sub-dependencies.",
+        "",
+        "**Please complete the following steps before merging:**",
+        "1. Check out this branch locally.",
+        "2. Update the submodule and sub-dependencies:",
+        "   ```bash",
+        "   cd submodules/github.com/scylladb/scylla-monitoring",
+        "   git fetch --tags",
+        "   git checkout tags/{{{newValue}}}",
+        "   cd ../../../..",
+        "   git add submodules/github.com/scylladb/scylla-monitoring",
+        "   make update",
+        "   git add .",
+        "   git commit --amend && git push --force",
+        "   ```",
+        "3. Remove the `do-not-merge/hold` label."
       ]
     }
   ],
@@ -128,6 +154,16 @@
       ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\nFROM\\s+\\S+:(?<currentValue>\\S+)"
+      ]
+    },
+    {
+      "description": "Custom manager for git submodules with Renovate annotations matching the regex.",
+      "customType": "regex",
+      "fileMatch": [
+        "^\\.gitmodules$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+branch = (?<currentValue>.*)"
       ]
     }
   ],


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** As `scylla-monitoring` happens to move git tags for already published proper release tags (e.g., `1.14.0`), we need to adapt to take that into account so that we do not use git tags that are not considered by the team as properly published (i.e., having a production Github release created).

This PR changes the Renovate config so that we do not rely on the git-submodule manager, which can only use git-refs as its datasource. Instead, we use a custom regex manager that will detect a GH release and will update the `.gitmodules`' `branch` field. Because we use Mend.io workers, we cannot use a custom post upgrade action to update the git submodules for us. To work around this, there will be a `do-not-merge/hold` label assigned to PRs updating this dependency, and instructions for required manual actions will be added to the PR description.

Sample PR generated by Renove in my fork: https://github.com/czeslavo/scylla-operator/pull/28

**Which issue is resolved by this Pull Request:**
Related to https://github.com/scylladb/scylla-operator/pull/3282.