### PR TITLE
Clarify supported ScyllaDB Monitoring version and extend the support matrix with tested versions of third-party dependencies

### DIFF
--- a/docs/source/_ext/version_context_substitutions.py
+++ b/docs/source/_ext/version_context_substitutions.py
@@ -112,6 +112,30 @@ def get_versions_from_config(repo_root: str) -> dict[str, str]:
     if scylla_db_manager_agent_version is not None:
         result['agentVersion'] = strip_digest(scylla_db_manager_agent_version)
 
+    # Try to extract cert-manager version
+    cert_manager_version = get_nested_value(config_data, 'thirdParty.certManager.version')
+    if cert_manager_version is not None:
+        result['certManagerVersion'] = cert_manager_version
+
+    # Try to extract Grafana version from the full image string (e.g. "docker.io/grafana/grafana:12.3.3" -> "12.3.3")
+    grafana_image = get_nested_value(config_data, 'operator.grafanaImage')
+    if grafana_image is not None:
+        # Strip digest if present, then extract the tag after the last ':'
+        grafana_image_no_digest = strip_digest(grafana_image)
+        colon_idx = grafana_image_no_digest.rfind(':')
+        if colon_idx != -1:
+            result['grafanaVersion'] = grafana_image_no_digest[colon_idx + 1:]
+
+    # Try to extract Prometheus version, stripping the leading 'v' prefix (e.g. "v3.9.1" -> "3.9.1")
+    prometheus_version = get_nested_value(config_data, 'operator.prometheusVersion')
+    if prometheus_version is not None:
+        result['prometheusVersion'] = prometheus_version.lstrip('v')
+
+    # Try to extract Prometheus Operator version
+    prometheus_operator_version = get_nested_value(config_data, 'thirdParty.prometheusOperator.version')
+    if prometheus_operator_version is not None:
+        result['prometheusOperatorVersion'] = prometheus_operator_version
+
     return result
 
 
@@ -159,10 +183,10 @@ def format_version_range(min_version: str, max_version: str) -> str:
 
 
 def extract_version_range(
-        data: dict,
-        min_key: str,
-        max_key: str,
-        transform_fn: Optional[callable] = None
+    data: dict,
+    min_key: str,
+    max_key: str,
+    transform_fn: Optional[callable] = None
 ) -> Optional[str]:
     """
     Extract and format a version range from nested dictionary data.

--- a/docs/source/support/releases.md
+++ b/docs/source/support/releases.md
@@ -155,6 +155,26 @@ The support matrix table shows the version requirements for ScyllaDB Operator. M
 
 [^scylladb-monitoring-version]: ScyllaDB Operator embeds the specified version of ScyllaDB Monitoring, which includes a set of Grafana dashboards and Prometheus rules.
 
+### Third-party dependencies
+
+The following table lists the versions of third-party dependencies that ScyllaDB Operator is tested against.
+
+:::{list-table}
+:widths: 50 50
+:header-rows: 1
+
+* - Component
+  - Version
+* - cert-manager
+  - {{certManagerVersion}}
+* - Grafana
+  - {{grafanaVersion}}
+* - Prometheus
+  - {{prometheusVersion}}
+* - Prometheus Operator
+  - {{prometheusOperatorVersion}}
+:::
+
 ### Architectures
 
 ScyllaDB Operator image is published as a manifest list to `docker.io/scylladb/scylla-operator:X.Y.Z` containing image build for `amd64` and `aarch64`.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** Currently, the support matrix uses "(CRD)" as a supported version of ScyllaDB Monitoring. The meaning behind this was supposed to be that the version is embedded in a given operator version. This PR clarifies it by explicitly stating the supported version and adding a footnote explaining that the version is embedded and what it means from the user perspective.

<img width="1183" height="634" alt="image" src="https://github.com/user-attachments/assets/e2538b29-9cc3-44db-8bf6-30e3a79a944a" />

<img width="1183" height="101" alt="image" src="https://github.com/user-attachments/assets/6b6a74ef-12ee-4140-9585-ebbdd598808e" />


Additionally, this PR extends the support matrix with a table specifying the supported and tested versions of third-party dependencies.

<img width="1183" height="472" alt="image" src="https://github.com/user-attachments/assets/3673aaac-41eb-49af-8890-bf8807d1a214" />

All of the values are dynamically sourced from config files.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/3063

/kind documentation
/priority important-longterm