### PR TITLE
feat(api): deprecate serverless CQL-SNI APIs and default ScyllaDBMonitoring to Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Please refer to the [1.20 to 1.21 upgrade guide](https://operator.docs.scylladb.
 - `ScyllaCluster` backup and repair task names not conforming to RFC 1123 subdomain requirements (e.g. containing underscores `_`)
   are now rejected on object creation or update. The operator will refuse to start if any existing `ScyllaClusters` have non-conforming task names.
   [#3326](https://github.com/scylladb/scylla-operator/pull/3326)
+- `ScyllaCluster` `spec.exposeOptions.cql` and `ScyllaDBDatacenter` `spec.exposeOptions.cql` are deprecated and will be removed
+  in a future release, along with operator support for exposing CQL over an SNI proxy. The admission webhook emits a warning
+  when these fields are set.
+  [#3410](https://github.com/scylladb/scylla-operator/pull/3410)
+- `ScyllaDBMonitoring` `spec.type` value `SaaS` is deprecated and will be removed in a future release. The admission webhook
+  emits a warning when `SaaS` is explicitly set. The default value of `spec.type` changed from `SaaS` to `Platform`; existing
+  objects that omit `spec.type` will render `Platform` dashboards after the upgrade.
+  [#3410](https://github.com/scylladb/scylla-operator/pull/3410)
 
 ### Features & Enhancements
 

--- a/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
@@ -3543,11 +3543,13 @@ spec:
                     description: |-
                       cql specifies expose options for CQL SSL backend.
                       EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+                      Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                     properties:
                       ingress:
                         description: |-
                           ingress is an Ingress configuration options.
                           EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+                          Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                         properties:
                           annotations:
                             additionalProperties:

--- a/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -128,13 +128,16 @@ spec:
                         type: object
                     type: object
                   cql:
-                    description: cql specifies expose options for CQL SSL backend.
+                    description: |-
+                      cql specifies expose options for CQL SSL backend.
+                      Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                     properties:
                       ingress:
                         description: |-
                           ingress specifies an Ingress configuration options.
                           If provided and enabled, Ingress objects routing to CQL SSL port are generated for each ScyllaDB node
                           with the following options.
+                          Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                         properties:
                           annotations:
                             additionalProperties:

--- a/bundle/manifests/scylla.scylladb.com_scylladbmonitorings.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scylladbmonitorings.yaml
@@ -2602,7 +2602,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               type:
-                default: SaaS
+                default: Platform
                 description: type determines the platform type of the monitoring setup.
                 enum:
                 - SaaS

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -5130,11 +5130,13 @@ spec:
                       description: |-
                         cql specifies expose options for CQL SSL backend.
                         EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+                        Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                       properties:
                         ingress:
                           description: |-
                             ingress is an Ingress configuration options.
                             EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+                            Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                           properties:
                             annotations:
                               additionalProperties:
@@ -35677,13 +35679,16 @@ spec:
                           type: object
                       type: object
                     cql:
-                      description: cql specifies expose options for CQL SSL backend.
+                      description: |-
+                        cql specifies expose options for CQL SSL backend.
+                        Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                       properties:
                         ingress:
                           description: |-
                             ingress specifies an Ingress configuration options.
                             If provided and enabled, Ingress objects routing to CQL SSL port are generated for each ScyllaDB node
                             with the following options.
+                            Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                           properties:
                             annotations:
                               additionalProperties:
@@ -48702,7 +48707,7 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type:
-                  default: SaaS
+                  default: Platform
                   description: type determines the platform type of the monitoring setup.
                   enum:
                     - SaaS

--- a/docs/source/management/upgrading/upgrade.md
+++ b/docs/source/management/upgrading/upgrade.md
@@ -126,6 +126,35 @@ If the command returns no output, all your `ScyllaClusters` are unaffected. If a
 A `ScyllaCluster` with an empty `spec.version` was never functional. The migration controller would fail to reconcile it, leaving the cluster in a permanently degraded state. Making the field required only prevents new broken clusters from being created.
 :::
 
+#### Review ScyllaDBMonitoring spec.type default change
+
+The default value of `ScyllaDBMonitoring` `spec.type` has changed from `SaaS` to `Platform`. Any existing `ScyllaDBMonitoring`
+object that omits `spec.type` will render `Platform` dashboards after the upgrade instead of `SaaS`. The `SaaS` value is
+also now deprecated and will be removed in a future release; the admission webhook will emit a warning when it is set explicitly.
+
+You can run the following snippet to list `ScyllaDBMonitoring` objects that will be affected by the default change or that
+still use the deprecated `SaaS` value:
+
+```bash
+output=$(kubectl get scylladbmonitorings --all-namespaces -o json | jq -r '
+  .items[] |
+  select((.spec.type // "SaaS") == "SaaS") |
+  "\(.metadata.namespace)/\(.metadata.name)\t(spec.type=\(.spec.type // "<unset, defaults to SaaS>"))"
+') && if [ -z "$output" ]; then echo "No ScyllaDBMonitoring objects rely on the SaaS type."; else echo "$output"; fi
+```
+
+If the command returns no output, none of your `ScyllaDBMonitoring` objects are affected. Otherwise, for each listed object,
+decide whether you want to:
+- keep the previous behavior by setting `spec.type: SaaS` explicitly before upgrading (the admission webhook will emit a
+  deprecation warning, and you will need to migrate to `Platform` before a future release removes `SaaS`), or
+- adopt the new default by either setting `spec.type: Platform` explicitly or leaving `spec.type` unset.
+
+:::{note}
+**Why is this not a breaking change?**
+The `Platform` dashboards are a superset of the `SaaS` dashboards, so switching from `SaaS` to `Platform` does not remove
+functionality.
+:::
+
 ### 1.17 to 1.18
 
 Upgrading from v1.17.x requires extra actions due to the removal of the standalone ScyllaDB Manager controller.

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -4353,7 +4353,7 @@ object
      - BroadcastOptions defines how ScyllaDB node publishes its IP address to other nodes and clients.
    * - :ref:`cql<api-scylla.scylladb.com-scyllaclusters-v1-.spec.exposeOptions.cql>`
      - object
-     - cql specifies expose options for CQL SSL backend. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+     - cql specifies expose options for CQL SSL backend. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field. Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
    * - :ref:`nodeService<api-scylla.scylladb.com-scyllaclusters-v1-.spec.exposeOptions.nodeService>`
      - object
      - nodeService controls properties of Service dedicated for each ScyllaCluster node.
@@ -4499,7 +4499,7 @@ object
 
 Description
 """""""""""
-cql specifies expose options for CQL SSL backend. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+cql specifies expose options for CQL SSL backend. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field. Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 
 Type
 """"
@@ -4515,7 +4515,7 @@ object
      - Description
    * - :ref:`ingress<api-scylla.scylladb.com-scyllaclusters-v1-.spec.exposeOptions.cql.ingress>`
      - object
-     - ingress is an Ingress configuration options. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+     - ingress is an Ingress configuration options. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field. Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 
 .. _api-scylla.scylladb.com-scyllaclusters-v1-.spec.exposeOptions.cql.ingress:
 
@@ -4524,7 +4524,7 @@ object
 
 Description
 """""""""""
-ingress is an Ingress configuration options. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+ingress is an Ingress configuration options. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field. Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 
 Type
 """"

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
@@ -156,7 +156,7 @@ object
      - BroadcastOptions defines how ScyllaDB node publishes its IP address to other nodes and clients.
    * - :ref:`cql<api-scylla.scylladb.com-scylladbdatacenters-v1alpha1-.spec.exposeOptions.cql>`
      - object
-     - cql specifies expose options for CQL SSL backend.
+     - cql specifies expose options for CQL SSL backend. Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
    * - :ref:`nodeService<api-scylla.scylladb.com-scylladbdatacenters-v1alpha1-.spec.exposeOptions.nodeService>`
      - object
      - nodeService controls properties of Service dedicated for each ScyllaDBDatacenter node.
@@ -302,7 +302,7 @@ object
 
 Description
 """""""""""
-cql specifies expose options for CQL SSL backend.
+cql specifies expose options for CQL SSL backend. Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 
 Type
 """"
@@ -318,7 +318,7 @@ object
      - Description
    * - :ref:`ingress<api-scylla.scylladb.com-scylladbdatacenters-v1alpha1-.spec.exposeOptions.cql.ingress>`
      - object
-     - ingress specifies an Ingress configuration options. If provided and enabled, Ingress objects routing to CQL SSL port are generated for each ScyllaDB node with the following options.
+     - ingress specifies an Ingress configuration options. If provided and enabled, Ingress objects routing to CQL SSL port are generated for each ScyllaDB node with the following options. Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 
 .. _api-scylla.scylladb.com-scylladbdatacenters-v1alpha1-.spec.exposeOptions.cql.ingress:
 
@@ -327,7 +327,7 @@ object
 
 Description
 """""""""""
-ingress specifies an Ingress configuration options. If provided and enabled, Ingress objects routing to CQL SSL port are generated for each ScyllaDB node with the following options.
+ingress specifies an Ingress configuration options. If provided and enabled, Ingress objects routing to CQL SSL port are generated for each ScyllaDB node with the following options. Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 
 Type
 """"

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -306,10 +306,10 @@
               "type": "object"
             },
             "cql": {
-              "description": "cql specifies expose options for CQL SSL backend.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",
+              "description": "cql specifies expose options for CQL SSL backend.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.\nDeprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
               "properties": {
                 "ingress": {
-                  "description": "ingress is an Ingress configuration options.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",
+                  "description": "ingress is an Ingress configuration options.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.\nDeprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
                   "properties": {
                     "annotations": {
                       "additionalProperties": {

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -249,10 +249,10 @@
           "type": "object"
         },
         "cql": {
-          "description": "cql specifies expose options for CQL SSL backend.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",
+          "description": "cql specifies expose options for CQL SSL backend.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.\nDeprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
           "properties": {
             "ingress": {
-              "description": "ingress is an Ingress configuration options.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",
+              "description": "ingress is an Ingress configuration options.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.\nDeprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -3341,11 +3341,13 @@ spec:
                       description: |-
                         cql specifies expose options for CQL SSL backend.
                         EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+                        Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                       properties:
                         ingress:
                           description: |-
                             ingress is an Ingress configuration options.
                             EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+                            Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                           properties:
                             annotations:
                               additionalProperties:

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -254,6 +254,7 @@ type NodeServiceTemplate struct {
 type ExposeOptions struct {
 	// cql specifies expose options for CQL SSL backend.
 	// EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+	// Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 	// +optional
 	CQL *CQLExposeOptions `json:"cql,omitempty"`
 
@@ -282,6 +283,7 @@ type RackNodeServiceTemplate struct {
 type CQLExposeOptions struct {
 	// ingress is an Ingress configuration options.
 	// EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+	// Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 	// +optional
 	Ingress *IngressOptions `json:"ingress,omitempty"`
 }

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -122,13 +122,16 @@ spec:
                           type: object
                       type: object
                     cql:
-                      description: cql specifies expose options for CQL SSL backend.
+                      description: |-
+                        cql specifies expose options for CQL SSL backend.
+                        Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                       properties:
                         ingress:
                           description: |-
                             ingress specifies an Ingress configuration options.
                             If provided and enabled, Ingress objects routing to CQL SSL port are generated for each ScyllaDB node
                             with the following options.
+                            Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
                           properties:
                             annotations:
                               additionalProperties:

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbmonitorings.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbmonitorings.yaml
@@ -2463,7 +2463,7 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type:
-                  default: SaaS
+                  default: Platform
                   description: type determines the platform type of the monitoring setup.
                   enum:
                     - SaaS

--- a/pkg/api/scylla/v1alpha1/types_monitoring.go
+++ b/pkg/api/scylla/v1alpha1/types_monitoring.go
@@ -299,6 +299,7 @@ const (
 	ScyllaDBMonitoringTypePlatform ScyllaDBMonitoringType = "Platform"
 
 	// ScyllaDBMonitoringTypeSAAS defines ScyllaDB monitoring setup focused only on the ScyllaDB service.
+	// Deprecated: `SaaS` is deprecated and will be removed in future releases. Use `Platform` instead.
 	ScyllaDBMonitoringTypeSAAS ScyllaDBMonitoringType = "SaaS"
 )
 
@@ -314,14 +315,14 @@ type ScyllaDBMonitoringSpec struct {
 	Components *Components `json:"components"`
 
 	// type determines the platform type of the monitoring setup.
-	// +kubebuilder:default:="SaaS"
+	// +kubebuilder:default:="Platform"
 	// +optional
 	Type *ScyllaDBMonitoringType `json:"type,omitempty"`
 }
 
 func (smc *ScyllaDBMonitoringSpec) GetType() ScyllaDBMonitoringType {
 	if smc.Type == nil {
-		return ScyllaDBMonitoringTypeSAAS
+		return ScyllaDBMonitoringTypePlatform
 	}
 
 	return *smc.Type

--- a/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
+++ b/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
@@ -402,6 +402,7 @@ type RackNodeServiceTemplate struct {
 // ExposeOptions hold options related to exposing ScyllaDBDatacenter backends.
 type ExposeOptions struct {
 	// cql specifies expose options for CQL SSL backend.
+	// Deprecated: `cql` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 	// +optional
 	CQL *CQLExposeOptions `json:"cql,omitempty"`
 
@@ -418,6 +419,7 @@ type CQLExposeOptions struct {
 	// ingress specifies an Ingress configuration options.
 	// If provided and enabled, Ingress objects routing to CQL SSL port are generated for each ScyllaDB node
 	// with the following options.
+	// Deprecated: `ingress` is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.
 	Ingress *CQLExposeIngressOptions `json:"ingress,omitempty"`
 }
 

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -530,6 +530,13 @@ func getWarningsForScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *
 		warnings = append(warnings, fmt.Sprintf("%s: deprecated; use NodeConfig's .spec.sysctls instead", fldPath.Child("sysctls")))
 	}
 
+	if spec.ExposeOptions != nil && spec.ExposeOptions.CQL != nil {
+		warnings = append(warnings, fmt.Sprintf(
+			"`%s` field is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
+			fldPath.Child("exposeOptions", "cql"),
+		))
+	}
+
 	return warnings
 }
 

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -1430,6 +1430,19 @@ func TestGetWarningsOnScyllaClusterCreate(t *testing.T) {
 				"spec.sysctls: deprecated; use NodeConfig's .spec.sysctls instead",
 			},
 		},
+		{
+			name: "cql expose options deprecation warning",
+			cluster: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.ExposeOptions = &scyllav1.ExposeOptions{
+					CQL: &scyllav1.CQLExposeOptions{},
+				}
+				return sc
+			}(),
+			expectedWarnings: []string{
+				"`spec.exposeOptions.cql` field is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
+			},
+		},
 	}
 
 	for _, tc := range tt {
@@ -1471,6 +1484,20 @@ func TestGetWarningsOnScyllaClusterUpdate(t *testing.T) {
 			}(),
 			expectedWarnings: []string{
 				"spec.sysctls: deprecated; use NodeConfig's .spec.sysctls instead",
+			},
+		},
+		{
+			name:  "cql expose options deprecation warning",
+			oldSC: unit.NewSingleRackCluster(3),
+			newSC: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.ExposeOptions = &scyllav1.ExposeOptions{
+					CQL: &scyllav1.CQLExposeOptions{},
+				}
+				return sc
+			}(),
+			expectedWarnings: []string{
+				"`spec.exposeOptions.cql` field is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
 			},
 		},
 	}

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation.go
@@ -639,9 +639,30 @@ func validateScyllaArgIPAddress(argName string, expectedIPFamily corev1.IPFamily
 }
 
 func GetWarningsOnScyllaDBDatacenterCreate(sdc *scyllav1alpha1.ScyllaDBDatacenter) []string {
-	return nil
+	var warnings []string
+
+	warnings = append(warnings, getWarningsForScyllaDBDatacenterSpec(&sdc.Spec, field.NewPath("spec"))...)
+
+	return warnings
 }
 
 func GetWarningsOnScyllaDBDatacenterUpdate(new, old *scyllav1alpha1.ScyllaDBDatacenter) []string {
-	return nil
+	var warnings []string
+
+	warnings = append(warnings, getWarningsForScyllaDBDatacenterSpec(&new.Spec, field.NewPath("spec"))...)
+
+	return warnings
+}
+
+func getWarningsForScyllaDBDatacenterSpec(spec *scyllav1alpha1.ScyllaDBDatacenterSpec, fldPath *field.Path) []string {
+	var warnings []string
+
+	if spec.ExposeOptions != nil && spec.ExposeOptions.CQL != nil {
+		warnings = append(warnings, fmt.Sprintf(
+			"`%s` field is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
+			fldPath.Child("exposeOptions", "cql"),
+		))
+	}
+
+	return warnings
 }

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
@@ -1506,3 +1506,107 @@ func TestValidateScyllaArgsIPFamily(t *testing.T) {
 		})
 	}
 }
+
+func newValidScyllaDBDatacenterForWarnings() *scyllav1alpha1.ScyllaDBDatacenter {
+	return &scyllav1alpha1.ScyllaDBDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "basic",
+			UID:  "the-uid",
+		},
+		Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
+			ClusterName:    "basic",
+			DatacenterName: pointer.Ptr("dc"),
+			ScyllaDB: scyllav1alpha1.ScyllaDB{
+				Image: unit.ScyllaDBImage,
+			},
+			Racks: []scyllav1alpha1.RackSpec{
+				{
+					Name: "rack",
+				},
+			},
+		},
+	}
+}
+
+func TestGetWarningsOnScyllaDBDatacenterCreate(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name             string
+		datacenter       *scyllav1alpha1.ScyllaDBDatacenter
+		expectedWarnings []string
+	}{
+		{
+			name:             "no warnings",
+			datacenter:       newValidScyllaDBDatacenterForWarnings(),
+			expectedWarnings: nil,
+		},
+		{
+			name: "cql expose options deprecation warning",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.ExposeOptions = &scyllav1alpha1.ExposeOptions{
+					CQL: &scyllav1alpha1.CQLExposeOptions{},
+				}
+				return sdc
+			}(),
+			expectedWarnings: []string{
+				"`spec.exposeOptions.cql` field is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			warnings := validation.GetWarningsOnScyllaDBDatacenterCreate(tc.datacenter)
+			if !reflect.DeepEqual(tc.expectedWarnings, warnings) {
+				t.Errorf("expected and actual warnings differ: %s", cmp.Diff(tc.expectedWarnings, warnings))
+			}
+		})
+	}
+}
+
+func TestGetWarningsOnScyllaDBDatacenterUpdate(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name             string
+		oldSDC           *scyllav1alpha1.ScyllaDBDatacenter
+		newSDC           *scyllav1alpha1.ScyllaDBDatacenter
+		expectedWarnings []string
+	}{
+		{
+			name:             "no warnings",
+			oldSDC:           newValidScyllaDBDatacenterForWarnings(),
+			newSDC:           newValidScyllaDBDatacenterForWarnings(),
+			expectedWarnings: nil,
+		},
+		{
+			name:   "cql expose options deprecation warning",
+			oldSDC: newValidScyllaDBDatacenterForWarnings(),
+			newSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.ExposeOptions = &scyllav1alpha1.ExposeOptions{
+					CQL: &scyllav1alpha1.CQLExposeOptions{},
+				}
+				return sdc
+			}(),
+			expectedWarnings: []string{
+				"`spec.exposeOptions.cql` field is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			warnings := validation.GetWarningsOnScyllaDBDatacenterUpdate(tc.newSDC, tc.oldSDC)
+			if !reflect.DeepEqual(tc.expectedWarnings, warnings) {
+				t.Errorf("expected and actual warnings differ: %s", cmp.Diff(tc.expectedWarnings, warnings))
+			}
+		})
+	}
+}

