### PR TITLE
docs(staging): sidecar and pod anatomy, ignition, PDB, security, STS and racks

### DIFF
--- a/docs-staging/source/understand/ignition.md
+++ b/docs-staging/source/understand/ignition.md
@@ -1,5 +1,68 @@
 # Ignition
 
-:::{todo}
-This page is not yet written.
+This page explains the ignition mechanism that gates ScyllaDB startup until all prerequisites are satisfied.
+
+## Why ignition exists
+
+ScyllaDB must not start until:
+
+- **Node-level tuning is complete** — performance settings (IRQ affinity, sysctl values, CPU frequency governors) must be applied before ScyllaDB begins benchmarking IO or pinning threads. Starting too early produces incorrect IO calibration and suboptimal performance.
+- **Network identity is assigned** — the pod must have an IP address, and if LoadBalancer broadcasting is used, the load balancer must have provisioned an ingress address.
+- **The container is ready** — the ScyllaDB container must be running (container ID assigned) so that per-container tuning can target it.
+
+Without ignition gating, ScyllaDB could start before tuning DaemonSets finish their work or before the cloud provider assigns a load balancer IP, leading to misconfiguration that is difficult to correct without a restart.
+
+## Signal-file mechanism
+
+Ignition uses a simple file-based signal on the shared emptyDir volume mounted at `/mnt/shared`:
+
+1. The `scylladb-ignition` sidecar container runs the ignition controller, which continuously evaluates prerequisites.
+2. When **all** prerequisites are met, the controller creates the file `/mnt/shared/ignition.done`.
+3. The `scylla` container's entrypoint polls for this file in a shell loop (`until [[ -f "/mnt/shared/ignition.done" ]]; do sleep 1; done`). Once the file appears, it execs into the sidecar binary that configures and starts ScyllaDB.
+4. The ScyllaDB Manager Agent container (when present) uses the same wait loop, ensuring the agent does not start before ScyllaDB is configured.
+
+## Prerequisites evaluated
+
+The ignition controller checks the following conditions. **All** must be true before the signal file is created:
+
+| # | Condition | Why |
+|---|-----------|-----|
+| 1 | **LoadBalancer ingress available** (only when broadcast address type is `ServiceLoadBalancerIngress`) | The broadcast address cannot be resolved until the cloud provider assigns an external IP or hostname to the member Service. |
+| 2 | **Pod has an IP** (`status.podIP` is set) | ScyllaDB needs a listen address. The sidecar cannot resolve `PodIP`-type broadcast addresses without it. |
+| 3 | **ScyllaDB container has a container ID** (`containerStatuses[].containerID` is set) | Per-container tuning (CPU pinning, cgroup settings) targets a specific container ID. Tuning cannot complete until the container exists. |
+| 4 | **Tuning ConfigMap exists** with matching container ID | A ConfigMap labeled for this pod must exist, created by the tuning infrastructure. Its `ContainerID` field must match the current ScyllaDB container ID, confirming that tuning ran for this specific container instance. |
+| 5 | **No blocking NodeConfigs** in the tuning ConfigMap | The ConfigMap must report that all `NodeConfig` resources have completed tuning. If any are still in progress, ignition waits. |
+
+## Cleanup on shutdown
+
+The `scylla` container's `preStop` hook removes the signal file:
+
+```
+rm -f /mnt/shared/ignition.done
+```
+
+This ensures that if the container restarts (due to a crash or rolling update), the ignition controller must re-evaluate all prerequisites before ScyllaDB starts again. This is important because a container restart assigns a new container ID, invalidating previous tuning results.
+
+## Force override
+
+For debugging or recovery scenarios, the annotation `internal.scylla-operator.scylladb.com/ignition-override` on the node's member Service can override the ignition decision:
+
+| Value | Effect |
+|-------|--------|
+| `"true"` | Ignition proceeds immediately, bypassing all prerequisite checks. |
+| `"false"` | Ignition is blocked indefinitely, regardless of prerequisite status. |
+
+:::{caution}
+The force override is an internal mechanism intended for debugging. Forcing ignition to `true` while tuning is incomplete results in degraded performance. Forcing it to `false` prevents the ScyllaDB node from starting.
 :::
+
+## Readiness probe
+
+The ignition container exposes a readiness endpoint at `/readyz` on port 42081. It returns HTTP 200 only after the signal file has been created. This allows external tools and monitoring to determine whether a pod has passed the ignition gate.
+
+## Related pages
+
+- [Sidecar and pod anatomy](sidecar.md) — the full container list and how they coordinate.
+- [Tuning](tuning.md) — the node and container tuning that must complete before ignition.
+- [Bootstrap synchronisation](bootstrap-sync.md) — the init container barrier that runs before ignition.
+- [Security](security.md) — TLS certificate provisioning that feeds into ignition prerequisites.

--- a/docs-staging/source/understand/ignition.md
+++ b/docs-staging/source/understand/ignition.md
@@ -10,7 +10,7 @@ ScyllaDB must not start until:
 - **Network identity is assigned** — the pod must have an IP address, and if LoadBalancer broadcasting is used, the load balancer must have provisioned an ingress address.
 - **The container is ready** — the ScyllaDB container must be running (container ID assigned) so that per-container tuning can target it.
 
-Without ignition gating, ScyllaDB could start before tuning DaemonSets finish their work or before the cloud provider assigns a load balancer IP, leading to misconfiguration that is difficult to correct without a restart.
+Without ignition gating, the ScyllaDB process could start before tuning DaemonSets finish their work or before the cloud provider assigns a load balancer IP, leading to misconfiguration that is difficult to correct without a restart.
 
 ## Signal-file mechanism
 
@@ -18,7 +18,7 @@ Ignition uses a simple file-based signal on the shared emptyDir volume mounted a
 
 1. The `scylladb-ignition` sidecar container runs the ignition controller, which continuously evaluates prerequisites.
 2. When **all** prerequisites are met, the controller creates the file `/mnt/shared/ignition.done`.
-3. The `scylla` container's entrypoint polls for this file in a shell loop (`until [[ -f "/mnt/shared/ignition.done" ]]; do sleep 1; done`). Once the file appears, it execs into the sidecar binary that configures and starts ScyllaDB.
+3. The `scylla` container's entrypoint polls for this file in a shell loop. Once the file appears, it execs into the sidecar binary that configures and starts ScyllaDB.
 4. The ScyllaDB Manager Agent container (when present) uses the same wait loop, ensuring the agent does not start before ScyllaDB is configured.
 
 ## Prerequisites evaluated
@@ -45,7 +45,7 @@ This ensures that if the container restarts (due to a crash or rolling update), 
 
 ## Force override
 
-For debugging or recovery scenarios, the annotation `internal.scylla-operator.scylladb.com/ignition-override` on the node's member Service can override the ignition decision:
+For debugging or recovery scenarios, the annotation `internal.scylla-operator.scylladb.com/force-ignition-value` on the node's member Service can override the ignition decision:
 
 | Value | Effect |
 |-------|--------|

--- a/docs-staging/source/understand/pod-disruption-budgets.md
+++ b/docs-staging/source/understand/pod-disruption-budgets.md
@@ -63,32 +63,6 @@ Node replacement follows a similar pattern — one node is replaced at a time. T
 
 When a Kubernetes node is drained (for example, during a Kubernetes upgrade), the drain process evicts pods through the Eviction API, which respects PDBs. If the ScyllaDB cluster already has one node unavailable (due to a concurrent operation or failure), the PDB blocks further evictions until the first node recovers.
 
