### PR TITLE
Fix relative paths in debug-flake.sh

### DIFF
--- a/hack/kind/debug-flake.sh
+++ b/hack/kind/debug-flake.sh
@@ -123,13 +123,13 @@ export CLUSTER_NAME
 # Set up the KIND cluster once before the loop (unless recreate is requested).
 if [ "${RECREATE_CLUSTER}" = false ]; then
   echo "Setting up KIND cluster..."
-  RECREATE=false "${parent_dir}/../cluster-setup.sh"
+  RECREATE=false "${parent_dir}/cluster-setup.sh"
   echo ""
 fi
 
 # Build and push the operator image once (unless SO_IMAGE is already set).
 echo "Preparing operator image..."
-build-and-push-operator-image "${parent_dir}/../../.."
+build-and-push-operator-image "${parent_dir}/../.."
 echo ""
 
 # Initialize counters.
@@ -153,9 +153,9 @@ for ((i=1; i<=NUM_RUNS; i++)); do
   if [ "${RECREATE_CLUSTER}" = true ]; then
     echo "Recreating KIND cluster..."
     if [ "${VERBOSE}" = true ]; then
-      RECREATE=true "${parent_dir}/../cluster-setup.sh"
+      RECREATE=true "${parent_dir}/cluster-setup.sh"
     else
-      RECREATE=true "${parent_dir}/../cluster-setup.sh" > /dev/null 2>&1
+      RECREATE=true "${parent_dir}/cluster-setup.sh" > /dev/null 2>&1
     fi
     echo ""
   fi
@@ -168,7 +168,7 @@ for ((i=1; i<=NUM_RUNS; i++)); do
 
   # Run the test and capture the exit code
   if [ "${VERBOSE}" = true ]; then
-    if "${parent_dir}/../run-e2e-tests.sh"; then
+    if "${parent_dir}/run-e2e-tests.sh"; then
       echo "✓ Run ${i}/${NUM_RUNS} PASSED"
       PASSED_RUNS=$((PASSED_RUNS + 1))
     else
@@ -176,7 +176,7 @@ for ((i=1; i<=NUM_RUNS; i++)); do
       FAILED_RUNS=$((FAILED_RUNS + 1))
     fi
   else
-    if "${parent_dir}/../run-e2e-tests.sh" > /dev/null 2>&1; then
+    if "${parent_dir}/run-e2e-tests.sh" > /dev/null 2>&1; then
       echo "✓ Run ${i}/${NUM_RUNS} PASSED"
       PASSED_RUNS=$((PASSED_RUNS + 1))
     else


### PR DESCRIPTION
The script fails early because everything relative to `$parent_dir` is incorrectly referenced.

This PR fixes the paths.

/kind machinery
/priority important-soon