### PR TITLE
docs(staging): add "Connect your app"

### DIFF
--- a/docs-staging/source/connect-your-app/alternator.md
+++ b/docs-staging/source/connect-your-app/alternator.md
@@ -110,7 +110,7 @@ The Operator creates these resources for Alternator:
 ### Troubleshoot
 
 - **`AccessDeniedException`**: Confirms Alternator is reachable but credentials are wrong. Re-extract credentials per the steps above and verify they match.
-- **`Could not connect to the endpoint`**: Alternator may not be enabled on the cluster. Verify `spec.alternator` is set in the ScyllaCluster and pods are running. Check that the Service port (8043 for HTTPS by default) is reachable.
+- **`Could not connect to the endpoint`**: Alternator may not be enabled on the cluster. Verify `spec.alternator` is set in the ScyllaCluster and Pods are running. Check that the Service port (8043 for HTTPS by default) is reachable.
 
 ## Multi-datacenter limitations
 

--- a/docs-staging/source/connect-your-app/alternator.md
+++ b/docs-staging/source/connect-your-app/alternator.md
@@ -111,7 +111,6 @@ The Operator creates these resources for Alternator:
 
 - **`AccessDeniedException`**: Confirms Alternator is reachable but credentials are wrong. Re-extract credentials per the steps above and verify they match.
 - **`Could not connect to the endpoint`**: Alternator may not be enabled on the cluster. Verify `spec.alternator` is set in the ScyllaCluster and pods are running. Check that the Service port (8043 for HTTPS by default) is reachable.
-- **`salted_hash not set`**: The credentials were created without the required `options={'timeout': 300}` parameter or were created before Alternator was enabled. Recreate the credentials via CQL.
 
 ## Multi-datacenter limitations
 

--- a/docs-staging/source/connect-your-app/alternator.md
+++ b/docs-staging/source/connect-your-app/alternator.md
@@ -33,7 +33,7 @@ Unlike CQL clients, Alternator clients do not need to connect to every ScyllaDB 
 
 ## Obtain credentials
 
-Alternator uses the CQL `salted_hash` from `system_auth.roles` as the AWS secret access key. The access key ID is the CQL username.
+Alternator uses the CQL `salted_hash` from `system.roles` as the AWS secret access key. The access key ID is the CQL username.
 
 :::{caution}
 The `salted_hash` is only available when CQL password authentication is enabled. Always configure authentication before using Alternator.
@@ -44,7 +44,7 @@ CLUSTER_NAME=scylladb
 CQL_USER=cassandra
 
 kubectl exec -it service/${CLUSTER_NAME}-client -c scylla -- cqlsh --user ${CQL_USER} \
-  -e "SELECT salted_hash FROM system_auth.roles WHERE role = '${CQL_USER}'"
+  -e "SELECT salted_hash FROM system.roles WHERE role = '${CQL_USER}'"
 ```
 
 ## Connect with AWS CLI
@@ -68,7 +68,7 @@ export AWS_ACCESS_KEY_ID="${CQL_USER}"
 **Step 3: Get the secret access key**
 ```shell
 AWS_SECRET_ACCESS_KEY="$(kubectl exec -i service/${CLUSTER_NAME}-client -c scylla -- cqlsh --user ${CQL_USER} --no-color \
-  -e "SELECT salted_hash from system_auth.roles WHERE role = '${AWS_ACCESS_KEY_ID}';" \
+  -e "SELECT salted_hash from system.roles WHERE role = '${AWS_ACCESS_KEY_ID}';" \
   | sed -e 's/\r//g' | sed -e '4q;d' | sed -E -e 's/^\s+//')"
 export AWS_SECRET_ACCESS_KEY
 ```

--- a/docs-staging/source/connect-your-app/alternator.md
+++ b/docs-staging/source/connect-your-app/alternator.md
@@ -119,7 +119,6 @@ When using Alternator with a multi-datacenter ScyllaDB deployment (multiple `Scy
 | Limitation | Detail |
 |---|---|
 | No built-in cross-DC routing | Alternator endpoints are per-datacenter. There is no built-in load balancer that routes DynamoDB API requests across datacenters. Connect your application to the Alternator endpoint in the datacenter closest to it. |
