### PR TITLE
Refactor e2e tests to delint from spec pollution

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,12 +11,6 @@ linters:
     presets:
       - common-false-positives
       - std-error-handling
-    rules:
-      # TODO: https://github.com/scylladb/scylla-operator/issues/3190
-      - path: test/e2e/
-        linters:
-          - ginkgolinter
-        text: "use BeforeEach\\(\\) to assign variable"
   settings:
     importas:
       no-unaliased: true

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -46,7 +46,13 @@ type Framework struct {
 var _ FullClientInterface = &Framework{}
 var _ ClusterInterface = &Framework{}
 
-func NewFramework(namePrefix string) *Framework {
+// NewFramework creates a new test framework. It creates a unique namespace for a test to run in and provides a client
+// with permissions limited to that namespace. It also creates clients for worker clusters (for multi-DC) if configured.
+// It should be called in a ginkgo BeforeEach closure.
+//
+// At the end of the test, artifacts are going to be collected, and the namespace and all objects in it will be
+// automatically cleaned up, unless the cleanup policy is set to skip.
+func NewFramework(ctx context.Context, namePrefix string) *Framework {
 	var err error
 
 	e2eArtifactsDir := ""
@@ -105,11 +111,19 @@ func NewFramework(namePrefix string) *Framework {
 		)
 	}
 
-	g.BeforeEach(f.beforeEach)
-	g.JustAfterEach(f.justAfterEach)
-	g.AfterEach(f.afterEach)
+	ns, nsClient := f.CreateUserNamespace(ctx)
+	f.cluster.defaultNamespace = ns
+	f.cluster.defaultClient = nsClient
+	f.FullClient.Client = nsClient
+
+	g.DeferCleanup(f.cleanup)
 
 	return f
+}
+
+func (f *Framework) cleanup(ctx context.Context) {
+	f.collectArtifacts(ctx)
+	f.cleanupObjects(ctx)
 }
 
 func (f *Framework) Cluster() ClusterInterface {
@@ -258,14 +272,7 @@ func (f *Framework) GetObjectStorageSettingsForWorkerCluster(workerName string) 
 	return settings
 }
 
-func (f *Framework) beforeEach(ctx context.Context) {
-	ns, nsClient := f.CreateUserNamespace(ctx)
-	f.cluster.defaultNamespace = ns
-	f.cluster.defaultClient = nsClient
-	f.FullClient.Client = nsClient
-}
-
-func (f *Framework) justAfterEach(ctx context.Context) {
+func (f *Framework) collectArtifacts(ctx context.Context) {
 	ginkgoNamespace := f.cluster.defaultNamespace.Name
 	f.cluster.Collect(ctx, ginkgoNamespace)
 	for _, c := range f.workerClusters {
@@ -273,15 +280,7 @@ func (f *Framework) justAfterEach(ctx context.Context) {
 	}
 }
 
-func (f *Framework) afterEach(ctx context.Context) {
-	nilClient := Client{
-		Config: nil,
-	}
-
-	f.cluster.defaultNamespace = nil
-	f.cluster.defaultClient = nilClient
-	f.FullClient.Client = nilClient
-
+func (f *Framework) cleanupObjects(ctx context.Context) {
 	shouldCleanup := true
 	switch TestContext.CleanupPolicy {
 	case CleanupPolicyNever:

--- a/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
@@ -37,14 +37,19 @@ var (
 )
 
 var _ = g.Describe("Node Setup", framework.Serial, framework.NotSupportedOnKind, func() {
-	f := framework.NewFramework("nodesetup")
+	var (
+		f             *framework.Framework
+		ncTemplate    *scyllav1alpha1.NodeConfig
+		nodeUnderTest *corev1.Node
+	)
 
-	ncTemplate := scyllafixture.NodeConfig.ReadOrFail()
-	var nodeUnderTest *corev1.Node
-
-	g.JustBeforeEach(func() {
+	g.BeforeEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		f = framework.NewFramework(ctx, "nodesetup")
+
+		ncTemplate = scyllafixture.NodeConfig.ReadOrFail()
 
 		g.By("Verifying there is at least one scylla node")
 		var err error

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -14,6 +14,7 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	configassests "github.com/scylladb/scylla-operator/assets/config"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
@@ -36,14 +37,19 @@ const (
 // These tests modify global resource affecting global cluster state.
 // They must not be run asynchronously with other tests.
 var _ = g.Describe("NodeConfig Optimizations", framework.Serial, framework.NotSupportedOnKind, func() {
-	f := framework.NewFramework("nodeconfig")
+	var (
+		f             *framework.Framework
+		ncTemplate    *scyllav1alpha1.NodeConfig
+		matchingNodes []*corev1.Node
+	)
 
-	ncTemplate := scyllafixture.NodeConfig.ReadOrFail()
-	var matchingNodes []*corev1.Node
-
-	g.JustBeforeEach(func() {
+	g.BeforeEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		f = framework.NewFramework(ctx, "nodesetup")
+
+		ncTemplate = scyllafixture.NodeConfig.ReadOrFail()
 
 		g.By("Verifying there is at least one scylla node")
 		var err error

--- a/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
+++ b/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
@@ -17,7 +17,11 @@ import (
 )
 
 var _ = g.Describe("RemoteKubernetesCluster finalizer", func() {
-	f := framework.NewFramework("remotekubernetescluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "remotekubernetescluster")
+	})
 
 	g.It("should block deletion when there are ScyllaDBClusters referencing the object", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/remotekubernetescluster/remotekubernetescluster_healthcheck.go
+++ b/test/e2e/set/remotekubernetescluster/remotekubernetescluster_healthcheck.go
@@ -17,17 +17,18 @@ import (
 )
 
 var _ = g.Describe("RemoteKubernetesCluster", func() {
-	f := framework.NewFramework("remotekubernetescluster")
+	var f *framework.Framework
 
 	var (
 		rkcs          []*scyllav1alpha1.RemoteKubernetesCluster
 		rkcClusterMap map[string]framework.ClusterInterface
 	)
 
-	g.JustBeforeEach(func() {
+	g.BeforeEach(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testSetupTimeout)
 		defer cancel()
 
+		f = framework.NewFramework(ctx, "remotekubernetescluster")
 		metaCluster := f.Cluster()
 		// Use the meta cluster to simulate the remote clusters.
 		availableClusters := map[string]framework.ClusterInterface{metaCluster.Name(): metaCluster}

--- a/test/e2e/set/scyllacluster/multidatacenter/scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/multidatacenter/scyllacluster_external_seeds.go
@@ -20,7 +20,11 @@ import (
 )
 
 var _ = g.Describe("MultiDC cluster", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should form when external seeds are provided to ScyllaClusters", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_alternator.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_alternator.go
@@ -61,7 +61,11 @@ func (movie Movie) GetKey() map[string]types.AttributeValue {
 }
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should set up Alternator API when enabled", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_auth.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_auth.go
@@ -24,7 +24,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster authentication", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("agent requires authentication", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -26,7 +26,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("nodes are cleaned up after horizontal scaling", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_evictions.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_evictions.go
@@ -17,7 +17,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster evictions", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should allow one disruption", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -42,7 +42,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should connect to cluster via Ingresses", func() {
 		if !utilfeature.DefaultMutableFeatureGate.Enabled(features.AutomaticTLSCertificates) {

--- a/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
@@ -18,7 +18,11 @@ import (
 )
 
 var _ = g.Describe("MultiDC cluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should form when external seeds are provided to ScyllaClusters", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_hostid.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_hostid.go
@@ -17,7 +17,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster HostID", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should be reflected as a Service annotation", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_ipv6.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_ipv6.go
@@ -29,7 +29,11 @@ type ipv6TestEntry struct {
 }
 
 var _ = g.Describe("ScyllaCluster IPv6", framework.IPv6, func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.DescribeTable("should support IPv6 with different expose options", func(e *ipv6TestEntry) {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_listen.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_listen.go
@@ -21,7 +21,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("listens only on secure ports", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -36,7 +36,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	const cloneLabelKey = "e2e.operator.scylladb.com/orphaned-pv-test"
 

--- a/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
@@ -20,8 +20,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
+	var f *framework.Framework
 
-	f := framework.NewFramework("scyllacluster")
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should re-bootstrap from old PVCs", func() {
 		const membersCount = 3

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -3,6 +3,7 @@
 package scyllacluster
 
 import (
+	"context"
 	"sync"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -19,7 +20,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should replace a node", func(ctx g.SpecContext) {
 		ns, nsClient, ok := f.DefaultNamespaceIfAny()

--- a/test/e2e/set/scyllacluster/scyllacluster_restarts.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_restarts.go
@@ -28,7 +28,11 @@ const (
 )
 
 var _ = g.Describe("ScyllaCluster graceful termination", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	// This test verifies correct signal handling in the bash wait routine
 	// which oscillates between a sleep (external program) and a file check.

--- a/test/e2e/set/scyllacluster/scyllacluster_sa.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sa.go
@@ -20,7 +20,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should claim preexisting member ServiceAccount and RoleBinding", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -21,7 +21,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should support scaling", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
@@ -24,7 +24,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should allow to build connection pool using shard aware ports", func() {
 		const (

--- a/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
@@ -3,6 +3,7 @@
 package scyllacluster
 
 import (
+	"context"
 	"fmt"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -23,7 +24,11 @@ import (
 // Despite the sysctl configuration being a part of ScyllaCluster's API, it configures kernel parameters on the host.
 // Therefore, the test is disruptive and needs to run serially.
 var _ = g.Describe("ScyllaCluster sysctl", framework.Serial, framework.NotSupportedOnKind, func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	// Delete any NodeConfigs before each test to ensure we don't race against NodeConfig's sysctl functionality.
 	// NodeConfigs are restored after the test.

--- a/test/e2e/set/scyllacluster/scyllacluster_tls.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_tls.go
@@ -37,7 +37,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should setup and maintain up to date TLS certificates", func() {
 		if !utilfeature.DefaultMutableFeatureGate.Enabled(features.AutomaticTLSCertificates) {

--- a/test/e2e/set/scyllacluster/scyllacluster_updates.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_updates.go
@@ -31,7 +31,11 @@ func addQuantity(lhs resource.Quantity, rhs resource.Quantity) *resource.Quantit
 }
 
 var _ = g.Describe("ScyllaCluster", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should rolling restart cluster when forceRedeploymentReason is changed", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
@@ -19,7 +19,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster upgrades", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	type entry struct {
 		rackSize       int32

--- a/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
@@ -3,6 +3,7 @@
 package scyllacluster
 
 import (
+	"context"
 	"fmt"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -18,9 +19,12 @@ import (
 )
 
 var _ = g.Describe("ScyllaCluster's admission webhook", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
 
-	f.AdminClient.Config = verification.RestConfigWithWarningCaptureHandler(f.AdminClient.Config)
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+		f.Client.Config = verification.RestConfigWithWarningCaptureHandler(f.Client.Config)
+	})
 
 	type entry struct {
 		modifierFuncs          []func(*scyllav1.ScyllaCluster)

--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -26,7 +26,11 @@ import (
 )
 
 var _ = g.Describe("Scylla Manager integration", func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.DescribeTable("should register and deregister a ScyllaCluster", func(ctx g.SpecContext, deregistrationHook func(context.Context, *scyllav1.ScyllaCluster)) {
 		ns, nsClient, ok := f.DefaultNamespaceIfAny()

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -29,7 +29,11 @@ import (
 )
 
 var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage, func() {
-	f := framework.NewFramework("scyllacluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	type entry struct {
 		scyllaRepository           string

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
@@ -13,7 +13,11 @@ import (
 )
 
 var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scylladbcluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should boostrap all datacenters and form single cluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
@@ -24,7 +24,11 @@ import (
 )
 
 var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scylladbcluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should mirror ConfigMaps and Secrets referenced by ScyllaDBCluster into remote datacenters", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_fault_tolerance.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_fault_tolerance.go
@@ -22,7 +22,11 @@ import (
 )
 
 var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scylladbcluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should reconcile healthy datacenters when any of DCs are down", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_finalizer.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_finalizer.go
@@ -17,7 +17,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBCluster finalizer", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scylladbcluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should delete remote Namespaces when ScyllaDBCluster is deleted", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_globalmanager.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_globalmanager.go
@@ -22,7 +22,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBCluster integration with global ScyllaDB Manager", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scylladbcluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	hasDeletionFinalizer := func(smcr *scyllav1alpha1.ScyllaDBManagerClusterRegistration) (bool, error) {
 		return oslices.ContainsItem(smcr.Finalizers, naming.ScyllaDBManagerClusterRegistrationFinalizer), nil

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_replace.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_replace.go
@@ -3,6 +3,7 @@
 package multidatacenter
 
 import (
+	"context"
 	"maps"
 	"slices"
 	"sync"
@@ -21,7 +22,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBCluster", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scylladbcluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should reconcile a node replacement performed directly in a datacenter", func(ctx g.SpecContext) {
 		ns, _, ok := f.DefaultNamespaceIfAny()

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_upgrade.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_upgrade.go
@@ -3,6 +3,7 @@
 package multidatacenter
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
@@ -22,7 +23,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBCluster", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scylladbcluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	type entry struct {
 		initialScyllaDBImage string

--- a/test/e2e/set/scylladbcluster/scylladbcluster_webhook.go
+++ b/test/e2e/set/scylladbcluster/scylladbcluster_webhook.go
@@ -18,7 +18,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBCluster webhook", func() {
-	f := framework.NewFramework("scylladbcluster")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
 
 	g.It("should forbid create and update of invalid cluster", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scylladbdatacenter/scylladbdatacenter_globalmanager.go
+++ b/test/e2e/set/scylladbdatacenter/scylladbdatacenter_globalmanager.go
@@ -23,7 +23,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBDatacenter integration with global ScyllaDB Manager", func() {
-	f := framework.NewFramework("scylladbdatacenter")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbdatacenter")
+	})
 
 	hasDeletionFinalizer := func(smcr *scyllav1alpha1.ScyllaDBManagerClusterRegistration) (bool, error) {
 		return oslices.ContainsItem(smcr.Finalizers, naming.ScyllaDBManagerClusterRegistrationFinalizer), nil

--- a/test/e2e/set/scylladbdatacenter/scylladbdatacenter_webhooks.go
+++ b/test/e2e/set/scylladbdatacenter/scylladbdatacenter_webhooks.go
@@ -15,7 +15,11 @@ import (
 var _ = g.Describe("ScyllaDBDatacenter webhook", func() {
 	defer g.GinkgoRecover()
 
-	f := framework.NewFramework("scylladbdatacenter")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbdatacenter")
+	})
 
 	g.It("should forbid invalid requests", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
+++ b/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
@@ -28,7 +28,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with global ScyllaDB Manager", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scylladbmanagertask")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbmanagertask")
+	})
 
 	g.It("should synchronise a repair task", func(ctx g.SpecContext) {
 		ns, nsClient := f.CreateUserNamespace(ctx)

--- a/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager_object_storage.go
+++ b/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager_object_storage.go
@@ -33,7 +33,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with global ScyllaDB Manager", framework.MultiDatacenter, func() {
-	f := framework.NewFramework("scylladbmanagertask")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbmanagertask")
+	})
 
 	g.It("should synchronise a backup task and support a manual restore procedure", func(ctx g.SpecContext) {
 		ns, nsClient := f.CreateUserNamespace(ctx)

--- a/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager.go
+++ b/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager.go
@@ -27,7 +27,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with global ScyllaDB Manager", func() {
-	f := framework.NewFramework("scylladbmanagertask")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbmanagertask")
+	})
 
 	g.It("should synchronise a repair task", func(ctx g.SpecContext) {
 		ns, nsClient, ok := f.DefaultNamespaceIfAny()

--- a/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
+++ b/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
@@ -31,7 +31,11 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with global ScyllaDB Manager", framework.RequiresObjectStorage, func() {
-	f := framework.NewFramework("scylladbmanagertask")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbmanagertask")
+	})
 
 	type entry struct {
 		scyllaDBImage              string

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
@@ -68,7 +68,11 @@ func describeEntry(e *scyllaDBMonitoringEntry) string {
 }
 
 var _ = g.Describe("ScyllaDBMonitoring", func() {
-	f := framework.NewFramework("scylladbmonitoring")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbmonitoring")
+	})
 
 	g.DescribeTable("should setup monitoring stack", func(ctx g.SpecContext, e *scyllaDBMonitoringEntry) {
 		framework.By("Creating a ScyllaCluster with a single node")

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring_webhooks.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring_webhooks.go
@@ -1,6 +1,7 @@
 package scylladbmonitoring
 
 import (
+	"context"
 	"fmt"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -15,36 +16,42 @@ import (
 )
 
 var _ = g.Describe("ScyllaDBMonitoring webhook", func() {
-	f := framework.NewFramework("scylladbmonitoring")
+	var (
+		f         *framework.Framework
+		validSDBM *scyllav1alpha1.ScyllaDBMonitoring
+	)
 
-	f.AdminClient.Config = verification.RestConfigWithWarningCaptureHandler(f.AdminClient.Config)
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbmonitoring")
+		f.AdminClient.Config = verification.RestConfigWithWarningCaptureHandler(f.AdminClient.Config)
+
+		validSDBM = &scyllav1alpha1.ScyllaDBMonitoring{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: names.SimpleNameGenerator.GenerateName("valid-"),
+			},
+			Spec: scyllav1alpha1.ScyllaDBMonitoringSpec{
+				Components: &scyllav1alpha1.Components{
+					Prometheus: &scyllav1alpha1.PrometheusSpec{
+						Mode: scyllav1alpha1.PrometheusModeExternal,
+					},
+					Grafana: &scyllav1alpha1.GrafanaSpec{
+						Resources: corev1.ResourceRequirements{},
+						Datasources: []scyllav1alpha1.GrafanaDatasourceSpec{
+							{
+								URL:               "https://prometheus.example:9091",
+								PrometheusOptions: &scyllav1alpha1.GrafanaPrometheusDatasourceOptions{},
+							},
+						},
+					},
+				},
+			},
+		}
+	})
 
 	type entry struct {
 		modifierFuncs          []func(*scyllav1alpha1.ScyllaDBMonitoring)
 		expectedErrMatcherFunc func(sm *scyllav1alpha1.ScyllaDBMonitoring) o.OmegaMatcher
 		expectedWarning        string
-	}
-
-	validSDBM := &scyllav1alpha1.ScyllaDBMonitoring{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: names.SimpleNameGenerator.GenerateName("valid-"),
-		},
-		Spec: scyllav1alpha1.ScyllaDBMonitoringSpec{
-			Components: &scyllav1alpha1.Components{
-				Prometheus: &scyllav1alpha1.PrometheusSpec{
-					Mode: scyllav1alpha1.PrometheusModeExternal,
-				},
-				Grafana: &scyllav1alpha1.GrafanaSpec{
-					Resources: corev1.ResourceRequirements{},
-					Datasources: []scyllav1alpha1.GrafanaDatasourceSpec{
-						{
-							URL:               "https://prometheus.example:9091",
-							PrometheusOptions: &scyllav1alpha1.GrafanaPrometheusDatasourceOptions{},
-						},
-					},
-				},
-			},
-		},
 	}
 
 	g.DescribeTableSubtree("should respond", func(e *entry) {

--- a/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_status.go
+++ b/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_status.go
@@ -23,12 +23,16 @@ import (
 var _ = g.Describe("ScyllaOperatorConfig ", framework.Serial, func() {
 	defer g.GinkgoRecover()
 
-	f := framework.NewFramework("scyllaoperatorconfig")
-	globalSOC := scyllafixture.DefaultScyllaOperatorConfig.ReadOrFail()
+	var (
+		f         *framework.Framework
+		globalSOC *scyllav1alpha1.ScyllaOperatorConfig
+	)
 
-	g.BeforeEach(func() {
+	g.BeforeEach(func(ctx context.Context) {
 		ctx, cancel := context.WithTimeoutCause(context.Background(), 1*time.Minute, errors.New("exceeded wait timeout"))
 		defer cancel()
+		f = framework.NewFramework(ctx, "scyllaoperatorconfig")
+		globalSOC = scyllafixture.DefaultScyllaOperatorConfig.ReadOrFail()
 		_, err := utils.WaitForScyllaOperatorConfigState(
 			ctx,
 			f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaOperatorConfigs(),

--- a/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_webhooks.go
+++ b/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_webhooks.go
@@ -18,7 +18,11 @@ import (
 var _ = g.Describe("ScyllaOperatorConfig webhook", func() {
 	defer g.GinkgoRecover()
 
-	f := framework.NewFramework("scyllaoperatorconfig")
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllaoperatorconfig")
+	})
 
 	g.It("should forbid invalid requests", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)


### PR DESCRIPTION
**Description of your changes:**
This change:
- enables the previously disabled [ginkgo spec pollution linting rule](https://onsi.github.io/ginkgo/#avoid-spec-pollution-dont-initialize-variables-in-container-nodes)
- adjusts all the e2e tests so they pass the linting check
- as a side effect, limited the scope of tests using k8s AdminClient in setting up ginkgo framework to a more limited (user) Client (where applicable)

**Which issue is resolved by this Pull Request:**
Resolves #3190 

Tested the linting rule with running `$ ginkgolinter -forbid-spec-pollution ./...` (should also auto-check now since the rule is not muted any more)

<img width="453" height="226" alt="image" src="https://github.com/user-attachments/assets/200b80a6-2be6-4c6a-8ee9-ff1f3636b69b" />