-## Common pitfall: PDB blocking node drains
-
-If a ScyllaDB node is already down (crash, stuck, or undergoing replacement), the `maxUnavailable: 1` budget is already consumed. A subsequent `kubectl drain` on another Kubernetes node will be blocked indefinitely because evicting an additional ScyllaDB pod would exceed the budget.
-
-**Symptoms:**
-
-- `kubectl drain` hangs with a message like `Cannot evict pod as it would violate the pod's disruption budget`.
-- The PDB shows `disruptionsAllowed: 0`.
-
-**Diagnosis:**
-
-```bash
-kubectl get pdb -n <namespace>
-kubectl get pods -n <namespace> -o wide
-```
-
-Check which ScyllaDB pod is already unavailable and why.
-
-**Workaround:**
-
-Resolve the existing disruption first (fix the failed node, complete the replacement). If the drain is urgent and you accept the risk, you can temporarily delete the PDB, drain the node, and let the Operator recreate the PDB on the next reconciliation.
-
-:::{caution}
-Deleting a PDB removes the safety net. Draining a node while another ScyllaDB node is already down can cause quorum loss and data unavailability if the replication factor is not sufficient.
-:::
-
 ## Related pages
 
 - [Statefulsets and racks](statefulsets-and-racks.md) — rolling update strategy and partition-based rollout.

--- a/docs-staging/source/understand/pod-disruption-budgets.md
+++ b/docs-staging/source/understand/pod-disruption-budgets.md
@@ -1,5 +1,95 @@
 # Pod disruption budgets
 
-:::{todo}
-This page is not yet written.
+This page explains how ScyllaDB Operator uses Kubernetes PodDisruptionBudgets (PDBs) to protect ScyllaDB availability during voluntary disruptions.
+
+## What a PDB does
+
+A [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) limits how many pods matching a selector can be voluntarily evicted at the same time. Voluntary disruptions include:
+
+- Kubernetes node drains (maintenance, upgrades).
+- Cluster autoscaler scale-down.
+- Manual pod evictions via the Eviction API.
+
+PDBs do **not** protect against involuntary disruptions such as hardware failures or OOM kills.
+
+## ScyllaDB cluster PDB
+
+The Operator creates one PDB per ScyllaDB datacenter with:
+
+```yaml
+spec:
+  maxUnavailable: 1
+```
+
+This ensures that **at most one ScyllaDB node** can be voluntarily disrupted at a time across the entire datacenter. The Kubernetes API server blocks eviction requests that would violate this budget.
+
+### Excluding cleanup Jobs
+
+The PDB selector uses the same labels as the ScyllaDB pods but adds a `MatchExpression` that excludes pods with the `batch.kubernetes.io/job-name` label. Kubernetes automatically adds this label to every pod created by a Job. This means cleanup Job pods (see [Automatic data cleanup](automatic-data-cleanup.md)) do not count toward the PDB budget and cannot block node drains.
+
+## Operator and webhook PDBs
+
+The Operator deployment and the webhook server deployment each have their own PDB:
+
+| Component | PDB spec | When created |
+|-----------|----------|-------------|
+| `scylla-operator` | `minAvailable: 1` | When running with more than one replica |
+| `webhook-server` | `minAvailable: 1` | When running with more than one replica |
+
+These PDBs ensure that at least one Operator pod and one webhook pod remain available during node drains, preventing a complete loss of the control plane during cluster maintenance.
+
+## PDB interaction with operations
+
+### Rolling updates
+
+The Operator uses a **partition-based rollout** strategy for StatefulSets. During an upgrade:
+
+1. All StatefulSets are partitioned at their current replica count, preventing any pod from restarting.
+2. The partition is decremented by one, allowing a single pod to pick up the new template and restart.
+3. The controller waits for the restarted pod to become ready before decrementing the partition again.
+4. Only one rack makes progress per reconciliation cycle.
+
+This one-at-a-time rollout naturally respects the `maxUnavailable: 1` PDB because at most one pod is unavailable during each step.
+
+### Scale-down
+
+When scaling down, the Operator decommissions one member at a time. The SidecarController drives the decommission process inside each pod. Because only one pod is being removed at a time, the PDB is not violated.
+
+### Node replacement
+
+Node replacement follows a similar pattern — one node is replaced at a time. The PDB prevents the Kubernetes scheduler from evicting additional ScyllaDB pods while a replacement is in progress.
+
+### Kubernetes node drains
+
+When a Kubernetes node is drained (for example, during a Kubernetes upgrade), the drain process evicts pods through the Eviction API, which respects PDBs. If the ScyllaDB cluster already has one node unavailable (due to a concurrent operation or failure), the PDB blocks further evictions until the first node recovers.
+
+## Common pitfall: PDB blocking node drains
+
+If a ScyllaDB node is already down (crash, stuck, or undergoing replacement), the `maxUnavailable: 1` budget is already consumed. A subsequent `kubectl drain` on another Kubernetes node will be blocked indefinitely because evicting an additional ScyllaDB pod would exceed the budget.
+
+**Symptoms:**
+
+- `kubectl drain` hangs with a message like `Cannot evict pod as it would violate the pod's disruption budget`.
+- The PDB shows `disruptionsAllowed: 0`.
+
+**Diagnosis:**
+
+```bash
+kubectl get pdb -n <namespace>
+kubectl get pods -n <namespace> -o wide
+```
+
+Check which ScyllaDB pod is already unavailable and why.
+
+**Workaround:**
+
+Resolve the existing disruption first (fix the failed node, complete the replacement). If the drain is urgent and you accept the risk, you can temporarily delete the PDB, drain the node, and let the Operator recreate the PDB on the next reconciliation.
+
+:::{caution}
+Deleting a PDB removes the safety net. Draining a node while another ScyllaDB node is already down can cause quorum loss and data unavailability if the replication factor is not sufficient.
 :::
+
+## Related pages
+
+- [Statefulsets and racks](statefulsets-and-racks.md) — rolling update strategy and partition-based rollout.
+- [Overview](overview.md) — reconciliation model.

