### PR TITLE
docs: add hierarchical AGENTS.md knowledge base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# scylla-operator — Agent Guide
+
+## What this repo is
+
+Kubernetes operator for ScyllaDB. Written in Go. Uses **client-go informers + workqueue** — NOT controller-runtime Reconciler. All business logic lives in `pkg/`. `cmd/` contains thin `main()` entrypoints only.
+
+## Repo layout deviations (vs Kubebuilder defaults)
+
+| Expected path | Actual path | Notes |
+|---|---|---|
+| `api/` | `pkg/api/scylla/` | All CRD types here |
+| `controllers/` | `pkg/controller/` | 18 controllers |
+| `config/` (kustomize) | `deploy/` + `helm/` | Raw manifests + Helm chart |
+| reconciler cobra | `pkg/cmd/` | All cobra/flag logic here |
+
+`submodules/scylla-monitoring/` — full git submodule. Do not modify. `pkg/thirdparty/` — in-tree forks of external helpers. Do not replace with upstream imports.
+
+## API groups
+
+- `scylla.scylladb.com/v1`: **ScyllaCluster** (stable)
+- `scylla.scylladb.com/v1alpha1`: ScyllaDBCluster, ScyllaDBDatacenter, ScyllaDBMonitoring, ScyllaOperatorConfig, NodeConfig, RemoteKubernetesCluster, ScyllaDBManagerTask, ScyllaDBManagerClusterRegistration, ScyllaDBDatacenterNodesStatusReport, RemoteOwner
+- `cqlclient.scylla.scylladb.com/v1alpha1`: CQLConnectionConfig
+
+Types marked `*(internal)*` are implementation details — not for external consumers.
+
+## Core packages (import these, don't reinvent)
+
+| Package | Use for |
+|---|---|
+| `pkg/naming` | ALL labels, annotation keys, name generators, constants — **always** import this |
+| `pkg/controllerhelpers` | Handler wiring, claim/release, status aggregation, finalizers, WaitFor* |
+| `pkg/resourceapply` | Idempotent ApplyXxx(required) — hash-based create/update for k8s resources |
+| `pkg/helpers` | IP parsing, MergeMaps, ParseScyllaArguments, CreateTwoWayMergePatch |
+| `pkg/pointer` | `pointer.Ptr[T](v)` — generic pointer helper |
+| `pkg/scyllaclient` | HTTP client to ScyllaDB REST API |
+| `pkg/remoteclient` | Multi-cluster remote client management |
+
+## Commit message format
+
+Conventional Commits: `<type>(<scope>): <subject>`
+- Imperative, lowercase subject, ≤72 chars
+- No `@mentions`, no issue-closing keywords (`Fixes #N`, `Closes #N`), no `#N` refs in message body
+- Types: `feat`, `fix`, `refactor`, `test`, `docs`, `ci`, `chore`
+
+## Import aliases (enforced by golangci-lint `importas`)
+
+```go
+corev1 "k8s.io/api/core/v1"
+metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
+```
+Run `make lint` — it will catch wrong aliases. Full list in `.golangci.yaml` under `linters-settings.importas`.
+
+## Build & verify commands
+
+```bash
+make build                        # build all binaries
+make test-unit                    # unit tests
+make verify                       # ALL CI checks — run before any PR
+make lint                         # golangci-lint
+make gofmt                        # gofmt check
+make update-codegen               # regenerate deepcopy/client/informers/listers
+make update-crds                  # regenerate CRD YAMLs (controller-gen)
+make update-go-mod-replace        # update go.mod replace entries (DO NOT edit manually)
+```
+
+E2E requires podman: `KIND_EXPERIMENTAL_PROVIDER=podman CLUSTER_NAME=test make test-e2e-kind`
+
+## Hard rules
+
+- **Never edit generated files**: `zz_generated.*`, `clientset_generated.*`, `*_generated.go`
+- **Never manually edit `go.mod` replace entries** — use `make update-go-mod-replace`
+- **Never hardcode names/labels** — always use `pkg/naming`
+- **Never use controller-runtime Reconcile pattern** — use informers + workqueue (see `pkg/controller/`)
+- **Never raise `maxSyncDuration`** in controllers — controllers must not actively wait
+- **No ginkgo Focus markers**: `FIt`, `FDescribe`, `FContext`, `FWhen` — CI will fail
+- `make lint` + `make gofmt` must pass before commit
+
+## API design conventions
+
+Discriminated unions: `Type` field (required string) + `<Type>Options *TypeOptions omitempty`. See `API_CONVENTIONS.md` for full rules.
+
+## Go toolchain
+
+Go 1.25.1. Requires GNU Make ≥ 4.2.

--- a/helm/AGENTS.md
+++ b/helm/AGENTS.md
@@ -1,0 +1,121 @@
+# helm/
+
+Three Helm charts for deploying the operator ecosystem. **CRDs and deploy manifests are generated** — never edit them manually.
+
+## Charts
+
+| Chart | Purpose | Key content |
+|---|---|---|
+| `helm/scylla-operator/` | Operator + webhooks + RBAC + CRDs | Operator Deployment, webhookserver, ClusterRoles, cert-manager resources, CRDs in `crds/` |
+| `helm/scylla/` | ScyllaCluster CR deployment | Wraps a `ScyllaCluster` CR and optional ServiceMonitor |
+| `helm/scylla-manager/` | Scylla Manager deployment | Manager Deployment + ConfigMap; depends on `scylla` subchart |
+
+`scylla-manager` depends on `scylla` via `file://../scylla` — the embedded subchart lives at `helm/scylla-manager/charts/scylla/`.
+
+## Key values (scylla-operator)
+
+```yaml
+replicas: 2                     # 1 disables HA and PDB creation
+image:
+  repository: scylladb
+  tag: ""                       # defaults to chart appVersion
+logLevel: 2
+additionalArgs: []
+resources:
+  requests: { cpu: 100m, memory: 20Mi }
+
+# Webhook server (separate Deployment)
+webhookServerReplicas: 2
+webhookServerResources: ...
+
+# TLS
+webhook:
+  createSelfSignedCertificate: true
+  certificateSecretName: ""     # override generated name
+
+# RBAC
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+```
+
+Version placeholders: `Chart.yaml` versions are `0.0.0` / `latest` — overwritten by `make update-helm-charts` during release. Do not rely on `Chart.yaml` for version info; check `assets/config/config.yaml`.
+
+## Template conventions
+
+- Use `_helpers.tpl` for all naming: `include "scylla-operator.fullname" .`, `include "scylla-operator.serviceAccountName" .`, etc. **Never hardcode release names.**
+- Labels follow `app.kubernetes.io/` conventions — use the `include "scylla-operator.labels"` helper.
+- RBAC split: `*.clusterrole.yaml` = the ClusterRole resource; `*.clusterrole_def.yaml` = aggregate/docs variant. Follow the existing pattern when adding new roles.
+- OpenShift variants use a `_openshift.yaml` / `_def_openshift.yaml` suffix.
+- CRDs live in `helm/scylla-operator/crds/` — Helm installs these before all templates. They are **not templated**.
+
+## CRDs — never edit manually
+
+CRDs are generated from Go API types in `pkg/api/`:
+
+```bash
+make update-crds          # regenerate CRDs from pkg/api using controller-gen
+make verify-crds          # verify committed CRDs match generated output (run in CI)
+```
+
+After `update-crds`, commit the updated files under `helm/scylla-operator/crds/`.
+
+## Helm value schemas — also generated
+
+`values.schema.json` files are derived from the CRD OpenAPI schemas:
+
+```bash
+make update-helm-schemas  # regenerate from CRDs
+make verify-helm-schemas  # CI check
+```
+
+## deploy/ manifests — also generated
+
+`deploy/` YAML files are produced by running `helm template` on the charts:
+
+```bash
+make update-deploy        # regenerate deploy/ from helm template
+make verify-deploy        # CI check
+```
+
+The Makefile maps specific helm template outputs to numbered deploy manifest filenames (`00_`, `10_`, `50_` prefix scheme).
+
+## Full update workflow
+
+**After changing a Go API type:**
+```bash
+make update-crds
+make update-helm-schemas
+make update-deploy
+make verify
+```
+
+**After changing chart templates or values:**
+```bash
+helm lint helm/scylla-operator    # local syntax check
+make update-deploy
+make verify-deploy
+```
+
+**For a release:**
+```bash
+make update-helm-charts           # bump appVersion from assets/config/config.yaml
+make helm-build                   # package charts
+make helm-publish                 # publish to GCS
+```
+
+## Gotchas
+
+| Situation | What to do |
+|---|---|
+| Changed a CRD type | `make update-crds && make update-helm-schemas && make update-deploy` |
+| Added a new value | Update `values.yaml` and `values.schema.json` (via `make update-helm-schemas`) |
+| Changed deploy manifests | `make update-deploy` — never edit `deploy/` by hand |
+| scylla-manager subchart out of date | Run `helm dependency update helm/scylla-manager` |
+| CI fails on verify-crds/verify-deploy | Regenerate the artifacts and commit them |
+
+## CI deploy scripts
+
+- `hack/ci-deploy.sh` — installs third-party components (cert-manager, prometheus-operator) then applies operator manifests. Waits for `crd/... condition=established` before applying manager.
+- `hack/ci-deploy-release.sh` — fetches version info from image labels; used for release deployments.

