### PR TITLE
test: switch test suites to pure label-based selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -780,7 +780,11 @@ verify-config:
 	$(diff) "$(tmp_dir)/config.yaml" ./assets/config/config.yaml || (echo 'Config is not up to date. Please run `make update-config` to update it.' && false)
 .PHONY: verify-config
 
-verify: verify-codegen verify-crds verify-helm-schemas verify-helm-charts verify-deploy verify-lint verify-helm-lint verify-links verify-examples verify-docs-api verify-monitoring verify-bundle verify-renovate-config verify-in-tree-prometheus-operator-exports verify-config
+verify-e2e-suite-coverage:
+	./hack/verify-e2e-suite-coverage.sh
+.PHONY: verify-e2e-suite-coverage
+
+verify: verify-codegen verify-crds verify-helm-schemas verify-helm-charts verify-deploy verify-lint verify-helm-lint verify-links verify-examples verify-docs-api verify-monitoring verify-bundle verify-renovate-config verify-in-tree-prometheus-operator-exports verify-config verify-e2e-suite-coverage
 .PHONY: verify
 
 update: update-codegen update-crds update-helm-schemas update-helm-charts update-deploy update-examples update-docs-api update-monitoring update-bundle update-go-mod-replace update-renovate-config update-in-tree-prometheus-operator-exports update-config

