### PR TITLE
fix: narrow identity service selector down to scylla nodes only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Please refer to the [1.20 to 1.21 upgrade guide](https://operator.docs.scylladb.
 - `must-gather` resource collection now tolerates partial API discovery failures (e.g., when aggregated API servers like `metrics.k8s.io` are transiently unavailable) instead of failing entirely.
   [#3396](https://github.com/scylladb/scylla-operator/pull/3396)
 - Fixed [#3302](https://github.com/scylladb/scylla-operator/issues/3302): `ScyllaCluster` `spec.version` is now a required field. Previously, an empty value was accepted but caused a silent failure in the migration controller.
+  [#3385](https://github.com/scylladb/scylla-operator/pull/3385)
+- Fixed [#3407](https://github.com/scylladb/scylla-operator/issues/3407): `ScyllaDBDatacenter` identity service selector now includes the `scylla-operator.scylladb.com/pod-type: scylladb-node` label, preventing cleanup job pods from being matched by the service and causing client connection failures.
+  [#3409](https://github.com/scylladb/scylla-operator/pull/3409)
 
 ### Dependencies
 

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -111,7 +111,7 @@ func IdentityService(sdc *scyllav1alpha1.ScyllaDBDatacenter) (*corev1.Service, e
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
-			Selector: naming.ClusterLabels(sdc),
+			Selector: naming.ScyllaDBNodePodsSelectorLabels(sdc),
 			Ports:    servicePorts,
 		},
 	}

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -2751,6 +2751,93 @@ func TestMakeIngresses(t *testing.T) {
 	}
 }
 
+func TestIdentityService(t *testing.T) {
+	basicSDC := &scyllav1alpha1.ScyllaDBDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "basic",
+			UID:  "the-uid",
+			Labels: map[string]string{
+				"default-sc-label": "foo",
+			},
+			Annotations: map[string]string{
+				"default-sc-annotation": "bar",
+			},
+		},
+		Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
+			ClusterName:    "basic",
+			DatacenterName: pointer.Ptr("dc"),
+			ScyllaDB: scyllav1alpha1.ScyllaDB{
+				Image: "scylladb/scylla:latest",
+			},
+			RackTemplate: &scyllav1alpha1.RackTemplate{},
+			Racks: []scyllav1alpha1.RackSpec{
+				{
+					Name: "rack",
+				},
+			},
+		},
+	}
+
+	got, err := IdentityService(basicSDC)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "basic-client",
+			Labels: map[string]string{
+				"app":                          "scylla",
+				"app.kubernetes.io/name":       "scylla",
+				"app.kubernetes.io/managed-by": "scylla-operator",
+				"scylla/cluster":               "basic",
+				"default-sc-label":             "foo",
+				"scylla-operator.scylladb.com/scylla-service-type": "identity",
+			},
+			Annotations: map[string]string{
+				"default-sc-annotation": "bar",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "scylla.scylladb.com/v1alpha1",
+					Kind:               "ScyllaDBDatacenter",
+					Name:               "basic",
+					UID:                "the-uid",
+					Controller:         pointer.Ptr(true),
+					BlockOwnerDeletion: pointer.Ptr(true),
+				},
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				"app":                                   "scylla",
+				"app.kubernetes.io/name":                "scylla",
+				"app.kubernetes.io/managed-by":          "scylla-operator",
+				"scylla/cluster":                        "basic",
+				"scylla-operator.scylladb.com/pod-type": string(naming.PodTypeScyllaDBNode),
+			},
+			Ports: []corev1.ServicePort{
+				{Name: "inter-node-communication", Port: 7000},
+				{Name: "ssl-inter-node-communication", Port: 7001},
+				{Name: "cql", Port: 9042},
+				{Name: "cql-ssl", Port: 9142},
+				{Name: "cql-shard-aware", Port: 19042},
+				{Name: "cql-ssl-shard-aware", Port: 19142},
+				{Name: "jmx-monitoring", Port: 7199},
+				{Name: "agent-api", Port: 10001},
+				{Name: "prometheus", Port: 9180},
+				{Name: "agent-prometheus", Port: 5090},
+				{Name: "node-exporter", Port: 9100},
+				{Name: "thrift", Port: 9160},
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("identity service differs from expected:\n%s", cmp.Diff(expected, got))
+	}
+}
+
 func TestMakeJobs(t *testing.T) {
 	basicScyllaDBDatacenter := func() *scyllav1alpha1.ScyllaDBDatacenter {
 		return &scyllav1alpha1.ScyllaDBDatacenter{

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -29,9 +29,20 @@ func ClusterLabelsForScyllaCluster(sc *scyllav1.ScyllaCluster) map[string]string
 // ScyllaDBNodesPodsLabelsForScyllaCluster returns a map of label keys and values for ScyllaDB nodes pods limited
 // to the given ScyllaCluster.
 func ScyllaDBNodesPodsLabelsForScyllaCluster(sc *scyllav1.ScyllaCluster) map[string]string {
-	labels := ClusterLabelsForScyllaCluster(sc)
-	labels[PodTypeLabel] = string(PodTypeScyllaDBNode)
-	return labels
+	return mergeLabels(
+		ClusterLabelsForScyllaCluster(sc),
+		ScyllaDBNodePodLabels(),
+	)
+}
+
+// ScyllaDBNodePodsSelectorLabels returns a map of label keys and values selecting ScyllaDB node pods
+// of the given ScyllaDBDatacenter. It restricts the selector to only match ScyllaDB node pods, excluding other
+// (e.g., cleanup job pods).
+func ScyllaDBNodePodsSelectorLabels(sdc *scyllav1alpha1.ScyllaDBDatacenter) map[string]string {
+	return mergeLabels(
+		ClusterLabels(sdc),
+		ScyllaDBNodePodLabels(),
+	)
 }
 
 // DatacenterLabels returns a map of label keys and values

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -26,9 +26,10 @@ func ClusterLabelsForScyllaCluster(sc *scyllav1.ScyllaCluster) map[string]string
 	return labels
 }
 
-// ScyllaDBNodesPodsLabelsForScyllaCluster returns a map of label keys and values for ScyllaDB nodes pods limited
-// to the given ScyllaCluster.
-func ScyllaDBNodesPodsLabelsForScyllaCluster(sc *scyllav1.ScyllaCluster) map[string]string {
+// ScyllaDBNodePodsSelectorLabelsForScyllaCluster returns a map of label keys and values selecting ScyllaDB node pods
+// of the given ScyllaCluster. It restricts the selector to only match ScyllaDB node pods, excluding other
+// (e.g., cleanup job pods).
+func ScyllaDBNodePodsSelectorLabelsForScyllaCluster(sc *scyllav1.ScyllaCluster) map[string]string {
 	return mergeLabels(
 		ClusterLabelsForScyllaCluster(sc),
 		ScyllaDBNodePodLabels(),

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -350,7 +350,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.Serial, framework.NotSu
 		o.Expect(utils.IsScyllaClusterRolledOut(sc)).To(o.BeFalse())
 
 		framework.By("Verifying the containers are blocked and not ready")
-		podSelector := labels.Set(naming.ScyllaDBNodesPodsLabelsForScyllaCluster(sc)).AsSelector()
+		podSelector := labels.Set(naming.ScyllaDBNodePodsSelectorLabelsForScyllaCluster(sc)).AsSelector()
 		scPods, err := f.KubeClient().CoreV1().Pods(sc.Namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: podSelector.String(),
 		})

--- a/test/e2e/set/scyllacluster/scyllacluster_ipv6.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_ipv6.go
@@ -174,7 +174,7 @@ var _ = g.Describe("ScyllaCluster IPv6", framework.IPv6, func() {
 
 func validateIPv6SingleStack(ctx context.Context, f *framework.Framework, sc *scyllav1.ScyllaCluster, expectClusterIP bool) {
 	pods, err := f.KubeClient().CoreV1().Pods(sc.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(naming.ScyllaDBNodesPodsLabelsForScyllaCluster(sc)).String(),
+		LabelSelector: labels.SelectorFromSet(naming.ScyllaDBNodePodsSelectorLabelsForScyllaCluster(sc)).String(),
 	})
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(pods.Items).ToNot(o.BeEmpty())
@@ -249,7 +249,7 @@ func validateDualStack(ctx context.Context, f *framework.Framework, sc *scyllav1
 	}
 
 	pods, err := f.KubeClient().CoreV1().Pods(sc.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(naming.ScyllaDBNodesPodsLabelsForScyllaCluster(sc)).String(),
+		LabelSelector: labels.SelectorFromSet(naming.ScyllaDBNodePodsSelectorLabelsForScyllaCluster(sc)).String(),
 	})
 	o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -601,7 +601,7 @@ func GetNodesServiceIPs(ctx context.Context, client corev1client.CoreV1Interface
 
 func GetNodesPodIPs(ctx context.Context, client corev1client.CoreV1Interface, sc *scyllav1.ScyllaCluster) ([]string, error) {
 	clusterPods, err := client.Pods(sc.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(naming.ScyllaDBNodesPodsLabelsForScyllaCluster(sc)).String(),
+		LabelSelector: labels.SelectorFromSet(naming.ScyllaDBNodePodsSelectorLabelsForScyllaCluster(sc)).String(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can't get cluster pods: %w", err)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Adds `scylla-operator.scylladb.com/pod-type: scylladb-node` to the identity service selector to prevent it from matching other cluster pods (e.g., cleanup job's ones) and causing connection issues.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/scylladb/scylla-operator/issues/3407