--- a/pkg/api/AGENTS.md
+++ b/pkg/api/AGENTS.md
@@ -1,0 +1,83 @@
+# pkg/api — Agent Guide
+
+## Layout
+
+```
+pkg/api/scylla/
+  v1/                 # stable API — ScyllaCluster only
+    types_cluster.go  # ScyllaCluster, ScyllaClusterSpec, ScyllaClusterStatus
+    zz_generated.*    # DO NOT EDIT
+  v1alpha1/           # all other CRDs + internal types
+    types_*.go        # one file per CRD
+    zz_generated.*    # DO NOT EDIT
+cqlclient/scylla.scylladb.com/
+  v1alpha1/
+    types_cqlconnectionconfig.go
+```
+
+## CRD inventory
+
+| Group | Version | Kind | Stability |
+|---|---|---|---|
+| `scylla.scylladb.com` | `v1` | ScyllaCluster | stable |
+| `scylla.scylladb.com` | `v1alpha1` | ScyllaDBCluster | external |
+| `scylla.scylladb.com` | `v1alpha1` | ScyllaDBDatacenter | external |
+| `scylla.scylladb.com` | `v1alpha1` | ScyllaDBMonitoring | external |
+| `scylla.scylladb.com` | `v1alpha1` | ScyllaOperatorConfig | external |
+| `scylla.scylladb.com` | `v1alpha1` | NodeConfig | external |
+| `scylla.scylladb.com` | `v1alpha1` | RemoteKubernetesCluster | external |
+| `scylla.scylladb.com` | `v1alpha1` | ScyllaDBManagerTask | external |
+| `scylla.scylladb.com` | `v1alpha1` | ScyllaDBManagerClusterRegistration | internal |
+| `scylla.scylladb.com` | `v1alpha1` | ScyllaDBDatacenterNodesStatusReport | internal |
+| `scylla.scylladb.com` | `v1alpha1` | RemoteOwner | internal |
+| `cqlclient.scylla.scylladb.com` | `v1alpha1` | CQLConnectionConfig | external |
+
+**Internal types** are implementation details between operator components — not for external consumers or documentation.
+
+## API design conventions (enforced)
+
+See `API_CONVENTIONS.md` at repo root for full rules. Key points:
+
+**Discriminated unions:**
+```go
+// CORRECT
+Type     StorageType  `json:"type"`
+LocalOptions *LocalStorageOptions `json:"localOptions,omitempty"`
+
+// WRONG — anonymous embedded struct, missing Type discriminator
+Options struct { ... } `json:"options"`
+```
+
+**Optional fields:** always `omitempty` + pointer (`*T`) for structs, plain `omitempty` for scalars with meaningful zero values.
+
+**Status conditions:** use `metav1.Condition` slice with standard `Type`, `Status`, `Reason`, `Message` fields. Reason must be CamelCase, no spaces.
+
+**Defaulting/validation:** in `pkg/api/scylla/<version>/validation/` and `*_webhook.go`. Never inline validation in controllers.
+
+## Generated code
+
+After any type change, run:
+```bash
+make update-codegen   # deepcopy, client, informers, listers
+make update-crds      # CRD YAML manifests (controller-gen)
+```
+
+Files named `zz_generated.*` or `*_generated.go` are **never edited by hand**.
+
+## Import aliases
+
+```go
+scyllav1       "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+```
+
+These are enforced by golangci-lint `importas`. Wrong aliases = lint failure.
+
+## Adding a new CRD
+
+1. Create `types_<name>.go` in the appropriate version directory
+2. Add `+kubebuilder:object:root=true` and required markers
+3. Register in `register.go` (add to `SchemeBuilder.Register(...)`)
+4. Run `make update-codegen && make update-crds`
+5. Add validation in `pkg/api/scylla/<version>/validation/`
+6. Never add business logic to type files

--- a/pkg/cmd/AGENTS.md
+++ b/pkg/cmd/AGENTS.md
@@ -1,0 +1,160 @@
+# pkg/cmd
+
+All cobra/flag wiring for the operator binaries. Contains **no business logic** — only command scaffolding, client construction, informer startup, and controller orchestration. Business logic lives in `pkg/controller/`.
+
+## Layout
+
+```
+pkg/cmd/
+├── operator/           # scylla-operator binary commands
+│   ├── cmd.go          # root command: composes subcommands, PersistentPreRunE, klog, feature gates
+│   ├── operator.go     # "operator" subcommand: leader election, informers, NewController calls
+│   ├── webhooks.go     # "webhooks" subcommand: TLS, admission validation server
+│   ├── sidecar/        # "sidecar" subcommand (runs inside Scylla pods)
+│   ├── probeserver/    # "serve-probes" subcommand
+│   ├── bootstrapbarrier/ # "bootstrap-barrier" subcommand
+│   ├── nodesetupdaemon.go
+│   ├── ignition.go
+│   ├── mustgather.go
+│   ├── cleanupjob.go
+│   └── rlimitsjob.go
+├── tests/              # scylla-operator-tests binary
+│   ├── tests.go        # root command
+│   ├── tests_run.go    # "run" subcommand
+│   └── options.go      # TestFrameworkOptions
+├── generateapireference/ # gen-api-reference binary
+└── version/            # version subcommand (shared)
+```
+
+## Cobra command pattern
+
+Every command follows the same structure:
+
+```go
+// 1. Options struct with sensible defaults
+func NewFooOptions(streams genericclioptions.IOStreams) *FooOptions {
+    return &FooOptions{
+        ClientConfig: genericclioptions.NewClientConfig("scylla-operator"),
+        LeaderElection: genericclioptions.NewLeaderElection(),
+        // ...
+    }
+}
+
+// 2. AddFlags registers all flags (including embedded options)
+func (o *FooOptions) AddFlags(cmd *cobra.Command) {
+    o.ClientConfig.AddFlags(cmd)
+    o.LeaderElection.AddFlags(cmd)
+    cmd.Flags().IntVar(&o.ConcurrentSyncs, "concurrent-syncs", ...)
+}
+
+// 3. NewFooCmd builds the cobra.Command
+func NewFooCmd(streams genericclioptions.IOStreams) *cobra.Command {
+    o := NewFooOptions(streams)
+    cmd := &cobra.Command{
+        Use: "foo", Short: "...",
+        SilenceErrors: true, SilenceUsage: true,
+        RunE: func(cmd *cobra.Command, args []string) error {
+            if err := o.Complete(); err != nil { return err }
+            if err := o.Validate(); err != nil { return err }
+            return o.Run(streams, cmd)
+        },
+    }
+    o.AddFlags(cmd)
+    return cmd
+}
+
+// 4. Validate — check flag constraints only
+// 5. Complete — build clientsets from ClientConfig.RestConfig / ProtoConfig
+// 6. Run — set up signals, ctx, and start the main logic
+```
+
+Add new commands to the root in `pkg/cmd/operator/cmd.go`:
+```go
+cmd.AddCommand(NewFooCmd(streams))
+```
+
+## Generic CLI options (pkg/genericclioptions)
+
+Embed these into your `Options` struct rather than rolling your own:
+
+| Type | Provides | Key method |
+|---|---|---|
+| `ClientConfig` | `RestConfig`, `ProtoConfig`, QPS/Burst, kubeconfig flag | `Complete()` loads kubeconfig |
+| `MultiDatacenterClientConfig` | Worker kubeconfigs map (e2e tests) | `Complete()` builds per-worker configs |
+| `InClusterReflection` | `--namespace` flag, auto-detects from pod | `Complete()` |
+| `LeaderElection` | Leader election duration flags | `AddFlags(cmd)` |
+| `IOStreams` | `In`, `Out`, `ErrOut` writers | — |
+
+```go
+// Build clientsets in Complete():
+kubeClient, err := kubernetes.NewForConfig(o.ProtoConfig)  // use ProtoConfig for k8s
+scyllaClient, err := scyllav.NewForConfig(o.RestConfig)    // use RestConfig for CRD clients
+```
+
+## Environment variable → flag mapping
+
+`pkg/cmdutil.ReadFlagsFromEnv(prefix, cmd)` is called in each root's `PersistentPreRunE`. It maps every unflagged flag to an env var:
+
+```
+env var = uppercase(prefix + flag-name).replace('-', '_')
+
+Example: prefix="SCYLLA_OPERATOR_", flag="concurrent-syncs"
+      → SCYLLA_OPERATOR_CONCURRENT_SYNCS
+```
+
+The operator uses `naming.OperatorEnvVarPrefix`; tests use `"SCYLLA_OPERATOR_TESTS_"`.
+
+## Feature gates & logging
+
+Both root commands call these in `NewOperatorCommand` / `NewTestsCommand`:
+
+```go
+cmdutil.InstallKlog(cmd)                                  // adds --loglevel persistent flag
+utilfeature.DefaultMutableFeatureGate.AddFlag(cmd.PersistentFlags()) // adds --feature-gates
+```
+
+These are persistent flags — all subcommands inherit them automatically.
+
+## Operator startup sequence
+
+```
+PersistentPreRunE:
+  maxprocs.Set()
+  cmdutil.ReadFlagsFromEnv(naming.OperatorEnvVarPrefix, cmd)
+
+Complete():
+  o.ClientConfig.Complete()         // load kubeconfig, set RestConfig/ProtoConfig
+  o.InClusterReflection.Complete()  // detect namespace
+  o.LeaderElection.Complete()
+  kubernetes.NewForConfig(o.ProtoConfig)   → kubeClient
+  scyllaversionedclient.NewForConfig(...)  → scyllaClient
+  // ... monitoring, remote clients ...
+
+Run() → Execute() → leaderelection.Run(ctx, ..., func(ctx) { o.run(ctx) })
+
+run():
+  rsaKeyGenerator := ocrypto.NewRSAKeyGenerator(...)
+  kubeInformers  := informers.NewSharedInformerFactory(kubeClient, resyncPeriod)
+  scyllaInformers := scyllainformers.NewSharedInformerFactory(scyllaClient, resyncPeriod)
+  // ...create all controllers via NewController(...)...
+  go rsaKeyGenerator.Run(ctx)
+  go kubeInformers.Start(ctx.Done())
+  go scyllaInformers.Start(ctx.Done())
+  go controller.Run(ctx, o.ConcurrentSyncs)  // one goroutine per controller
+  <-ctx.Done()
+```
+
+## Adding a controller command
+
+1. Create `pkg/cmd/operator/myfeature.go` with `NewMyFeatureOptions`, `AddFlags`, `NewMyFeatureCmd`, `Validate`, `Complete`, `Run`.
+2. In `Complete()`, use `o.ClientConfig.Complete()` then build clientsets.
+3. In `Run()`, create informer factories → `NewController(...)` → `factory.Start(ctx.Done())` → `controller.Run(ctx, workers)`.
+4. Register in `pkg/cmd/operator/cmd.go`: `cmd.AddCommand(NewMyFeatureCmd(streams))`.
+5. Env-var support is automatic via the root `PersistentPreRunE`.
+
+## Hard rules
+
+- **Never put business logic here.** If it's more than wiring, it belongs in `pkg/controller/`.
+- **`cmd/`** contains only thin `main()` entrypoints — actual cobra setup lives in `pkg/cmd/`.
+- Always start informer factories **before** calling `controller.Run`.
+- Pass `o.ProtoConfig` to Kubernetes core clients; `o.RestConfig` to CRD/custom clients.