--- a/pkg/api/scylla/validation/scylladbmonitoring_validation.go
+++ b/pkg/api/scylla/validation/scylladbmonitoring_validation.go
@@ -44,6 +44,13 @@ func GetWarningsOnScyllaDBMonitoringUpdate(new, _ *scyllav1alpha1.ScyllaDBMonito
 func getWarningsForScyllaDBMonitoringSpec(spec scyllav1alpha1.ScyllaDBMonitoringSpec, fldPath *field.Path) []string {
 	var warnings []string
 
+	if spec.Type != nil && *spec.Type == scyllav1alpha1.ScyllaDBMonitoringTypeSAAS {
+		warnings = append(warnings, fmt.Sprintf(
+			"`%s` = `SaaS` is deprecated and will be removed in future releases, please use `Platform` instead.",
+			fldPath.Child("type"),
+		))
+	}
+
 	if spec.Components != nil {
 		warnings = append(warnings, getWarningsForScyllaDBMonitoringComponents(*spec.Components, fldPath.Child("components"))...)
 	}

--- a/pkg/api/scylla/validation/scylladbmonitoring_validation_test.go
+++ b/pkg/api/scylla/validation/scylladbmonitoring_validation_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -481,6 +482,35 @@ func TestGetWarningsOnScyllaDBMonitoringCreate(t *testing.T) {
 				"`spec.components.prometheus.exposeOptions` field is deprecated and will be removed in future releases, please expose managed Prometheus Service on your own (e.g., via Ingress or HTTPRoute).",
 			},
 		},
+		{
+			name: "warning on spec.type = SaaS",
+			sm: func() *scyllav1alpha1.ScyllaDBMonitoring {
+				sm := validScyllaDBMonitoringWithExternalPrometheus()
+				sm.Spec.Type = pointer.Ptr(scyllav1alpha1.ScyllaDBMonitoringTypeSAAS)
+				return sm
+			}(),
+			expectedWarning: []string{
+				"`spec.type` = `SaaS` is deprecated and will be removed in future releases, please use `Platform` instead.",
+			},
+		},
+		{
+			name: "no warning on spec.type = Platform",
+			sm: func() *scyllav1alpha1.ScyllaDBMonitoring {
+				sm := validScyllaDBMonitoringWithExternalPrometheus()
+				sm.Spec.Type = pointer.Ptr(scyllav1alpha1.ScyllaDBMonitoringTypePlatform)
+				return sm
+			}(),
+			expectedWarning: nil,
+		},
+		{
+			name: "no warning on nil spec.type",
+			sm: func() *scyllav1alpha1.ScyllaDBMonitoring {
+				sm := validScyllaDBMonitoringWithExternalPrometheus()
+				sm.Spec.Type = nil
+				return sm
+			}(),
+			expectedWarning: nil,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -598,6 +628,28 @@ func TestGetWarningsOnScyllaDBMonitoringUpdate(t *testing.T) {
 			}(),
 			expectedWarning: []string{
 				"`spec.components.prometheus.exposeOptions` field is deprecated and will be removed in future releases, please expose managed Prometheus Service on your own (e.g., via Ingress or HTTPRoute).",
+			},
+		},
+		{
+			name: "no warning on spec.type = SaaS in old monitoring",
+			old: func() *scyllav1alpha1.ScyllaDBMonitoring {
+				sm := validScyllaDBMonitoringWithExternalPrometheus()
+				sm.Spec.Type = pointer.Ptr(scyllav1alpha1.ScyllaDBMonitoringTypeSAAS)
+				return sm
+			}(),
+			new:             validScyllaDBMonitoringWithExternalPrometheus(),
+			expectedWarning: nil,
+		},
+		{
+			name: "warning on spec.type = SaaS in new monitoring",
+			old:  validScyllaDBMonitoringWithExternalPrometheus(),
+			new: func() *scyllav1alpha1.ScyllaDBMonitoring {
+				sm := validScyllaDBMonitoringWithExternalPrometheus()
+				sm.Spec.Type = pointer.Ptr(scyllav1alpha1.ScyllaDBMonitoringTypeSAAS)
+				return sm
+			}(),
+			expectedWarning: []string{
+				"`spec.type` = `SaaS` is deprecated and will be removed in future releases, please use `Platform` instead.",
 			},
 		},
 	}

