### PR TITLE
Add warnings for ScyllaCluster's manager task names not adhering to RFC 1123 subdomain requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## Unreleased
 
+### API Changes
+
+- Extended the admission webhook to emit warnings when ScyllaCluster's backup or repair task names do not adhere to RFC 1123
+  subdomain requirements. Invalid task names currently cause silent failures where the underlying ScyllaDBManagerTask objects fail to be created.
+  **In the next minor release, these warnings will become validation errors that prevent ScyllaCluster creation or updates.**
+  Users must update their resources to comply with the requirements.
+  [#3295](https://github.com/scylladb/scylla-operator/pull/3295)
+
 ### Dependencies
 
 - Updated ScyllaDB Monitoring (`github.com/scylladb/scylla-monitoring` git submodule) from `4.14.0` (`88dd086`) pre-release version


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** As per https://github.com/scylladb/scylla-operator/issues/3294, operator fails silently when ScyllaCluster's task names do not adhere to RFC 1123 subdomain requirements. As part of the proposed solution, this PR extends the admission webhook to log warnings and inform about backwards-incompatible validation tightening in a future minor release.

**Which issue is resolved by this Pull Request:**
It's an intermediate step towards https://github.com/scylladb/scylla-operator/issues/3294

/kind api-change
/priority important-soon
/cc @czeslavo