-| No Helm-based multi-DC install | Helm charts do not support multi-DC deployments. Use manifests directly for multi-DC setups. |
 | Authentication tokens are DC-local | Each `ScyllaCluster` has its own Alternator authentication credentials. If you require the same credentials across DCs, you must configure the same `alternatorWriteIsolation` and authentication settings on each cluster independently. |
 
 See [Known issues](../reference/known-issues.md#multi-datacenter-limitations) for the complete list of multi-datacenter limitations in ScyllaDB Operator.

--- a/docs-staging/source/connect-your-app/alternator.md
+++ b/docs-staging/source/connect-your-app/alternator.md
@@ -110,7 +110,7 @@ The Operator creates these resources for Alternator:
 ### Troubleshoot
 
 - **`AccessDeniedException`**: Confirms Alternator is reachable but credentials are wrong. Re-extract credentials per the steps above and verify they match.
-- **`Could not connect to the endpoint`**: Alternator may not be enabled on the cluster. Verify `spec.alternator` is set in the ScyllaCluster and pods are running. Check that the Service port (8000 by default) is reachable.
+- **`Could not connect to the endpoint`**: Alternator may not be enabled on the cluster. Verify `spec.alternator` is set in the ScyllaCluster and pods are running. Check that the Service port (8043 for HTTPS by default) is reachable.
 - **`salted_hash not set`**: The credentials were created without the required `options={'timeout': 300}` parameter or were created before Alternator was enabled. Recreate the credentials via CQL.
 
 ## Multi-datacenter limitations

--- a/docs-staging/source/connect-your-app/alternator.md
+++ b/docs-staging/source/connect-your-app/alternator.md
@@ -1,5 +1,132 @@
 # Alternator (DynamoDB API)
 
-:::{todo}
-This page is not yet written.
+This page explains how to enable and use ScyllaDB's Alternator, a DynamoDB-compatible API, on Kubernetes.
+
+## Enable Alternator
+
+Add the `alternator` section to your ScyllaCluster spec:
+
+```yaml
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: scylladb
+spec:
+  alternator: {}
+  # ... rest of the spec
+```
+
+This enables the Alternator API with HTTPS on port `8043` and authorization enabled by default.
+
+### Configuration options
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `writeIsolation` | Write isolation level for Alternator operations. | `""` (ScyllaDB default) |
+| `insecureEnableHTTP` | Also serve Alternator on the unencrypted HTTP port. | `false` |
+| `insecureDisableAuthorization` | Disable Alternator authorization. | `false` |
+| `servingCertificate` | TLS certificate configuration (`OperatorManaged` or `UserManaged`). | `OperatorManaged` |
+
+:::{note}
+Unlike CQL clients, Alternator clients do not need to connect to every ScyllaDB node directly or discover individual node IP addresses. The Alternator protocol is HTTP-based, so you can also expose it through an Ingress or other HTTP networking concepts.
 :::
+
+## Obtain credentials
+
+Alternator uses the CQL `salted_hash` from `system_auth.roles` as the AWS secret access key. The access key ID is the CQL username.
+
+:::{caution}
+The `salted_hash` is only available when CQL password authentication is enabled. Always configure authentication before using Alternator.
+:::
+
+```shell
+CLUSTER_NAME=scylladb
+CQL_USER=cassandra
+
+kubectl exec -it service/${CLUSTER_NAME}-client -c scylla -- cqlsh --user ${CQL_USER} \
+  -e "SELECT salted_hash FROM system_auth.roles WHERE role = '${CQL_USER}'"
+```
+
+## Connect with AWS CLI
+
+Set up the environment variables and TLS CA bundle:
+
+**Step 1: Look up the Alternator endpoint**
+```shell
+CLUSTER_NAME=scylladb
+CQL_USER=cassandra
+
+SCYLLADB_EP="$(kubectl get service/${CLUSTER_NAME}-client -o='jsonpath={.spec.clusterIP}')"
+export AWS_ENDPOINT_URL_DYNAMODB="https://${SCYLLADB_EP}:8043"
+```
+
+**Step 2: Set the access key ID**
+```shell
+export AWS_ACCESS_KEY_ID="${CQL_USER}"
+```
+
+**Step 3: Get the secret access key**
+```shell
+AWS_SECRET_ACCESS_KEY="$(kubectl exec -i service/${CLUSTER_NAME}-client -c scylla -- cqlsh --user ${CQL_USER} --no-color \
+  -e "SELECT salted_hash from system_auth.roles WHERE role = '${AWS_ACCESS_KEY_ID}';" \
+  | sed -e 's/\r//g' | sed -e '4q;d' | sed -E -e 's/^\s+//')"
+export AWS_SECRET_ACCESS_KEY
+```
+
+**Step 4: Download the TLS CA bundle**
+```shell
+AWS_CA_BUNDLE="$(mktemp)"
+export AWS_CA_BUNDLE
+kubectl get configmap/${CLUSTER_NAME}-alternator-local-serving-ca \
+  --template='{{ index .data "ca-bundle.crt" }}' > "${AWS_CA_BUNDLE}"
+```
+
+Now use the `aws dynamodb` CLI normally:
+
+```shell
+aws dynamodb create-table \
+  --table-name SeaMonsters \
+  --attribute-definitions AttributeName=Species,AttributeType=S AttributeName=MonsterName,AttributeType=S \
+  --key-schema AttributeName=Species,KeyType=HASH AttributeName=MonsterName,KeyType=RANGE \
+  --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
+```
+
+```shell
+aws dynamodb list-tables
+```
+
+```
+TABLENAMES      SeaMonsters
+```
+
+## TLS certificate resources
+
+The Operator creates these resources for Alternator:
+
+| Resource | Name | Contents |
+|----------|------|----------|
+| Serving CA | `configmap/<cluster-name>-alternator-local-serving-ca` | `ca-bundle.crt` — CA to validate Alternator HTTPS. |
+
+### Troubleshoot
+
+- **`AccessDeniedException`**: Confirms Alternator is reachable but credentials are wrong. Re-extract credentials per the steps above and verify they match.
+- **`Could not connect to the endpoint`**: Alternator may not be enabled on the cluster. Verify `spec.alternator` is set in the ScyllaCluster and pods are running. Check that the Service port (8000 by default) is reachable.
+- **`salted_hash not set`**: The credentials were created without the required `options={'timeout': 300}` parameter or were created before Alternator was enabled. Recreate the credentials via CQL.
+
+## Multi-datacenter limitations
+
+When using Alternator with a multi-datacenter ScyllaDB deployment (multiple `ScyllaCluster` resources connected via `externalSeeds`), the following constraints apply:
+
+| Limitation | Detail |
+|---|---|
+| No built-in cross-DC routing | Alternator endpoints are per-datacenter. There is no built-in load balancer that routes DynamoDB API requests across datacenters. Connect your application to the Alternator endpoint in the datacenter closest to it. |
+| No Helm-based multi-DC install | Helm charts do not support multi-DC deployments. Use manifests directly for multi-DC setups. |
+| Authentication tokens are DC-local | Each `ScyllaCluster` has its own Alternator authentication credentials. If you require the same credentials across DCs, you must configure the same `alternatorWriteIsolation` and authentication settings on each cluster independently. |
+
+See [Known issues](../reference/known-issues.md#multi-datacenter-limitations) for the complete list of multi-datacenter limitations in ScyllaDB Operator.
+
+## Related pages
+
+- [Connect via CQL](connect-via-cql.md) — CQL connection and authentication setup.
+- [Discovery endpoint](discovery.md) — how the client Service works.
+- [Security](../understand/security.md) — TLS certificate management.

--- a/docs-staging/source/connect-your-app/alternator.md
+++ b/docs-staging/source/connect-your-app/alternator.md
@@ -25,7 +25,7 @@ This enables the Alternator API with HTTPS on port `8043` and authorization enab
 | `writeIsolation` | Write isolation level for Alternator operations. | `""` (ScyllaDB default) |
 | `insecureEnableHTTP` | Also serve Alternator on the unencrypted HTTP port. | `false` |
 | `insecureDisableAuthorization` | Disable Alternator authorization. | `false` |
-| `servingCertificate` | TLS certificate configuration (`OperatorManaged` or `UserManaged`). | `OperatorManaged` |
+| `servingCertificate.type` | TLS certificate configuration (`OperatorManaged` or `UserManaged`). | `OperatorManaged` |
 
 :::{note}
 Unlike CQL clients, Alternator clients do not need to connect to every ScyllaDB node directly or discover individual node IP addresses. The Alternator protocol is HTTP-based, so you can also expose it through an Ingress or other HTTP networking concepts.

--- a/docs-staging/source/connect-your-app/configure-external-access.md
+++ b/docs-staging/source/connect-your-app/configure-external-access.md
@@ -193,20 +193,6 @@ kubectl run -it --rm --restart=Never cqlsh-test --image=scylladb/scylla \
 
 Replace `<EXTERNAL-IP>` with the address shown in the Service output.
 
-## Troubleshoot
-
-**Service stuck in `<pending>` state**
-: Cloud provider quota exceeded, or missing IAM permissions for load balancer creation. Check cloud provider events with `kubectl describe service <service-name> -n scylla`.
-
-**Cannot connect from outside**
-: Check firewall rules allow traffic on port 9042 (CQL) and 9142 (CQL/TLS) from client IP ranges. See [Prerequisites](../install-operator/prerequisites.md) for required firewall rules.
-
-**Broadcast address mismatch**
-: If ScyllaDB advertises an internal IP instead of the LoadBalancer IP, verify `broadcastOptions.clients.type` is set to `ServiceLoadBalancerIngress` and the LoadBalancer has an external IP assigned.
-
-**TLS connection refused**
-: Ensure clients use the correct CA certificate. See [Connect via CQL](connect-via-cql.md) for TLS connection setup.
-
 ## Related pages
 
 - [Discovery endpoint](discovery.md) — exposing the discovery Service.

--- a/docs-staging/source/connect-your-app/configure-external-access.md
+++ b/docs-staging/source/connect-your-app/configure-external-access.md
@@ -176,10 +176,10 @@ scylla-us-east-1-us-east-1a-0             LoadBalancer   10.96.0.1      203.0.11
 
 ### Verify broadcast addresses
 
-Confirm that ScyllaDB is advertising the correct address to clients:
+Confirm that ScyllaDB node Services have the expected addresses by inspecting the per-node Services:
 
 ```bash
-kubectl -n scylla get scyllacluster scylla -o jsonpath='{range .status.racks[*].members[*]}{.name}{"\t"}{.address}{"\n"}{end}'
+kubectl -n scylla get services -l scylla/cluster=scylla -o custom-columns='NAME:.metadata.name,TYPE:.spec.type,CLUSTER-IP:.spec.clusterIP,EXTERNAL-IP:.status.loadBalancer.ingress[0].ip'
 ```
 
 ### Test connectivity

--- a/docs-staging/source/connect-your-app/configure-external-access.md
+++ b/docs-staging/source/connect-your-app/configure-external-access.md
@@ -3,7 +3,7 @@
 This page explains how to configure ScyllaDB clusters for access from outside the Kubernetes cluster using the `exposeOptions` API.
 
 :::{note}
-`exposeOptions` are immutable — they cannot be changed after the ScyllaDB cluster is created.
+The following `exposeOptions` sub-fields are immutable after the ScyllaDB cluster is created: `nodeService.type`, `broadcastOptions.clients.type`, and `broadcastOptions.nodes.type`. Other fields (such as annotations and `loadBalancerClass`) can be updated.
 :::
 
 ## Expose options overview

--- a/docs-staging/source/connect-your-app/configure-external-access.md
+++ b/docs-staging/source/connect-your-app/configure-external-access.md
@@ -1,5 +1,217 @@
 # Configure external access
 
-:::{todo}
-This page is not yet written.
+This page explains how to configure ScyllaDB clusters for access from outside the Kubernetes cluster using the `exposeOptions` API.
+
+:::{note}
+`exposeOptions` are immutable — they cannot be changed after the ScyllaDB cluster is created.
 :::
+
+## Expose options overview
+
+The `exposeOptions` field controls two things:
+
+1. **Node Service type** — what kind of Kubernetes Service is created for each ScyllaDB node.
+2. **Broadcast options** — what address ScyllaDB advertises to clients and other nodes.
+
+### Defaults
+
+```yaml
+spec:
+  exposeOptions:
+    nodeService:
+      type: ClusterIP
+    broadcastOptions:
+      clients:
+        type: ServiceClusterIP
+      nodes:
+        type: ServiceClusterIP
+```
+
+### Node Service types
+
+| Type | Description |
+|------|-------------|
+| `Headless` | No additional IP allocated. DNS resolves to Pod IP. Use when broadcasting Pod IPs. |
+| `ClusterIP` | Allocates a cluster-internal virtual IP. Routable only within the Kubernetes cluster. |
+| `LoadBalancer` | Provisions an external load balancer. Use for internet-facing or cross-VPC access. Supports custom annotations and `loadBalancerClass`. |
+
+### Broadcast address types
+
+| Type | Source | Use case |
+|------|--------|----------|
+| `PodIP` | `Pod.status.podIP` | When Pod IPs are routable (same VPC, VPC peering, multi-DC). |
+| `ServiceClusterIP` | `Service.spec.clusterIP` | In-cluster access only. |
+| `ServiceLoadBalancerIngress` | `Service.status.loadBalancer.ingress[0]` | External access via load balancer. |
+
+## Common deployment scenarios
+
+### In-cluster only (default for ScyllaCluster)
+
+Clients and nodes communicate via ClusterIP. The cluster is not reachable from outside Kubernetes.
+
+```yaml
+spec:
+  exposeOptions:
+    nodeService:
+      type: ClusterIP
+    broadcastOptions:
+      clients:
+        type: ServiceClusterIP
+      nodes:
+        type: ServiceClusterIP
+```
+
+### VPC-routable clients, in-cluster nodes
+
+Clients within the VPC connect directly to Pod IPs. Nodes communicate via ClusterIP within the Kubernetes cluster.
+
+```yaml
+spec:
+  exposeOptions:
+    nodeService:
+      type: ClusterIP
+    broadcastOptions:
+      clients:
+        type: PodIP
+      nodes:
+        type: ServiceClusterIP
+```
+
+### Multi-VPC (cross-datacenter)
+
+Both clients and nodes use Pod IPs. Requires VPC peering or a shared network between Kubernetes clusters. Use this configuration for multi-DC clusters with multiple `ScyllaCluster` resources connected via `externalSeeds`.
+
+```yaml
+spec:
+  exposeOptions:
+    nodeService:
+      type: Headless
+    broadcastOptions:
+      clients:
+        type: PodIP
+      nodes:
+        type: PodIP
+```
+
+### Internet-facing via LoadBalancer
+
+Each ScyllaDB node gets a dedicated load balancer with a public or internal address. Clients connect through the load balancer addresses. Nodes communicate via ClusterIP within the same Kubernetes cluster.
+
+::::{tabs}
+:::{group-tab} EKS
+```yaml
+spec:
+  exposeOptions:
+    nodeService:
+      type: LoadBalancer
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    broadcastOptions:
+      clients:
+        type: ServiceLoadBalancerIngress
+      nodes:
+        type: ServiceClusterIP
+```
+:::
+
+:::{group-tab} GKE
+```yaml
+spec:
+  exposeOptions:
+    nodeService:
+      type: LoadBalancer
+      annotations:
+        networking.gke.io/load-balancer-type: Internal
+    broadcastOptions:
+      clients:
+        type: ServiceLoadBalancerIngress
+      nodes:
+        type: ServiceClusterIP
+```
+:::
+::::
+
+:::{note}
+LoadBalancer Services should be configured for TCP passthrough. Check your cloud provider's documentation for available annotations and configuration options.
+:::
+
+## TLS for external clients
+
+When exposing ScyllaDB externally, ensure TLS certificates include the external addresses as Subject Alternative Names (SANs). Use `operatorManagedOptions` to add custom DNS names or IP addresses:
+
+```yaml
+spec:
+  exposeOptions:
+    nodeService:
+      type: LoadBalancer
+  network:
+    tlsConfig:
+      servingCertificate:
+        type: OperatorManaged
+        operatorManagedOptions:
+          additionalDNSNames:
+          - scylladb.example.com
+          additionalIPAddresses:
+          - 203.0.113.10
+```
+
+Alternatively, use `UserManaged` certificates from your own PKI or cert-manager.
+
+## Verify external access
+
+After applying your expose options, verify that the Services have received external addresses and that ScyllaDB is reachable.
+
+### Check Service external addresses
+
+```bash
+kubectl -n scylla get services -l scylla/cluster=scylla
+```
+
+For LoadBalancer services, wait until `EXTERNAL-IP` is populated (this may take 1–2 minutes on cloud providers):
+
+```
+Expected output:
+NAME                                      TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)          AGE
+scylla-us-east-1-us-east-1a-0             LoadBalancer   10.96.0.1      203.0.113.10      9042:30000/TCP   2m
+```
+
+### Verify broadcast addresses
+
+Confirm that ScyllaDB is advertising the correct address to clients:
+
+```bash
+kubectl -n scylla get scyllacluster scylla -o jsonpath='{range .status.racks[*].members[*]}{.name}{"\t"}{.address}{"\n"}{end}'
+```
+
+### Test connectivity
+
+Test a CQL connection using the external address:
+
+```bash
+kubectl run -it --rm --restart=Never cqlsh-test --image=scylladb/scylla \
+  -- cqlsh <EXTERNAL-IP> 9042
+```
+
+Replace `<EXTERNAL-IP>` with the address shown in the Service output.
+
+## Troubleshoot
+
+**Service stuck in `<pending>` state**
+: Cloud provider quota exceeded, or missing IAM permissions for load balancer creation. Check cloud provider events with `kubectl describe service <service-name> -n scylla`.
+
+**Cannot connect from outside**
+: Check firewall rules allow traffic on port 9042 (CQL) and 9142 (CQL/TLS) from client IP ranges. See [Prerequisites](../install-operator/prerequisites.md) for required firewall rules.
+
+**Broadcast address mismatch**
+: If ScyllaDB advertises an internal IP instead of the LoadBalancer IP, verify `broadcastOptions.clients.type` is set to `ServiceLoadBalancerIngress` and the LoadBalancer has an external IP assigned.
+
+**TLS connection refused**
+: Ensure clients use the correct CA certificate. See [Connect via CQL](connect-via-cql.md) for TLS connection setup.
+
+## Related pages
+
+- [Discovery endpoint](discovery.md) — exposing the discovery Service.
+- [Connect via CQL](connect-via-cql.md) — client connection setup.
+- [Networking architecture](../understand/networking.md) — how Services and expose options work.
+- [Security](../understand/security.md) — TLS certificate management.

--- a/docs-staging/source/connect-your-app/configure-external-access.md
+++ b/docs-staging/source/connect-your-app/configure-external-access.md
@@ -138,25 +138,23 @@ LoadBalancer Services should be configured for TCP passthrough. Check your cloud
 
 ## TLS for external clients
 
-When exposing ScyllaDB externally, ensure TLS certificates include the external addresses as Subject Alternative Names (SANs). Use `operatorManagedOptions` to add custom DNS names or IP addresses:
+When exposing ScyllaDB externally, the operator-managed CQL serving certificates automatically include the node Service DNS names and IP addresses as Subject Alternative Names (SANs). No additional TLS configuration is needed for CQL.
+
+For Alternator, you can add custom DNS names or IP addresses to the serving certificate using `operatorManagedOptions`:
 
 ```yaml
 spec:
-  exposeOptions:
-    nodeService:
-      type: LoadBalancer
-  network:
-    tlsConfig:
-      servingCertificate:
-        type: OperatorManaged
-        operatorManagedOptions:
-          additionalDNSNames:
-          - scylladb.example.com
-          additionalIPAddresses:
-          - 203.0.113.10
+  alternator:
+    servingCertificate:
+      type: OperatorManaged
+      operatorManagedOptions:
+        additionalDNSNames:
+        - scylladb.example.com
+        additionalIPAddresses:
+        - 203.0.113.10
 ```
 
-Alternatively, use `UserManaged` certificates from your own PKI or cert-manager.
+Alternatively, use `UserManaged` certificates from your own PKI or cert-manager for Alternator. See [Alternator](alternator.md) for details.
 
 ## Verify external access
 

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -77,9 +77,9 @@ Replace `scylla-local-client-ca` with the actual secret name from Step 1.
 **Step 3: Extract client credentials**
 
 ```bash
-kubectl -n scylla get secret scylla-user-admin \
+kubectl -n scylla get secret scylla-local-user-admin \
   -o jsonpath='{.data.tls\.crt}' | base64 -d > client.crt
-kubectl -n scylla get secret scylla-user-admin \
+kubectl -n scylla get secret scylla-local-user-admin \
   -o jsonpath='{.data.tls\.key}' | base64 -d > client.key
 ```
 

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -19,6 +19,12 @@ data:
 
 Reference this ConfigMap from your ScyllaCluster via `scyllaConfig` on each rack.
 
+After deployment, follow the [Creating a Custom Superuser](https://docs.scylladb.com/manual/stable/operating-scylla/security/create-superuser.html) guide in the ScyllaDB documentation to replace the default `cassandra` superuser with a dedicated role.
+
+:::{caution}
+Starting with ScyllaDB 2026.2, the default `cassandra`/`cassandra` superuser credentials are being removed. New clusters will require configuring a custom superuser via `auth_superuser_name` and `auth_superuser_salted_password` in `scylla.yaml`. See [scylladb/scylladb#27215](https://github.com/scylladb/scylladb/pull/27215) for details.
+:::
+
 ## Embedded cqlsh
 
 Every ScyllaDB pod includes a built-in `cqlsh`. This is the simplest way to run queries:

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -59,20 +59,20 @@ In future releases, the unencrypted CQL port `9042` will be disabled by default 
 The example below simplifies credential file creation for brevity. In production, create the credentials file with a text editor to avoid passwords leaking into shell history or environment variables.
 :::
 
-**Step 1: Identify the CA certificate Secret**
+**Step 1: Identify the serving CA ConfigMap**
 
-The CA certificate secret is named `<cluster-name>-local-client-ca`:
+The serving CA is stored in a ConfigMap named `<cluster-name>-local-serving-ca`:
 ```bash
-kubectl -n scylla get secrets | grep client-ca
+kubectl -n scylla get configmaps | grep serving-ca
 ```
 
 **Step 2: Extract the CA certificate**
 
 ```bash
-kubectl -n scylla get secret scylla-local-client-ca \
-  -o jsonpath='{.data.tls\.crt}' | base64 -d > ca.crt
+kubectl -n scylla get configmap scylla-local-serving-ca \
+  --template='{{ index .data "ca-bundle.crt" }}' > ca.crt
 ```
-Replace `scylla-local-client-ca` with the actual secret name from Step 1.
+Replace `scylla-local-serving-ca` with the actual ConfigMap name from Step 1.
 
 **Step 3: Extract client credentials**
 

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -45,8 +45,8 @@ kubectl exec -it pod/<cluster-name>-<datacenter>-<rack>-<ordinal> -c scylla -- c
 
 ```
 Password:
-Connected to scylla at 127.0.0.1:9042
-[cqlsh 6.2.0 | Scylla 2025.4.2 | CQL spec 3.3.1 | Native protocol v4]
+Connected to scylla at 0.0.0.0:9042
+[cqlsh 6.0.32 | Scylla 2026.1.0-0.20260309.9190d42863d4 | CQL spec 3.3.1 | Native protocol v4]
 Use HELP for help.
 <user>@cqlsh>
 ```

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -222,7 +222,7 @@ The Operator creates these resources automatically:
 | Serving CA | `configmap/<cluster-name>-local-serving-ca` | `ca-bundle.crt` — CA to validate server certificates. |
 | Admin client cert | `secret/<cluster-name>-local-user-admin` | `tls.crt`, `tls.key` — client certificate for mTLS. |
 
-To use your own TLS certificates instead of operator-managed ones, set `servingCertificate.type: UserManaged` on the ScyllaCluster. See [TLS and certificate management](../understand/security.md).
+For more details, see [TLS and certificate management](../understand/security.md).
 
 ## Related pages
 

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -17,7 +17,20 @@ data:
     authorizer: CassandraAuthorizer
 ```
 
-Reference this ConfigMap from your ScyllaCluster via `scyllaConfig` on each rack.
+Reference this ConfigMap from your ScyllaCluster via `scyllaConfig` on each rack:
+
+```yaml
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: scylladb
+spec:
+  datacenter:
+    racks:
+    - name: us-east-1a
+      scyllaConfig: scylladb-config
+      # ...
+```
 
 After deployment, follow the [Creating a Custom Superuser](https://docs.scylladb.com/manual/stable/operating-scylla/security/create-superuser.html) guide in the ScyllaDB documentation to replace the default `cassandra` superuser with a dedicated role.
 
@@ -27,7 +40,7 @@ Starting with ScyllaDB 2026.2, the default `cassandra`/`cassandra` superuser cre
 
 ## Embedded cqlsh
 
-Every ScyllaDB pod includes a built-in `cqlsh`. This is the simplest way to run queries:
+Every ScyllaDB Pod includes a built-in `cqlsh`. This is the simplest way to run queries:
 
 ::::{tabs}
 :::{group-tab} Any node (via Service)
@@ -57,44 +70,26 @@ ScyllaDB Operator configures TLS certificates automatically. The encrypted CQL p
 
 ### Prepare credentials and certificates
 
+The Operator automatically creates TLS resources for each ScyllaCluster. For programmatic access using the Go driver with clusters that have `dnsDomains` configured, use the pre-built connection bundle from `secret/<cluster-name>-local-cql-connection-configs-admin` directly (see [Security](../understand/security.md) for details).
+
+For `cqlsh`, extract the certificates and create a `cqlshrc` file:
+
 :::{caution}
 The example below simplifies credential file creation for brevity. In production, create the credentials file with a text editor to avoid passwords leaking into shell history or environment variables.
 :::
 
-**Step 1: Identify the serving CA ConfigMap**
-
-The serving CA is stored in a ConfigMap named `<cluster-name>-local-serving-ca`:
-```bash
-kubectl -n scylla get configmaps | grep serving-ca
-```
-
-**Step 2: Extract the CA certificate**
+**Step 1: Extract certificates**
 
 ```bash
-kubectl -n scylla get configmap scylla-local-serving-ca \
+kubectl -n scylla get configmap <cluster-name>-local-serving-ca \
   --template='{{ index .data "ca-bundle.crt" }}' > ca.crt
-```
-Replace `scylla-local-serving-ca` with the actual ConfigMap name from Step 1.
-
-**Step 3: Extract client credentials**
-
-```bash
-kubectl -n scylla get secret scylla-local-user-admin \
+kubectl -n scylla get secret <cluster-name>-local-user-admin \
   -o jsonpath='{.data.tls\.crt}' | base64 -d > client.crt
-kubectl -n scylla get secret scylla-local-user-admin \
+kubectl -n scylla get secret <cluster-name>-local-user-admin \
   -o jsonpath='{.data.tls\.key}' | base64 -d > client.key
 ```
 
-**Step 4: Verify the extracted files**
-
-```bash
-openssl x509 -in ca.crt -noout -subject -dates
-openssl x509 -in client.crt -noout -subject -dates
-```
-
-**Step 5: Create a cqlshrc file**
-
-Set `SCYLLADB_CONFIG` to a directory containing the certificates and create a `cqlshrc` file:
+**Step 2: Create a cqlshrc file**
 
 ```bash
 export SCYLLADB_CONFIG=/path/to/scylladb-config
@@ -156,22 +151,11 @@ When using a ScyllaDB or Cassandra driver in your application:
 
 | Setting | Recommended value | Why |
 |---------|-------------------|-----|
-| Contact points | `<cluster-name>-client.<namespace>.svc` (DNS) or the Service ClusterIP | Use the discovery Service, not individual pod IPs. The driver discovers all nodes automatically. |
+| Contact points | `<cluster-name>-client.<namespace>.svc` (DNS) or the Service ClusterIP | Use the discovery Service, not individual Pod IPs. The driver discovers all nodes automatically. |
 | Local datacenter | Your `datacenter.name` value (e.g., `us-east-1`) | Required for `DCAwareRoundRobinPolicy`. Prevents cross-DC queries. |
 | Load balancing | Token-aware + DC-aware round robin | Sends queries directly to the replica owning the partition. |
 | TLS | Enabled, with CA verification | Use the serving CA from `configmap/<cluster-name>-local-serving-ca`. |
 | Reconnection | Exponential backoff | Handles node restarts during rolling updates. |
-
-## TLS certificate resources
-
-The Operator creates these resources automatically:
-
-| Resource | Name | Contents |
-|----------|------|----------|
-| Serving CA | `configmap/<cluster-name>-local-serving-ca` | `ca-bundle.crt` — CA to validate server certificates. |
-| Admin client cert | `secret/<cluster-name>-local-user-admin` | `tls.crt`, `tls.key` — client certificate for mTLS. |
-
-For more details, see [TLS and certificate management](../understand/security.md).
 
 ## Related pages
 

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -120,31 +120,35 @@ EOF
 
 ### Connect
 
-::::{tabs}
-:::{group-tab} Native
+:::::{tabs}
+::::{group-tab} Native
 ```shell
 cqlsh --cqlshrc="${SCYLLADB_CONFIG}/cqlshrc"
 ```
-:::
+::::
 
-:::{group-tab} Podman
-```shell
+::::{group-tab} Podman
+:::{code-block} shell
+:substitutions:
+
 podman run -it --rm --entrypoint=cqlsh \
   -v="${SCYLLADB_CONFIG}:${SCYLLADB_CONFIG}:ro,Z" \
   -v="${SCYLLADB_CONFIG}/cqlshrc:/root/.cassandra/cqlshrc:ro,Z" \
-  docker.io/scylladb/scylla:2025.4.2
-```
+  {{imageRepository}}:{{scyllaDBImageTag}}
 :::
+::::
 
-:::{group-tab} Docker
-```shell
+::::{group-tab} Docker
+:::{code-block} shell
+:substitutions:
+
 docker run -it --rm --entrypoint=cqlsh \
   -v="${SCYLLADB_CONFIG}:${SCYLLADB_CONFIG}:ro" \
   -v="${SCYLLADB_CONFIG}/cqlshrc:/root/.cassandra/cqlshrc:ro" \
-  docker.io/scylladb/scylla:2025.4.2
-```
+  {{imageRepository}}:{{scyllaDBImageTag}}
 :::
 ::::
+:::::
 
 ## Driver configuration tips
 

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -90,6 +90,32 @@ openssl x509 -in ca.crt -noout -subject -dates
 openssl x509 -in client.crt -noout -subject -dates
 ```
 
+**Step 5: Create a cqlshrc file**
+
+Set `SCYLLADB_CONFIG` to a directory containing the certificates and create a `cqlshrc` file:
+
+```bash
+export SCYLLADB_CONFIG=/path/to/scylladb-config
+mkdir -p "${SCYLLADB_CONFIG}"
+cp ca.crt client.crt client.key "${SCYLLADB_CONFIG}/"
+cat > "${SCYLLADB_CONFIG}/cqlshrc" <<EOF
+[connection]
+hostname = <cluster-name>-client.<namespace>.svc
+port = 9142
+ssl = true
+
+[ssl]
+certfile = ${SCYLLADB_CONFIG}/ca.crt
+usercert = ${SCYLLADB_CONFIG}/client.crt
+userkey = ${SCYLLADB_CONFIG}/client.key
+validate = true
+
+[authentication]
+username = cassandra
+password = <password>
+EOF
+```
+
 ### Connect
 
 ::::{tabs}

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -49,10 +49,6 @@ Use HELP for help.
 
 ScyllaDB Operator configures TLS certificates automatically. The encrypted CQL port `9142` works by default.
 
-:::{caution}
-In future releases, the unencrypted CQL port `9042` will be disabled by default unless explicitly opted in. Always use the TLS port `9142` for remote connections.
-:::
-
 ### Prepare credentials and certificates
 
 :::{caution}

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -152,63 +152,6 @@ When using a ScyllaDB or Cassandra driver in your application:
 | TLS | Enabled, with CA verification | Use the serving CA from `configmap/<cluster-name>-local-serving-ca`. |
 | Reconnection | Exponential backoff | Handles node restarts during rolling updates. |
 
-### Code examples
-
-The following snippets show minimal working examples. Replace `<discovery-service-clusterip>` with the ClusterIP address from [Discovery endpoint](discovery.md) and `<password>` with the credentials from the ScyllaDB Secret.
-
-**Python (cassandra-driver):**
-```python
-from cassandra.cluster import Cluster
-from cassandra.auth import PlainTextAuthProvider
-from ssl import SSLContext, PROTOCOL_TLS_CLIENT, CERT_REQUIRED
-
-# TLS connection (recommended for production)
-ssl_context = SSLContext(PROTOCOL_TLS_CLIENT)
-ssl_context.load_verify_locations('/path/to/ca.crt')
-ssl_context.check_hostname = False
-ssl_context.verify_mode = CERT_REQUIRED
-
-auth_provider = PlainTextAuthProvider(username='cassandra', password='<password>')
-cluster = Cluster(
-    contact_points=['<discovery-service-clusterip>'],
-    port=9142,  # TLS port
-    ssl_context=ssl_context,
-    auth_provider=auth_provider,
-    load_balancing_policy=...,  # configure local_dc
-)
-session = cluster.connect()
-```
-
-**Java (DataStax Java Driver 4.x):**
-```java
-// application.conf (in resources/)
-// datastax-java-driver {
-//   basic.contact-points = ["<discovery-service-clusterip>:9042"]
-//   basic.load-balancing-policy.local-datacenter = "us-east-1"
-//   advanced.auth-provider.class = PlainTextAuthProvider
-//   advanced.auth-provider.username = cassandra
-//   advanced.auth-provider.password = "<password>"
-// }
-
-CqlSession session = CqlSession.builder().build();
-```
-
-**Go (gocql):**
-```go
-cluster := gocql.NewCluster("<discovery-service-clusterip>")
-cluster.Keyspace = "system"
-cluster.Authenticator = gocql.PasswordAuthenticator{
-    Username: "cassandra",
-    Password: "<password>",
-}
-// cluster.SslOpts = &gocql.SslOptions{...} // for TLS
-session, err := cluster.CreateSession()
-if err != nil {
-    log.Fatal(err)
-}
-defer session.Close()
-```
-
 ## TLS certificate resources
 
 The Operator creates these resources automatically:

--- a/docs-staging/source/connect-your-app/connect-via-cql.md
+++ b/docs-staging/source/connect-your-app/connect-via-cql.md
@@ -1,5 +1,206 @@
 # Connect via CQL
 
-:::{todo}
-This page is not yet written.
+This page explains how to connect to a ScyllaDB cluster running on Kubernetes using CQL (Cassandra Query Language).
+
+## Authentication setup
+
+For security, always enable authentication and authorization. Create a ConfigMap with the ScyllaDB configuration before deploying your cluster:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scylladb-config
+data:
+  scylla.yaml: |
+    authenticator: PasswordAuthenticator
+    authorizer: CassandraAuthorizer
+```
+
+Reference this ConfigMap from your ScyllaCluster via `scyllaConfig` on each rack.
+
+## Embedded cqlsh
+
+Every ScyllaDB pod includes a built-in `cqlsh`. This is the simplest way to run queries:
+
+::::{tabs}
+:::{group-tab} Any node (via Service)
+```shell
+kubectl exec -it service/<cluster-name>-client -c scylla -- cqlsh -u <user>
+```
 :::
+
+:::{group-tab} Specific node
+```shell
+kubectl exec -it pod/<cluster-name>-<datacenter>-<rack>-<ordinal> -c scylla -- cqlsh -u <user>
+```
+:::
+::::
+
+```
+Password:
+Connected to scylla at 127.0.0.1:9042
+[cqlsh 6.2.0 | Scylla 2025.4.2 | CQL spec 3.3.1 | Native protocol v4]
+Use HELP for help.
+<user>@cqlsh>
+```
+
+## Remote cqlsh with TLS
+
+ScyllaDB Operator configures TLS certificates automatically. The encrypted CQL port `9142` works by default.
+
+:::{caution}
+In future releases, the unencrypted CQL port `9042` will be disabled by default unless explicitly opted in. Always use the TLS port `9142` for remote connections.
+:::
+
+### Prepare credentials and certificates
+
+:::{caution}
+The example below simplifies credential file creation for brevity. In production, create the credentials file with a text editor to avoid passwords leaking into shell history or environment variables.
+:::
+
+**Step 1: Identify the CA certificate Secret**
+
+The CA certificate secret is named `<cluster-name>-local-client-ca`:
+```bash
+kubectl -n scylla get secrets | grep client-ca
+```
+
+**Step 2: Extract the CA certificate**
+
+```bash
+kubectl -n scylla get secret scylla-local-client-ca \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d > ca.crt
+```
+Replace `scylla-local-client-ca` with the actual secret name from Step 1.
+
+**Step 3: Extract client credentials**
+
+```bash
+kubectl -n scylla get secret scylla-user-admin \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d > client.crt
+kubectl -n scylla get secret scylla-user-admin \
+  -o jsonpath='{.data.tls\.key}' | base64 -d > client.key
+```
+
+**Step 4: Verify the extracted files**
+
+```bash
+openssl x509 -in ca.crt -noout -subject -dates
+openssl x509 -in client.crt -noout -subject -dates
+```
+
+### Connect
+
+::::{tabs}
+:::{group-tab} Native
+```shell
+cqlsh --cqlshrc="${SCYLLADB_CONFIG}/cqlshrc"
+```
+:::
+
+:::{group-tab} Podman
+```shell
+podman run -it --rm --entrypoint=cqlsh \
+  -v="${SCYLLADB_CONFIG}:${SCYLLADB_CONFIG}:ro,Z" \
+  -v="${SCYLLADB_CONFIG}/cqlshrc:/root/.cassandra/cqlshrc:ro,Z" \
+  docker.io/scylladb/scylla:2025.4.2
+```
+:::
+
+:::{group-tab} Docker
+```shell
+docker run -it --rm --entrypoint=cqlsh \
+  -v="${SCYLLADB_CONFIG}:${SCYLLADB_CONFIG}:ro" \
+  -v="${SCYLLADB_CONFIG}/cqlshrc:/root/.cassandra/cqlshrc:ro" \
+  docker.io/scylladb/scylla:2025.4.2
+```
+:::
+::::
+
+## Driver configuration tips
+
+When using a ScyllaDB or Cassandra driver in your application:
+
+| Setting | Recommended value | Why |
+|---------|-------------------|-----|
+| Contact points | `<cluster-name>-client.<namespace>.svc` (DNS) or the Service ClusterIP | Use the discovery Service, not individual pod IPs. The driver discovers all nodes automatically. |
+| Local datacenter | Your `datacenter.name` value (e.g., `us-east-1`) | Required for `DCAwareRoundRobinPolicy`. Prevents cross-DC queries. |
+| Load balancing | Token-aware + DC-aware round robin | Sends queries directly to the replica owning the partition. |
+| TLS | Enabled, with CA verification | Use the serving CA from `configmap/<cluster-name>-local-serving-ca`. |
+| Reconnection | Exponential backoff | Handles node restarts during rolling updates. |
+
+### Code examples
+
+The following snippets show minimal working examples. Replace `<discovery-service-clusterip>` with the ClusterIP address from [Discovery endpoint](discovery.md) and `<password>` with the credentials from the ScyllaDB Secret.
+
+**Python (cassandra-driver):**
+```python
+from cassandra.cluster import Cluster
+from cassandra.auth import PlainTextAuthProvider
+from ssl import SSLContext, PROTOCOL_TLS_CLIENT, CERT_REQUIRED
+
+# TLS connection (recommended for production)
+ssl_context = SSLContext(PROTOCOL_TLS_CLIENT)
+ssl_context.load_verify_locations('/path/to/ca.crt')
+ssl_context.check_hostname = False
+ssl_context.verify_mode = CERT_REQUIRED
+
+auth_provider = PlainTextAuthProvider(username='cassandra', password='<password>')
+cluster = Cluster(
+    contact_points=['<discovery-service-clusterip>'],
+    port=9142,  # TLS port
+    ssl_context=ssl_context,
+    auth_provider=auth_provider,
+    load_balancing_policy=...,  # configure local_dc
+)
+session = cluster.connect()
+```
+
+**Java (DataStax Java Driver 4.x):**
+```java
+// application.conf (in resources/)
+// datastax-java-driver {
+//   basic.contact-points = ["<discovery-service-clusterip>:9042"]
+//   basic.load-balancing-policy.local-datacenter = "us-east-1"
+//   advanced.auth-provider.class = PlainTextAuthProvider
+//   advanced.auth-provider.username = cassandra
+//   advanced.auth-provider.password = "<password>"
+// }
+
+CqlSession session = CqlSession.builder().build();
+```
+
+**Go (gocql):**
+```go
+cluster := gocql.NewCluster("<discovery-service-clusterip>")
+cluster.Keyspace = "system"
+cluster.Authenticator = gocql.PasswordAuthenticator{
+    Username: "cassandra",
+    Password: "<password>",
+}
+// cluster.SslOpts = &gocql.SslOptions{...} // for TLS
+session, err := cluster.CreateSession()
+if err != nil {
+    log.Fatal(err)
+}
+defer session.Close()
+```
+
+## TLS certificate resources
+
+The Operator creates these resources automatically:
+
+| Resource | Name | Contents |
+|----------|------|----------|
+| Serving CA | `configmap/<cluster-name>-local-serving-ca` | `ca-bundle.crt` — CA to validate server certificates. |
+| Admin client cert | `secret/<cluster-name>-local-user-admin` | `tls.crt`, `tls.key` — client certificate for mTLS. |
+
+To use your own TLS certificates instead of operator-managed ones, set `servingCertificate.type: UserManaged` on the ScyllaCluster. See [TLS and certificate management](../understand/security.md).
+
+## Related pages
+
+- [Discovery endpoint](discovery.md) — how the client Service works and how to expose it.
+- [Alternator (DynamoDB API)](alternator.md) — connecting via the DynamoDB-compatible API.
+- [Configure external access](configure-external-access.md) — connecting from outside the Kubernetes cluster.
+- [Security](../understand/security.md) — TLS certificate management.

--- a/docs-staging/source/connect-your-app/discovery.md
+++ b/docs-staging/source/connect-your-app/discovery.md
@@ -29,32 +29,65 @@ Clients should use this endpoint as their initial contact point. The driver conn
 
 ## Exposing beyond the Kubernetes cluster
 
-If you need to connect from outside the Kubernetes cluster and are using Pod IPs as the broadcast address type, you can expose the `<cluster-name>-client` Service using a cloud provider's internal load balancer.
+If you need to connect from outside the Kubernetes cluster and are using Pod IPs as the broadcast address type, you can expose the discovery endpoint by creating a separate LoadBalancer Service that selects the same pods. Do **not** patch the operator-managed `<cluster-name>-client` Service directly — the operator reconciles it and will revert manual changes.
 
 ::::{tabs}
 :::{group-tab} GKE
-```shell
-kubectl patch service/<cluster-name>-client -p '{"metadata": {"annotations": {"networking.gke.io/load-balancer-type": "Internal"}}, "spec": {"type": "LoadBalancer"}}'
-kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' service/<cluster-name>-client
-kubectl get service/<cluster-name>-client -o='jsonpath={.status.loadBalancer.ingress[0].ip}'
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: <cluster-name>-client-external
+  namespace: scylla
+  annotations:
+    networking.gke.io/load-balancer-type: Internal
+spec:
+  type: LoadBalancer
+  selector:
+    scylla/cluster: <cluster-name>
+    app: scylla
+  ports:
+  - name: cql
+    port: 9042
+    targetPort: 9042
+  - name: cql-ssl
+    port: 9142
+    targetPort: 9142
 ```
 
-Expected output:
-```
-10.128.0.5
+```shell
+kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' service/<cluster-name>-client-external -n scylla
+kubectl get service/<cluster-name>-client-external -n scylla -o='jsonpath={.status.loadBalancer.ingress[0].ip}'
 ```
 :::
 
 :::{group-tab} EKS
-```shell
-kubectl patch service/<cluster-name>-client -p '{"metadata": {"annotations": {"service.beta.kubernetes.io/aws-load-balancer-scheme": "internal", "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "tcp"}}, "spec": {"type": "LoadBalancer"}}'
-kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' service/<cluster-name>-client
-kubectl get service/<cluster-name>-client -o='jsonpath={.status.loadBalancer.ingress[0].hostname}'
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: <cluster-name>-client-external
+  namespace: scylla
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+spec:
+  type: LoadBalancer
+  selector:
+    scylla/cluster: <cluster-name>
+    app: scylla
+  ports:
+  - name: cql
+    port: 9042
+    targetPort: 9042
+  - name: cql-ssl
+    port: 9142
+    targetPort: 9142
 ```
 
-Expected output:
-```
-internal-a1b2c3d4e5f6g7h8-123456789.us-east-1.elb.amazonaws.com
+```shell
+kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' service/<cluster-name>-client-external -n scylla
+kubectl get service/<cluster-name>-client-external -n scylla -o='jsonpath={.status.loadBalancer.ingress[0].hostname}'
 ```
 :::
 ::::

--- a/docs-staging/source/connect-your-app/discovery.md
+++ b/docs-staging/source/connect-your-app/discovery.md
@@ -1,5 +1,78 @@
 # Discovery endpoint
 
-:::{todo}
-This page is not yet written.
+This page explains how ScyllaDB clusters are discoverable by clients on Kubernetes and how to expose the discovery endpoint beyond the cluster boundary.
+
+## How discovery works
+
+For every ScyllaCluster, the Operator creates a Kubernetes Service named `<cluster-name>-client` that selects all ready ScyllaDB nodes. This Service acts as a stable entry point: clients connect to it to reach any available ScyllaDB node, and from there the driver automatically discovers all other nodes in the cluster.
+
+```shell
+kubectl get scyllacluster/scylladb service/scylladb-client
+```
+
+```
+NAME                                          READY   MEMBERS   RACKS   AVAILABLE
+scyllacluster.scylla.scylladb.com/scylladb    1       1         1       True
+
+NAME                      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)
+service/scylladb-client   ClusterIP   10.102.44.43   <none>        7000/TCP,7001/TCP,9042/TCP,9142/TCP,...
+```
+
+### Using the endpoint
+
+You can reach the discovery endpoint by:
+
+- **ClusterIP**: `kubectl get service/<cluster-name>-client -o='jsonpath={.spec.clusterIP}'`
+- **DNS name**: `<cluster-name>-client.<namespace>.svc` (for in-cluster clients)
+
+Clients should use this endpoint as their initial contact point. The driver connects to one of the ready nodes, fetches the cluster topology, and establishes connections to all nodes.
+
+## Exposing beyond the Kubernetes cluster
+
+If you need to connect from outside the Kubernetes cluster and are using Pod IPs as the broadcast address type, you can expose the `<cluster-name>-client` Service using a cloud provider's internal load balancer.
+
+::::{tabs}
+:::{group-tab} GKE
+```shell
+kubectl patch service/<cluster-name>-client -p '{"metadata": {"annotations": {"networking.gke.io/load-balancer-type": "Internal"}}, "spec": {"type": "LoadBalancer"}}'
+kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' service/<cluster-name>-client
+kubectl get service/<cluster-name>-client -o='jsonpath={.status.loadBalancer.ingress[0].ip}'
+```
+
+Expected output:
+```
+10.128.0.5
+```
 :::
+
+:::{group-tab} EKS
+```shell
+kubectl patch service/<cluster-name>-client -p '{"metadata": {"annotations": {"service.beta.kubernetes.io/aws-load-balancer-scheme": "internal", "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "tcp"}}, "spec": {"type": "LoadBalancer"}}'
+kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' service/<cluster-name>-client
+kubectl get service/<cluster-name>-client -o='jsonpath={.status.loadBalancer.ingress[0].hostname}'
+```
+
+Expected output:
+```
+internal-a1b2c3d4e5f6g7h8-123456789.us-east-1.elb.amazonaws.com
+```
+:::
+::::
+
+:::{tip}
+Having a stable discovery contact point is especially important when using ephemeral Pod IPs, because individual node IPs can change when pods are rescheduled.
+:::
+
+## Troubleshoot discovery failures
+
+**Discovery Service has no EXTERNAL-IP**: The LoadBalancer has not yet been provisioned. Wait 1–2 minutes and retry, or check cloud provider events with `kubectl describe service <name> -n scylla`.
+
+**Clients cannot reach discovery endpoint**: Verify that firewall rules allow traffic on port 9042. See [Prerequisites](../install-operator/prerequisites.md).
+
+**Driver loses all contact points after a restart**: The ClusterIP (`<cluster>-client`) is stable across pod restarts. Prefer it over Pod IPs as the initial contact point. See [Connect via CQL](connect-via-cql.md).
+
+## Related pages
+
+- [Connect via CQL](connect-via-cql.md) — using the discovery endpoint for CQL connections.
+- [Configure external access](configure-external-access.md) — configuring expose options for external connectivity.
+- [Networking architecture](../understand/networking.md) — how Services and expose options work.

--- a/docs-staging/source/connect-your-app/discovery.md
+++ b/docs-staging/source/connect-your-app/discovery.md
@@ -4,7 +4,7 @@ This page explains how ScyllaDB clusters are discoverable by clients on Kubernet
 
 ## How discovery works
 
-For every ScyllaCluster, the Operator creates a Kubernetes Service named `<cluster-name>-client` that selects all ready ScyllaDB nodes. This Service acts as a stable entry point: clients connect to it to reach any available ScyllaDB node, and from there the driver automatically discovers all other nodes in the cluster.
+For every ScyllaCluster, the Operator creates a Kubernetes Service named `<cluster-name>-client` that matches all ScyllaDB pods in the cluster by label. Kubernetes routes traffic only to pods that pass their readiness probe. This Service acts as a stable entry point: clients connect to it to reach any available ScyllaDB node, and from there the driver automatically discovers all other nodes in the cluster.
 
 ```shell
 kubectl get scyllacluster/scylladb service/scylladb-client

--- a/docs-staging/source/connect-your-app/discovery.md
+++ b/docs-staging/source/connect-your-app/discovery.md
@@ -4,7 +4,7 @@ This page explains how ScyllaDB clusters are discoverable by clients on Kubernet
 
 ## How discovery works
 
-For every ScyllaCluster, the Operator creates a Kubernetes Service named `<cluster-name>-client` that matches all ScyllaDB pods in the cluster by label. Kubernetes routes traffic only to pods that pass their readiness probe. This Service acts as a stable entry point: clients connect to it to reach any available ScyllaDB node, and from there the driver automatically discovers all other nodes in the cluster.
+For every ScyllaCluster, the Operator creates a Kubernetes Service named `<cluster-name>-client` that matches all ScyllaDB Pods in the cluster by label. Kubernetes routes traffic only to Pods that pass their readiness probe. This Service acts as a stable entry point: clients connect to it to reach any available ScyllaDB node, and from there the driver automatically discovers all other nodes in the cluster.
 
 ```shell
 kubectl get scyllacluster/scylladb service/scylladb-client
@@ -29,7 +29,7 @@ Clients should use this endpoint as their initial contact point. The driver conn
 
 ## Exposing beyond the Kubernetes cluster
 
-If you need to connect from outside the Kubernetes cluster and are using Pod IPs as the broadcast address type, you can expose the discovery endpoint by creating a separate LoadBalancer Service that selects the same pods. Do **not** patch the operator-managed `<cluster-name>-client` Service directly — the operator reconciles it and will revert manual changes.
+If you need to connect from outside the Kubernetes cluster and are using Pod IPs as the broadcast address type, you can expose the discovery endpoint by creating a separate LoadBalancer Service that selects the same Pods. Do **not** patch the operator-managed `<cluster-name>-client` Service directly — the operator reconciles it and will revert manual changes.
 
 ::::{tabs}
 :::{group-tab} GKE
@@ -46,6 +46,7 @@ spec:
   selector:
     scylla/cluster: <cluster-name>
     app: scylla
+    scylla-operator.scylladb.com/pod-type: scylladb-node
   ports:
   - name: cql
     port: 9042
@@ -76,6 +77,7 @@ spec:
   selector:
     scylla/cluster: <cluster-name>
     app: scylla
+    scylla-operator.scylladb.com/pod-type: scylladb-node
   ports:
   - name: cql
     port: 9042
@@ -93,16 +95,8 @@ kubectl get service/<cluster-name>-client-external -n scylla -o='jsonpath={.stat
 ::::
 
 :::{tip}
-Having a stable discovery contact point is especially important when using ephemeral Pod IPs, because individual node IPs can change when pods are rescheduled.
+Having a stable discovery contact point is especially important when using ephemeral Pod IPs, because individual node IPs can change when Pods are rescheduled.
 :::
-
-## Troubleshoot discovery failures
-
-**Discovery Service has no EXTERNAL-IP**: The LoadBalancer has not yet been provisioned. Wait 1–2 minutes and retry, or check cloud provider events with `kubectl describe service <name> -n scylla`.
-
-**Clients cannot reach discovery endpoint**: Verify that firewall rules allow traffic on port 9042. See [Prerequisites](../install-operator/prerequisites.md).
-
-**Driver loses all contact points after a restart**: The ClusterIP (`<cluster>-client`) is stable across pod restarts. Prefer it over Pod IPs as the initial contact point. See [Connect via CQL](connect-via-cql.md).
 
 ## Related pages
 

--- a/docs-staging/source/connect-your-app/discovery.md
+++ b/docs-staging/source/connect-your-app/discovery.md
@@ -15,7 +15,7 @@ NAME                                          READY   MEMBERS   RACKS   AVAILABL
 scyllacluster.scylla.scylladb.com/scylladb    1       1         1       True
 
 NAME                      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)
-service/scylladb-client   ClusterIP   10.102.44.43   <none>        7000/TCP,7001/TCP,9042/TCP,9142/TCP,...
+service/scylladb-client   ClusterIP   10.102.44.43   <none>        7000/TCP,7001/TCP,9042/TCP,9142/TCP,19042/TCP,19142/TCP,7199/TCP,10001/TCP,9180/TCP,5090/TCP,9100/TCP,9160/TCP,8043/TCP
 ```
 
 ### Using the endpoint


### PR DESCRIPTION
Part of OPERATOR-32 and productionization of #3305

Adds the "Connect Your App" section to `/docs-staging`, transplanted from #3305, with some review fixes (listed as separate commits).

/kind documentation
/priority important-longterm
/cc czeslavo