### PR TITLE
fix(test): wait for ghost node cleanup before quorum check in re-bootstrap test

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
@@ -110,6 +110,11 @@ var _ = g.Describe("ScyllaCluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+
+		framework.By("Waiting for ghost nodes from the old cluster to be cleaned up")
+		err = utils.WaitForScyllaClusterGhostNodeCleanup(ctx, f.KubeClient().CoreV1(), sc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		oldHostUUIDs := hostUUIDs

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -672,6 +672,82 @@ func GetMemberServiceSelector(sc *scyllav1.ScyllaCluster) labels.Selector {
 	}.AsSelector()
 }
 
+// WaitForScyllaClusterGhostNodeCleanup waits until all nodes in the ScyllaCluster report
+// only the expected set of host IDs (i.e., no ghost entries from a previous cluster incarnation).
+// Ghost host IDs appear after re-bootstrapping a cluster on existing PVCs because the old
+// system.topology entries persist. ScyllaDB's topology coordinator cleans up orphan nodes
+// in the background, and it was proven that the cleanup may take 1-5 minutes.
+func WaitForScyllaClusterGhostNodeCleanup(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) error {
+	scyllaClient, hosts, err := GetScyllaClient(ctx, client, sc)
+	if err != nil {
+		return fmt.Errorf("can't get scylla client: %w", err)
+	}
+	defer scyllaClient.Close()
+
+	// Collect the expected host IDs by asking each node for its local host ID.
+	expectedHostIDs := make(map[string]struct{}, len(hosts))
+	for _, host := range hosts {
+		hostID, err := scyllaClient.GetLocalHostId(ctx, host, false)
+		if err != nil {
+			return fmt.Errorf("can't get local host ID from host %q: %w", host, err)
+		}
+		expectedHostIDs[hostID] = struct{}{}
+	}
+
+	if len(expectedHostIDs) != len(hosts) {
+		return fmt.Errorf("expected %d unique host IDs but got %d", len(hosts), len(expectedHostIDs))
+	}
+
+	sortedExpectedHostIDs := make([]string, 0, len(expectedHostIDs))
+	for id := range expectedHostIDs {
+		sortedExpectedHostIDs = append(sortedExpectedHostIDs, id)
+	}
+	sort.Strings(sortedExpectedHostIDs)
+
+	framework.Infof("Waiting for ghost node cleanup on ScyllaCluster %q. Expected host IDs: %v", naming.ObjRef(sc), sortedExpectedHostIDs)
+
+	// Ghost node cleanup typically takes 1-5 minutes. Use a 10-minute timeout for margin.
+	return apimachineryutilwait.PollImmediateWithContext(ctx, 5*time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
+		allClean := true
+		var infoMessages []string
+
+		for _, host := range hosts {
+			ipToHostID, err := scyllaClient.GetIPToHostIDMap(ctx, host)
+			if err != nil {
+				return true, fmt.Errorf("can't get host ID map from host %q: %w", host, err)
+			}
+
+			// Collect host IDs reported by this node.
+			reportedHostIDs := make([]string, 0, len(ipToHostID))
+			for _, hostID := range ipToHostID {
+				reportedHostIDs = append(reportedHostIDs, hostID)
+			}
+			sort.Strings(reportedHostIDs)
+
+			// Find ghost host IDs (reported but not expected).
+			var ghostHostIDs []string
+			for _, hostID := range reportedHostIDs {
+				if _, ok := expectedHostIDs[hostID]; !ok {
+					ghostHostIDs = append(ghostHostIDs, hostID)
+				}
+			}
+
+			if len(ghostHostIDs) > 0 {
+				allClean = false
+				infoMessages = append(infoMessages, fmt.Sprintf("host %q still sees %d ghost node(s): %v", host, len(ghostHostIDs), ghostHostIDs))
+			}
+		}
+
+		if !allClean {
+			framework.Infof("Ghost node cleanup in progress for ScyllaCluster %q: %s", naming.ObjRef(sc), strings.Join(infoMessages, "; "))
+		} else {
+			framework.Infof("Ghost node cleanup complete for ScyllaCluster %q. All nodes report only expected host IDs.", naming.ObjRef(sc))
+		}
+
+		return allClean, nil
+	})
+}
+
 func WaitForFullMultiDCQuorum(ctx context.Context, dcClientMap map[string]corev1client.CoreV1Interface, scs []*scyllav1.ScyllaCluster) error {
 	allHostIDs := map[string][]string{}
 	var sortedAllHostIDs []string


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

This PR makes the most noisy `ScyllaCluster should re-bootstrap from old PVCs` E2E test case stable. It adds a dedicated `WaitForScyllaClusterGhostNodeCleanup` step (with 10 min timeout)  that waits for the ghost nodes to disappear before we proceed to the actual `WaitForFullQuorum` check.

This is needed as after re-bootstrapping a ScyllaCluster on existing PVCs, ghost host IDs from the previous cluster persist in `system.topology`. ScyllaDB's topology coordinator cleans them up in the background, which takes 1-5 minutes (observed in CI). The existing `WaitForFullQuorum` (5-min timeout) could time out before cleanup finishes, causing flaky failures. To make the test stable, I didn't just extend the `WaitForFullQuorum` timeout, but added a deterministic check, focused on waiting for a precondition that's required for full quorum as we expect it.

**Which issue is resolved by this Pull Request:**

Resolves major instability reason of the kind-fast suite (based on the past 2 month results analysis):

- Total failure rate: 43/214 = 20.1%
- Infra failure rate: 16/214 = 7.5%
- Test failure rate: 27/214 = 12.6%

| Rank | Test Name | Failures | % of test failures |
|------|-----------|----------|-------------------|
| 1 | ScyllaCluster should re-bootstrap from old PVCs | 22 | 81.5% (22/27) |
| 2 | ScyllaCluster should connect to cluster via Ingresses (already addressed in https://github.com/scylladb/scylla-operator/pull/3392) | 5 | 18.5% (5/27) |
| - | No JUnit artifact (failed before tests) | 3 | - |