--- a/pkg/controller/AGENTS.md
+++ b/pkg/controller/AGENTS.md
@@ -1,0 +1,80 @@
+# pkg/controller — Agent Guide
+
+## What lives here
+
+18 controllers, each in its own subdirectory. Every controller is a standalone package; no shared init or registration magic.
+
+## Controller anatomy (standard pattern)
+
+```
+<name>/
+  controller.go   # struct definition, New(), Run(), informer handler wiring
+  sync.go         # business logic: sync(), calculateXxx(), ensureXxx()
+  options.go      # CLI flags (if applicable)
+```
+
+Some controllers split `sync.go` into multiple files by resource type (`sync_statefulsets.go`, `sync_services.go`, etc.).
+
+## Two instantiation idioms
+
+### 1. Informer-driven (most controllers)
+
+```go
+c := &Controller{
+    queue: workqueue.NewTypedRateLimitingQueueWithConfig[string](...),
+}
+// Wire handlers in New():
+scyllaInformers.V1().ScyllaClusters().Informer().AddEventHandler(
+    cache.ResourceEventHandlerFuncs{...},
+)
+// Run() starts workers that call c.processNextItem() → c.sync(ctx, key)
+```
+
+Key: `controllerhelpers.NewHandlers(...)` for standard add/update/delete wiring.
+
+### 2. Observer/singleton (bootstrapbarrier, ignition, globalscylladbmanager, statusreport)
+
+```go
+observer := controllertools.NewObserver(...)
+observer.GetGenericHandlers()  // returns handler funcs to wire
+```
+
+Used for controllers that watch a single object or have no queue.
+
+## Registration
+
+Controllers are **NOT** registered via `SetupWithManager`. They are explicitly instantiated in `pkg/cmd/operator/operator.go` and started with `go c.Run(ctx, workers)`.
+
+## sync() contract
+
+- Takes `(ctx context.Context, key string)` — key is `namespace/name` or just `name`
+- Must be idempotent
+- Returns `error` (requeueing is handled by the workqueue caller)
+- Use `controllerhelpers.WaitForCacheSync(...)` at startup before processing
+
+## maxSyncDuration
+
+Every controller has a `maxSyncDuration` const. **Do not raise it.** Controllers must not actively wait (no `time.Sleep`, no polling loops in sync). If you need to wait, re-enqueue with a delay via the workqueue.
+
+## Status updates
+
+Use `controllerhelpers.SetStatusCondition` / `AggregateStatusConditions` — never build condition lists manually. Patch status via `UpdateStatus` sub-resource, not full object update.
+
+## Claim/release pattern
+
+Child resources (StatefulSets, Services, etc.) are "claimed" to a controller instance via label selectors + `controllerhelpers.ClaimXxx(...)`. Never directly own resources that weren't claimed.
+
+## Adding a new controller
+
+1. Create `pkg/controller/<name>/` with `controller.go` + `sync.go`
+2. Add constructor `New(...)` that accepts informers + clients
+3. Register in `pkg/cmd/operator/operator.go` (look for the block of `NewXxx(...)` calls)
+4. Add to `pkg/cmd/operator/cmd.go` worker-count flags if needed
+5. Wire informer cache sync in the controller's `Run()` before starting workers
+
+## Common mistakes
+
+- Never `time.Sleep` in `sync()` — use `workqueue.AddAfter`
+- Never call `Update` on the full object to change status — always use `UpdateStatus` sub-resource
+- Never hardcode label keys — import `pkg/naming`
+- Observer controllers do NOT have a queue; don't add one

--- a/pkg/controllerhelpers/AGENTS.md
+++ b/pkg/controllerhelpers/AGENTS.md
@@ -1,0 +1,80 @@
+# pkg/controllerhelpers — Agent Guide
+
+## Purpose
+
+Shared infrastructure for all 18 controllers. Not business logic — plumbing. Import here instead of reimplementing.
+
+## Key functions by category
+
+### Handler wiring
+```go
+// Wire typed event handlers for an informer — generic, requires scheme + GVK
+handlers, err := controllerhelpers.NewHandlers[*scyllav1.ScyllaCluster](
+    queue, keyFunc, scheme, gvk, getterLister,
+)
+// Returns *Handlers[T] with methods: HandleAdd, HandleUpdate, HandleDelete,
+// Enqueue, EnqueueAll, EnqueueOwner, EnqueueOwnerFunc, etc.
+```
+
+### Claim / release (via `pkg/controllertools`)
+```go
+// Claim child resources matching selector — lives in pkg/controllertools, not here
+mgr := controllertools.NewControllerRefManager[*appsv1.StatefulSet](
+    ctx, controller, selector, controllerGVK, controlFuncs,
+)
+claimed, err := mgr.ClaimObjects(statefulsets)
+
+// Release orphaned child resources — this one IS in controllerhelpers
+err := controllerhelpers.ReleaseObjects[CT, T](ctx, controller, controllerGVK, selector, control)
+```
+
+### Status conditions
+```go
+// Set a condition derived from an error (nil err → Available=True, non-nil → Degraded)
+controllerhelpers.SetStatusConditionFromError(&conditions, err, conditionType, observedGeneration)
+
+// Aggregate a slice of child conditions into a single parent condition
+result, err := controllerhelpers.AggregateStatusConditions(childConditions, parentCondition)
+
+// Aggregate Available/Progressing/Degraded by suffix convention
+err := controllerhelpers.SetAggregatedWorkloadConditions(&conditions, generation)
+```
+
+### Finalizers
+```go
+// Produce a JSON merge-patch that removes/adds a finalizer (no network call — caller must Patch)
+patchBytes, err := controllerhelpers.RemoveFinalizerPatch(obj, naming.MyFinalizer)
+patchBytes, err := controllerhelpers.AddFinalizerPatch(obj, naming.MyFinalizer)
+ok := controllerhelpers.HasFinalizer(obj, naming.MyFinalizer)
+```
+
+### WaitFor* helpers (tests only)
+```go
+// Generic watch-based wait — use specific wrappers below
+obj, err := controllerhelpers.WaitForObjectState[*scyllav1.ScyllaCluster, *scyllav1.ScyllaClusterList](
+    ctx, client, name, controllerhelpers.WaitForStateOptions{TolerateDelete: false}, conditionFn,
+)
+
+// Typed convenience wrappers (same signature pattern):
+sc,  err := controllerhelpers.WaitForScyllaClusterState(ctx, client, name, opts, condFn)
+sdc, err := controllerhelpers.WaitForScyllaDBDatacenterState(ctx, client, name, opts, condFn)
+nc,  err := controllerhelpers.WaitForNodeConfigState(ctx, client, name, opts, condFn)
+pod, err := controllerhelpers.WaitForPodState(ctx, client, name, opts, condFn)
+// ...and more per resource type in wait.go
+```
+
+**WaitFor\* are test helpers** — never call them inside `sync()` or any controller path.
+
+## Ownership / controller reference
+
+`metav1.GetControllerOfNoCopy(obj)` (from `k8s.io/apimachinery`) — returns the ownerReference with `controller: true`. Not in this package.
+
+When creating child resources, always set a controller reference using `metav1.NewControllerRef(owner, gvk)` before calling `resourceapply.ApplyXxx`.
+
+## Common mistakes
+
+- `ClaimXxx` functions don't exist here — use `pkg/controllertools.NewControllerRefManager`
+- `SetStatusCondition` doesn't exist — use `SetStatusConditionFromError`
+- `EnsureFinalizer`/`RemoveFinalizer` don't exist — use `AddFinalizerPatch`/`RemoveFinalizerPatch` (return bytes, require a separate Patch call)
+- Don't call `WaitFor*` in production code paths — test-only
+- `GetControllerRef` is `metav1.GetControllerOfNoCopy` from apimachinery, not this package

