### PR TITLE
docs: override User-Agent for docs.redhat.com linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -184,3 +184,11 @@ linkcheck_anchors_ignore_for_url = [
 # Linkcheck timeout and retry configuration to handle slow-responding external sites.
 linkcheck_timeout = 180  # Increase from default for slow sites like docs.redhat.com.
 linkcheck_retries = 3   # Retry 3 times before failing to handle transient network issues.
+
+# docs.redhat.com blocks a User-Agent containing "Mozilla", which is what Sphinx sends by default.
+# Overriding with a plain non-browser UA bypasses the restriction.
+linkcheck_request_headers = {
+    'https://docs.redhat.com/': {
+        'User-Agent': 'python-requests/2.32.5',
+    },
+}


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Looks like RedHat has enabled some bot protection on docs.redhat.com - all of the links return 403 when requests are sent from the Sphinx links verification (`User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0 Sphinx/9.1.0`). This PR sets the `User-Agent` header to `python-requests/2.32.5`, which is accepted. 