--- a/pkg/controller/scylladbmonitoring/sync_grafana_test.go
+++ b/pkg/controller/scylladbmonitoring/sync_grafana_test.go
@@ -192,13 +192,13 @@ func Test_makeGrafanaDashboards(t *testing.T) {
 	}
 	tt := []testEntry{
 		{
-			name: "renders data for default SaaS type",
+			name: "renders data for SaaS type",
 			sm: &scyllav1alpha1.ScyllaDBMonitoring{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "sm-name",
 				},
 				Spec: scyllav1alpha1.ScyllaDBMonitoringSpec{
-					Type: nil,
+					Type: pointer.Ptr(scyllav1alpha1.ScyllaDBMonitoringTypeSAAS),
 				},
 			},
 			expectedConfigMaps: []*corev1.ConfigMap{
@@ -228,6 +228,19 @@ func Test_makeGrafanaDashboards(t *testing.T) {
 				},
 				Spec: scyllav1alpha1.ScyllaDBMonitoringSpec{
 					Type: pointer.Ptr(scyllav1alpha1.ScyllaDBMonitoringTypePlatform),
+				},
+			},
+			expectedConfigMaps: getExpectedPlatformConfigMaps("sm-name"),
+			expectedErr:        nil,
+		},
+		{
+			name: "renders data for default (nil) type",
+			sm: &scyllav1alpha1.ScyllaDBMonitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sm-name",
+				},
+				Spec: scyllav1alpha1.ScyllaDBMonitoringSpec{
+					Type: nil,
 				},
 			},
 			expectedConfigMaps: getExpectedPlatformConfigMaps("sm-name"),