--- a/pkg/helpers/AGENTS.md
+++ b/pkg/helpers/AGENTS.md
@@ -1,0 +1,155 @@
+# pkg/helpers
+
+General-purpose utility library. Imported by ~45 packages across the repo. **Before writing any utility function, check here first.**
+
+## Packages
+
+| Import path | Alias | Purpose |
+|---|---|---|
+| `github.com/scylladb/scylla-operator/pkg/helpers` | (none) | Collections, networking, merge/patch, fs, args, status, cache |
+| `github.com/scylladb/scylla-operator/pkg/helpers/slices` | `oslices` | Generic slice utilities |
+| `github.com/scylladb/scylla-operator/pkg/helpers/managerclienterrors` | — | Scylla Manager HTTP error helpers |
+
+Always import the slices subpackage as `oslices` — that is the established alias across the entire codebase.
+
+---
+
+## Collections
+
+```go
+MergeMaps[Key comparable, Value any](maps ...map[Key]Value) map[Key]Value
+// Merge multiple maps into a new map. Later maps win on key collisions.
+```
+
+---
+
+## Slices (`oslices`)
+
+```go
+ToSlice[T any](objs ...T) []T
+ConvertToSlice[To, From any](convert func(From) To, objs ...From) []To
+ConvertSlice[To, From any](slice []From, convert func(From) To) []To
+
+Filter[T any](array []T, filterFunc func(T) bool) []T
+FilterOut[T any](array []T, filterOutFunc func(T) bool) []T
+FilterOutNil[T any](array []*T) []*T
+
+Contains[T any](array []T, cmp func(v T) bool) bool
+ContainsItem[T comparable](slice []T, item T) bool
+IdentityFunc[T comparable](item T) func(T) bool   // returns a cmp func for ContainsItem
+
+Find[T any](slice []T, filterFunc func(T) bool) (T, int, bool)
+FindItem[T comparable](slice []T, item T) (T, int, bool)
+
+ToString[T ~string](v T) string
+```
+
+---
+
+## Networking
+
+```go
+ParseIP(s string) (net.IP, error)
+ParseIPs(ipStrings []string) ([]net.IP, error)
+NormalizeIPs(ips []net.IP) []net.IP          // converts each to 16-byte To16() form
+IsIPv6(ip net.IP) bool                        // ip.To4() == nil
+IsIPv4(ip net.IP) bool                        // ip.To4() != nil
+GetIPFamily(ip net.IP) corev1.IPFamily
+
+// Pick preferred IP from a list
+GetPreferredIP(ips []string, preferredFamily *corev1.IPFamily) (string, error)
+GetPreferredPodIP(pod *corev1.Pod, preferredFamily *corev1.IPFamily) (string, error)
+GetPreferredServiceIP(svc *corev1.Service, preferredFamily *corev1.IPFamily) (string, bool)
+GetPreferredServiceIPFamily(svc *corev1.Service) corev1.IPFamily
+DetectEndpointsIPFamily(endpoints []discoveryv1.Endpoint) corev1.IPFamily
+IPFamilyToAddressType(ipFamily corev1.IPFamily) discoveryv1.AddressType
+```
+
+---
+
+## Merge / patch
+
+```go
+CreateTwoWayMergePatch[T runtime.Object](original, modified T) ([]byte, error)
+// Strategic merge patch (JSON bytes) between two k8s objects.
+```
+
+---
+
+## Args parsing
+
+```go
+ParseScyllaArguments(scyllaArguments string) map[string]*string
+// Parse Scylla daemon argument string.
+// nil *string = flag present without value (e.g. "--developer-mode")
+// non-nil *string = raw parsed value (may still contain surrounding quotes)
+```
+
+---
+
+## Filesystem
+
+```go
+TouchFile(filePath string) error
+// Create file if missing, or update mtime. Does NOT create parent directories.
+```
+
+---
+
+## Status conditions
+
+```go
+IsStatusConditionPresentAndTrue(conditions []metav1.Condition, conditionType string, generation int64) bool
+IsStatusConditionPresentAndFalse(conditions []metav1.Condition, conditionType string, generation int64) bool
+IsStatusConditionPresentAndEqual(conditions []metav1.Condition, conditionType string, status metav1.ConditionStatus, generation int64) bool
+
+// NodeConfig-specific variants:
+IsStatusNodeConfigConditionPresentAndTrue(...)
+IsStatusNodeConfigConditionPresentAndFalse(...)
+IsStatusNodeConfigConditionPresentAndEqual(...)
+```
+
+All condition helpers validate that `ObservedGeneration` matches `generation`.
+
+---
+
+## Cache
+
+```go
+UncachedListFunc(f func(options metav1.ListOptions) (runtime.Object, error)) func(...)
+// Wraps a List function so ResourceVersion "0" becomes "" — bypasses apiserver watch cache.
+// Use when you need a strictly-current list, not a cached snapshot.
+```
+
+---
+
+## Misc
+
+```go
+Must[T any](r T, err error) T
+// Panics on non-nil error. Use ONLY in init() or test helpers — never in reconcile loops.
+```
+
+---
+
+## managerclienterrors
+
+```go
+IsBadRequest(err error) bool   // HTTP 400
+IsNotFound(err error) bool     // HTTP 404
+GetPayloadMessage(err error) string  // payload.Message or err.Error()
+```
+
+---
+
+## Gotchas
+
+| Function | Pitfall |
+|---|---|
+| `NormalizeIPs` | Returns 16-byte (`To16`) form. IPv4 addresses become IPv4-mapped IPv6 — don't compare with `To4()` results. |
+| `ParseScyllaArguments` | Quoted values keep their quotes. Strip them if passing to downstream code that expects unquoted strings. |
+| `GetPreferredIP` | Silently skips invalid IPs. If none match `preferredFamily`, returns the first valid IP — not an error. |
+| `GetPreferredServiceIP` | Returns `("", false)` (not an error) when no suitable ClusterIP exists. |
+| `Must` | **Panics.** Only for test/init contexts. |
+| `TouchFile` | Parent directory must exist. Returns an error if it doesn't. |
+| `UncachedListFunc` | Changes `ResourceVersion` semantics — only use when you explicitly need to bypass watch cache. |

--- a/pkg/internalapi/AGENTS.md
+++ b/pkg/internalapi/AGENTS.md
@@ -1,0 +1,163 @@
+# pkg/internalapi
+
+Internal types and constants shared across controllers. Three concerns: **condition naming**, **sidecar runtime coordination**, and **datacenter upgrade state**.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `conditions.go` | Condition name formats, reason constants, name-builder functions |
+| `nodeconfig.go` | `SidecarRuntimeConfig` — operator↔sidecar coordination via ConfigMap |
+| `statusreport.go` | `NodeStatusReport` — node status encoded into pod annotation |
+| `upgrade.go` | `UpgradePhase`, `DatacenterUpgradeContext` — upgrade state machine payload |
+
+---
+
+## Condition naming
+
+### Formats (use `fmt.Sprintf`)
+
+```go
+NodeAvailableConditionFormat   = "Node%sAvailable"
+NodeProgressingConditionFormat = "Node%sProgressing"
+NodeDegradedConditionFormat    = "Node%sDegraded"
+
+NodeSetupAvailableConditionFormat   = "NodeSetup%sAvailable"
+NodeSetupProgressingConditionFormat = "NodeSetup%sProgressing"
+NodeSetupDegradedConditionFormat    = "NodeSetup%sDegraded"
+
+NodeTuneAvailableConditionFormat   = "NodeTune%sAvailable"
+NodeTuneProgressingConditionFormat = "NodeTune%sProgressing"
+NodeTuneDegradedConditionFormat    = "NodeTune%sDegraded"
+```
+
+Example: `fmt.Sprintf(NodeSetupAvailableConditionFormat, "node-0")` → `"NodeSetupnode-0Available"`
+
+### Datacenter condition builders
+
+```go
+// Pre-built package-level vars of type func(string) string
+var MakeDatacenterAvailableCondition   func(dcName string) string
+var MakeDatacenterProgressingCondition func(dcName string) string
+var MakeDatacenterDegradedCondition    func(dcName string) string
+// Pattern: "Datacenter<dcName><ConditionType>"
+
+// Build your own for other condition types
+MakeDatacenterConditionFunc(conditionType string) func(dcName string) string
+```
+
+### Controller/finalizer condition builders
+
+```go
+MakeKindControllerCondition(kind, conditionType string) string
+// → "<kind>Controller<conditionType>"
+// e.g. MakeKindControllerCondition("Service", "Progressing") → "ServiceControllerProgressing"
+
+MakeKindFinalizerCondition(kind, conditionType string) string
+// → "<kind>Finalizer<conditionType>"
+```
+
+### Reason constants
+
+```go
+AsExpectedReason        = "AsExpected"       // nominal state (Available=true, Degraded=false)
+ErrorReason             = "Error"            // error state
+ProgressingReason       = "Progressing"      // in progress
+AwaitingConditionReason = "AwaitingCondition" // placeholder for missing child conditions
+```
+
+**Always use these constants for `metav1.Condition.Reason`** — do not hardcode strings.
+
+### Condition aggregation chain
+
+```
+Child controllers set:
+  NodeSetup<node>Available/Progressing/Degraded
+  NodeTune<node>Available/Progressing/Degraded
+    ↓
+nodeconfig controller aggregates into:
+  Node<node>Available/Progressing/Degraded
+    ↓
+NodeConfig top-level Available/Progressing/Degraded
+```
+
+When a child condition is missing, `nodeconfig/status.go` synthesizes an `Unknown` condition with `AwaitingConditionReason` so aggregation always has inputs.
+
+---
+
+## SidecarRuntimeConfig
+
+Exchanged via ConfigMap key `naming.ScyllaRuntimeConfigKey`. Small JSON struct.
+
+```go
+type SidecarRuntimeConfig struct {
+    ContainerID        string   `json:"containerID"`
+    MatchingNodeConfigs []string `json:"matchingNodeConfigs"`
+    BlockingNodeConfigs []string `json:"blockingNodeConfigs"`
+}
+```
+
+- `ContainerID` — operator detects container restarts by comparing this value.
+- `MatchingNodeConfigs` — NodeConfig names that currently apply to this pod.
+- `BlockingNodeConfigs` — NodeConfig names blocking this pod from proceeding.
+
+Read via `controllerhelpers.GetSidecarRuntimeConfigFromConfigMap(cm)`. Written by `pkg/controller/nodeconfigpod`.
+
+---
+
+## NodeStatusReport
+
+Encoded into pod annotation `naming.NodeStatusReportAnnotation`.
+
+```go
+type NodeStatusReport struct {
+    ObservedNodes []scyllav1alpha1.ObservedNodeStatus `json:"observedNodes,omitempty"`
+    Error         *string                             `json:"error,omitempty"`
+}
+
+func (nsr *NodeStatusReport) Encode() ([]byte, error)
+func (nsr *NodeStatusReport) Decode(reader io.Reader) error
+```
+
+Written by `pkg/controller/statusreport` (runs in sidecar), read by `pkg/controller/scylladbdatacenter`.
+
+---
+
+## DatacenterUpgradeContext
+
+Upgrade state machine payload stored in a ConfigMap (`naming.UpgradeContextConfigMapName(sdc)`).
+
+```go
+type UpgradePhase string
+
+const (
+    PreHooksUpgradePhase    UpgradePhase = "PreHooks"
+    RolloutInitUpgradePhase UpgradePhase = "RolloutInit"
+    RolloutRunUpgradePhase  UpgradePhase = "RolloutRun"
+    PostHooksUpgradePhase   UpgradePhase = "PostHooks"
+)
+
+type DatacenterUpgradeContext struct {
+    State             UpgradePhase `json:"state"`
+    FromVersion       string       `json:"fromVersion"`
+    ToVersion         string       `json:"toVersion"`
+    SystemSnapshotTag string       `json:"systemSnapshotTag"`
+    DataSnapshotTag   string       `json:"dataSnapshotTag"`
+}
+
+func (uc *DatacenterUpgradeContext) Encode() ([]byte, error)
+func (uc *DatacenterUpgradeContext) Decode(reader io.Reader) error
+```
+
+Lifecycle: `PreHooks → RolloutInit → RolloutRun → PostHooks` → ConfigMap deleted when upgrade is complete.
+
+**Always use `Encode`/`Decode`** — do not hand-roll JSON for this type.
+
+---
+
+## Hard rules
+
+- **Never hardcode condition type strings** — always use the format constants or builder functions from this package.
+- **Never hardcode reason strings** — use the reason constants (`AsExpectedReason`, etc.).
+- **`DatacenterUpgradeContext`** must be serialized via its `Encode`/`Decode` methods.
+- **`SidecarRuntimeConfig`** is read via `controllerhelpers.GetSidecarRuntimeConfigFromConfigMap` — don't deserialize it manually.

