### PR TITLE
chore(renovate): fix scylla-monitoring bumps in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,27 +84,29 @@
       ]
     },
     {
-      "description": "Monitoring dependencies should be grouped and updated every weekday",
+      "description": "prometheus-operator dependency should be updated every weekday",
       "matchDepNames": [
-        "scylladb/scylla-monitoring",
         "prometheus-operator"
       ],
-      "groupName": "monitoring",
       "schedule": [
         "before 5am every weekday"
       ],
+      "addLabels": [
+        "do-not-merge/hold"
+      ],
       "prBodyNotes": [
         "### ⚠️ Manual Action Required",
-        "Renovate has bumped a monitoring dependency, but cannot automatically regenerate the manifests.",
+        "Renovate has bumped the prometheus-operator dependency, but cannot automatically regenerate the manifests.",
         "",
         "**Please complete the following steps before merging:**",
         "1. Check out this branch locally.",
         "2. Propagate changes by running:",
         "   ```bash",
         "   make update",
-        "   git add .",
+        "   git add pkg/thirdparty/github.com/prometheus-operator/ examples/third-party/prometheus-operator.yaml",
         "   git commit -m \"chore(deps): update generated files\" && git push --force",
-        "   ```"
+        "   ```",
+        "3. Remove the `do-not-merge/hold` label."
       ]
     },
     {
@@ -147,11 +149,15 @@
       ]
     },
     {
+      "description": "scylla-monitoring submodule dependency should be updated every weekday",
       "matchManagers": [
         "regex"
       ],
       "matchDepNames": [
         "scylladb/scylla-monitoring"
+      ],
+      "schedule": [
+        "before 5am every weekday"
       ],
       "addLabels": [
         "do-not-merge/hold"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
The `scylladb/scylla-monitoring` dep matched both the "monitoring" packageRule (by depName) and the submodule regex packageRule (by manager + depName), causing Renovate to concatenate both rules' `prBodyNotes` into a garbled PR body (see #3399).

This PR fixes the rules by scoping the monitoring rule to `prometheus-operator` only.


**Which issue is resolved by this Pull Request:**
Resolves #

/priority important-longterm
/kind machinery
/cc czeslavo
