### PR TITLE
Make shell scripts discover bash instead of hardcoding the interpreter

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 ScyllaDB
 #

--- a/hack/.ci/olm/build-catalog.sh
+++ b/hack/.ci/olm/build-catalog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 ScyllaDB
 #

--- a/hack/.ci/olm/postprocess-bundle.sh
+++ b/hack/.ci/olm/postprocess-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 ScyllaDB
 #

--- a/hack/.ci/run-e2e-shared.env.sh
+++ b/hack/.ci/run-e2e-shared.env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 ScyllaDB
 #

--- a/hack/check-renovate.sh
+++ b/hack/check-renovate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This scripts runs renovate in dry-run mode against the local config.
 # It can be used to check if changes to the config result in the expected updates.

--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 ScyllaDB
 #

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 ScyllaDB
 #

--- a/hack/kind/cluster-setup.sh
+++ b/hack/kind/cluster-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euEo pipefail
 shopt -s inherit_errexit

--- a/hack/kind/cluster-teardown.sh
+++ b/hack/kind/cluster-teardown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euEo pipefail
 shopt -s inherit_errexit

--- a/hack/lib/assets.sh
+++ b/hack/lib/assets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euExo pipefail
 shopt -s inherit_errexit

--- a/hack/lib/bash.sh
+++ b/hack/lib/bash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 ScyllaDB
 #

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 ScyllaDB
 #

--- a/hack/lib/kube.sh
+++ b/hack/lib/kube.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 ScyllaDB
 #

--- a/hack/lib/semver.sh
+++ b/hack/lib/semver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 ScyllaDB
 #

--- a/hack/sync-renovate-config-with-go-mod-replace.sh
+++ b/hack/sync-renovate-config-with-go-mod-replace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxEo pipefail
 shopt -s inherit_errexit

--- a/hack/third-party/build-prometheus-operator-manifest.sh
+++ b/hack/third-party/build-prometheus-operator-manifest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 ScyllaDB
 #

--- a/hack/update-go-mod-replace.sh
+++ b/hack/update-go-mod-replace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxEo pipefail
 shopt -s inherit_errexit

--- a/recordings/basic-setup/run.sh
+++ b/recordings/basic-setup/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euEo pipefail
 shopt -s inherit_errexit


### PR DESCRIPTION
**Description of your changes:**
This change replaces the hardcoded bash shebang with a OS-agnostic discovery lookup.
The benefits are that the shell scripts will be able to run on non-Linux OS (MacOS, BSD....).