--- a/pkg/kubecrypto/AGENTS.md
+++ b/pkg/kubecrypto/AGENTS.md
@@ -1,0 +1,137 @@
+# pkg/kubecrypto
+
+Kubernetes-aware TLS certificate lifecycle manager. Stores certificates and CA bundles in `corev1.Secret` and `corev1.ConfigMap` objects, with automatic creation and rotation. Builds on the lower-level crypto primitives in `pkg/crypto`.
+
+## Package relationship
+
+```
+pkg/crypto          — pure crypto: Signer, CertCreator, RSAKeyGetter, PEM encode/decode
+pkg/kubecrypto      — k8s layer: maps crypto primitives to Secrets/ConfigMaps, manages lifecycle
+```
+
+Use `pkg/kubecrypto` from controllers. Import `pkg/crypto` only when you need to construct `CertCreator` configs or `Signer` types.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `certmanager.go` | `CertificateManager`, config types (`CAConfig`, `CertificateConfig`, `CABundleConfig`), `NewCertificateManager` |
+| `certs.go` | `makeCertificate`, `extractExistingSecret`, `needsRefresh`, `MakeSelfSignedCA` |
+| `tlssecret.go` | `TLSSecret` — wrapper over `corev1.Secret` with cert/key cache and CA bundle creation |
+| `signingtlssecret.go` | `SigningTLSSecret` — `TLSSecret` that can act as a CA (`AsCertificateAuthority`) |
+
+## Key types
+
+```go
+// pkg/crypto (lower level — used when building config)
+type Signer interface { Now() time.Time; GetSubjectKeyID() []byte; SignCertificate(...); VerifyCertificate(...) }
+// Implementations: ocrypto.NewSelfSignedSigner(nowFunc), ocrypto.NewCertificateAuthority(cert, key, nowFunc)
+
+type CertCreator interface { MakeCertificateTemplate(now, validity) *x509.Certificate; MakeCertificate(...) }
+// Built via config helpers:
+ocrypto.CACertCreatorConfig{...}.ToCreator()
+ocrypto.ServingCertCreatorConfig{Subject, IPAddresses, DNSNames, ...}.ToCreator()
+ocrypto.ClientCertCreatorConfig{...}.ToCreator()
+
+type RSAKeyGetter interface { ... }
+// Implementation: ocrypto.NewRSAKeyGenerator(min, max, keySize, delay)
+
+// pkg/kubecrypto (high level)
+type TLSSecret        // wraps *corev1.Secret, caches parsed certs/key
+type SigningTLSSecret // embeds TLSSecret; .AsCertificateAuthority() → *ocrypto.CertificateAuthority
+type CertificateManager
+```
+
+## Constructor
+
+```go
+cm := kubecrypto.NewCertificateManager(
+    keyGetter,        // ocrypto.RSAKeyGetter
+    kubeClient.CoreV1(),  // corev1client.SecretsGetter
+    secretLister,         // corev1listers.SecretLister
+    kubeClient.CoreV1(),  // corev1client.ConfigMapsGetter
+    configMapLister,      // corev1listers.ConfigMapLister
+    recorder,             // record.EventRecorder
+)
+```
+
+## Controller integration recipe
+
+```go
+// 1. Build config objects
+caConfig := &kubecrypto.CAConfig{
+    MetaConfig: kubecrypto.MetaConfig{Name: "my-ca", Labels: labels},
+    Validity:   10 * 365 * 24 * time.Hour,
+    Refresh:    7 * 24 * time.Hour,
+}
+caBundleConfig := &kubecrypto.CABundleConfig{
+    MetaConfig: kubecrypto.MetaConfig{Name: "my-ca-bundle", Labels: labels},
+}
+certConfigs := []*kubecrypto.CertificateConfig{
+    {
+        MetaConfig:  kubecrypto.MetaConfig{Name: "my-serving-cert", Labels: labels},
+        Validity:    90 * 24 * time.Hour,
+        Refresh:     7 * 24 * time.Hour,
+        CertCreator: ocrypto.ServingCertCreatorConfig{
+            Subject:    pkix.Name{CommonName: "my-service"},
+            DNSNames:   []string{"my-service.ns.svc"},
+        }.ToCreator(),
+    },
+}
+
+// 2. Prefetch existing secrets/configmaps using listers (nil if not found)
+existingSecrets := map[string]*corev1.Secret{
+    caConfig.Name:       getOrNil(secretLister.Secrets(ns).Get(caConfig.Name)),
+    certConfigs[0].Name: getOrNil(secretLister.Secrets(ns).Get(certConfigs[0].Name)),
+}
+existingConfigMaps := map[string]*corev1.ConfigMap{
+    caBundleConfig.Name: getOrNil(configMapLister.ConfigMaps(ns).Get(caBundleConfig.Name)),
+}
+
+// 3. Call ManageCertificates in every reconcile iteration
+err := cm.ManageCertificates(
+    ctx,
+    time.Now,     // nowFunc
+    controllerMeta,    // metav1.ObjectMeta of the owning object (sets ownerRefs)
+    controllerGVK,     // schema.GroupVersionKind of the owning object
+    caConfig,
+    caBundleConfig,
+    certConfigs,
+    existingSecrets,
+    existingConfigMaps,
+)
+```
+
+`ManageCertificates` is **idempotent** — call it on every reconcile. It uses `resourceapply.ApplySecret` / `ApplyConfigMap` internally; do not apply these Secrets/ConfigMaps yourself.
+
+## Rotation logic (`needsRefresh`)
+
+A certificate is refreshed when **any** of the following is true:
+1. Certificate is expired (`now > NotAfter`)
+2. Reached 80% of its lifetime
+3. `NotBefore + refresh interval` has passed
+4. Desired template fields differ from existing certificate
+5. Issuer's `SubjectKeyId` changed (CA was rotated)
+
+## CA bundle behavior
+
+`MakeCABundle` combines the current CA cert with any non-expired previous CA certs. The bundle ConfigMap uses key `ca-bundle.crt`.
+
+## Annotations set automatically
+
+`makeCertificate` writes these annotations before applying the Secret (do not set them manually):
+- `certificates.internal.scylladb.com/refresh-reason`
+- `certificates.internal.scylladb.com/count`
+- `certificates.internal.scylladb.com/not-before`
+- `certificates.internal.scylladb.com/not-after`
+- `certificates.internal.scylladb.com/is-ca`
+- `certificates.internal.scylladb.com/issuer`
+- `certificates.internal.scylladb.com/key-size-bits`
+
+## Informer wiring
+
+Your controller must watch the Secrets and ConfigMaps managed by `CertificateManager` to react to out-of-band modifications. Because `ManageCertificates` sets `ownerReferences` on created resources, use the standard claim/release pattern in `pkg/controllerhelpers` to enqueue the owner when these resources change.
+
+## Testing
+
+Pass a deterministic `nowFunc` (e.g., `func() time.Time { return fixedTime }`) to control rotation timing in unit tests. Use an `RSAKeyGenerator` stub if you need deterministic key generation.