--- a/hack/list-e2e-suite-test-cases.sh
+++ b/hack/list-e2e-suite-test-cases.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# list-e2e-suite-test-cases.sh prints the test cases (Ginkgo spec FullTexts)
+# selected by a given scylla-operator test suite, one per line, sorted and
+# deduplicated.
+#
+# Usage:
+#   hack/list-e2e-suite-test-cases.sh <exact-suite-name>
+#
+# The suite name must match an entry in pkg/cmd/tests/tests.go exactly; no
+# aliases are accepted.
+
+set -euEo pipefail
+shopt -s inherit_errexit
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <exact-suite-name>" >&2
+    exit 2
+fi
+
+suite="$1"
+
+for dep in go jq; do
+    if ! command -v "${dep}" >/dev/null 2>&1; then
+        echo "${dep} is required but not found in PATH" >&2
+        exit 2
+    fi
+done
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+tmp_dir="$( mktemp -d )"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+# The binary's output is captured and only replayed to stderr if the run fails,
+# so a successful invocation produces only the spec list on stdout and nothing on stderr.
+binary_log="${tmp_dir}/scylla-operator-tests.log"
+if ! (
+    cd "${repo_root}"
+    go run ./cmd/scylla-operator-tests run \
+        --dry-run \
+        --artifacts-dir="${tmp_dir}" \
+        "${suite}"
+) > "${binary_log}" 2>&1; then
+    echo "scylla-operator-tests dry-run for suite ${suite} failed; output:" >&2
+    cat "${binary_log}" >&2
+    exit 1
+fi
+
+# Extract FullText: ContainerHierarchyTexts joined by " " + " " + LeafNodeText.
+jq -r '
+    .[0].SpecReports[]
+    | select(.LeafNodeType == "It" and .State == "passed")
+    | (((.ContainerHierarchyTexts // []) + [.LeafNodeText]) | join(" "))
+' "${tmp_dir}/e2e.json" \
+    | sort -u

--- a/hack/verify-e2e-suite-coverage.sh
+++ b/hack/verify-e2e-suite-coverage.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# verify-e2e-suite-coverage.sh asserts that every Ginkgo spec in the e2e test
+# tree is selected by at least one registered scylla-operator test suite (other
+# than "all"). It guards the pure-suite-label model: a spec missing its suite
+# label would be silently excluded from every CI run while still being picked
+# up by the special "all" suite.
+
+set -euEo pipefail
+shopt -s inherit_errexit
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+list_script="${repo_root}/hack/list-e2e-suite-test-cases.sh"
+
+tmp_dir="$( mktemp -d )"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+suites="$( cd "${repo_root}" && go run ./cmd/scylla-operator-tests list-suites )"
+if [[ -z "${suites}" ]]; then
+    echo "scylla-operator-tests list-suites produced no output" >&2
+    exit 1
+fi
+
+all_list="${tmp_dir}/all.list"
+union_raw="${tmp_dir}/union.raw"
+union_list="${tmp_dir}/union.list"
+
+echo "Listing test cases for suite all..." >&2
+"${list_script}" all > "${all_list}"
+if [[ ! -s "${all_list}" ]]; then
+    echo "the \"all\" suite produced no test cases; this is unexpected" >&2
+    exit 1
+fi
+
+while IFS= read -r suite; do
+    [[ "${suite}" == "all" ]] && continue
+    echo "Listing test cases for suite ${suite}..." >&2
+    "${list_script}" "${suite}" >> "${union_raw}"
+done <<< "${suites}"
+
+sort -u "${union_raw}" -o "${union_list}"
+
+uncovered="$( comm -23 "${all_list}" "${union_list}" )"
+if [[ -n "${uncovered}" ]]; then
+    echo >&2
+    echo "FAIL: the following test case(s) are not selected by any non-\"all\" suite:" >&2
+    printf '  %s\n' "${uncovered}" >&2
+    echo >&2
+    echo "Every spec must be labeled with at least one suite. See test/e2e/framework/meta.go for the suite labels." >&2
+    exit 1
+fi
+
+echo "All test cases are covered by at least one registered suite." >&2

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -72,6 +72,7 @@ type TestFrameworkOptions struct {
 	ScyllaDBManagerAgentVersion string
 	ScyllaDBUpdateFrom          string
 	ScyllaDBUpgradeFrom         string
+	DryRun                      bool
 }
 
 func NewTestFrameworkOptions(streams genericclioptions.IOStreams, userAgent string) *TestFrameworkOptions {
@@ -146,9 +147,13 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 func (o *TestFrameworkOptions) Validate(args []string) error {
 	var errors []error
 
-	err := o.MultiDatacenterClientConfig.Validate()
-	if err != nil {
-		errors = append(errors, err)
+	// In dry-run mode no spec body executes, so client configs aren't accessed.
+	// Skip validating them so dry-run can run without a kubeconfig.
+	if !o.DryRun {
+		err := o.MultiDatacenterClientConfig.Validate()
+		if err != nil {
+			errors = append(errors, err)
+		}
 	}
 
 	switch p := framework.CleanupPolicyType(o.CleanupPolicyUntyped); p {
@@ -217,7 +222,7 @@ func (o *TestFrameworkOptions) Validate(args []string) error {
 	}
 
 	if len(o.ArtifactsDir) > 0 {
-		_, err = os.Stat(o.ArtifactsDir)
+		_, err := os.Stat(o.ArtifactsDir)
 		if err != nil {
 			if os.IsNotExist(err) {
 				errors = append(errors, fmt.Errorf("artifacts directory %q does not exist", o.ArtifactsDir))
@@ -231,8 +236,12 @@ func (o *TestFrameworkOptions) Validate(args []string) error {
 }
 
 func (o *TestFrameworkOptions) Complete(args []string) error {
-	if err := o.MultiDatacenterClientConfig.Complete(); err != nil {
-		return fmt.Errorf("can't complete multi-datacenter client config: %w", err)
+	// In dry-run mode no spec body executes, so client configs aren't accessed.
+	// Skip completing them so dry-run can run without a kubeconfig.
+	if !o.DryRun {
+		if err := o.MultiDatacenterClientConfig.Complete(); err != nil {
+			return fmt.Errorf("can't complete multi-datacenter client config: %w", err)
+		}
 	}
 	if err := o.ObjectStorageOptions.Complete(); err != nil {
 		return fmt.Errorf("can't complete object storage options: %w", err)

--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -20,6 +20,8 @@ const (
 	EnvVarPrefix = "SCYLLA_OPERATOR_TESTS_"
 )
 
+// Suites is the canonical list of scylla-operator test suites.
+// Each suite (other than "all") declares membership through a single Ginkgo label.
 var Suites = ginkgotest.TestSuites{
 	{
 		Name: "all",
@@ -33,13 +35,7 @@ var Suites = ginkgotest.TestSuites{
 		Description: templates.LongDesc(`
 		Tests that can be run in parallel.
 		`),
-		LabelFilter: fmt.Sprintf(
-			"!%s && !%s && !%s && !%s",
-			framework.SerialLabelName,
-			framework.MultiDatacenterLabelName,
-			framework.SupportedOnlyOnOpenShiftLabelName,
-			framework.IPv6LabelName,
-		),
+		LabelFilter:        framework.SuiteParallelLabelName,
 		DefaultParallelism: 70,
 	},
 	{
@@ -47,13 +43,7 @@ var Suites = ginkgotest.TestSuites{
 		Description: templates.LongDesc(`
 		Tests that can be run in parallel on an OpenShift cluster.
 		`),
-		LabelFilter: fmt.Sprintf(
-			"!%s && !%s && !%s && !%s",
-			framework.SerialLabelName,
-			framework.MultiDatacenterLabelName,
-			framework.NotSupportedOnOpenShiftLabelName,
-			framework.IPv6LabelName,
-		),
+		LabelFilter:        framework.SuiteParallelOpenShiftLabelName,
 		DefaultParallelism: 70,
 	},
 	{
@@ -61,11 +51,7 @@ var Suites = ginkgotest.TestSuites{
 		Description: templates.LongDesc(`
 		Tests that must be run serially.
 		`),
-		LabelFilter: fmt.Sprintf(
-			"%s && !%s",
-			framework.SerialLabelName,
-			framework.SupportedOnlyOnOpenShiftLabelName,
-		),
+		LabelFilter:        framework.SuiteSerialLabelName,
 		DefaultParallelism: 1,
 	},
 	{
@@ -73,11 +59,7 @@ var Suites = ginkgotest.TestSuites{
 		Description: templates.LongDesc(`
 		Tests for multi-datacenter setups that can be run in parallel.
 		`),
-		LabelFilter: fmt.Sprintf(
-			"%s && !%s",
-			framework.MultiDatacenterLabelName,
-			framework.SupportedOnlyOnOpenShiftLabelName,
-		),
+		LabelFilter:        framework.SuiteMultiDatacenterParallelLabelName,
 		DefaultParallelism: 10,
 	},
 	{
@@ -85,7 +67,7 @@ var Suites = ginkgotest.TestSuites{
 		Description: templates.LongDesc(`
 		Tests that ensure Scylla Operator is working properly with IPv6 and dual-stack networking.
 		`),
-		LabelFilter:        fmt.Sprintf("%s", framework.IPv6LabelName),
+		LabelFilter:        framework.SuiteParallelIPv6LabelName,
 		DefaultParallelism: 10,
 	},
 	{
@@ -93,16 +75,7 @@ var Suites = ginkgotest.TestSuites{
 		Description: templates.LongDesc(`
 		Relatively fast tests that can be run on kind clusters.
 		`),
-		LabelFilter: fmt.Sprintf(
-			"!%s && !%s && !%s && !%s && !%s && !%s && !%s",
-			framework.NotSupportedOnKindLabelName,
-			framework.LongRunningLabelName,
-			framework.RequiresObjectStorageLabelName,
-			framework.MultiDatacenterLabelName,
-			framework.SerialLabelName,
-			framework.SupportedOnlyOnOpenShiftLabelName,
-			framework.IPv6LabelName,
-		),
+		LabelFilter:        framework.SuiteKindFastLabelName,
 		DefaultParallelism: 60,
 	},
 }

--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -112,6 +112,7 @@ func NewTestsCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	userAgent := "scylla-operator-e2e"
 	cmd.AddCommand(versioncmd.NewCmd(streams))
 	cmd.AddCommand(NewRunCommand(streams, Suites, userAgent))
+	cmd.AddCommand(NewListSuitesCommand(streams, Suites))
 
 	// TODO: wrap help func for the root command and every subcommand to add a line about automatic env vars and the prefix.
 

--- a/pkg/cmd/tests/tests_listsuites.go
+++ b/pkg/cmd/tests/tests_listsuites.go
@@ -1,0 +1,36 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	ginkgotest "github.com/scylladb/scylla-operator/pkg/test/ginkgo"
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// NewListSuitesCommand returns a command that prints the names of all
+// registered test suites, one per line, on stdout.
+func NewListSuitesCommand(streams genericclioptions.IOStreams, testSuites ginkgotest.TestSuites) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "list-suites",
+		Long: templates.LongDesc(`
+		Prints the names of registered test suites, one per line.
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, name := range testSuites.Names() {
+				_, err := fmt.Fprintln(streams.Out, name)
+				if err != nil {
+					return fmt.Errorf("can't write suite name: %w", err)
+				}
+			}
+			return nil
+		},
+
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	return cmd
+}

--- a/pkg/cmd/tests/tests_run.go
+++ b/pkg/cmd/tests/tests_run.go
@@ -53,7 +53,6 @@ type RunOptions struct {
 	FocusStrings          []string
 	SkipStrings           []string
 	RandomSeed            int64
-	DryRun                bool
 	Color                 bool
 	Parallelism           int
 	ParallelShard         int
@@ -76,7 +75,6 @@ func NewRunOptions(streams genericclioptions.IOStreams, testSuites ginkgotest.Te
 		FocusStrings:          []string{},
 		SkipStrings:           []string{},
 		RandomSeed:            time.Now().Unix(),
-		DryRun:                false,
 		Color:                 true,
 		Parallelism:           0,
 		ParallelShard:         0,

--- a/test/e2e/framework/meta.go
+++ b/test/e2e/framework/meta.go
@@ -6,33 +6,29 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 )
 
+// Suite labels declare which test suite a spec belongs to. Every spec MUST be
+// labeled with at least one of these. A spec may belong to multiple suites.
 const (
-	SerialLabelName          = "Serial"
-	MultiDatacenterLabelName = "MultiDatacenter"
-	IPv6LabelName            = "IPv6"
-
-	RequiresObjectStorageLabelName    = "RequiresObjectStorage"
-	NotSupportedOnOpenShiftLabelName  = "NotSupportedOnOpenShift"
-	SupportedOnlyOnOpenShiftLabelName = "SupportedOnlyOnOpenShift"
-	NotSupportedOnKindLabelName       = "NotSupportedOnKind"
-	LongRunningLabelName              = "LongRunning"
+	SuiteParallelLabelName                = "SuiteParallel"
+	SuiteParallelOpenShiftLabelName       = "SuiteParallelOpenShift"
+	SuiteSerialLabelName                  = "SuiteSerial"
+	SuiteMultiDatacenterParallelLabelName = "SuiteMultiDatacenterParallel"
+	SuiteParallelIPv6LabelName            = "SuiteParallelIPv6"
+	SuiteKindFastLabelName                = "SuiteKindFast"
 )
 
 var (
-	Serial = []interface{}{
+	SuiteParallel                = g.Label(SuiteParallelLabelName)
+	SuiteParallelOpenShift       = g.Label(SuiteParallelOpenShiftLabelName)
+	SuiteMultiDatacenterParallel = g.Label(SuiteMultiDatacenterParallelLabelName)
+	SuiteParallelIPv6            = g.Label(SuiteParallelIPv6LabelName)
+	SuiteKindFast                = g.Label(SuiteKindFastLabelName)
+
+	// SuiteSerial bundles the Ginkgo serial-execution decorator with the
+	// suite label, so a single value is enough to mark a spec as part of the
+	// serial suite.
+	SuiteSerial = []interface{}{
 		g.Serial,
-		g.Label(SerialLabelName),
+		g.Label(SuiteSerialLabelName),
 	}
-	MultiDatacenter = g.Label(MultiDatacenterLabelName)
-	IPv6            = g.Label(IPv6LabelName)
-
-	RequiresObjectStorage    = g.Label(RequiresObjectStorageLabelName)
-	NotSupportedOnOpenShift  = g.Label(NotSupportedOnOpenShiftLabelName)
-	SupportedOnlyOnOpenShift = g.Label(SupportedOnlyOnOpenShiftLabelName)
-
-	// NotSupportedOnKind is a label is for tests not supported on kind clusters (e.g., due to lack of access to host filesystem).
-	NotSupportedOnKind = g.Label(NotSupportedOnKindLabelName)
-
-	// LongRunning is a label for tests that are long-running (over ~20 minutes).
-	LongRunning = g.Label(LongRunningLabelName)
 )

--- a/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_disksetup.go
@@ -36,7 +36,9 @@ var (
 	xfsVolumeSize = resource.MustParse("320M")
 )
 
-var _ = g.Describe("Node Setup", framework.Serial, framework.NotSupportedOnKind, func() {
+// Not part of SuiteKindFast: requires host-level disk operations (creating
+// loop devices, mkfs, mounts) that aren't available in kind clusters.
+var _ = g.Describe("Node Setup", framework.SuiteSerial, func() {
 	var (
 		f             *framework.Framework
 		ncTemplate    *scyllav1alpha1.NodeConfig

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -36,7 +36,9 @@ const (
 
 // These tests modify global resource affecting global cluster state.
 // They must not be run asynchronously with other tests.
-var _ = g.Describe("NodeConfig Optimizations", framework.Serial, framework.NotSupportedOnKind, func() {
+// Not part of SuiteKindFast: applies node-level performance tuning that
+// requires host kernel access not available in kind clusters.
+var _ = g.Describe("NodeConfig Optimizations", framework.SuiteSerial, func() {
 	var (
 		f             *framework.Framework
 		ncTemplate    *scyllav1alpha1.NodeConfig

--- a/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
+++ b/test/e2e/set/remotekubernetescluster/remotekubernetescluster_finalizer.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("RemoteKubernetesCluster finalizer", func() {
+var _ = g.Describe("RemoteKubernetesCluster finalizer", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/remotekubernetescluster/remotekubernetescluster_healthcheck.go
+++ b/test/e2e/set/remotekubernetescluster/remotekubernetescluster_healthcheck.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var _ = g.Describe("RemoteKubernetesCluster", func() {
+var _ = g.Describe("RemoteKubernetesCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	var (

--- a/test/e2e/set/scyllacluster/multidatacenter/scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/multidatacenter/scyllacluster_external_seeds.go
@@ -19,7 +19,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var _ = g.Describe("MultiDC cluster", framework.MultiDatacenter, func() {
+var _ = g.Describe("MultiDC cluster", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_alternator.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_alternator.go
@@ -60,7 +60,7 @@ func (movie Movie) GetKey() map[string]types.AttributeValue {
 	}
 }
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_auth.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_auth.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaCluster authentication", func() {
+var _ = g.Describe("ScyllaCluster authentication", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_coredumps.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_coredumps.go
@@ -30,7 +30,9 @@ const (
 	coredumpCollectionTimeout = 2 * time.Minute
 )
 
-var _ = g.Describe("ScyllaCluster coredumps", framework.Serial, framework.NotSupportedOnKind, func() {
+// Not part of SuiteKindFast: requires host-level coredump configuration
+// (sysctl, kernel.core_pattern) that isn't available in kind clusters.
+var _ = g.Describe("ScyllaCluster coredumps", framework.SuiteSerial, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_evictions.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_evictions.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("ScyllaCluster evictions", func() {
+var _ = g.Describe("ScyllaCluster evictions", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_expose.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_expose.go
@@ -41,7 +41,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
@@ -17,7 +17,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var _ = g.Describe("MultiDC cluster", func() {
+var _ = g.Describe("MultiDC cluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_hostid.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_hostid.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("ScyllaCluster HostID", func() {
+var _ = g.Describe("ScyllaCluster HostID", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_ipv6.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_ipv6.go
@@ -28,7 +28,7 @@ type ipv6TestEntry struct {
 	validateScyllaAddrs func(ctx context.Context, configClient *scyllaclient.ConfigClient, svc *corev1.Service, pod *corev1.Pod)
 }
 
-var _ = g.Describe("ScyllaCluster IPv6", framework.IPv6, func() {
+var _ = g.Describe("ScyllaCluster IPv6", framework.SuiteParallelIPv6, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_listen.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_listen.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/component-helpers/storage/volume"
 )
 
-var _ = g.Describe("ScyllaCluster Orphaned PV controller", func() {
+var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
@@ -19,7 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_restarts.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_restarts.go
@@ -27,7 +27,7 @@ const (
 	gracePeriod = utils.ScyllaDBTerminationTimeout + (7 * 24 * time.Hour)
 )
 
-var _ = g.Describe("ScyllaCluster graceful termination", func() {
+var _ = g.Describe("ScyllaCluster graceful termination", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_sa.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sa.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_shardawareness.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_sysctl.go
@@ -23,7 +23,8 @@ import (
 
 // Despite the sysctl configuration being a part of ScyllaCluster's API, it configures kernel parameters on the host.
 // Therefore, the test is disruptive and needs to run serially.
-var _ = g.Describe("ScyllaCluster sysctl", framework.Serial, framework.NotSupportedOnKind, func() {
+// Not part of SuiteKindFast: setting host sysctls isn't supported in kind clusters.
+var _ = g.Describe("ScyllaCluster sysctl", framework.SuiteSerial, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_tls.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_tls.go
@@ -36,7 +36,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_updates.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_updates.go
@@ -30,7 +30,7 @@ func addQuantity(lhs resource.Quantity, rhs resource.Quantity) *resource.Quantit
 	return &res
 }
 
-var _ = g.Describe("ScyllaCluster", func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_upgrades.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaCluster upgrades", func() {
+var _ = g.Describe("ScyllaCluster upgrades", framework.SuiteParallel, framework.SuiteParallelOpenShift, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {
@@ -136,35 +136,37 @@ var _ = g.Describe("ScyllaCluster upgrades", func() {
 			}
 		},
 		// Test 1 and 3 member rack to cover e.g. handling PDBs correctly.
+		// 3-member-rack entries are excluded from SuiteKindFast because they are long-running
+		// (~20+ minutes) and SuiteKindFast targets relatively quick tests.
 		g.Entry(describeEntry, &entry{
 			rackCount:       1,
 			rackSize:        1,
 			initialImageRef: framework.ScyllaDBImageRefForVersion(framework.TestContext.ScyllaDBUpdateFrom),
 			targetImageRef:  framework.ScyllaDBTargetImageRef(framework.TestContext.ScyllaDBImageRef, framework.TestContext.ScyllaDBVersion),
-		}),
+		}, framework.SuiteKindFast),
 		g.Entry(describeEntry, &entry{
 			rackCount:       1,
 			rackSize:        3,
 			initialImageRef: framework.ScyllaDBImageRefForVersion(framework.TestContext.ScyllaDBUpdateFrom),
 			targetImageRef:  framework.ScyllaDBTargetImageRef(framework.TestContext.ScyllaDBImageRef, framework.TestContext.ScyllaDBVersion),
-		}, framework.LongRunning),
+		}),
 		g.Entry(describeEntry, &entry{
 			rackCount:       1,
 			rackSize:        1,
 			initialImageRef: framework.ScyllaDBImageRefForVersion(framework.TestContext.ScyllaDBUpgradeFrom),
 			targetImageRef:  framework.ScyllaDBTargetImageRef(framework.TestContext.ScyllaDBImageRef, framework.TestContext.ScyllaDBVersion),
-		}),
+		}, framework.SuiteKindFast),
 		g.Entry(describeEntry, &entry{
 			rackCount:       1,
 			rackSize:        3,
 			initialImageRef: framework.ScyllaDBImageRefForVersion(framework.TestContext.ScyllaDBUpgradeFrom),
 			targetImageRef:  framework.ScyllaDBTargetImageRef(framework.TestContext.ScyllaDBImageRef, framework.TestContext.ScyllaDBVersion),
-		}, framework.LongRunning),
+		}),
 		g.Entry(describeEntry, &entry{
 			rackCount:       2,
 			rackSize:        3,
 			initialImageRef: framework.ScyllaDBImageRefForVersion(framework.TestContext.ScyllaDBUpgradeFrom),
 			targetImageRef:  framework.ScyllaDBTargetImageRef(framework.TestContext.ScyllaDBImageRef, framework.TestContext.ScyllaDBVersion),
-		}, framework.LongRunning),
+		}),
 	)
 })

--- a/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_webhooks.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 )
 
-var _ = g.Describe("ScyllaCluster's admission webhook", func() {
+var _ = g.Describe("ScyllaCluster's admission webhook", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("Scylla Manager integration", func() {
+var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -27,7 +27,8 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var _ = g.Describe("Scylla Manager integration", framework.RequiresObjectStorage, func() {
+// Not part of SuiteKindFast: requires external object storage configured on the cluster.
+var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framework.SuiteParallelOpenShift, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_boostrap.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter, func() {
+var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_config.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter, func() {
+var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_fault_tolerance.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_fault_tolerance.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.MultiDatacenter, func() {
+var _ = g.Describe("Multi datacenter ScyllaDBCluster", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_finalizer.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_finalizer.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("ScyllaDBCluster finalizer", framework.MultiDatacenter, func() {
+var _ = g.Describe("ScyllaDBCluster finalizer", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_globalmanager.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_globalmanager.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaDBCluster integration with global ScyllaDB Manager", framework.MultiDatacenter, func() {
+var _ = g.Describe("ScyllaDBCluster integration with global ScyllaDB Manager", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_replace.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_replace.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaDBCluster", framework.MultiDatacenter, func() {
+var _ = g.Describe("ScyllaDBCluster", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_upgrade.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_upgrade.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaDBCluster", framework.MultiDatacenter, func() {
+var _ = g.Describe("ScyllaDBCluster", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbcluster/scylladbcluster_webhook.go
+++ b/test/e2e/set/scylladbcluster/scylladbcluster_webhook.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 )
 
-var _ = g.Describe("ScyllaDBCluster webhook", func() {
+var _ = g.Describe("ScyllaDBCluster webhook", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbdatacenter/scylladbdatacenter_globalmanager.go
+++ b/test/e2e/set/scylladbdatacenter/scylladbdatacenter_globalmanager.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaDBDatacenter integration with global ScyllaDB Manager", func() {
+var _ = g.Describe("ScyllaDBDatacenter integration with global ScyllaDB Manager", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbdatacenter/scylladbdatacenter_webhooks.go
+++ b/test/e2e/set/scylladbdatacenter/scylladbdatacenter_webhooks.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("ScyllaDBDatacenter webhook", func() {
+var _ = g.Describe("ScyllaDBDatacenter webhook", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	defer g.GinkgoRecover()
 
 	var f *framework.Framework

--- a/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
+++ b/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with global ScyllaDB Manager", framework.MultiDatacenter, func() {
+var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with global ScyllaDB Manager", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager_object_storage.go
+++ b/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager_object_storage.go
@@ -30,7 +30,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with global ScyllaDB Manager", framework.MultiDatacenter, func() {
+var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with global ScyllaDB Manager", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager.go
+++ b/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with global ScyllaDB Manager", func() {
+var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with global ScyllaDB Manager", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
+++ b/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
@@ -29,7 +29,8 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with global ScyllaDB Manager", framework.RequiresObjectStorage, func() {
+// Not part of SuiteKindFast: requires external object storage configured on the cluster.
+var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with global ScyllaDB Manager", framework.SuiteParallel, framework.SuiteParallelOpenShift, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring.go
@@ -100,6 +100,7 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 		framework.By("Verifying that Grafana is configured correctly")
 		e.VerifyGrafanaFn(ctx, f, sm)
 	},
+		// Not in SuiteParallelOpenShift: managed Prometheus is not supported on OpenShift.
 		g.Entry(describeEntry, &scyllaDBMonitoringEntry{
 			Description: "SAAS type",
 			ScyllaDBMonitoringModifierFn: func(sm *scyllav1alpha1.ScyllaDBMonitoring) {
@@ -117,7 +118,8 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 			},
 				"cql-overview",
 			),
-		}, framework.NotSupportedOnOpenShift),
+		}, framework.SuiteParallel, framework.SuiteKindFast),
+		// Not in SuiteParallelOpenShift: managed Prometheus is not supported on OpenShift.
 		g.Entry(describeEntry, &scyllaDBMonitoringEntry{
 			Description: "Platform type",
 			ScyllaDBMonitoringModifierFn: func(sm *scyllav1alpha1.ScyllaDBMonitoring) {
@@ -126,7 +128,9 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 			PrepareExternalPrometheusFn: nil, // Using managed Prometheus.
 			VerifyPrometheusFn:          verifyManagedPrometheus,
 			VerifyGrafanaFn:             verifyManagedGrafanaWithDashboards(getExpectedPlatformDashboards()),
-		}, framework.NotSupportedOnOpenShift),
+		}, framework.SuiteParallel, framework.SuiteKindFast),
+		// Not in SuiteParallelOpenShift: relies on a self-hosted external Prometheus,
+		// while OpenShift uses its built-in monitoring stack instead.
 		g.Entry(describeEntry, &scyllaDBMonitoringEntry{
 			Description: "Platform type with external Prometheus without TLS",
 			ScyllaDBMonitoringModifierFn: func(sm *scyllav1alpha1.ScyllaDBMonitoring) {
@@ -151,7 +155,9 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 			PrepareExternalPrometheusFn: prepareExternalPrometheusWithoutTLS,
 			VerifyPrometheusFn:          verifyExternalPrometheusWithoutTLS,
 			VerifyGrafanaFn:             verifyManagedGrafanaWithDashboards(getExpectedPlatformDashboards()),
-		}, framework.NotSupportedOnOpenShift),
+		}, framework.SuiteParallel, framework.SuiteKindFast),
+		// Not in SuiteParallelOpenShift: relies on a self-hosted external Prometheus,
+		// while OpenShift uses its built-in monitoring stack instead.
 		g.Entry(describeEntry, &scyllaDBMonitoringEntry{
 			Description: "Platform type with external Prometheus with TLS",
 			ScyllaDBMonitoringModifierFn: func(sm *scyllav1alpha1.ScyllaDBMonitoring) {
@@ -177,7 +183,9 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 			PrepareExternalPrometheusFn: prepareExternalPrometheusWithTLS,
 			VerifyPrometheusFn:          verifyExternalPrometheusWithTLS,
 			VerifyGrafanaFn:             verifyManagedGrafanaWithDashboards(getExpectedPlatformDashboards()),
-		}, framework.NotSupportedOnOpenShift),
+		}, framework.SuiteParallel, framework.SuiteKindFast),
+		// Only in SuiteParallelOpenShift: targets OpenShift's built-in
+		// Thanos Querier as the external Prometheus source.
 		g.Entry(describeEntry, &scyllaDBMonitoringEntry{
 			Description: "Platform type with Thanos Querier on OpenShift",
 			ScyllaDBMonitoringModifierFn: func(sm *scyllav1alpha1.ScyllaDBMonitoring) {
@@ -212,7 +220,7 @@ var _ = g.Describe("ScyllaDBMonitoring", func() {
 			PrepareExternalPrometheusFn: prepareOpenShiftMonitoring,
 			VerifyPrometheusFn:          nil, // Grafana datasource is enough to verify access to Thanos Querier.
 			VerifyGrafanaFn:             verifyManagedGrafanaWithDashboards(getExpectedPlatformDashboards()),
-		}, framework.SupportedOnlyOnOpenShift),
+		}, framework.SuiteParallelOpenShift),
 	)
 })
 

--- a/test/e2e/set/scylladbmonitoring/scylladbmonitoring_webhooks.go
+++ b/test/e2e/set/scylladbmonitoring/scylladbmonitoring_webhooks.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 )
 
-var _ = g.Describe("ScyllaDBMonitoring webhook", func() {
+var _ = g.Describe("ScyllaDBMonitoring webhook", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var (
 		f         *framework.Framework
 		validSDBM *scyllav1alpha1.ScyllaDBMonitoring

--- a/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_status.go
+++ b/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_status.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-var _ = g.Describe("ScyllaOperatorConfig ", framework.Serial, func() {
+var _ = g.Describe("ScyllaOperatorConfig ", framework.SuiteSerial, func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_webhooks.go
+++ b/test/e2e/set/scyllaoperatorconfig/scyllaoperatorconfig_webhooks.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var _ = g.Describe("ScyllaOperatorConfig webhook", func() {
+var _ = g.Describe("ScyllaOperatorConfig webhook", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	defer g.GinkgoRecover()
 
 	var f *framework.Framework


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Switches the e2e test suite selection to a pure label-based model: each suite (other than `all`) is defined by a single Ginkgo label, and every spec must carry at least one suite label (verified by `hack/verify-e2e-suite-coverage.sh` script wired into Makefile's `verify` target).

Had to make some changes to enable dry-run mode to work without a kubeconfig passed. Also, had to add a subcommand to the test binary that allows listing available test suites (for the verifying script).

I've dumped the per-suite test case lists from `master` and from this branch, and
diffed them; the cases selected by each suite are unchanged.

**Which issue is resolved by this Pull Request:**
Prerequisite for adding new `parallel-non-kind` and `kind-parallel` suites.