### PR TITLE
[v1.19] docs: override User-Agent for docs.redhat.com linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,3 +190,15 @@ linkcheck_anchors_ignore_for_url = [
    'https://github.com/prometheus-operator/prometheus-operator/blob/e4c727291acc543dab531bc4aaf16637067c1b86/pkg/apis/monitoring/v1/.*',
    'https://kubernetes.io/docs/concepts/storage/volumes',
 ]
+
+# Linkcheck timeout and retry configuration to handle slow-responding external sites.
+linkcheck_timeout = 180  # Increase from default for slow sites like docs.redhat.com.
+linkcheck_retries = 3   # Retry 3 times before failing to handle transient network issues.
+
+# docs.redhat.com blocks a User-Agent containing "Mozilla", which is what Sphinx sends by default.
+# Overriding with a plain non-browser UA bypasses the restriction.
+linkcheck_request_headers = {
+    'https://docs.redhat.com/': {
+        'User-Agent': 'python-requests/2.32.5',
+    },
+}


### PR DESCRIPTION
Backports https://github.com/scylladb/scylla-operator/pull/3418 to v1.19