--- a/pkg/naming/AGENTS.md
+++ b/pkg/naming/AGENTS.md
@@ -1,0 +1,48 @@
+# pkg/naming — Agent Guide
+
+## Golden rule
+
+**Every label key, annotation key, resource name, and constant that appears in more than one file must come from this package.** Never hardcode strings that could live here.
+
+## What's here
+
+| File | Contents |
+|---|---|
+| `names.go` | Name generators: `StatefulSetNameForRack`, `ServiceNameForPod`, `HeadlessServiceNameForCluster`, `ConfigMapNameForRack`, `SecretNameForAgent`, etc. |
+| `labels.go` | Label key constants (`OwnerUIDLabel`, `ClusterNameLabel`, `DatacenterNameLabel`, `RackNameLabel`, …) and label-set builders (`ClusterLabels`, `RackLabels`, `PodLabels`, …) |
+| `annotations.go` | Annotation key constants |
+| `constants.go` | Port names/numbers, container names, file paths, feature flag names, finalizer strings |
+| `selectors.go` | `LabelSelectorForRack`, `LabelSelectorForCluster`, etc. |
+
+## Usage pattern
+
+```go
+import "github.com/scylladb/scylla-operator/pkg/naming"
+
+// Name generation
+stsName := naming.StatefulSetNameForRack(rack, sc)
+svcName := naming.HeadlessServiceNameForCluster(sc)
+
+// Label keys
+labels := naming.ClusterLabels(sc)
+labels[naming.RackNameLabel] = rack.Name
+
+// Constants
+containerName := naming.ScyllaContainerName  // "scylla"
+port := naming.CQLPort                       // 9042
+finalizer := naming.ScyllaFinalizer
+```
+
+## Adding new constants / generators
+
+1. Choose the right file (`names.go` for generators, `constants.go` for literals, `labels.go` for label keys)
+2. Follow the existing naming convention: exported, no abbreviations, self-documenting
+3. If a name depends on a CR (e.g., `StatefulSetNameForRack(rack, sc)`), add a function — don't inline templates elsewhere
+4. After adding, verify all callers compile: `make build`
+
+## Common mistakes
+
+- Hardcoding `"scylla"` instead of `naming.ScyllaContainerName`
+- Hardcoding `"scylla/rack"` instead of `naming.RackNameLabel`
+- Building label maps without `naming.ClusterLabels(sc)` as base
+- Duplicating a name generator in a controller instead of adding it here

--- a/pkg/remoteclient/AGENTS.md
+++ b/pkg/remoteclient/AGENTS.md
@@ -1,0 +1,125 @@
+# pkg/remoteclient
+
+Generic multi-cluster Kubernetes client manager. Used by the operator to manage client connections to remote clusters (defined by `RemoteKubernetesCluster` CRs).
+
+## Packages
+
+| Package | Purpose |
+|---|---|
+| `pkg/remoteclient/client` | `ClusterClient[CT]` — per-cluster client registry |
+| `pkg/remoteclient/informers` | `SharedInformerFactory` — per-cluster shared informers |
+| `pkg/remoteclient/lister` | `GenericClusterLister` — per-cluster typed listers |
+
+## Core concepts
+
+- **Cluster key** — the `RemoteKubernetesCluster.Name` string. All APIs are keyed by this.
+- **Config** — raw kubeconfig bytes from `Secret.Data[naming.KubeConfigSecretKey]`.
+- **`DynamicClusterInterface`** — the common interface for receiving `UpdateCluster` / `DeleteCluster` events. Both `ClusterClient` and `SharedInformerFactory` implement it.
+
+## Client API
+
+```go
+// Create a cluster client for a specific client type (e.g., kubernetes.Interface)
+clusterClient := client.NewClusterClient(func(cfg []byte) (kubernetes.Interface, error) {
+    restCfg, err := clientcmd.RESTConfigFromKubeConfig(cfg)
+    // ...
+    return kubernetes.NewForConfig(restCfg)
+})
+
+// Register or refresh a cluster (called by RemoteKubernetesCluster controller)
+err := clusterClient.UpdateCluster("remote-cluster-name", kubeconfigBytes)
+
+// Remove a cluster
+clusterClient.DeleteCluster("remote-cluster-name")
+
+// Get client for a specific cluster
+kube, err := clusterClient.Cluster("remote-cluster-name")
+```
+
+`UpdateCluster` hashes the config bytes — if unchanged, the existing client is reused.
+
+## Informer API
+
+```go
+// Create a shared informer factory
+factory := remoteinformers.NewSharedInformerFactory[kubernetes.Interface](clusterClient, defaultResync)
+
+// Create a GenericClusterInformer for a resource type
+podInformer := factory.ForResource(&corev1.Pod{}, remoteinformers.ClusterListWatch[kubernetes.Interface]{
+    ListFunc: func(ctx context.Context, cluster string, options metav1.ListOptions) (runtime.Object, error) {
+        kube, err := clusterClient.Cluster(cluster)
+        if err != nil { return nil, err }
+        return kube.CoreV1().Pods(namespace).List(ctx, options)
+    },
+    WatchFunc: func(ctx context.Context, cluster string, options metav1.ListOptions) (watch.Interface, error) {
+        kube, err := clusterClient.Cluster(cluster)
+        if err != nil { return nil, err }
+        return kube.CoreV1().Pods(namespace).Watch(ctx, options)
+    },
+})
+
+// Add event handlers (applied to ALL clusters — including future ones)
+podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{...})
+
+// Start the factory
+factory.Start(stopCh)
+
+// Wait for caches to sync
+factory.WaitForCacheSync(stopCh)
+```
+
+Handlers registered via `AddEventHandler` on an `UnboundInformer` automatically apply to new clusters as they are registered via `UpdateCluster`.
+
+## Lister API
+
+```go
+// Build a cluster-aware lister from the informer's indexer
+podLister := remotelister.NewClusterLister(
+    corev1listers.NewPodLister,         // typed lister constructor
+    podInformer.Indexer().Cluster,      // per-cluster indexer accessor
+)
+
+// Query remote cluster
+pods, err := podLister.Cluster("remote-cluster-name").Pods(namespace).List(labels.Everything())
+```
+
+## Registration flow (how clusters get registered)
+
+```
+RemoteKubernetesCluster CR + Secret
+  → RemoteKubernetesCluster controller (pkg/controller/remotekubernetescluster)
+  → reads Secret.Data[naming.KubeConfigSecretKey]
+  → calls dch.UpdateCluster(rkc.Name, kubeconfigBytes) for each DynamicClusterInterface
+  → clients and informer factories receive the new cluster
+```
+
+On CR deletion: controller calls `dch.DeleteCluster(rkc.Name)`, factory stops per-cluster informers.
+
+## Wiring a new remote client consumer
+
+1. Create a `ClusterClient` for your client type and add it to the `dynamicClusterHandlers` slice passed to `NewRemoteKubernetesClusterController`.
+2. Create a `SharedInformerFactory` wrapping that `ClusterClient` — also add it to `dynamicClusterHandlers`.
+3. Call `factory.ForResource(...)` with a `ClusterListWatch` that uses `clusterClient.Cluster(name)`.
+4. Register event handlers on the `GenericClusterInformer`.
+5. Pass `factory` to `factory.Start(stopCh)` in the operator startup sequence.
+
+The `RemoteKubernetesCluster` controller automatically calls `UpdateCluster` on all registered handlers when kubeconfigs appear or change.
+
+## Files
+
+| File | Key content |
+|---|---|
+| `pkg/remoteclient/client/client.go` | `ClusterClient[CT]`, `ClusterClientInterface`, `DynamicClusterInterface` |
+| `pkg/remoteclient/informers/factory.go` | `sharedInformerFactory[CT]`, `UpdateCluster`/`DeleteCluster` semantics |
+| `pkg/remoteclient/informers/factory_interfaces.go` | `SharedInformerFactory`, `UnboundInformer`, `GenericClusterInformer`, `ClusterListWatch` |
+| `pkg/remoteclient/informers/generic.go` | `UnboundInformer` — binds to per-cluster `SharedIndexInformer` on demand |
+| `pkg/remoteclient/lister/lister.go` | `ClusterIndexer`, `GenericClusterLister`, `NewClusterLister` |
+| `pkg/controller/remotekubernetescluster/sync_dynamicclusterhandlers.go` | Canonical `UpdateCluster` call site |
+| `pkg/controller/scylladbcluster/controller.go` | Canonical consumer of remote informers + listers |
+
+## Important notes
+
+- **`UnboundInformer`** allows registering handlers *before* the cluster exists. Handlers are applied retroactively when `UpdateCluster` is called.
+- **Factory is a `DynamicClusterInterface`** — add it directly to `dynamicClusterHandlers` along with `ClusterClient` instances.
+- **Cluster identity is `RemoteKubernetesCluster.Name`** — use it consistently as the cluster key everywhere.
+- **Config is opaque bytes** — pass raw kubeconfig bytes as read from `Secret.Data[naming.KubeConfigSecretKey]`; the factory hashes them to detect changes.

--- a/pkg/resourceapply/AGENTS.md
+++ b/pkg/resourceapply/AGENTS.md
@@ -1,0 +1,83 @@
+# pkg/resourceapply — Agent Guide
+
+## Purpose
+
+Idempotent create-or-update for Kubernetes resources. All controllers use this instead of raw client calls.
+
+## The Apply pattern
+
+```go
+// Signature (all ApplyXxx functions follow this shape):
+func ApplyStatefulSet(
+    ctx context.Context,
+    client appsv1client.StatefulSetsGetter,
+    lister appsv1listers.StatefulSetLister,
+    recorder record.EventRecorder,
+    required *appsv1.StatefulSet,
+    options ApplyOptions,
+) (*appsv1.StatefulSet, bool, error)
+```
+
+- `required` — the desired state (what you want it to look like)
+- Returns `(actual, changed, error)`
+- `changed == true` → resource was created or updated
+- Internally: computes a hash of `required`, compares with existing, skips update if hash matches
+
+## ApplyOptions
+
+```go
+type ApplyOptions struct {
+    AllowMissingControllerRef bool  // set true only for cluster-scoped resources
+    ForceOwnership            bool  // overwrite fields owned by other field managers
+}
+```
+
+Default (zero value) is correct for most controller usage.
+
+## Available Apply functions
+
+```
+ApplyConfigMap       ApplySecret          ApplyService
+ApplyStatefulSet     ApplyDaemonSet       ApplyDeployment
+ApplyServiceAccount  ApplyClusterRole     ApplyClusterRoleBinding
+ApplyRole            ApplyRoleBinding     ApplyJob
+ApplyPodDisruptionBudget                  ApplyValidatingWebhookConfiguration
+```
+
+All live in files named after the resource type (`core.go`, `apps.go`, `rbac.go`, etc.).
+
+## Usage in sync()
+
+```go
+// Build desired state
+required := &appsv1.StatefulSet{
+    ObjectMeta: metav1.ObjectMeta{
+        Name:      naming.StatefulSetNameForRack(rack, sc),
+        Namespace: sc.Namespace,
+        Labels:    naming.RackLabels(rack, sc),
+        OwnerReferences: []metav1.OwnerReference{
+            *metav1.NewControllerRef(sc, scyllaClusterGVK),
+        },
+    },
+    Spec: ...,
+}
+
+// Apply — idempotent
+sts, changed, err := resourceapply.ApplyStatefulSet(ctx, c.kubeClient.AppsV1(), c.statefulSetLister, c.eventRecorder, required, resourceapply.ApplyOptions{})
+if err != nil {
+    return err
+}
+```
+
+## Hash mechanism
+
+The package annotates applied objects with a hash of the desired spec. On the next reconcile it recomputes the hash and skips the API call if unchanged. This means:
+- Never mutate the object after calling `Apply` and expect the change to persist
+- Never manually set the hash annotation — it's managed internally
+
+## Common mistakes
+
+- Calling `client.Create` / `client.Update` directly — always use `ApplyXxx`
+- Forgetting to set `OwnerReferences` on `required` before calling Apply
+- Passing a mutated existing object as `required` instead of a freshly constructed desired state
+- Checking `changed` to decide whether to requeue — it's informational, not a requeue signal

