### PR TITLE
 fix(validation): reject ScyllaCluster with empty spec.version at admission time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,8 @@
 ### Highlights
 
 ### Upgrade requirements
-
-- Rename `ScyllaCluster` backup and repair tasks to comply with RFC 1123 (e.g., if they contain underscores `_`).
-- Ensure all `ScyllaCluster`'s `spec.version` is not empty.
   
-For details, refer to the [1.20 to 1.21 upgrade guide](https://operator.docs.scylladb.com/stable/management/upgrading/upgrade/#to-1-21).
+Please refer to the [1.20 to 1.21 upgrade guide](https://operator.docs.scylladb.com/stable/management/upgrading/upgrade/#to-1-21).
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 ### Upgrade requirements
 
 - Rename `ScyllaCluster` backup and repair tasks to comply with RFC 1123 (e.g., if they contain underscores `_`).
-  For details, refer to the [1.20 to 1.21 upgrade guide](https://operator.docs.scylladb.com/stable/management/upgrading/upgrade/#to-1-21).
+- Ensure all `ScyllaCluster`'s `spec.version` is not empty.
+  
+For details, refer to the [1.20 to 1.21 upgrade guide](https://operator.docs.scylladb.com/stable/management/upgrading/upgrade/#to-1-21).
 
 ### Deprecations
 
@@ -38,6 +40,7 @@
   [#3363](https://github.com/scylladb/scylla-operator/pull/3363)
 - `must-gather` resource collection now tolerates partial API discovery failures (e.g., when aggregated API servers like `metrics.k8s.io` are transiently unavailable) instead of failing entirely.
   [#3396](https://github.com/scylladb/scylla-operator/pull/3396)
+- Fixed [#3302](https://github.com/scylladb/scylla-operator/issues/3302): `ScyllaCluster` `spec.version` is now a required field. Previously, an empty value was accepted but caused a silent failure in the migration controller.
 
 ### Dependencies
 

--- a/docs/source/management/upgrading/upgrade.md
+++ b/docs/source/management/upgrading/upgrade.md
@@ -62,6 +62,8 @@ Make sure to familiarize yourself with both the standard upgrade procedure and t
 
 ### 1.20 to 1.21
 
+#### Ensure ScyllaCluster repair and backup task names are RFC 1123 compliant
+
 Before upgrading, ensure that all `ScyllaCluster` repair (`.spec.repairs[].name`) and backup (`.spec.backups[].name`) task names conform to [RFC 1123 subdomain](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names) requirements:
 - contain no more than 253 characters,
 - contain only lowercase alphanumeric characters, '-' or '.',
@@ -103,6 +105,25 @@ All ScyllaCluster repair and backup task names are RFC 1123 compliant.
 **Why is this necessary?**
 Starting with v1.20.1, ScyllaDB Operator emitted warnings for `ScyllaCluster` repair and backup task names not conforming to RFC 1123 subdomain requirements.
 In v1.21, these warnings have been replaced with hard validation errors, and the operator will refuse to start if any existing `ScyllaClusters` have non-conforming task names.
+:::
+
+#### Ensure ScyllaCluster spec.version is not empty
+
+`ScyllaCluster` `spec.version` is now a required field. Any create or update request with an empty value will be rejected by the admission webhook.
+You can run the following snippet to check whether any of your existing `ScyllaClusters` have an empty `spec.version`:
+
+```bash
+kubectl get scyllaclusters --all-namespaces -o json | jq -r '
+  .items[] | select((.spec.version // "") == "") |
+  "\(.metadata.namespace)/\(.metadata.name)"
+'
+```
+
+If the command returns no output, all your `ScyllaClusters` are unaffected. If any are listed, set their `spec.version` to a valid ScyllaDB image tag before upgrading.
+
+:::{note}
+**Why is this not a breaking change?**
+A `ScyllaCluster` with an empty `spec.version` was never functional. The migration controller would fail to reconcile it, leaving the cluster in a permanently degraded state. Making the field required only prevents new broken clusters from being created.
 :::
 
 ### 1.17 to 1.18

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -152,6 +152,10 @@ func ValidateAlternatorSpec(alternator *scyllav1.AlternatorSpec, fldPath *field.
 func ValidateScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
+	if len(spec.Version) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("version"), ""))
+	}
+
 	rackNames := apimachineryutilsets.NewString()
 
 	if spec.Alternator != nil {

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -38,6 +38,18 @@ func TestValidateScyllaCluster(t *testing.T) {
 			expectedErrorString: "",
 		},
 		{
+			name: "empty version",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.Version = ""
+				return cluster
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeRequired, Field: "spec.version", BadValue: ""},
+			},
+			expectedErrorString: `spec.version: Required value`,
+		},
+		{
 			name: "two racks with same name",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
@@ -1101,6 +1113,19 @@ func TestValidateScyllaClusterUpdate(t *testing.T) {
 			new:                 unit.NewSingleRackCluster(3),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
+		},
+		{
+			name: "empty version",
+			old:  unit.NewSingleRackCluster(3),
+			new: func() *scyllav1.ScyllaCluster {
+				cluster := unit.NewSingleRackCluster(3)
+				cluster.Spec.Version = ""
+				return cluster
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeRequired, Field: "spec.version", BadValue: ""},
+			},
+			expectedErrorString: `spec.version: Required value`,
 		},
 		{
 			name:                "major version changed",

--- a/pkg/controller/scyllacluster/migrate_test.go
+++ b/pkg/controller/scyllacluster/migrate_test.go
@@ -355,6 +355,47 @@ func TestMigrateV1ScyllaClusterToV1Alpha1ScyllaDBDatacenter(t *testing.T) {
 	}
 }
 
+func TestMigrateV1ScyllaClusterSpecToV1Alpha1ScyllaDBDatacenterSpec(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name           string
+		scyllaCluster  *scyllav1.ScyllaCluster
+		expectedErrMsg string
+	}{
+		{
+			name: "empty version returns an error",
+			scyllaCluster: func() *scyllav1.ScyllaCluster {
+				sc := newBasicScyllaCluster()
+				sc.Spec.Version = ""
+				return sc
+			}(),
+			expectedErrMsg: "v1alpha1.ScyllaCluster ScyllaDB version cannot be empty",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := MigrateV1ScyllaClusterSpecToV1Alpha1ScyllaDBDatacenterSpec(tc.scyllaCluster.Name, tc.scyllaCluster.Spec)
+			if len(tc.expectedErrMsg) == 0 {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.expectedErrMsg)
+			}
+			if !strings.Contains(err.Error(), tc.expectedErrMsg) {
+				t.Errorf("expected error to contain %q, got %q", tc.expectedErrMsg, err.Error())
+			}
+		})
+	}
+}
+
 func newBasicScyllaCluster() *scyllav1.ScyllaCluster {
 	return &scyllav1.ScyllaCluster{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Makes `ScyllaCluster` `spec.version` a required field. Previously, an empty value was silently accepted but caused the migration controller to fail, leaving the cluster degraded. This is shifting the feedback from runtime to object creation phase.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-70.

/cc @mflendrich 
