### PR TITLE
Make sure podman is always used with kind

### DIFF
--- a/hack/kind/cluster-setup.sh
+++ b/hack/kind/cluster-setup.sh
@@ -10,6 +10,9 @@ shopt -s inherit_errexit
 
 readonly parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
 
+# Ensure all kind calls use podman.
+export KIND_EXPERIMENTAL_PROVIDER=podman
+
 if [ -z "${CLUSTER_NAME}" ]; then
   echo "CLUSTER_NAME must be set" > /dev/stderr
   exit 1
@@ -30,9 +33,6 @@ fi
 # Ensure KinD cluster exists.
 if ! kind get clusters | grep -q "^${CLUSTER_NAME}$"; then
     KIND_CREATE_CMD=(kind create cluster --name="${CLUSTER_NAME}" --config="${parent_dir}/cluster-config.yaml" --retain)
-
-    # Ensure kind uses podman.
-    export KIND_EXPERIMENTAL_PROVIDER=podman
 
     # As we rely on rootless Podman, we need to delegate cgroup management to the user systemd instance (this is implicitly
     # done on systems with systemd >= 252, but needs to be explicit on older systems).

--- a/hack/kind/cluster-teardown.sh
+++ b/hack/kind/cluster-teardown.sh
@@ -5,6 +5,9 @@ shopt -s inherit_errexit
 
 # This script deletes the KinD cluster specified by CLUSTER_NAME.
 
+# Ensure all kind calls use podman.
+export KIND_EXPERIMENTAL_PROVIDER=podman
+
 if [ -z "${CLUSTER_NAME}" ]; then
   echo "CLUSTER_NAME must be set" > /dev/stderr
   exit 1

--- a/hack/kind/run-e2e-tests.sh
+++ b/hack/kind/run-e2e-tests.sh
@@ -3,6 +3,9 @@
 set -euExo pipefail
 shopt -s inherit_errexit
 
+# Ensure all kind calls use podman.
+export KIND_EXPERIMENTAL_PROVIDER=podman
+
 if [ -z "${CLUSTER_NAME}" ]; then
   echo "CLUSTER_NAME must be set" > /dev/stderr
   exit 1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** This ensures that all scripts that use `kind`, set `KIND_EXPERIMENTAL_PROVIDER=podman` for consistency and correctness. Without that, it was possible for a script to create a cluster using podman but list them with Docker, leading to unexpected behavior because the cluster is never found in such cases.
