### PR TITLE
fix: explicitly create a user for alternator API tests

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_alternator.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_alternator.go
@@ -37,8 +37,10 @@ import (
 )
 
 const (
-	cqlDefaultUser     = "cassandra"
-	cqlDefaultPassword = "cassandra"
+	cqlAlternatorUser     = "nondefaultcassandra"
+	cqlAlternatorPassword = "nondefaultcassandra"
+	// the SHA-512 crypt hash of cqlAlternatorPassword, for ScyllaDB's auth_superuser_salted_password config
+	cqlAlternatorPasswordSaltedHash = "$6$VbAwLOEIu18EYeOF$zb0/MC1/KmI3OZg8im1XjC4RmpqkZ/Xh0LDYBun/mKRjUFIh16t3.K.OO7y17XMR4ZiYTsYX3FcPxeoL9oiiD."
 )
 
 type Movie struct {
@@ -72,10 +74,12 @@ var _ = g.Describe("ScyllaCluster", func() {
 		defer cancel()
 
 		cm, _, err := scyllafixture.ScyllaDBConfigTemplate.RenderObject(map[string]any{
-			"config": strings.TrimPrefix(`
+			"config": strings.TrimPrefix(fmt.Sprintf(`
 authenticator: PasswordAuthenticator
 authorizer: CassandraAuthorizer
-`, "\n"),
+auth_superuser_name: %s
+auth_superuser_salted_password: '%s'
+`, cqlAlternatorUser, cqlAlternatorPasswordSaltedHash), "\n"),
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -117,8 +121,8 @@ authorizer: CassandraAuthorizer
 
 		cqlConfig := gocql.NewCluster(svcIP)
 		cqlConfig.Authenticator = gocql.PasswordAuthenticator{
-			Username: cqlDefaultUser,
-			Password: cqlDefaultPassword,
+			Username: cqlAlternatorUser,
+			Password: cqlAlternatorPassword,
 		}
 		cqlConfig.Consistency = gocql.All
 		cqlSession, err := cqlConfig.CreateSession()
@@ -126,7 +130,7 @@ authorizer: CassandraAuthorizer
 		defer cqlSession.Close()
 
 		awsCredentials := aws.Credentials{
-			AccessKeyID:     cqlDefaultUser,
+			AccessKeyID:     cqlAlternatorUser,
 			SecretAccessKey: "",
 		}
 


### PR DESCRIPTION
**Description of your changes:**
https://github.com/scylladb/scylladb/pull/27215 dropped the implicit creation of the `cassandra/cassandra` user. This change explicitly creates one for the purpose of the tests. It is backward compatible (ScyllaDB [supports](https://github.com/scylladb/scylladb/blob/f6532aca96cfc6140d522e46e54eddd8319430a4/db/config.cc#L1347) this config syntax since [ancient](https://github.com/scylladb/scylladb/blob/next-6.2/db/config.cc) open source versions). 

Essentially this fix enables further testing of Alternator API as is.

NB: This only addresses the newly failing tests in 2026.2 onwards. There is a related Operator production usage of these hardcoded credentials which will need to be addressed separately - see https://scylladb.atlassian.net/browse/OPERATOR-88


**Which issue is resolved by this Pull Request:**
Resolves OPERATOR-86

**Testing**
The fix can be verified locally by running a 2026.2 build, i.e.
```
SCYLLADB_IMAGE_REF="scylladb/scylla-nightly:2026.2.0-dev-0.20260420.6011cb8a4c25" SO_FOCUS=".*should set up Alternator API when enabled.*" ./hack/kind/run-e2e-tests.sh
```

/kind failing-test
/priority important-soon
