### PR TITLE
Set a Ginkgo logger explicitly in envtests

### DIFF
--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Environment struct {
@@ -41,6 +42,8 @@ type Environment struct {
 // for convenience.
 func Setup(ctx context.Context) *Environment {
 	g.GinkgoHelper()
+
+	log.SetLogger(g.GinkgoLogr)
 
 	testEnv := &envtest.Environment{
 		ControlPlaneStartTimeout:    time.Minute,


### PR DESCRIPTION
**Description of your changes:**
Set a Ginkgo logger explicitly in envtests

This avoids a logging exception noise while running `make test-envtest` in each of these tests:

```
  Captured StdOut/StdErr Output >>
  [controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
  Detected at:
  	>  goroutine 10 [running]:
  	>  runtime/debug.Stack()
  	>  	/opt/homebrew/Cellar/go/1.26.0/libexec/src/runtime/debug/stack.go:26 +0x64
  	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
  	>  	/Users/eugene/gitrepo/scylla-operator/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go:60 +0xe8
  	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0x157a4bed7200, 0x1)
  	>  	/Users/eugene/gitrepo/scylla-operator/vendor/sigs.k8s.io/controller-runtime/pkg/log/deleg.go:111 +0x30
  	>  github.com/go-logr/logr.Logger.Info({{0x1062717b0?, 0x157a4bed7200?}, 0x0?}, {0x104054d7c, 0x16}, {0x0, 0x0, 0x0})
  	>  	/Users/eugene/gitrepo/scylla-operator/vendor/github.com/go-logr/logr/logr.go:276 +0x5c
  	>  sigs.k8s.io/controller-runtime/pkg/envtest.(*Environment).Start(0x157a4bdb22c8)
  	>  	/Users/eugene/gitrepo/scylla-operator/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/server.go:303 +0x368
  	>  github.com/scylladb/scylla-operator/test/envtest.Setup({0x10626a2f0, 0x157a4bc5e720})
  	>  	/Users/eugene/gitrepo/scylla-operator/test/envtest/setup.go:52 +0x9c
  	>  github.com/scylladb/scylla-operator/test/envtest/controllers.init.func2.1({0x106273850?, 0x157a4bc5e720?})
  	>  	/Users/eugene/gitrepo/scylla-operator/test/envtest/controllers/scyllacluster_controller_test.go:35 +0x4c
  	>  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
  	>  	/Users/eugene/gitrepo/scylla-operator/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:946 +0x26c
  	>  created by github.com/onsi/ginkgo/v2/internal.(*Suite).runNode in goroutine 26
  	>  	/Users/eugene/gitrepo/scylla-operator/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:911 +0xa90
```

After the changes:

```
------------------------------
• [56.141 seconds]
BootstrapBarrierController Bootstrap precondition evaluation When a single status report with all nodes up is created
/Users/eugene/gitrepo/scylla-operator/test/envtest/controllers/bootstrap_barrier_test.go:79

  Captured StdOut/StdErr Output >>
  I0313 15:52:25.656214   13587 observer.go:137] "Starting observer" Name="scylladb-bootstrap-barrier"
  I0313 15:52:25.656273   13587 shared_informer.go:349] "Waiting for caches to sync" controller="Observer scylladb-bootstrap-barrier"
  I0313 15:52:25.756380   13587 shared_informer.go:356] "Caches are synced" controller="Observer scylladb-bootstrap-barrier"
  I0313 15:52:25.763418   13587 observer.go:146] "Shutting down observer" Name="scylladb-bootstrap-barrier"
  I0313 15:52:25.763466   13587 observer.go:149] "Shut down observer" Name="scylladb-bootstrap-barrier"
  << Captured StdOut/StdErr Output
------------------------------
```

This PR includes changes suggested by Copilot.