--- a/pkg/scyllaclient/AGENTS.md
+++ b/pkg/scyllaclient/AGENTS.md
@@ -1,0 +1,140 @@
+# pkg/scyllaclient
+
+HTTP client for the ScyllaDB REST API (v1 + v2). Wraps the auto-generated swagger client with a host-pool, middleware pipeline, and convenience methods used by controllers and the sidecar.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `client.go` | `Client` struct, `NewClient`, transport middleware assembly, most API methods |
+| `config.go` | `Config` struct, `DefaultConfig`, `Validate` |
+| `model.go` | All model types and helpers (`NodeState`, `NodeStatus`, `OperationalMode`, `Snapshot`, etc.) |
+| `client_ping.go` | `Ping` implementation |
+| `hostpool.go` | Host-pool middleware (EpsilonGreedy selection, host marking) |
+| `timeout.go` | Timeout middleware, `ErrTimeout` |
+| `context.go` | Per-request context helpers (`forceHost`, `noRetry`, `customTimeout`) |
+| `status.go` | `StatusCodeOf` — extract HTTP status code from error |
+| `log.go` | Request/response logging middleware |
+| `config_client.go` | `ConfigClient` (v2) for reading Scylla config parameters |
+
+## Construction
+
+```go
+// Build with defaults (Scheme=https, Port=10001, Timeout=15s, PoolDecay=30m)
+cfg := scyllaclient.DefaultConfig(authToken, "10.0.0.1", "10.0.0.2")
+client, err := scyllaclient.NewClient(cfg)
+
+// ConfigClient (v2 API — config reads only)
+cc := scyllaclient.NewConfigClient(host, authToken)
+```
+
+`DefaultTransport()` sets `TLSClientConfig.InsecureSkipVerify = true` — intentional for the Scylla agent endpoint.
+
+## Transport pipeline (inner → outer)
+
+```
+base transport
+  → timeout        (per-request deadline; ErrTimeout on expiry)
+  → requestLogger  (dump req/resp on status ≥ 400)
+  → hostPool       (select host, rewrite URL, mark host on error)
+  → auth.AddToken  (Authorization header)
+  → fixContentType (force Content-Type: application/json)
+```
+
+## Context flags
+
+These are **package-internal** functions used within `pkg/scyllaclient` itself. They are not part of the public API and cannot be called from outside the package.
+
+```go
+// (inside pkg/scyllaclient only)
+
+// Target a specific node (bypasses host-pool selection)
+ctx = forceHost(ctx, "10.0.0.1")
+
+// Disable retry (used for Ping and Decommission)
+ctx = noRetry(ctx)
+
+// Override timeout for long-running ops
+ctx = customTimeout(ctx, 24*time.Hour)
+```
+
+## Key API method groups
+
+**Node/cluster status**
+- `NodesStatusInfo(ctx, host)` → `NodeStatusInfoSlice`
+- `NodesStatusAndStateInfo(ctx, host)` → `NodeStatusAndStateInfoSlice`
+- `GetLocalHostId(ctx, host, retry)` → `string`
+- `GetIPToHostIDMap(ctx, host)` → `map[string]string`
+- `GetTokenRing(ctx, host)` → `[]string`
+- `ScyllaVersion(ctx)` → `string`
+- `OperationMode(ctx, host)` → `OperationalMode`
+- `IsNativeTransportEnabled(ctx, host)` → `bool`
+- `HasSchemaAgreement(ctx, host)` → `bool`
+- `Ping(ctx, host)` → `(time.Duration, error)` — no retry, uses `SystemUptimeMsGet`
+
+**Keyspace/schema**
+- `Keyspaces(ctx)` → `[]string`
+- `GetSnitchDatacenter(ctx, host)` → `string`
+
+**Snapshots**
+- `Snapshots(ctx, host)` → tags `[]string`
+- `ListSnapshots(ctx, host)` → `[]*Snapshot`
+- `TakeSnapshot(ctx, host, tag, keyspace, tables...)` → `error`
+- `DeleteSnapshot(ctx, host, tag)` → `error`
+
+**Maintenance**
+- `Cleanup(ctx, host, keyspace)` — 24 h timeout, synchronous
+- `StopCleanup(ctx, host)` — stop CLEANUP compaction
+- `Drain(ctx, host)` — flush memtables; 5 min timeout
+- `Decommission(ctx, host)` — sets `noRetry` automatically
+
+**Config (v2 ConfigClient)**
+- `BroadcastRPCAddress`, `BroadcastAddress`, `ReplaceAddressFirstBoot`, `ReplaceNodeFirstBoot`, `ReadRequestTimeoutInMs`
+
+## Key model types
+
+```go
+type NodeStatus   string  // NodeStatusUp / NodeStatusDown
+type NodeState    string  // NodeStateNormal / Leaving / Joining / Moving
+type OperationalMode string // many constants + IsDecommissioned(), IsJoining(), etc.
+
+type NodeStatusInfo struct { ... }
+type Snapshot struct { Tag, Keyspace, Table string }
+```
+
+## Error handling
+
+```go
+// Get HTTP status code from any error shape
+code := scyllaclient.StatusCodeOf(err) // returns 0 if no code
+
+// Detect timeout
+if errors.Is(err, scyllaclient.ErrTimeout) { ... }
+```
+
+`StatusCodeOf` handles: errors with `Code() int`, `GetPayload() *models.ErrorModel`, and `runtime.APIError`.
+
+## Host-pool behavior
+
+- Pool type: `EpsilonGreedy` with `PoolDecayDuration` (default 30 min).
+- After each request the middleware marks the host:
+  - `err != nil` → `mark(err)` — reduces host score
+  - `status 401/403` or `≥ 500` → `mark(errPoolServerError)`
+  - otherwise → `mark(nil)` — success
+- Use `forceHost(ctx, host)` to bypass pool selection and target a specific node.
+
+## Gotchas
+
+- **`InsecureSkipVerify = true`** — DefaultTransport skips TLS verification. This is intentional for the Scylla agent port but means certificate errors are silently ignored.
+- **`fixContentType` middleware** — Scylla sometimes returns `text/plain`; this wrapper forces `application/json` so the generated swagger client can unmarshal.
+- **Long-running ops** — `Cleanup` uses a 24 h timeout internally. Don't wrap it in a short context or you'll cut it off. Use `customTimeout` when you need a different value.
+- **Decommission** — internally sets `noRetry` because retrying decommission can cause split-brain. Don't retry at the call site.
+- **Config timeout** — `Config.Timeout` (default 15 s) applies to all requests unless overridden with `customTimeout`.
+
+## Import aliases
+
+```go
+scyllaclient "github.com/scylladb/scylla-operator/pkg/scyllaclient"
+```
+
+The generated swagger clients use internal aliases (`scyllaoperations`, `scyllav2models`, etc.) — do not import those directly from callers; use the `Client` methods instead.