@@ -278,6 +291,202 @@ func Test_makeGrafanaDeployment(t *testing.T) {
 		},
 	}
 
+	platformDashboardsCMs := []*corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sm-name-grafana-scylladb-dashboards-scylladb-6.0",
+				Annotations: map[string]string{
+					"internal.scylla-operator.scylladb.com/dashboard-name": "scylladb-6.0",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sm-name-grafana-scylladb-dashboards-scylladb-6.1",
+				Annotations: map[string]string{
+					"internal.scylla-operator.scylladb.com/dashboard-name": "scylladb-6.1",
+				},
+			},
+		},
+	}
+
+	platformExpectedDeploymentYAML := strings.TrimLeft(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "sm-name-grafana"
+spec:
+  selector:
+    matchLabels:
+      scylla-operator.scylladb.com/deployment-name: "sm-name-grafana"
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        scylla-operator.scylladb.com/inputs-hash: "restart-trigger-hash"
+      labels:
+        scylla-operator.scylladb.com/deployment-name: "sm-name-grafana"
+    spec:
+      serviceAccountName: "sm-name-grafana"
+      affinity:
+        {}
+      tolerations:
+        null
+      initContainers:
+      - name: gzip
+        image: "bash-tools-image"
+        command:
+        - /usr/bin/bash
+        - -euExo
+        - pipefail
+        - -O
+        - inherit_errexit
+        - -c
+        args:
+        - |
+          mkdir /var/run/decompressed-configmaps/grafana-scylladb-dashboards
+          find /var/run/configmaps -mindepth 2 -maxdepth 2 -type d | while read -r d; do
+            tp="/var/run/decompressed-configmaps/${d#"/var/run/configmaps/"}"
+            mkdir "${tp}"
+            find "${d}" -mindepth 1 -maxdepth 1 -name '*.gz.base64' -exec cp -L -t "${tp}" {} +
+          done
+          find /var/run/decompressed-configmaps -name '*.gz.base64' | while read -r f; do
+            base64 -d "${f}" > "${f%.base64}"
+            rm "${f}"
+          done
+          find /var/run/decompressed-configmaps -name '*.gz' -exec gzip -d {} +
+        volumeMounts:
+        - name: decompressed-configmaps
+          mountPath: /var/run/decompressed-configmaps
+        - name: "scylladb-6-0"
+          mountPath: "/var/run/configmaps/grafana-scylladb-dashboards/scylladb-6.0"
+        - name: "scylladb-6-1"
+          mountPath: "/var/run/configmaps/grafana-scylladb-dashboards/scylladb-6.1"
+      containers:
+      - name: grafana
+        image: "grafana-image"
+        command:
+        - grafana-server
+        - --packaging=docker
+        - --homepath=/usr/share/grafana
+        - --config=/var/run/configmaps/grafana-configs/grafana.ini
+        env:
+        - name: GF_PATHS_PROVISIONING
+        - name: GF_PATHS_HOME
+        - name: GF_PATHS_DATA
+        - name: GF_PATHS_LOGS
+        - name: GF_PATHS_PLUGINS
+        - name: GF_PATHS_CONFIG
+        ports:
+        - containerPort: 3000
+          name: grafana
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 1
+          httpGet:
+            path: /api/health
+            port: 3000
+            scheme: HTTPS
+        livenessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 10
+          httpGet:
+            path: /api/health
+            port: 3000
+            scheme: HTTPS
+        resources:
+          {}
+        volumeMounts:
+        - name: grafana-configs
+          mountPath: /var/run/configmaps/grafana-configs
+        - name: decompressed-configmaps
+          mountPath: /var/run/dashboards/scylladb
+          subPath: grafana-scylladb-dashboards
+        - name: grafana-provisioning
+          mountPath: /var/run/configmaps/grafana-provisioning/access-control/access-control.yaml
+          subPath: access-control.yaml
+        - name: grafana-provisioning
+          mountPath: /var/run/configmaps/grafana-provisioning/alerting/alerting.yaml
+          subPath: alerting.yaml
+        - name: grafana-provisioning
+          mountPath: /var/run/configmaps/grafana-provisioning/dashboards/dashboards.yaml
+          subPath: dashboards.yaml
+        - name: grafana-provisioning
+          mountPath: /var/run/configmaps/grafana-provisioning/datasources/datasources.yaml
+          subPath: datasources.yaml
+        - name: grafana-provisioning
+          mountPath: /var/run/configmaps/grafana-provisioning/notifiers/notifiers.yaml
+          subPath: notifiers.yaml
+        - name: grafana-provisioning
+          mountPath: /var/run/configmaps/grafana-provisioning/plugins/plugins.yaml
+          subPath: plugins.yaml
+        - name: grafana-admin-credentials
+          mountPath: /var/run/secrets/grafana-admin-credentials
+        - name: grafana-serving-certs
+          mountPath: /var/run/secrets/grafana-serving-certs
+        - name: prometheus-client-certs
+          mountPath: /var/run/secrets/prometheus-client-certs
+        - name: prometheus-serving-ca
+          mountPath: /var/run/configmaps/prometheus-serving-ca
+        - name: grafana-storage
+          mountPath: /var/lib/grafana
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 472
+          runAsGroup: 472
+          capabilities:
+            drop:
+            - ALL
+      volumes:
+      - name: decompressed-configmaps
+        emptyDir:
+          sizeLimit: 50Mi
+      - name: grafana-configs
+        configMap:
+          name: "sm-name-grafana-configs"
+      - name: "scylladb-6-0"
+        configMap:
+          name: "sm-name-grafana-scylladb-dashboards-scylladb-6.0"
+      - name: "scylladb-6-1"
+        configMap:
+          name: "sm-name-grafana-scylladb-dashboards-scylladb-6.1"
+      - name: grafana-provisioning
+        configMap:
+          name: "sm-name-grafana-provisioning"
+      - name: grafana-admin-credentials
+        secret:
+          secretName: "sm-name-grafana-admin-credentials"
+      - name: grafana-serving-certs
+        secret:
+          secretName: "serving-secret"
+      - name: prometheus-client-certs
+        secret:
+          secretName: "sm-name-prometheus-client-grafana-2w56m"
+      - name: prometheus-serving-ca
+        configMap:
+          name: "sm-name-prometheus-serving-ca-3ah2z"
+      - name: grafana-storage
+        emptyDir:
+          sizeLimit: 100Mi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 472
+        runAsGroup: 472
+        fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault
+`, "\n")
+
 	tt := []struct {
 		name                         string
 		sm                           *scyllav1alpha1.ScyllaDBMonitoring
@@ -289,13 +498,13 @@ func Test_makeGrafanaDeployment(t *testing.T) {
 		expectedErr                  error
 	}{
 		{
-			name: "renders data for default SaaS type",
+			name: "renders data for SaaS type",
 			sm: &scyllav1alpha1.ScyllaDBMonitoring{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "sm-name",
 				},
 				Spec: scyllav1alpha1.ScyllaDBMonitoringSpec{
-					Type: nil,
+					Type: pointer.Ptr(scyllav1alpha1.ScyllaDBMonitoringTypeSAAS),
 				},
 			},
 			soc:                          defaultSOC,
@@ -496,202 +705,27 @@ spec:
 			},
 			soc:                          defaultSOC,
 			grafanaServingCertSecretName: "serving-secret",
-			dashboardsCMs: []*corev1.ConfigMap{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "sm-name-grafana-scylladb-dashboards-scylladb-6.0",
-						Annotations: map[string]string{
-							"internal.scylla-operator.scylladb.com/dashboard-name": "scylladb-6.0",
-						},
-					},
+			dashboardsCMs:                platformDashboardsCMs,
+			restartTriggerHash:           "restart-trigger-hash",
+			expectedString:               platformExpectedDeploymentYAML,
+			expectedErr:                  nil,
+		},
+		{
+			name: "renders data for default (nil) type",
+			sm: &scyllav1alpha1.ScyllaDBMonitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sm-name",
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "sm-name-grafana-scylladb-dashboards-scylladb-6.1",
-						Annotations: map[string]string{
-							"internal.scylla-operator.scylladb.com/dashboard-name": "scylladb-6.1",
-						},
-					},
+				Spec: scyllav1alpha1.ScyllaDBMonitoringSpec{
+					Type: nil,
 				},
 			},
-			restartTriggerHash: "restart-trigger-hash",
-			expectedString: strings.TrimLeft(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: "sm-name-grafana"
-spec:
-  selector:
-    matchLabels:
-      scylla-operator.scylladb.com/deployment-name: "sm-name-grafana"
-  strategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        scylla-operator.scylladb.com/inputs-hash: "restart-trigger-hash"
-      labels:
-        scylla-operator.scylladb.com/deployment-name: "sm-name-grafana"
-    spec:
-      serviceAccountName: "sm-name-grafana"
-      affinity:
-        {}
-      tolerations:
-        null
-      initContainers:
-      - name: gzip
-        image: "bash-tools-image"
-        command:
-        - /usr/bin/bash
-        - -euExo
-        - pipefail
-        - -O
-        - inherit_errexit
-        - -c
-        args:
-        - |
-          mkdir /var/run/decompressed-configmaps/grafana-scylladb-dashboards
-          find /var/run/configmaps -mindepth 2 -maxdepth 2 -type d | while read -r d; do
-            tp="/var/run/decompressed-configmaps/${d#"/var/run/configmaps/"}"
-            mkdir "${tp}"
-            find "${d}" -mindepth 1 -maxdepth 1 -name '*.gz.base64' -exec cp -L -t "${tp}" {} +
-          done
-          find /var/run/decompressed-configmaps -name '*.gz.base64' | while read -r f; do
-            base64 -d "${f}" > "${f%.base64}"
-            rm "${f}"
-          done
-          find /var/run/decompressed-configmaps -name '*.gz' -exec gzip -d {} +
-        volumeMounts:
-        - name: decompressed-configmaps
-          mountPath: /var/run/decompressed-configmaps
-        - name: "scylladb-6-0"
-          mountPath: "/var/run/configmaps/grafana-scylladb-dashboards/scylladb-6.0"
-        - name: "scylladb-6-1"
-          mountPath: "/var/run/configmaps/grafana-scylladb-dashboards/scylladb-6.1"
-      containers:
-      - name: grafana
-        image: "grafana-image"
-        command:
-        - grafana-server
-        - --packaging=docker
-        - --homepath=/usr/share/grafana
-        - --config=/var/run/configmaps/grafana-configs/grafana.ini
-        env:
-        - name: GF_PATHS_PROVISIONING
-        - name: GF_PATHS_HOME
-        - name: GF_PATHS_DATA
-        - name: GF_PATHS_LOGS
-        - name: GF_PATHS_PLUGINS
-        - name: GF_PATHS_CONFIG
-        ports:
-        - containerPort: 3000
-          name: grafana
-          protocol: TCP
-        readinessProbe:
-          initialDelaySeconds: 10
-          periodSeconds: 30
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 1
-          httpGet:
-            path: /api/health
-            port: 3000
-            scheme: HTTPS
-        livenessProbe:
-          initialDelaySeconds: 30
-          periodSeconds: 30
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 10
-          httpGet:
-            path: /api/health
-            port: 3000
-            scheme: HTTPS
-        resources:
-          {}
-        volumeMounts:
-        - name: grafana-configs
-          mountPath: /var/run/configmaps/grafana-configs
-        - name: decompressed-configmaps
-          mountPath: /var/run/dashboards/scylladb
-          subPath: grafana-scylladb-dashboards
-        - name: grafana-provisioning
-          mountPath: /var/run/configmaps/grafana-provisioning/access-control/access-control.yaml
-          subPath: access-control.yaml
-        - name: grafana-provisioning
-          mountPath: /var/run/configmaps/grafana-provisioning/alerting/alerting.yaml
-          subPath: alerting.yaml
-        - name: grafana-provisioning
-          mountPath: /var/run/configmaps/grafana-provisioning/dashboards/dashboards.yaml
-          subPath: dashboards.yaml
-        - name: grafana-provisioning
-          mountPath: /var/run/configmaps/grafana-provisioning/datasources/datasources.yaml
-          subPath: datasources.yaml
-        - name: grafana-provisioning
-          mountPath: /var/run/configmaps/grafana-provisioning/notifiers/notifiers.yaml
-          subPath: notifiers.yaml
-        - name: grafana-provisioning
-          mountPath: /var/run/configmaps/grafana-provisioning/plugins/plugins.yaml
-          subPath: plugins.yaml
-        - name: grafana-admin-credentials
-          mountPath: /var/run/secrets/grafana-admin-credentials
-        - name: grafana-serving-certs
-          mountPath: /var/run/secrets/grafana-serving-certs
-        - name: prometheus-client-certs
-          mountPath: /var/run/secrets/prometheus-client-certs
-        - name: prometheus-serving-ca
-          mountPath: /var/run/configmaps/prometheus-serving-ca
-        - name: grafana-storage
-          mountPath: /var/lib/grafana
-        securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
-          runAsNonRoot: true
-          runAsUser: 472
-          runAsGroup: 472
-          capabilities:
-            drop:
-            - ALL
-      volumes:
-      - name: decompressed-configmaps
-        emptyDir:
-          sizeLimit: 50Mi
-      - name: grafana-configs
-        configMap:
-          name: "sm-name-grafana-configs"
-      - name: "scylladb-6-0"
-        configMap:
-          name: "sm-name-grafana-scylladb-dashboards-scylladb-6.0"
-      - name: "scylladb-6-1"
-        configMap:
-          name: "sm-name-grafana-scylladb-dashboards-scylladb-6.1"
-      - name: grafana-provisioning
-        configMap:
-          name: "sm-name-grafana-provisioning"
-      - name: grafana-admin-credentials
-        secret:
-          secretName: "sm-name-grafana-admin-credentials"
-      - name: grafana-serving-certs
-        secret:
-          secretName: "serving-secret"
-      - name: prometheus-client-certs
-        secret:
-          secretName: "sm-name-prometheus-client-grafana-2w56m"
-      - name: prometheus-serving-ca
-        configMap:
-          name: "sm-name-prometheus-serving-ca-3ah2z"
-      - name: grafana-storage
-        emptyDir:
-          sizeLimit: 100Mi
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 472
-        runAsGroup: 472
-        fsGroup: 472
-        seccompProfile:
-          type: RuntimeDefault
-`, "\n"),
-			expectedErr: nil,
+			soc:                          defaultSOC,
+			grafanaServingCertSecretName: "serving-secret",
+			dashboardsCMs:                platformDashboardsCMs,
+			restartTriggerHash:           "restart-trigger-hash",
+			expectedString:               platformExpectedDeploymentYAML,
+			expectedErr:                  nil,
 		},
 		{
 			name: "external prometheus datasource",


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Deprecates `ScyllaCluster`/`ScyllaDBDatacenter` `spec.exposeOptions.cql` and `ScyllaDBMonitoring.spec.type = SaaS`, and flips the `ScyllaDBMonitoring.spec.type` default from `SaaS` to `Platform`. Existing `ScyllaDBMonitoring` objects that omit `spec.type` will render `Platform` dashboards after the upgrade; `exposeOptions.cql` continues to work with an admission warning.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-92

/kind api-change
/priority important-longterm