--- a/docs-staging/source/understand/security.md
+++ b/docs-staging/source/understand/security.md
@@ -45,10 +45,7 @@ The operator does not configure inter-node encryption (`server_encryption_option
 
 #### User-managed certificates
 
-`ScyllaCluster` supports a `TLSCertificate` configuration with two modes:
-
-- **`OperatorManaged`** (default): the operator provisions and rotates certificates automatically as described above. You can specify `additionalDNSNames` and `additionalIPAddresses` to include custom SANs in the serving certificate.
-- **`UserManaged`**: you provide your own TLS certificate in a `kubernetes.io/tls` Secret referenced by `secretName`. The operator mounts this Secret but does not manage its lifecycle — you are responsible for rotation.
+The `OperatorManaged` / `UserManaged` certificate toggle described below under [Alternator TLS](#alternator-tls) applies only to Alternator's serving certificate (`spec.alternator.servingCertificate`). CQL certificates are always operator-managed when `AutomaticTLSCertificates` is enabled.
 
 ### Alternator TLS
 
@@ -59,9 +56,10 @@ When Alternator is enabled (`spec.alternator` in `ScyllaCluster`), the operator 
 | `<name>-alternator-local-serving-ca` | CA for Alternator serving certificates. |
 | `<name>-alternator-local-serving-certs` | Server certificate for the Alternator HTTPS endpoint (port 8043). |
 
-The Alternator certificate includes the same SANs as the CQL serving certificate, plus any `additionalDNSNames` and `additionalIPAddresses` specified in `servingCertificate.operatorManagedOptions`.
+The Alternator serving certificate is configured through `spec.alternator.servingCertificate`, which supports two modes:
 
-Like CQL certificates, Alternator certificates can be set to `UserManaged` if you want to provide your own.
+- **`OperatorManaged`** (default): the operator provisions and rotates the Alternator serving certificate automatically. You can specify `additionalDNSNames` and `additionalIPAddresses` in `operatorManagedOptions` to include custom SANs.
+- **`UserManaged`**: you provide your own TLS certificate in a `kubernetes.io/tls` Secret referenced by `userManagedOptions.secretName`. The operator mounts this Secret but does not manage its lifecycle — you are responsible for rotation.
 
 ## Authentication and authorization
 

--- a/docs-staging/source/understand/security.md
+++ b/docs-staging/source/understand/security.md
@@ -4,7 +4,7 @@ This page explains the security model of ScyllaDB Operator: how TLS certificates
 
 ## TLS certificates
 
-ScyllaDB Operator manages TLS certificates at two levels: for the **operator infrastructure** (webhook server) and for **ScyllaDB clusters** (client-to-node and inter-node encryption, Alternator).
+ScyllaDB Operator manages TLS certificates at two levels: for the **operator infrastructure** (webhook server) and for **ScyllaDB clusters** (client-to-node encryption, Alternator).
 
 ### Operator webhook TLS
 
@@ -14,7 +14,7 @@ The operator's validating webhook server requires a TLS certificate so that the 
 2. A **Certificate** (`scylla-operator-serving-cert`) is issued for the DNS name `scylla-operator-webhook.scylla-operator.svc`, stored in a Secret of the same name.
 3. The `ValidatingWebhookConfiguration` has the annotation `cert-manager.io/inject-ca-from: scylla-operator/scylla-operator-serving-cert`, which tells cert-manager to inject the CA bundle into the webhook configuration so the Kubernetes API server trusts the webhook's certificate.
 
-cert-manager is a **hard dependency** of the operator. Without it, the webhook server cannot obtain a serving certificate and the operator cannot start.
+cert-manager is a hard dependency of the operator unless it is deployed via OLM on OpenShift, which handles webhook certificate provisioning natively.
 
 ### ScyllaDB cluster TLS
 
@@ -30,12 +30,6 @@ For each ScyllaDB datacenter (that is, each `ScyllaCluster` resource) the operat
 | `<name>-local-serving-certs` | Secret | Server certificate for ScyllaDB — contains a multi-SAN certificate covering all pod IPs, Service ClusterIPs, LoadBalancer addresses, internal DNS names, and `cql.<domain>` / `<hostID>.cql.<domain>` DNS names for each configured DNS domain. |
 | `<name>-local-cql-connection-configs-admin` | Secret | Pre-built CQL connection configuration file containing the admin client certificate, key, and serving CA bundle for each DNS domain. |
 
-**Certificate lifetimes:**
-
-- CA certificates: 10-year validity, refreshed after 8 years.
-- Serving certificates: 30-day validity, refreshed after 20 days.
-- Client certificates: 10-year validity, refreshed after 8 years.
-
 The operator watches all member Services and pod IPs and regenerates the serving certificate whenever the set of addresses changes (new pods, LoadBalancer address assignment, etc.).
 
 #### How TLS is configured in ScyllaDB
@@ -46,7 +40,7 @@ When `AutomaticTLSCertificates` is enabled, the operator renders a managed `scyl
 - **Encrypted CQL ports**: port `9142` (CQL over TLS) and port `19142` (shard-aware CQL over TLS) are configured alongside the unencrypted ports.
 
 :::{note}
-Inter-node encryption is configured through the same serving certificate infrastructure, but inter-node transport security settings depend on the ScyllaDB version and configuration.
+The operator does not configure inter-node encryption (`server_encryption_options`). Only client-to-node encryption is managed automatically.
 :::
 
 #### User-managed certificates

--- a/docs-staging/source/understand/security.md
+++ b/docs-staging/source/understand/security.md
@@ -1,5 +1,196 @@
 # Security
 
-:::{todo}
-This page is not yet written.
+This page explains the security model of ScyllaDB Operator: how TLS certificates are managed, how ScyllaDB authentication and authorization work on Kubernetes, how RBAC is structured, and how ScyllaDB Manager Agent communicates securely.
+
+## TLS certificates
+
+ScyllaDB Operator manages TLS certificates at two levels: for the **operator infrastructure** (webhook server) and for **ScyllaDB clusters** (client-to-node and inter-node encryption, Alternator).
+
+### Operator webhook TLS
+
+The operator's validating webhook server requires a TLS certificate so that the Kubernetes API server can securely call it. This certificate is provisioned by [cert-manager](https://cert-manager.io/):
+
+1. A **self-signed Issuer** (`scylla-operator-selfsigned-issuer`) is created in the `scylla-operator` namespace.
+2. A **Certificate** (`scylla-operator-serving-cert`) is issued for the DNS name `scylla-operator-webhook.scylla-operator.svc`, stored in a Secret of the same name.
+3. The `ValidatingWebhookConfiguration` has the annotation `cert-manager.io/inject-ca-from: scylla-operator/scylla-operator-serving-cert`, which tells cert-manager to inject the CA bundle into the webhook configuration so the Kubernetes API server trusts the webhook's certificate.
+
+cert-manager is a **hard dependency** of the operator. Without it, the webhook server cannot obtain a serving certificate and the operator cannot start.
+
+### ScyllaDB cluster TLS
+
+When the `AutomaticTLSCertificates` feature gate is enabled (default since v1.11, beta), the operator provisions a full PKI for each ScyllaDB cluster **without** requiring cert-manager. The operator manages certificates directly using its own internal certificate manager.
+
+For each ScyllaDB datacenter (that is, each `ScyllaCluster` resource) the operator creates:
+
+| Resource | Type | Purpose |
+|----------|------|---------|
+| `<name>-local-client-ca` | Secret + ConfigMap | Client certificate authority — signs client certificates used for mutual TLS authentication to CQL. The CA bundle ConfigMap is distributed to ScyllaDB nodes as a truststore. |
+| `<name>-local-user-admin` | Secret | Client certificate for the `admin` user — used for mTLS authentication to CQL. |
+| `<name>-local-serving-ca` | Secret + ConfigMap | Serving certificate authority — signs the server certificate used by ScyllaDB for encrypted CQL connections. |
+| `<name>-local-serving-certs` | Secret | Server certificate for ScyllaDB — contains a multi-SAN certificate covering all pod IPs, Service ClusterIPs, LoadBalancer addresses, internal DNS names, and `cql.<domain>` / `<hostID>.cql.<domain>` DNS names for each configured DNS domain. |
+| `<name>-local-cql-connection-configs-admin` | Secret | Pre-built CQL connection configuration file containing the admin client certificate, key, and serving CA bundle for each DNS domain. |
+
+**Certificate lifetimes:**
+
+- CA certificates: 10-year validity, refreshed after 8 years.
+- Serving certificates: 30-day validity, refreshed after 20 days.
+- Client certificates: 10-year validity, refreshed after 8 years.
+
+The operator watches all member Services and pod IPs and regenerates the serving certificate whenever the set of addresses changes (new pods, LoadBalancer address assignment, etc.).
+
+#### How TLS is configured in ScyllaDB
+
+When `AutomaticTLSCertificates` is enabled, the operator renders a managed `scylla.yaml` configuration that enables:
+
+- **Client-to-node encryption** (`client_encryption_options`): enabled with `require_client_auth: true`, using the serving certificate and client CA truststore. CQL clients must present a valid client certificate signed by the cluster's client CA.
+- **Encrypted CQL ports**: port `9142` (CQL over TLS) and port `19142` (shard-aware CQL over TLS) are configured alongside the unencrypted ports.
+
+:::{note}
+Inter-node encryption is configured through the same serving certificate infrastructure, but inter-node transport security settings depend on the ScyllaDB version and configuration.
 :::
+
+#### User-managed certificates
+
+`ScyllaCluster` supports a `TLSCertificate` configuration with two modes:
+
+- **`OperatorManaged`** (default): the operator provisions and rotates certificates automatically as described above. You can specify `additionalDNSNames` and `additionalIPAddresses` to include custom SANs in the serving certificate.
+- **`UserManaged`**: you provide your own TLS certificate in a `kubernetes.io/tls` Secret referenced by `secretName`. The operator mounts this Secret but does not manage its lifecycle — you are responsible for rotation.
+
+### Alternator TLS
+
+When Alternator is enabled (`spec.alternator` in `ScyllaCluster`), the operator creates a separate serving CA and certificate:
+
+| Resource | Purpose |
+|----------|---------|
+| `<name>-alternator-local-serving-ca` | CA for Alternator serving certificates. |
+| `<name>-alternator-local-serving-certs` | Server certificate for the Alternator HTTPS endpoint (port 8043). |
+
+The Alternator certificate includes the same SANs as the CQL serving certificate, plus any `additionalDNSNames` and `additionalIPAddresses` specified in `servingCertificate.operatorManagedOptions`.
+
+Like CQL certificates, Alternator certificates can be set to `UserManaged` if you want to provide your own.
+
+## Authentication and authorization
+
+### CQL authentication
+
+ScyllaDB authentication and authorization are **not** enabled by the operator by default. To enable them, provide a ConfigMap with a custom `scylla.yaml` that sets:
+
+```yaml
+authenticator: PasswordAuthenticator
+authorizer: CassandraAuthorizer
+```
+
+This ConfigMap is referenced in the `ScyllaCluster` spec and is merged with the operator-managed configuration.
+
+When `AutomaticTLSCertificates` is enabled, CQL connections also require mutual TLS (client certificate authentication). This provides two layers of authentication: TLS client certificates at the transport level and username/password at the CQL protocol level.
+
+The default superuser credentials are `cassandra`/`cassandra`. You should change the superuser password immediately after enabling authentication, and create application-specific roles with minimal privileges.
+
+### Alternator authorization
+
+Alternator authorization is controlled by the `insecureDisableAuthorization` field in the Alternator spec:
+
+- When authorization is **enabled** (the default for new clusters), Alternator requests must include valid AWS Signature Version 4 credentials. The credentials are derived from CQL roles — the `username` maps to the AWS access key, and the `salted_hash` of the password maps to the secret key.
+- When `insecureDisableAuthorization` is set to `true`, any request is accepted without authentication. This is intended only for development and testing.
+
+:::{caution}
+For backwards compatibility, authorization is disabled when using a manual Alternator port (the deprecated `port` field) and `insecureDisableAuthorization` is not explicitly set. Always set `insecureDisableAuthorization: false` explicitly in production.
+:::
+
+## RBAC
+
+The operator uses [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to control access at three levels: operator permissions, ScyllaDB pod permissions, and user-facing roles.
+
+### Operator ClusterRole
+
+The `scylladb:controller:operator` ClusterRole is an [aggregated ClusterRole](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles) that combines permissions from multiple component ClusterRoles selected by the label `rbac.operator.scylladb.com/aggregate-to-scylla-operator: "true"`. This includes permissions to manage pods, Services, StatefulSets, PVCs, Secrets, ConfigMaps, Jobs, PodDisruptionBudgets, ServiceMonitors, PrometheusRules, and all ScyllaDB CRDs.
+
+The operator runs as the `scylla-operator` ServiceAccount in the `scylla-operator` namespace, bound to the aggregate ClusterRole via a ClusterRoleBinding.
+
+On OpenShift, additional permissions are added through a separate component ClusterRole (e.g., SecurityContextConstraints access).
+
+### Member ClusterRole
+
+Each ScyllaDB pod runs with a dedicated ServiceAccount created for each ScyllaDB cluster (named `<cluster-name>-member`). This ServiceAccount is bound to the `scyllacluster-member` aggregate ClusterRole via a namespaced RoleBinding.
+
+The member ClusterRole grants the sidecar running inside each ScyllaDB pod the minimum permissions it needs:
+
+- **Read** pods, Secrets, ConfigMaps, Services, and StatefulSets — the sidecar reads its own identity, certificates, and cluster topology.
+- **Write** pods and Services — the sidecar updates annotations on its own Service (host ID, token ring hash) and pod labels.
+- **Read** internal node-status report resources — used for [bootstrap synchronisation](bootstrap-sync.md) state.
+
+The member role does **not** grant permissions to modify StatefulSets, create or delete pods, or access resources outside the namespace.
+
+### User-facing ClusterRoles
+
+The operator installs two ClusterRoles for Kubernetes users who manage ScyllaDB resources:
+
+| ClusterRole | Aggregated to | Permissions |
+|-------------|---------------|-------------|
+| `scyllacluster-view` | `admin`, `edit`, `view` | Read-only access to ScyllaDB CRDs (`ScyllaClusters`, `ScyllaDBMonitorings`, `ScyllaDBManagerClusterRegistrations`, `ScyllaDBManagerTasks`). |
+| `scyllacluster-edit` | `admin`, `edit` | Create, update, patch, and delete ScyllaDB CRDs. |
+
+These ClusterRoles are aggregated into the default Kubernetes `admin`, `edit`, and `view` ClusterRoles. This means any user who has the Kubernetes `edit` role in a namespace can automatically create and manage ScyllaDB clusters in that namespace.
+
+### Monitoring ClusterRoles
+
+Additional aggregate ClusterRoles exist for monitoring components:
+
+- **Prometheus** (`scylladb:controller:prometheus`): permissions to read endpoints, pods, Services, and nodes. Required for Prometheus service discovery.
+- **Grafana** (`scylladb:controller:grafana`): permissions to manage Grafana-related ConfigMaps and Secrets.
+
+## ScyllaDB Manager Agent security
+
+ScyllaDB Manager communicates with ScyllaDB nodes through the [Manager Agent](manager.md), which runs as a sidecar container in each ScyllaDB pod. The Agent exposes a REST API on port 10001.
+
+### Authentication token
+
+The operator generates a unique authentication token for each `ScyllaCluster` and stores it in a Secret named `<cluster-name>-auth-token`. This token is:
+
+- Mounted into the Agent sidecar container as a configuration file.
+- Used by ScyllaDB Manager to authenticate API calls to the Agent.
+- Used by the operator itself when it communicates with the Agent (for example, to coordinate cleanup jobs).
+
+In multi-DC deployments using multiple `ScyllaCluster` resources, ScyllaDB Manager needs a single token to communicate with all datacenters. You must manually extract the token from one datacenter's `<cluster-name>-auth-token` Secret, patch it into the other datacenters' Secrets, and then rolling-restart those datacenters so the Agent picks up the new token. See [Deploy a multi-datacenter cluster](../deploy-scylladb/deploy-multi-dc-cluster.md) for the step-by-step procedure.
+
+### Shared namespace
+
+ScyllaDB Manager is deployed in the `scylla-manager` namespace. It needs network access to the Agent API port (10001) on every ScyllaDB pod, regardless of namespace. The Manager does not require RBAC access to the Kubernetes API — it communicates directly with the Agents over HTTP using the authentication token.
+
+:::{caution}
+The Agent authentication token is a bearer token. Anyone with read access to the token Secret can impersonate ScyllaDB Manager and issue commands to the Agent (backups, repairs, host operations). Restrict Secret read access in the ScyllaDB namespace to trusted operators.
+:::
+
+## Webhook validation
+
+The operator runs a dedicated webhook server (separate Deployment from the operator controller) that validates all CREATE and UPDATE operations on ScyllaDB CRDs:
+
+- `ScyllaCluster` (v1)
+- `NodeConfig`, `ScyllaOperatorConfig`, `ScyllaDBManagerClusterRegistration`, `ScyllaDBManagerTask`, `ScyllaDBMonitoring` (v1alpha1)
+
+The webhook is configured with `failurePolicy: Fail`, meaning that if the webhook server is unreachable, the Kubernetes API server rejects the request. This prevents invalid configurations from being applied when the webhook is down, but it also means the webhook server must be available for any ScyllaDB resource mutation.
+
+The webhook server has its own PDB (`minAvailable: 1`) to ensure availability during node drains. See [Pod disruption budgets](pod-disruption-budgets.md).
+
+## Network policies
+
+The operator does **not** create Kubernetes NetworkPolicy resources. If your cluster enforces network policies, you must ensure that the following traffic is allowed:
+
+| Source | Destination | Port | Purpose |
+|--------|-------------|------|---------|
+| ScyllaDB pods | ScyllaDB pods | 7000, 7001 | Inter-node communication |
+| ScyllaDB pods | ScyllaDB pods | 9042, 9142 | CQL (seed resolution, sidecar) |
+| Application pods | ScyllaDB pods | 9042, 9142, 19042, 19142 | CQL client traffic |
+| Application pods | ScyllaDB pods | 8000, 8043 | Alternator (if enabled) |
+| ScyllaDB Manager | ScyllaDB pods | 10001 | Manager Agent API |
+| Prometheus | ScyllaDB pods | 9180, 5090, 9100 | Metrics scraping |
+| Kubernetes API server | Webhook server pods | 5000 | Admission webhook calls |
+| Operator pods | Kubernetes API server | 443 | Controller reconciliation |
+
+## Related pages
+
+- [Overview](overview.md) — reconciliation model and component layout.
+- [Manager](manager.md) — ScyllaDB Manager deployment model.
+- [Pod disruption budgets](pod-disruption-budgets.md) — how operator and webhook PDBs protect availability.
+- [Sidecar](sidecar.md) — containers in a ScyllaDB pod, including the Agent sidecar.
+- [Ignition](ignition.md) — startup gating that depends on certificate readiness.

--- a/docs-staging/source/understand/security.md
+++ b/docs-staging/source/understand/security.md
@@ -76,7 +76,7 @@ This ConfigMap is referenced in the `ScyllaCluster` spec and is merged with the 
 
 When `AutomaticTLSCertificates` is enabled, CQL connections also require mutual TLS (client certificate authentication). This provides two layers of authentication: TLS client certificates at the transport level and username/password at the CQL protocol level.
 
-The default superuser credentials are `cassandra`/`cassandra`. You should change the superuser password immediately after enabling authentication, and create application-specific roles with minimal privileges.
+Starting with ScyllaDB 2026.2, the default `cassandra`/`cassandra` superuser no [longer exists by default](https://github.com/scylladb/scylladb/pull/27215). It is recommended to create application-specific roles with minimal privileges.
 
 ### Alternator authorization
 
@@ -111,8 +111,6 @@ The member ClusterRole grants the sidecar running inside each ScyllaDB pod the m
 - **Write** pods and Services — the sidecar updates annotations on its own Service (host ID, token ring hash) and pod labels.
 - **Read** internal node-status report resources — used for [bootstrap synchronisation](bootstrap-sync.md) state.
 
-The member role does **not** grant permissions to modify StatefulSets, create or delete pods, or access resources outside the namespace.
-
 ### User-facing ClusterRoles
 
 The operator installs two ClusterRoles for Kubernetes users who manage ScyllaDB resources:
@@ -128,8 +126,8 @@ These ClusterRoles are aggregated into the default Kubernetes `admin`, `edit`, a
 
 Additional aggregate ClusterRoles exist for monitoring components:
 
-- **Prometheus** (`scylladb:controller:prometheus`): permissions to read endpoints, pods, Services, and nodes. Required for Prometheus service discovery.
-- **Grafana** (`scylladb:controller:grafana`): permissions to manage Grafana-related ConfigMaps and Secrets.
+- **Prometheus** (`scylladb:monitoring:prometheus`): permissions to read endpoints, pods, Services, and nodes. Required for Prometheus service discovery.
+- **Grafana** (`scylladb:monitoring:grafana`): permissions to manage Grafana-related ConfigMaps and Secrets.
 
 ## ScyllaDB Manager Agent security
 
@@ -155,29 +153,13 @@ The Agent authentication token is a bearer token. Anyone with read access to the
 
 ## Webhook validation
 
-The operator runs a dedicated webhook server (separate Deployment from the operator controller) that validates all CREATE and UPDATE operations on ScyllaDB CRDs:
-
-- `ScyllaCluster` (v1)
-- `NodeConfig`, `ScyllaOperatorConfig`, `ScyllaDBManagerClusterRegistration`, `ScyllaDBManagerTask`, `ScyllaDBMonitoring` (v1alpha1)
+The operator runs a dedicated webhook server (separate Deployment from the operator controller) that validates ScyllaDB CRDs upon creation or modification.
 
 The webhook is configured with `failurePolicy: Fail`, meaning that if the webhook server is unreachable, the Kubernetes API server rejects the request. This prevents invalid configurations from being applied when the webhook is down, but it also means the webhook server must be available for any ScyllaDB resource mutation.
 
-The webhook server has its own PDB (`minAvailable: 1`) to ensure availability during node drains. See [Pod disruption budgets](pod-disruption-budgets.md).
-
 ## Network policies
 
-The operator does **not** create Kubernetes NetworkPolicy resources. If your cluster enforces network policies, you must ensure that the following traffic is allowed:
-
-| Source | Destination | Port | Purpose |
-|--------|-------------|------|---------|
-| ScyllaDB pods | ScyllaDB pods | 7000, 7001 | Inter-node communication |
-| ScyllaDB pods | ScyllaDB pods | 9042, 9142 | CQL (seed resolution, sidecar) |
-| Application pods | ScyllaDB pods | 9042, 9142, 19042, 19142 | CQL client traffic |
-| Application pods | ScyllaDB pods | 8000, 8043 | Alternator (if enabled) |
-| ScyllaDB Manager | ScyllaDB pods | 10001 | Manager Agent API |
-| Prometheus | ScyllaDB pods | 9180, 5090, 9100 | Metrics scraping |
-| Kubernetes API server | Webhook server pods | 5000 | Admission webhook calls |
-| Operator pods | Kubernetes API server | 443 | Controller reconciliation |
+The operator does **not** create Kubernetes NetworkPolicy resources automatically. You can create them manually so that their selectors match node labels defined in `ScyllaCluster`'s `.spec.podMetadata.labels`.
 
 ## Related pages
 

--- a/docs-staging/source/understand/sidecar.md
+++ b/docs-staging/source/understand/sidecar.md
@@ -1,5 +1,133 @@
 # Sidecar and pod anatomy
 
-:::{todo}
-This page is not yet written.
-:::
+This page describes every container that runs inside a ScyllaDB pod, how they coordinate through shared volumes, and what the sidecar subcommand does.
+
+## Container overview
+
+A ScyllaDB pod contains init containers that run sequentially before the main workload, followed by long-running containers that run concurrently.
+
+### Init containers (in order)
+
+| # | Name | Image | Purpose | Conditional |
+|---|------|-------|---------|-------------|
+| 1 | `scylla-operator-binary-injector` | Operator | Copies the `scylla-operator` binary into the `/mnt/shared` volume so that other containers can use it without bundling the Operator image. | Always present |
+| 2 | `sysctl-buddy` | Operator | Applies sysctl settings from a pod annotation. Used during migration from legacy tuning. | Only when the sysctls annotation is set |
+| 3 | `scylladb-bootstrap-barrier` | ScyllaDB | Blocks until all nodes in the cluster report each other as UP, preventing a new node from bootstrapping into an unhealthy cluster. See [Bootstrap synchronisation](bootstrap-sync.md). | Only when the `BootstrapSynchronisation` feature gate is enabled and the ScyllaDB version is ≥ 2025.2 |
+
+### Long-running containers
+
+| # | Name | Image | Purpose | Conditional |
+|---|------|-------|---------|-------------|
+| 1 | `scylla` | ScyllaDB | The main container. Waits for the ignition signal, then execs the sidecar binary which configures and starts ScyllaDB. | Always present |
+| 2 | `scylladb-api-status-probe` | Operator | Translates ScyllaDB's native HTTP API status into Kubernetes health-check endpoints (`/healthz`, `/readyz`) on port 8080. | Always present |
+| 3 | `scylladb-ignition` | Operator | Evaluates startup prerequisites (tuning done, IPs assigned, container running) and creates the ignition signal file when all are met. See [Ignition](ignition.md). | Always present |
+| 4 | `scylla-manager-agent` | Manager Agent | Runs the ScyllaDB Manager Agent for backup, repair, and health-check operations. Waits for the ignition signal before starting. | Only when Manager integration is configured |
+
+## Shared volumes
+
+Containers coordinate through volumes mounted into the pod:
+
+| Volume | Mount path | Purpose |
+|--------|-----------|---------|
+| `shared` (emptyDir) | `/mnt/shared` | Carries the Operator binary (injected by init container 1) and the ignition signal file (`/mnt/shared/ignition.done`). Shared by all containers. |
+| Data PVC | `/var/lib/scylla` | Persistent storage for ScyllaDB data files. Mounted read-write in the main container, read-only in the bootstrap barrier. |
+| Managed ScyllaDB config (ConfigMap) | `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/managed-config/scylla.yaml` | Operator-generated `scylla.yaml` with cluster name, snitch, TLS, and other managed settings. |
+| User ScyllaDB config (ConfigMap) | `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/config/scylla.yaml` | User-provided `scylla.yaml` overrides. |
+| Rack config (ConfigMap) | Snitch properties path | Datacenter and rack assignment for the gossip endpoint snitch. |
+| Agent auth token (Secret) | Agent config path | Manager Agent authentication token. |
+
+Additional TLS-related volumes (serving certificates, client CA, admin user credentials, Alternator certificates) are mounted when the `AutomaticTLSCertificates` feature gate is enabled or when Alternator is configured.
+
+## The ignition signal file
+
+The `/mnt/shared/ignition.done` file is the coordination point between the ignition sidecar and the main container:
+
+1. The `scylla` container's entrypoint loops, sleeping until the file appears.
+2. The `scylladb-ignition` container evaluates prerequisites and creates the file when all conditions are satisfied.
+3. On container termination, the `scylla` container's shutdown trap removes the file so that on restart the ignition sidecar must re-evaluate.
+4. The Manager Agent container uses the same wait loop before starting the agent process.
+
+This mechanism ensures that ScyllaDB never starts before node-level tuning is complete and network addresses are assigned. See [Ignition](ignition.md) for the full list of prerequisites.
+
+## The sidecar subcommand
+
+When the ignition signal file appears, the `scylla` container execs into `/mnt/shared/scylla-operator sidecar`. This subcommand runs inside the main container for the lifetime of the pod and is responsible for:
+
+### 1. Resolving the node identity
+
+The sidecar creates a `Member` identity by querying the pod's own Service and pod status. It resolves broadcast addresses according to the configured `broadcastOptions`:
+
+- `PodIP` → reads `status.podIP` (or selects by IP family from `status.podIPs`).
+- `ServiceClusterIP` → reads `spec.clusterIP` from the member Service.
+- `ServiceLoadBalancerIngress` → reads the first entry in `status.loadBalancer.ingress`.
+
+Two addresses are resolved independently: one for inter-node communication (`broadcast_address`) and one for CQL clients (`broadcast_rpc_address`).
+
+### 2. Configuring ScyllaDB
+
+The sidecar merges configuration from multiple sources:
+
+1. **Default `scylla.yaml`** shipped with the ScyllaDB image.
+2. **Operator-managed config** from the managed ConfigMap — sets `cluster_name`, `rpc_address`, `endpoint_snitch`, TLS options, and Alternator settings.
+3. **User-provided config** from the user's ConfigMap — overlaid on top, but operator-managed keys take precedence.
+
+The merged configuration is written to disk. The sidecar also:
+
+- Sets up **rack and datacenter properties** for the gossip endpoint snitch.
+- Copies pre-computed **IO properties** if available.
+- Configures **CPU pinning** arguments when the pod has a Guaranteed QoS class and the kubelet uses a static CPU manager policy.
+
+### 3. Starting ScyllaDB
+
+The sidecar builds the ScyllaDB command line (`/usr/bin/scylla`) with arguments including:
+
+- `--broadcast-address` and `--broadcast-rpc-address` (from the resolved identity).
+- `--listen-address=0.0.0.0` (or `::` for IPv6).
+- `--developer-mode` flag.
+- Any additional ScyllaDB arguments from `spec.additionalScyllaDBArguments`.
+
+ScyllaDB is started as a child process with `Pdeathsig` set so that it terminates if the sidecar exits.
+
+### 4. Running internal controllers
+
+While ScyllaDB runs, the sidecar starts two controllers concurrently:
+
+#### SidecarController
+
+Watches the node's own member Service and keeps it in sync with ScyllaDB's runtime state:
+
+- Queries ScyllaDB for the node's **host ID** and **token ring membership**.
+- Updates the Service annotations with the current host ID and token ring hash. These annotations are consumed by the datacenter controller to detect token ring changes (for [automatic data cleanup](automatic-data-cleanup.md)) and to track node identity.
+- Drives **decommission**: when the Service carries the decommission label, the SidecarController executes `nodetool decommission`, monitoring the node's state transitions (`NORMAL` → `LEAVING` → `DECOMMISSIONED`).
+
+#### StatusReporter
+
+Periodically polls the ScyllaDB storage service API and writes the node's gossip view (which other nodes are `UP` or `DOWN`) as an annotation on the pod. This annotation is consumed by the internal datacenter controller to build `ScyllaDBDatacenterNodesStatusReport` resources (an internal CRD used for coordinating operations) that feed into [bootstrap synchronisation](bootstrap-sync.md).
+
+## The probe sidecar
+
+The `scylladb-api-status-probe` container runs an HTTP server on port 8080 that translates ScyllaDB's native HTTP API into Kubernetes probe responses:
+
+| Endpoint | Kubernetes probe | What it checks |
+|----------|-----------------|----------------|
+| `/healthz` | Startup and liveness | ScyllaDB process is alive and responsive. |
+| `/readyz` | Readiness | ScyllaDB node is ready to serve traffic. |
+
+The `scylla` container's health probes point to these endpoints rather than directly to ScyllaDB, because ScyllaDB's native API is not designed to return the HTTP status codes that Kubernetes expects.
+
+## Shutdown sequence
+
+When a pod is terminated:
+
+1. The `scylla` container's `preStop` hook runs `nodetool drain` to flush memtables and stop accepting new connections.
+2. The container's trap sends SIGTERM to all child processes (including ScyllaDB) and waits for them to exit.
+3. The trap removes `/mnt/shared/ignition.done` so that if the container restarts, ignition must re-evaluate prerequisites.
+
+## Related pages
+
+- [Ignition](ignition.md) — detailed startup prerequisites and the ignition controller.
+- [Bootstrap synchronisation](bootstrap-sync.md) — the barrier init container.
+- [Tuning](tuning.md) — how node tuning feeds into ignition readiness.
+- [Networking](networking.md) — broadcast address types and Service model.
+- [Security](security.md) — TLS certificates mounted into pod containers and Manager Agent authentication.
+- [StatefulSets and racks](statefulsets-and-racks.md) — pod identity, scaling, and decommission flow.

--- a/docs-staging/source/understand/sidecar.md
+++ b/docs-staging/source/understand/sidecar.md
@@ -10,7 +10,7 @@ A ScyllaDB pod contains init containers that run sequentially before the main wo
 
 | # | Name | Image | Purpose | Conditional |
 |---|------|-------|---------|-------------|
-| 1 | `scylla-operator-binary-injector` | Operator | Copies the `scylla-operator` binary into the `/mnt/shared` volume so that other containers can use it without bundling the Operator image. | Always present |
+| 1 | `sidecar-injection` | Operator | Copies the `scylla-operator` binary into the `/mnt/shared` volume so that other containers can use it without bundling the Operator image. | Always present |
 | 2 | `sysctl-buddy` | Operator | Applies sysctl settings from a pod annotation. Used during migration from legacy tuning. | Only when the sysctls annotation is set |
 | 3 | `scylladb-bootstrap-barrier` | ScyllaDB | Blocks until all nodes in the cluster report each other as UP, preventing a new node from bootstrapping into an unhealthy cluster. See [Bootstrap synchronisation](bootstrap-sync.md). | Only when the `BootstrapSynchronisation` feature gate is enabled and the ScyllaDB version is ≥ 2025.2 |
 
@@ -31,7 +31,7 @@ Containers coordinate through volumes mounted into the pod:
 |--------|-----------|---------|
 | `shared` (emptyDir) | `/mnt/shared` | Carries the Operator binary (injected by init container 1) and the ignition signal file (`/mnt/shared/ignition.done`). Shared by all containers. |
 | Data PVC | `/var/lib/scylla` | Persistent storage for ScyllaDB data files. Mounted read-write in the main container, read-only in the bootstrap barrier. |
-| Managed ScyllaDB config (ConfigMap) | `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/managed-config/scylla.yaml` | Operator-generated `scylla.yaml` with cluster name, snitch, TLS, and other managed settings. |
+| Managed ScyllaDB config (ConfigMap) | `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/managed-config/scylladb-managed-config.yaml` | Operator-generated `scylla.yaml` with cluster name, snitch, TLS, and other managed settings. |
 | User ScyllaDB config (ConfigMap) | `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/config/scylla.yaml` | User-provided `scylla.yaml` overrides. |
 | Rack config (ConfigMap) | Snitch properties path | Datacenter and rack assignment for the gossip endpoint snitch. |
 | Agent auth token (Secret) | Agent config path | Manager Agent authentication token. |

--- a/docs-staging/source/understand/statefulsets-and-racks.md
+++ b/docs-staging/source/understand/statefulsets-and-racks.md
@@ -1,5 +1,125 @@
 # StatefulSets and racks
 
-:::{todo}
-This page is not yet written.
+This page explains how ScyllaDB Operator maps ScyllaDB topology onto Kubernetes primitives, and how that mapping affects scaling, rolling updates, node replacement, and day-to-day operations.
+
+## One StatefulSet per rack
+
+Each **rack** defined in a `ScyllaCluster` is backed by exactly one Kubernetes **StatefulSet**. The StatefulSet is named using the pattern:
+
+```
+<cluster-name>-<datacenter-name>-<rack-name>
+```
+
+For example, a ScyllaCluster named `scylla` with datacenter `us-east-1` and rack `a` produces a StatefulSet named `scylla-us-east-1-a`.
+
+Each pod in the StatefulSet is named with an ordinal suffix:
+
+```
+scylla-us-east-1-a-0
+scylla-us-east-1-a-1
+scylla-us-east-1-a-2
+```
+
+The `members` field in the rack spec maps directly to the StatefulSet's `replicas` count.
+
+## Pod identity and ordering
+
+StatefulSets provide two guarantees that are essential for running ScyllaDB:
+
+1. **Stable network identity** — each pod gets a predictable DNS name (`<pod>.<headless-service>.<namespace>.svc.cluster.local`) and a dedicated member Service. The network identity survives pod restarts because the pod name (and therefore the Service name) is derived from the StatefulSet name plus a fixed ordinal.
+
+2. **Stable persistent storage** — each pod's PersistentVolumeClaim (PVC) is named deterministically (`data-<pod-name>`) and is **not** deleted when the pod is deleted or the StatefulSet is scaled down. When a pod comes back (restart or scale-up), it reattaches to the same PVC and recovers its data.
+
+The Operator uses `OrderedReady` pod management policy. This means pods are created in order (0, 1, 2, …) and each pod must become Ready before the next one is created. On shutdown, pods are terminated in reverse order.
+
+## Scaling
+
+### Scaling up
+
+When you increase the `members` count of a rack, the Operator increases the StatefulSet's `replicas`. Kubernetes creates new pods at the **end** of the ordinal sequence. For example, if the rack has 3 members (ordinals 0, 1, 2) and you scale to 5, pods with ordinals 3 and 4 are created.
+
+Each new pod joins the ScyllaDB cluster as a new node, takes ownership of a portion of the token range, and begins streaming data from existing nodes.
+
+### Scaling down
+
+When you decrease the `members` count, the Operator removes nodes from the **end** of the ordinal sequence — always the highest ordinal first. Before the pod is deleted:
+
+1. The Operator sets the `scylla/decommissioned` label on the member Service to `"false"`, recording the intent to decommission.
+2. The sidecar running inside the pod detects this label and initiates `nodetool decommission`, which redistributes the node's token ranges and streams its data to other nodes.
+3. Once decommission completes, the sidecar updates the label to `"true"`.
+4. The Operator scales the StatefulSet's `replicas` down by one, which deletes the pod.
+
+The Operator scales down **one member at a time**, regardless of how large the requested scale-down is. This ensures that only one decommission is in progress at any moment, protecting data availability.
+
+:::{important}
+You cannot remove an arbitrary node from the middle of a rack's ordinal range by changing the `members` count. Scaling always operates on the tail of the StatefulSet. To remove a specific node (for example, ordinal 1 out of 0, 1, 2), use node replacement instead — see [Replacing nodes](../operate/replace-nodes.md).
 :::
+
+### PVC retention
+
+PVCs are **not** deleted when a StatefulSet is scaled down. The PVCs for decommissioned pods remain in the namespace until manually deleted. If you scale the rack back up to the same size, the new pods reuse the existing PVCs and their data.
+
+:::{caution}
+After a scale-down followed by a scale-up, the reattached PVC contains stale data from the decommissioned node. ScyllaDB handles this correctly — the new node joins as a replacement and the stale data is cleaned up — but be aware that the PVC is not wiped automatically.
+:::
+
+## Rolling updates
+
+When the pod template changes (for example, a ScyllaDB image change or a configuration update), the Operator rolls out the change across all racks.
+
+### Non-upgrade changes
+
+For changes that do not involve a ScyllaDB major or minor version change, the Operator applies the updated StatefulSet spec directly. Kubernetes uses the `RollingUpdate` strategy to restart pods one at a time in **reverse ordinal order** (highest ordinal first). The StatefulSet controller waits for each restarted pod to become Ready before proceeding to the next one.
+
+A stuck pod (one that does not become Ready after the update) **blocks the entire rollout**. No further pods in the rack are updated until the stuck pod recovers. This is a safety mechanism — it prevents a bad configuration from cascading across the entire rack.
+
+### Version upgrades
+
+When the ScyllaDB image version changes by major or minor version, the Operator runs a more controlled upgrade process using **partition-based rollouts**:
+
+1. **Partition all StatefulSets** — set each StatefulSet's `updateStrategy.rollingUpdate.partition` to its current replica count. This applies the new pod template to the StatefulSet without restarting any pods.
+2. **Run pre-upgrade hooks** — take system and data snapshots on each node for rollback safety.
+3. **Decrement the partition one at a time** — lowering the partition from N to N-1 allows exactly one pod (ordinal N-1) to pick up the new template and restart. The Operator waits for the restarted pod to become Ready, then runs post-node-upgrade hooks (e.g., `nodetool upgradesstables`) before moving to the next pod.
+4. **One rack at a time** — the partition can only advance in one rack per reconciliation cycle.
+5. **Run post-upgrade hooks** — after all racks have completed the rollout, the Operator cleans up the upgrade context.
+
+This process ensures that only one ScyllaDB node is restarting at any given time and that each node is verified healthy before the next one is updated.
+
+## Operating on a node in the middle
+
+StatefulSets are an ordered sequence. The Operator provides mechanisms for operating on a specific node regardless of its position:
+
+### Node replacement
+
+To replace a node at any ordinal (not just the tail), set the `scylla/replace` label on its member Service. The Operator deletes the pod (and optionally the PVC), then creates a new pod at the same ordinal. The new pod starts ScyllaDB with the `--replace-node-first-boot` flag, which tells ScyllaDB to take over the dead node's token ranges.
+
+Replacement works on any ordinal because the pod identity and PVC are tied to the ordinal — the StatefulSet recreates a pod with the same name at the same position.
+
+### Maintenance mode
+
+Setting the `scylla/node-maintenance` label on a member Service puts that node into maintenance mode. The Operator reconfigures the Service so that traffic is no longer routed to the node, allowing you to perform manual operations on it without affecting client traffic. See [Maintenance mode](../operate/use-maintenance-mode.md).
+
+## Common pitfalls
+
+### Stuck rollout
+
+If a pod fails to become Ready after a rolling update, the rollout stalls. No other pods in the rack are updated. Symptoms:
+
+- `kubectl get statefulset` shows `READY` count lower than `REPLICAS`.
+- The `ScyllaCluster` status condition reports `WaitingForStatefulSetRollout`.
+
+To diagnose, check the logs of the failing pod and its events. If the problem is with the new configuration, fix the spec and the rollout resumes automatically. If the pod is stuck for other reasons (crash loop, resource issues), see [Node not starting](../troubleshoot/diagnose-node-not-starting.md).
+
+For log-level changes on a stuck cluster where a rolling restart is not feasible, see [Changing log level](../troubleshoot/change-log-level.md).
+
+### Deleting a StatefulSet
+
+Deleting a StatefulSet with the default cascade policy also deletes all its pods (but not PVCs). If the Operator is running, it immediately recreates the StatefulSet, which recreates the pods. Using `--cascade=orphan` preserves the running pods — this is used during advanced recovery procedures such as [Recovering from a failed replace](../troubleshoot/recover-from-failed-replace.md).
+
+## Related pages
+
+- [Pod disruption budgets](pod-disruption-budgets.md) — how PDBs interact with rolling updates and scale-down.
+- [Sidecar](sidecar.md) — what runs inside each pod and how decommission is driven.
+- [Scaling](../operate/scale-cluster.md) — how-to guide for scaling operations.
+- [Replacing nodes](../operate/replace-nodes.md) — how-to guide for node replacement.
+- [Changing log level](../troubleshoot/change-log-level.md) — emergency changes when a rollout is stuck.

--- a/docs-staging/source/understand/statefulsets-and-racks.md
+++ b/docs-staging/source/understand/statefulsets-and-racks.md
@@ -55,13 +55,9 @@ The Operator scales down **one member at a time**, regardless of how large the r
 You cannot remove an arbitrary node from the middle of a rack's ordinal range by changing the `members` count. Scaling always operates on the tail of the StatefulSet. To remove a specific node (for example, ordinal 1 out of 0, 1, 2), use node replacement instead — see [Replacing nodes](../operate/replace-nodes.md).
 :::
 
-### PVC retention
+### PVC lifecycle
 
-PVCs are **not** deleted when a StatefulSet is scaled down. The PVCs for decommissioned pods remain in the namespace until manually deleted. If you scale the rack back up to the same size, the new pods reuse the existing PVCs and their data.
-
-:::{caution}
-After a scale-down followed by a scale-up, the reattached PVC contains stale data from the decommissioned node. ScyllaDB handles this correctly — the new node joins as a replacement and the stale data is cleaned up — but be aware that the PVC is not wiped automatically.
-:::
+After a successful decommission, the operator deletes both the member Service and its PVC. If you scale the rack back up to the same size, the StatefulSet creates new PVCs and the new nodes bootstrap with a clean data directory.
 
 ## Rolling updates
 

--- a/docs-staging/source/understand/statefulsets-and-racks.md
+++ b/docs-staging/source/understand/statefulsets-and-racks.md
@@ -89,7 +89,7 @@ StatefulSets are an ordered sequence. The Operator provides mechanisms for opera
 
 To replace a node at any ordinal (not just the tail), set the `scylla/replace` label on its member Service. The Operator deletes the pod (and optionally the PVC), then creates a new pod at the same ordinal. The new pod starts ScyllaDB with the `--replace-node-first-boot` flag, which tells ScyllaDB to take over the dead node's token ranges.
 
-Replacement works on any ordinal because the pod identity and PVC are tied to the ordinal — the StatefulSet recreates a pod with the same name at the same position.
+Replacement works on any ordinal because the pod identity and PVC are tied to the ordinal — the StatefulSet recreates a pod with the same name at the same position. See [Replace nodes](../operate/replace-nodes.md) for the step-by-step procedure.
 
 ### Maintenance mode
 


### PR DESCRIPTION
Part of OPERATOR-32 - a pilot PR promoting the first batch of 5 documents under `understand/` from #3305 to `/docs-staging`.

I have chosen these five documents for the first PR because it seemed like the claims should be easily verifiable. Most of the content can be cross-referenced in the old documentation and the CRD reference.

Comparing to #3305, docs required changes to get rid of some hallucinated content; see the commits other than the oldest one. I've pushed the fixes to the #3305 branch as well (and I intend to continue doing so as we progress with content migration).

Asking @tluck for review of the `docs-staging/source/understand/security.md` document. I'm specifically interested in ensuring that the claims on the security page (especially regarding encryption and authn/authz) match your experience.

Rich preview is available:
```shell
$ cd docs-staging
$ make setup
$ make preview

(and then navigate to http://localhost:5500/ to see the docs)
```

/cc czeslavo
/cc tluck

/kind documentation
/priority important-longterm