### PR TITLE
[v1.20] Bump builder image to golang-1.26

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ it's up to the developer to ensure they are available in the environment:
 - [golangci-lint](https://github.com/golangci/golangci-lint)
 - [operator-sdk](https://sdk.operatorframework.io/docs/installation/)
   (**Note:** Until [#6978](https://github.com/operator-framework/operator-sdk/pull/6978) is merged and released, you
-  need to use `operator-sdk` from the PR branch; `quay.io/scylladb/scylla-operator-images:golang-1.25` image has it preinstalled)
+  need to use `operator-sdk` from the PR branch; `quay.io/scylladb/scylla-operator-images:golang-1.26` image has it preinstalled)
 - [ginkgo](https://onsi.github.io/ginkgo/#getting-started) - for running envtests.
 - [podman](https://podman.io/get-started) - for building and running container images.
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) - for running local Kubernetes clusters for E2E tests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=golang packageName=quay.io/scylladb/scylla-operator-images versioning=regex:^golang-(?<major>\d+)\.(?<minor>\d+)$
-FROM quay.io/scylladb/scylla-operator-images:golang-1.25 AS builder
+FROM quay.io/scylladb/scylla-operator-images:golang-1.26 AS builder
 
 RUN groupadd -g 1001 scylla && \
     useradd -u 1001 -g scylla -m scylla


### PR DESCRIPTION
Backport of https://github.com/scylladb/scylla-operator/pull/3315.