--- a/pkg/sidecar/AGENTS.md
+++ b/pkg/sidecar/AGENTS.md
@@ -1,0 +1,123 @@
+# pkg/sidecar
+
+The sidecar runs **inside every Scylla pod** alongside the ScyllaDB binary. It is a separate process from the operator. Its responsibilities:
+
+1. **Prepare Scylla configuration** — merge `scylla.yaml`, snitch properties, IO-tune cache symlink.
+2. **Construct runtime arguments** — seeds, smp, cpuset, broadcast addresses.
+3. **Launch Scylla** — `exec` the Scylla entrypoint with computed args.
+4. **Mirror node state to Kubernetes** — write HostID and token-ring hash into Service annotations; handle decommission via Service labels.
+5. **Report node status** — poll the local Scylla HTTP API and store results in pod annotations.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `pkg/sidecar/identity/member.go` | `Member` type — pod/service identity, broadcast addresses, seed selection |
+| `pkg/sidecar/config/config.go` | `ScyllaConfig` — YAML merge, IO-tune cache, entrypoint Cmd construction |
+| `pkg/cmd/operator/sidecar/sidecar.go` | CLI entrypoint: flags, informers, controller + status reporter startup |
+| `pkg/cmd/operator/sidecar/statusreporter.go` | `StatusReporter` — polls local Scylla API, enqueues status-report work |
+| `pkg/controller/sidecar/controller.go` | Controller: watches the node Service, drives annotation updates |
+| `pkg/controller/sidecar/sync.go` | Sync logic: `syncAnnotations`, `decommissionNode` |
+
+## Key types
+
+### `identity.Member`
+
+Encapsulates the pod's Scylla identity.
+
+```go
+type Member struct {
+    Name, Namespace, Rack, Datacenter, Cluster string
+    BroadcastRPCAddress, BroadcastAddress string
+    // ...
+}
+
+// Compute seeds from cluster Service/Pod listing
+func (m *Member) GetSeeds(ctx, coreClient, externalSeeds) ([]string, error)
+```
+
+Seed selection logic (in priority order): first UN node in the same datacenter → any UN node → external seeds fallback.
+
+### `config.ScyllaConfig`
+
+```go
+func NewScyllaConfig(member *identity.Member, kubeClient, cpuCount, externalSeeds) *ScyllaConfig
+
+// Orchestrates all setup steps and returns a ready-to-start exec.Cmd for Scylla
+func (s *ScyllaConfig) Setup(ctx) (*exec.Cmd, error)
+```
+
+### Sidecar controller
+
+Watches a single Service (field-selected by `metadata.name`). Reads from the local Scylla HTTP API via `scyllaclient` and writes:
+- `naming.HostIDAnnotation` on the Service
+- `naming.CurrentTokenRingHashAnnotation` on the Service
+- `naming.DecommissionedLabel` on the Service (when decommission completes)
+
+## Launch path
+
+```
+pkg/cmd/operator/sidecar/sidecar.go → Run()
+  ↓
+identity.Member constructed from Service + Pod
+  ↓
+config.NewScyllaConfig(...).Setup(ctx) → exec.Cmd
+  ↓
+Start Scylla process (Pdeathsig = SIGKILL)
+  + start sidecar controller
+  + start status reporter
+```
+
+## Configuration sources (merge order, last wins)
+
+1. **Base** — default `/etc/scylla/scylla.yaml` from the image
+2. **Operator-managed overrides** — `naming.ScyllaManagedConfigPath`
+3. **User ConfigMap** — mounted at `naming.ScyllaConfigDirName/naming.ScyllaConfigName`
+
+For the snitch (`cassandra-rackdc.properties`): operator values for `dc`/`rack`/`prefer_local` always win; only `dc_suffix` is taken from the user config.
+
+Runtime arguments (seeds, smp, cpuset, addresses) are constructed by the sidecar and **cannot** be overridden by user-provided arguments (`mergeArguments` enforces this).
+
+## Files the sidecar mutates
+
+**Local filesystem:**
+- `/etc/scylla/scylla.yaml` — overwritten with merged config
+- `/etc/scylla/cassandra-rackdc.properties` — overwritten with merged snitch config
+- `/etc/scylla.d/<io-properties>` — symlink → `naming.DataDir/<io-properties>` (IO-tune cache)
+
+**Kubernetes API:**
+- Service annotations: `naming.HostIDAnnotation`, `naming.CurrentTokenRingHashAnnotation`
+- Service label: `naming.DecommissionedLabel` (set to `"true"` on decommission completion)
+
+## Decommission flow
+
+1. Operator sets `naming.DecommissionLabel` on the Service.
+2. Sidecar controller detects the label and calls `scyllaClient.Decommission(ctx, host)`.
+3. If the node is in `OperationalModeDrained`, restarts Scylla via `supervisorctl restart scylla`.
+4. Polls `OperationMode` until decommission is complete.
+5. Sets `naming.DecommissionedLabel = "true"` on the Service.
+
+## CLI flags (important ones)
+
+| Flag | Purpose |
+|---|---|
+| `--service-name` | Name of the pod's Kubernetes Service |
+| `--cpu-count` | Number of CPUs to pass as `smp` to Scylla |
+| `--external-seeds` | External seed list (fallback when cluster is empty) |
+| `--nodes-broadcast-address-type` | How to pick the node broadcast address |
+| `--clients-broadcast-address-type` | How to pick the client broadcast address |
+| `--ip-family` | IPv4 or IPv6 |
+| `--status-report-interval` | How often to poll Scylla for status |
+
+## Separation from the operator
+
+The sidecar and operator are **separate processes**. Do not import sidecar packages from operator controller packages. Communication happens via:
+- Kubernetes Service annotations/labels (operator ↔ sidecar)
+- ConfigMaps (`SidecarRuntimeConfig` — see `pkg/internalapi`)
+- Pod annotations (`NodeStatusReport` — see `pkg/internalapi`)
+
+## Hard rules
+
+- **Never import `pkg/controller/sidecar` from operator controllers.** The sidecar controller is sidecar-only.
+- **Never hardcode paths** — use constants from `pkg/naming` (e.g., `naming.ScyllaManagedConfigPath`, `naming.DataDir`).
+- **CPU set validation** — `setupEntrypoint` reads `/proc/1/status` to derive the allowed CPU list and warns on mismatches. Do not bypass this.

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,68 @@
+# test — Agent Guide
+
+## Three distinct test tiers
+
+| Tier | Location | Build tag | Runner | When to use |
+|---|---|---|---|---|
+| Unit | `pkg/**/*_test.go` | none | `go test ./...` | Pure logic, no k8s API |
+| Envtest | `test/envtest/` | `envtest` | `go test -tags envtest` | Controller logic with real API server |
+| E2E | `test/e2e/` | none | custom runner binary | Full cluster scenarios |
+
+## Unit tests
+
+- Colocated with source in `pkg/`
+- Standard Go testing, table-driven (`[]struct{ name, input, expected }`)
+- No Ginkgo — plain `t.Run` / `t.Error`
+- Run: `make test-unit` or `go test ./pkg/...`
+
+## Envtest tests (`test/envtest/`)
+
+```
+test/envtest/
+  controllers/    # one package per controller under test
+  setup.go        # shared env setup: NewEnvTestSuite, StartEnv, StopEnv
+```
+
+- Build tag: `//go:build envtest` in every file
+- Ginkgo v2 + Gomega; suite entry in `*_test.go` via `RunSpecs`
+- Uses `sigs.k8s.io/controller-runtime/pkg/envtest` for API server
+- Run: `go test -tags envtest ./test/envtest/controllers/...`
+- Shared fixtures in `test/envtest/setup.go` — reuse `NewEnvTestSuite`, don't re-implement env setup
+
+## E2E tests (`test/e2e/`)
+
+```
+test/e2e/
+  set/          # test sets, each a plain .go package
+  include.go    # blank imports that register all test sets
+  framework/    # test framework helpers (Framework, ScyllaCluster helpers, etc.)
+```
+
+- Tests are **registered via side-effect imports** in `include.go`, not discovered automatically
+- NOT run via `go test` directly — use the custom binary: `go run ./cmd/scylla-operator-tests run all`
+- Kind cluster setup: `KIND_EXPERIMENTAL_PROVIDER=podman CLUSTER_NAME=test make test-e2e-kind`
+- Requires a live cluster with the operator deployed
+
+## Framework (`test/e2e/framework/`)
+
+```go
+f := framework.NewFramework(ctx, "my-test")
+// f.Namespace() — creates a unique test namespace, auto-deleted on cleanup
+sc := f.NewScyllaCluster(ctx, ...)
+
+// Waiting uses controllerhelpers.WaitForXxxState — NOT framework methods:
+sc, err = controllerhelpers.WaitForScyllaClusterState(
+    ctx, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name,
+    controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut,
+)
+```
+
+Key helpers: `f.ScyllaClient()` (returns `*scyllaclientset.Clientset`). Wait helpers are in `pkg/controllerhelpers` (`WaitForScyllaClusterState`, `WaitForScyllaDBDatacenterState`, `WaitForNodeConfigState`, etc.), not in the framework package.
+
+## Hard rules
+
+- **No Ginkgo Focus markers**: `FIt`, `FDescribe`, `FContext`, `FWhen` — CI will fail immediately
+- New e2e test sets must be blank-imported in `test/e2e/include.go`
+- Envtest files must carry `//go:build envtest` tag
+- Don't add cluster-level assertions in unit tests — use envtest or e2e
+- `WaitFor*` helpers from `pkg/controllerhelpers` are for tests — never call in production sync()


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Adds hierarchical `AGENTS.md` files to guide AI agents working in this
repository. Each file covers the conventions, patterns, and APIs specific
to its package - reducing hallucinations and improving output quality.

Files added:
- `AGENTS.md` - root guide: repo layout, API groups, core packages, commit
  style, build commands, hard rules
- `pkg/api/AGENTS.md` - CRD type authoring conventions
- `pkg/naming/AGENTS.md` - naming constants, label/annotation keys, name
  generators
- `pkg/resourceapply/AGENTS.md` - idempotent resource apply pattern
- `pkg/controllerhelpers/AGENTS.md` - handler wiring, finalizers, status
  conditions, WaitFor* helpers
- `pkg/controller/AGENTS.md` - informer+workqueue controller pattern, all
  18 controllers
- `test/AGENTS.md` - e2e framework, test conventions
- `pkg/scyllaclient/AGENTS.md` - HTTP client for the ScyllaDB REST API,
  transport pipeline, host-pool, key API methods
- `pkg/cmd/AGENTS.md` - cobra/flag wiring, operator startup sequence,
  generic CLI options
- `pkg/helpers/AGENTS.md` - utility library: collections, networking,
  merge/patch, status conditions, slices
- `pkg/kubecrypto/AGENTS.md` - Kubernetes-aware TLS certificate lifecycle,
  rotation logic, controller integration recipe
- `pkg/sidecar/AGENTS.md` - in-pod sidecar: config setup, Scylla launch,
  node state mirroring, decommission flow
- `pkg/remoteclient/AGENTS.md` - multi-cluster client manager, informer
  factory, lister API, registration flow
- `pkg/internalapi/AGENTS.md` - condition naming constants, SidecarRuntimeConfig,
  NodeStatusReport, DatacenterUpgradeContext
- `helm/AGENTS.md` - chart structure, generated artifact workflow, update
  commands for CRDs, schemas, and deploy manifests

**Which issue is resolved by this Pull Request:**
Resolves #

---
I have used AI tools in the development of this PR: `yes`

- [x] I've self reviewed and tested the changes.