### PR TITLE
docs(staging): transplant old IPv6 networking docs

### DIFF
--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-dual-stack.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-dual-stack.md
@@ -23,10 +23,11 @@ For configuration details, see the [IPv6 configuration reference](../../../refer
 
 Apply the dual-stack configuration:
 
-```bash
+:::{code-block} shell
+:substitutions:
 kubectl create namespace scylla
 kubectl apply -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/ipv6/scylla-cluster-dual-stack.yaml
-```
+:::
 
 ## Step 2: Wait for the cluster to be ready
 

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-dual-stack.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-dual-stack.md
@@ -1,4 +1,13 @@
-# Configure dual-stack networking with IPv4
+# Configure dual-stack networking
+
+This guide covers two dual-stack configurations:
+
+- [IPv4-first dual-stack](#configure-dual-stack-networking-with-ipv4) (recommended) — ScyllaDB uses IPv4 internally, services accessible via both protocols
+- [IPv6-first dual-stack](#configure-dual-stack-networking-with-ipv6) — ScyllaDB uses IPv6 internally, services accessible via both protocols
+
+For IPv6-only (single-stack) deployments, see [Configure IPv6-only](configure-single-stack.md). For configuration field details, see the [IPv6 configuration reference](../../../reference/ipv6-configuration.md).
+
+## Configure dual-stack networking with IPv4
 
 **What you'll achieve**: Deploy a ScyllaDB cluster that uses IPv4 for ScyllaDB communication and provides services accessible via both IPv4 and IPv6.
 
@@ -10,16 +19,10 @@
 **After completion**: Your ScyllaDB cluster will use IPv4 for inter-node communication while services are accessible via both IPv4 and IPv6.
 
 :::{note}
-This is the recommended configuration for production IPv6 deployments. For other configurations, see:
-- [Configure IPv6-first dual-stack](#configure-dual-stack-networking-with-ipv6) - ScyllaDB uses IPv6
-- [Configure IPv6-only](configure-single-stack.md) - Experimental
-
-For configuration details, see the [IPv6 configuration reference](../../../reference/ipv6-configuration.md).
+This is the recommended configuration for production IPv6 deployments.
 :::
 
-:::
-
-## Step 1: Apply the configuration
+### Step 1: Apply the configuration
 
 Apply the dual-stack configuration:
 
@@ -29,7 +32,7 @@ kubectl create namespace scylla
 kubectl apply -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/ipv6/scylla-cluster-dual-stack.yaml
 :::
 
-## Step 2: Wait for the cluster to be ready
+### Step 2: Wait for the cluster to be ready
 
 Monitor pod creation:
 
@@ -39,7 +42,7 @@ kubectl get pods -n scylla -l scylla-operator.scylladb.com/pod-type=scylladb-nod
 
 Wait until all pods show `Running` status.
 
-## Step 3: Verify dual-stack configuration
+### Step 3: Verify dual-stack configuration
 
 Check that services have both IP families:
 
@@ -55,7 +58,7 @@ scylla-dual-stack-client        [IPv4 IPv6]        PreferDualStack
 scylla-dual-stack-us-east-1a-0  [IPv4 IPv6]        PreferDualStack
 ```
 
-## Step 4: Verify cluster health
+### Step 4: Verify cluster health
 
 Check that all nodes are up:
 
@@ -77,12 +80,12 @@ UN  fd00:10:244:3::6c 494.96 KB 256     ?     7a4bb6da-415e-4fc3-a6ca-0369c0e76b
 
 All nodes should show `UN` (Up/Normal) status.
 
-## Next steps
+### Next steps
 
 - [Migrate existing clusters to IPv6](migration.md)
 - [Troubleshoot IPv6 issues](troubleshooting.md)
 
-# Configure dual-stack networking with IPv6
+## Configure dual-stack networking with IPv6
 
 **What you'll achieve**: Deploy a ScyllaDB cluster that uses IPv6 for ScyllaDB communication and provides services accessible via both IPv6 and IPv4.
 
@@ -97,7 +100,7 @@ All nodes should show `UN` (Up/Normal) status.
 This configuration is production-ready. For IPv4-first dual-stack, see [Configure dual-stack with IPv4](#configure-dual-stack-networking-with-ipv4).
 :::
 
-## Step 1: Create the configuration
+### Step 1: Create the configuration
 
 Create a file `scylla-ipv6-first.yaml`:
 
@@ -145,14 +148,14 @@ spec:
         type: ServiceClusterIP
 ```
 
-## Step 2: Apply the configuration
+### Step 2: Apply the configuration
 
 ```bash
 kubectl create namespace scylla
 kubectl apply -f scylla-ipv6-first.yaml
 ```
 
-## Step 3: Wait for the cluster to be ready
+### Step 3: Wait for the cluster to be ready
 
 Monitor pod creation:
 
@@ -162,7 +165,7 @@ kubectl get pods -n scylla -l scylla-operator.scylladb.com/pod-type=scylladb-nod
 
 Wait until all pods show `Running` status.
 
-## Step 4: Verify dual-stack configuration
+### Step 4: Verify dual-stack configuration
 
 Check that services have both IP families:
 
@@ -178,7 +181,7 @@ scylla-ipv6-first-client          [IPv6 IPv4]        PreferDualStack
 scylla-ipv6-first-datacenter1-... [IPv6 IPv4]        PreferDualStack
 ```
 
-## Step 5: Verify cluster uses IPv6
+### Step 5: Verify cluster uses IPv6
 
 Check that ScyllaDB is using IPv6 addresses:
 
@@ -206,7 +209,7 @@ UN  fd00:10:244:2::6d    494.49 KB 256     ?     b1f889b4-80e7-4685-a3c5-1b81797
 UN  fd00:10:244:3::6c    494.96 KB 256     ?     7a4bb6da-415e-4fc3-a6ca-0369c0e76bf0 rack1
 ```
 
-## Next steps
+### Next steps
 
 - [Migrate existing clusters to IPv6](migration.md)
 - [Troubleshoot IPv6 issues](troubleshooting.md)

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-dual-stack.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-dual-stack.md
@@ -1,5 +1,211 @@
-# Configure dual-stack networking
+# Configure dual-stack networking with IPv4
 
-:::{todo}
-This page is not yet written.
+**What you'll achieve**: Deploy a ScyllaDB cluster that uses IPv4 for ScyllaDB communication and provides services accessible via both IPv4 and IPv6.
+
+**Before you begin**: 
+- You have a Kubernetes cluster with dual-stack networking enabled
+- You have ScyllaDB Operator installed
+- You have `kubectl` configured
+
+**After completion**: Your ScyllaDB cluster will use IPv4 for inter-node communication while services are accessible via both IPv4 and IPv6.
+
+:::{note}
+This is the recommended configuration for production IPv6 deployments. For other configurations, see:
+- [Configure IPv6-first dual-stack](#configure-dual-stack-networking-with-ipv6) - ScyllaDB uses IPv6
+- [Configure IPv6-only](configure-single-stack.md) - Experimental
+
+For configuration details, see the [IPv6 configuration reference](../../../reference/ipv6-configuration.md).
 :::
+
+:::
+
+## Step 1: Apply the configuration
+
+Apply the dual-stack configuration:
+
+```bash
+kubectl create namespace scylla
+kubectl apply -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/ipv6/scylla-cluster-dual-stack.yaml
+```
+
+## Step 2: Wait for the cluster to be ready
+
+Monitor pod creation:
+
+```bash
+kubectl get pods -n scylla -l scylla-operator.scylladb.com/pod-type=scylladb-node -w
+```
+
+Wait until all pods show `Running` status.
+
+## Step 3: Verify dual-stack configuration
+
+Check that services have both IP families:
+
+```bash
+kubectl get svc -n scylla -o custom-columns=NAME:.metadata.name,IP-FAMILIES:.spec.ipFamilies,POLICY:.spec.ipFamilyPolicy
+```
+
+Expected output shows `[IPv4 IPv6]` for IP families:
+
+```
+NAME                            IP-FAMILIES        POLICY
+scylla-dual-stack-client        [IPv4 IPv6]        PreferDualStack
+scylla-dual-stack-us-east-1a-0  [IPv4 IPv6]        PreferDualStack
+```
+
+## Step 4: Verify cluster health
+
+Check that all nodes are up:
+
+```bash
+kubectl exec -it scylla-dual-stack-example-rack-0 -n scylla -c scylla -- nodetool status
+```
+
+**Expected output:**
+```
+Datacenter: dual-stack-datacenter
+===================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address           Load      Tokens  Owns  Host ID                              Rack
+UN  fd00:10:244:1::7f 501.79 KB 256     ?     4583fff5-2aa6-4041-9be8-c74bcabaff8c dual-stack-rack-a
+UN  fd00:10:244:2::6d 494.49 KB 256     ?     b1f889b4-80e7-4685-a3c5-1b81797c2ce4 dual-stack-rack-a
+UN  fd00:10:244:3::6c 494.96 KB 256     ?     7a4bb6da-415e-4fc3-a6ca-0369c0e76bf0 dual-stack-rack-a
+```
+
+All nodes should show `UN` (Up/Normal) status.
+
+## Next steps
+
+- [Migrate existing clusters to IPv6](migration.md)
+- [Troubleshoot IPv6 issues](troubleshooting.md)
+
+# Configure dual-stack networking with IPv6
+
+**What you'll achieve**: Deploy a ScyllaDB cluster that uses IPv6 for ScyllaDB communication and provides services accessible via both IPv6 and IPv4.
+
+**Before you begin**: 
+- You have a Kubernetes cluster with dual-stack networking enabled
+- You have ScyllaDB Operator installed
+- You have `kubectl` configured
+
+**After completion**: Your ScyllaDB cluster will use IPv6 for inter-node communication while services are accessible via both IPv6 and IPv4.
+
+:::{note}
+This configuration is production-ready. For IPv4-first dual-stack, see [Configure dual-stack with IPv4](#configure-dual-stack-networking-with-ipv4).
+:::
+
+## Step 1: Create the configuration
+
+Create a file `scylla-ipv6-first.yaml`:
+
+```yaml
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: scylla-ipv6-first
+  namespace: scylla
+spec:
+  version: 6.2.2
+  agentVersion: 3.3.3
+  datacenter:
+    name: datacenter1
+    racks:
+      - name: rack1
+        members: 3
+        storage:
+          capacity: 100Gi
+          storageClassName: scylladb-local-xfs
+        resources:
+          limits:
+            cpu: 4
+            memory: 16Gi
+          requests:
+            cpu: 4
+            memory: 16Gi
+  
+  network:
+    ipFamilyPolicy: PreferDualStack
+    ipFamilies:
+      - IPv6  # ScyllaDB uses IPv6
+      - IPv4  # Services also support IPv4
+    dnsPolicy: ClusterFirst
+  
+  exposeOptions:
+    nodeService:
+      type: Headless
+    broadcastOptions:
+      nodes:
+        type: PodIP
+        podIP:
+          source: Status
+      clients:
+        type: ServiceClusterIP
+```
+
+## Step 2: Apply the configuration
+
+```bash
+kubectl create namespace scylla
+kubectl apply -f scylla-ipv6-first.yaml
+```
+
+## Step 3: Wait for the cluster to be ready
+
+Monitor pod creation:
+
+```bash
+kubectl get pods -n scylla -l scylla-operator.scylladb.com/pod-type=scylladb-node -w
+```
+
+Wait until all pods show `Running` status.
+
+## Step 4: Verify dual-stack configuration
+
+Check that services have both IP families:
+
+```bash
+kubectl get svc -n scylla -o custom-columns=NAME:.metadata.name,IP-FAMILIES:.spec.ipFamilies,POLICY:.spec.ipFamilyPolicy
+```
+
+Expected output shows `[IPv6 IPv4]` for IP families:
+
+```
+NAME                              IP-FAMILIES        POLICY
+scylla-ipv6-first-client          [IPv6 IPv4]        PreferDualStack
+scylla-ipv6-first-datacenter1-... [IPv6 IPv4]        PreferDualStack
+```
+
+## Step 5: Verify cluster uses IPv6
+
+Check that ScyllaDB is using IPv6 addresses:
+
+```bash
+NAMESPACE=scylla
+CLUSTER_NAME=scylla-ipv6-first
+
+pods=$(kubectl -n "${NAMESPACE}" get pods -l scylla/cluster="${CLUSTER_NAME}" -l scylla-operator.scylladb.com/pod-type=scylladb-node -o name)
+
+for pod in ${pods}; do
+  kubectl -n "${NAMESPACE}" exec "${pod}" -c scylla -- nodetool status
+done
+```
+
+Expected output shows IPv6 addresses (with colons):
+
+```
+Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address              Load      Tokens  Owns  Host ID                              Rack
+UN  fd00:10:244:1::7f    501.79 KB 256     ?     4583fff5-2aa6-4041-9be8-c74bcabaff8c rack1
+UN  fd00:10:244:2::6d    494.49 KB 256     ?     b1f889b4-80e7-4685-a3c5-1b81797c2ce4 rack1
+UN  fd00:10:244:3::6c    494.96 KB 256     ?     7a4bb6da-415e-4fc3-a6ca-0369c0e76bf0 rack1
+```
+
+## Next steps
+
+- [Migrate existing clusters to IPv6](migration.md)
+- [Troubleshoot IPv6 issues](troubleshooting.md)

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-single-stack.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-single-stack.md
@@ -1,5 +1,83 @@
-# Configure IPv6-only single-stack
+# Configure IPv6-only networking
 
-:::{todo}
-This page is not yet written.
+**What you'll achieve**: Deploy a ScyllaDB cluster that uses only IPv6 for all communication.
+
+**Before you begin**: 
+- You have a Kubernetes cluster with IPv6 support
+- You have ScyllaDB Operator installed
+- You have `kubectl` configured
+- Your cluster and applications support IPv6-only operation
+
+**After completion**: Your ScyllaDB cluster will use only IPv6 for all communication.
+
+:::{warning}
+**Experimental Feature**: IPv6-only configurations are experimental. See [Production readiness](../../../reference/ipv6-configuration.md#production-readiness) for details. For production deployments, use [dual-stack with IPv4](configure-dual-stack.md) or [dual-stack with IPv6](configure-dual-stack.md#configure-dual-stack-networking-with-ipv6) instead.
 :::
+
+## Step 1: Apply the configuration
+
+Apply the IPv6-only configuration:
+
+```bash
+kubectl create namespace scylla
+kubectl apply -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/ipv6/scylla-cluster-ipv6.yaml
+```
+
+## Step 2: Wait for the cluster to be ready
+
+Monitor pod creation:
+
+```bash
+kubectl get pods -n scylla -l scylla-operator.scylladb.com/pod-type=scylladb-node -w
+```
+
+Wait until all pods show `Running` status.
+
+## Step 3: Verify IPv6-only configuration
+
+Check that pods have IPv6 addresses:
+
+```bash
+kubectl get pods -n scylla -l scylla-operator.scylladb.com/pod-type=scylladb-node -o wide
+```
+
+Expected output shows IPv6 addresses in the IP column:
+
+```
+NAME                       READY   STATUS    RESTARTS   AGE   IP                NODE
+scylla-ipv6-datacenter-... 2/2     Running   0          5m    fd00:10:244:1::7f scylla-worker-1
+scylla-ipv6-datacenter-... 2/2     Running   0          4m    fd00:10:244:2::6d scylla-worker-2
+scylla-ipv6-datacenter-... 2/2     Running   0          3m    fd00:10:244:3::6c scylla-worker-3
+```
+
+## Step 4: Verify cluster health
+
+Check that all nodes are up:
+
+```bash
+NAMESPACE=scylla
+CLUSTER_NAME=scylla-ipv6
+
+pods=$(kubectl -n "${NAMESPACE}" get pods -l scylla/cluster="${CLUSTER_NAME}" -l scylla-operator.scylladb.com/pod-type=scylladb-node -o name)
+
+for pod in ${pods}; do
+  kubectl -n "${NAMESPACE}" exec "${pod}" -c scylla -- nodetool status
+done
+```
+
+Expected output shows IPv6 addresses:
+
+```
+Datacenter: datacenter
+======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address              Load      Tokens  Owns  Host ID                              Rack
+UN  fd00:10:244:1::7f    501.79 KB 256     ?     4583fff5-2aa6-4041-9be8-c74bcabaff8c rack
+UN  fd00:10:244:2::6d    494.49 KB 256     ?     b1f889b4-80e7-4685-a3c5-1b81797c2ce4 rack
+UN  fd00:10:244:3::6c    494.96 KB 256     ?     7a4bb6da-415e-4fc3-a6ca-0369c0e76bf0 rack
+```
+
+## Next steps
+
+- [Troubleshoot IPv6 issues](troubleshooting.md)

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-single-stack.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/configure-single-stack.md
@@ -18,10 +18,11 @@
 
 Apply the IPv6-only configuration:
 
-```bash
+:::{code-block} shell
+:substitutions:
 kubectl create namespace scylla
 kubectl apply -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/ipv6/scylla-cluster-ipv6.yaml
-```
+:::
 
 ## Step 2: Wait for the cluster to be ready
 

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/get-started.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/get-started.md
@@ -1,5 +1,238 @@
-# Get started with IPv6 networking
+# Getting started with IPv6 networking
 
-:::{todo}
-This page is not yet written.
+This tutorial teaches you how to deploy your first ScyllaDB cluster with IPv6 networking. You'll learn IPv6 networking concepts while setting up a working cluster.
+
+## What you'll learn
+
+In this tutorial, you'll:
+- Understand what IPv6 networking means for ScyllaDB
+- Verify your Kubernetes cluster supports IPv6
+- Deploy a ScyllaDB cluster with dual-stack networking
+- Verify your cluster is working correctly
+- Understand the configuration you created
+
+:::{note}
+This tutorial uses **dual-stack** configuration (both IPv4 and IPv6) because it's production-ready and well-tested. IPv6-only configurations are experimental. See [Production readiness](../../../reference/ipv6-configuration.md#production-readiness) for details.
 :::
+
+## Prerequisites
+
+Before you begin:
+
+### Kubernetes cluster
+
+- **Dual-stack support**: Your cluster needs both IPv4 and IPv6 network ranges configured
+
+### ScyllaDB
+
+- **ScyllaDB version**: 2024.1 or newer (recommended for IPv6 support)
+- **ScyllaDB Operator**: Already installed in your cluster
+
+### Tools
+
+- `kubectl` configured to access your cluster
+- Basic familiarity with ScyllaDB and Kubernetes concepts
+
+## Step 1: Verify IPv6 support
+
+Check if your cluster has at least one node that has an IPv6 address of type InternalIP:
+
+```bash
+kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' | tr ' ' '\n' | grep ':'
+```
+
+This command filters for IPv6 addresses. You can quickly tell if an IP address is IPv4 if it uses dots `.` as separators (e.g. 172.16.57.29); IPv6 addresses use colons `:` as separators (e.g. 2001:db8:1::1).
+
+**Example output for an IPv6-ready cluster:**
+```
+2001:db8:1::1
+2001:db8:1::2
+2001:db8:1::3
+```
+
+If you see IPv6 addresses in the output, then your cluster has some IPv6-enabled nodes.
+
+:::{tip}
+**No IPv6 addresses?** Your Kubernetes cluster may not have IPv6 enabled. Check your cluster's network configuration or consult your cluster administrator.
+:::
+
+## Step 2: Understand dual-stack networking
+
+Before deploying, let's understand what dual-stack means:
+
+- **Kubernetes services**: Have both IPv4 and IPv6 addresses
+- **ScyllaDB nodes**: Communicate using a single IP family (IPv4 in this tutorial)
+- **Client connectivity**: Clients can discover services via either protocol
+
+This is useful when you have clients on different network types that all need to access your database.
+
+## Step 3: Create your first IPv6-enabled cluster
+
+Download the example dual-stack configuration:
+
+```bash
+kubectl apply -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/ipv6/scylla-cluster-minimal-dual-stack.yaml
+```
+
+You can view the complete example configuration in the repository: [scylla-cluster-minimal-dual-stack.yaml](../../../../../examples/ipv6/scylla-cluster-minimal-dual-stack.yaml)
+
+The key networking configuration is:
+
+```yaml
+network:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4  # ScyllaDB will use IPv4 internally
+    - IPv6  # Services will also be accessible via IPv6
+  dnsPolicy: ClusterFirst
+```
+
+Or deploy directly:
+
+```bash
+kubectl create namespace scylla
+kubectl apply -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/ipv6/scylla-cluster-minimal-dual-stack.yaml
+```
+
+## Step 4: Watch the cluster deploy
+
+Monitor the cluster deployment:
+
+```bash
+kubectl get pods -n scylla -w
+```
+
+Wait until all pods show `Running` status with `4/4` ready:
+
+```
+NAME                                           READY   STATUS    RESTARTS   AGE   IP            NODE
+scylla-ipv6-tutorial-us-east-1-us-east-1a-0    4/4     Running   0          5m    10.244.1.5    worker-1
+scylla-ipv6-tutorial-us-east-1-us-east-1a-1    4/4     Running   0          4m    10.244.2.6    worker-2
+scylla-ipv6-tutorial-us-east-1-us-east-1a-2    4/4     Running   0          3m    10.244.3.7    worker-3
+```
+
+## Step 5: Verify IPv6 configuration
+
+Check that your services have both IPv4 and IPv6 addresses:
+
+```bash
+kubectl get svc -n scylla -o custom-columns=NAME:.metadata.name,IP-FAMILIES:.spec.ipFamilies,POLICY:.spec.ipFamilyPolicy
+```
+
+**Expected output:**
+```
+NAME                                                  IP-FAMILIES        POLICY
+scylla-ipv6-tutorial-client                           [IPv4 IPv6]        PreferDualStack
+scylla-ipv6-tutorial-tutorial-dc-tutorial-rack-0      [IPv4 IPv6]        PreferDualStack
+scylla-ipv6-tutorial-tutorial-dc-tutorial-rack-1      [IPv4 IPv6]        PreferDualStack
+scylla-ipv6-tutorial-tutorial-dc-tutorial-rack-2      [IPv4 IPv6]        PreferDualStack
+```
+
+The `IP-FAMILIES` column shows both IPv4 and IPv6, confirming dual-stack configuration.
+
+## Step 6: Verify cluster health
+
+Check the cluster status using nodetool:
+
+```bash
+kubectl exec -it scylla-ipv6-tutorial-tutorial-dc-tutorial-rack-0 -n scylla -c scylla -- nodetool status
+```
+
+**Expected output:**
+```
+Datacenter: tutorial-dc
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address        Load       Tokens       Owns    Host ID                               Rack
+UN  10.244.1.5     256 KB     256          ?       a1b2c3d4-...                          tutorial-rack
+UN  10.244.2.6     256 KB     256          ?       e5f6g7h8-...                          tutorial-rack
+UN  10.244.3.7     256 KB     256          ?       i9j0k1l2-...                          tutorial-rack
+```
+
+All nodes should have status `UN` (Up/Normal).
+
+:::{tip}
+Notice that the addresses are of the family (either IPv4 or IPv6) that matches the first family that we set under `ipFamilies` in an earlier step. In this case, the addresses are IPv4 (like `10.244.x.x`), while services are accessible via both protocols.  
+:::
+
+## Step 7: Test client connectivity
+
+Let's test connecting to the cluster via both IPv4 and IPv6:
+
+```bash
+# Get the client service IP addresses
+kubectl get svc scylla-ipv6-tutorial-client -n scylla -o jsonpath='{.spec.clusterIPs}' | jq .
+```
+
+**Example output:**
+```
+[
+  "10.96.10.20",           # IPv4 address
+  "fd00:10:96::1234"       # IPv6 address
+]
+```
+
+Test connectivity with cqlsh:
+
+```bash
+kubectl run -it --rm cqlsh --image=scylladb/scylla-cqlsh:latest --restart=Never -n scylla-test -- \
+    scylla-ipv6-tutorial-client.scylla.svc.cluster.local 9042 \
+  -e "SELECT cluster_name,broadcast_address FROM system.local;"  
+```
+
+**Example output**
+```
+-------------------+---------------------
+ cluster_name      | tutorial
+ broadcast_address | 10.96.136.225
+
+(1 rows)
+pod "cqlsh" deleted
+```
+
+## Understanding your configuration
+
+Let's break down what you configured:
+
+### Network settings
+
+```yaml
+network:
+  ipFamilyPolicy: PreferDualStack  # Use dual-stack if available
+  ipFamilies:
+    - IPv4  # First = ScyllaDB's internal protocol
+    - IPv6  # Second = Additional service accessibility
+  dnsPolicy: ClusterFirst  # Essential for proper DNS resolution
+```
+
+**Key points:**
+- The **first** IP family (`IPv4`) determines what protocol ScyllaDB uses internally
+- The **second** IP family (`IPv6`) makes services accessible via IPv6 too
+- `PreferDualStack` falls back to single-stack if dual-stack isn't available
+
+For more details on how ScyllaDB nodes advertise themselves, see [Exposing ScyllaDB clusters](../expose-clusters.md).
+
+## What's next?
+
+Now that you have a working IPv6-enabled cluster, you can:
+
+- Learn how to [configure different IPv6 setups](configure-dual-stack.md) (IPv6-only, different dual-stack configurations)
+- Understand [how IPv6 networking works](ipv6-concepts.md) in ScyllaDB
+- Explore the [IPv6 configuration reference](../../../reference/ipv6-configuration.md) for all available options
+- Learn how to [migrate existing clusters to IPv6](migration.md)
+
+## Clean up
+
+To remove the tutorial cluster:
+
+```bash
+kubectl delete -f scylla-cluster-ipv6.yaml
+kubectl delete namespace scylla
+```
+
+## Related documentation
+
+- [How to configure IPv6 networking](configure-dual-stack.md)
+- [IPv6 networking concepts](ipv6-concepts.md)
+- [IPv6 configuration reference](../../../reference/ipv6-configuration.md)

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/get-started.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/get-started.md
@@ -70,9 +70,10 @@ This is useful when you have clients on different network types that all need to
 
 Download the example dual-stack configuration:
 
-```bash
+:::{code-block} shell
+:substitutions:
 kubectl apply -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/ipv6/scylla-cluster-minimal-dual-stack.yaml
-```
+:::
 
 You can view the complete example configuration in the repository: [scylla-cluster-minimal-dual-stack.yaml](../../../../../examples/ipv6/scylla-cluster-minimal-dual-stack.yaml)
 
@@ -89,10 +90,11 @@ network:
 
 Or deploy directly:
 
-```bash
+:::{code-block} shell
+:substitutions:
 kubectl create namespace scylla
 kubectl apply -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/ipv6/scylla-cluster-minimal-dual-stack.yaml
-```
+:::
 
 ## Step 4: Watch the cluster deploy
 

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/index.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/index.md
@@ -117,7 +117,6 @@ If you need assistance:
 ## Related documentation
 
 - [Networking overview](../index.md)
-- [ScyllaCluster API Reference](../../../reference/api/groups/scylla.scylladb.com/scyllaclusters)
 - [Kubernetes IPv6 Documentation](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
 
 ```{toctree}

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/index.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/index.md
@@ -16,8 +16,7 @@ Start here if you're new to IPv6 networking in ScyllaDB:
 
 Practical guides for specific tasks:
 
-- [Configure dual-stack with IPv4](configure-dual-stack.md) - IPv4-first dual-stack (recommended)
-- [Configure dual-stack with IPv6](configure-dual-stack.md#configure-dual-stack-networking-with-ipv6) - IPv6-first dual-stack
+- [Configure dual-stack networking](configure-dual-stack.md) - IPv4-first (recommended) and IPv6-first dual-stack
 - [Configure IPv6-only](configure-single-stack.md) - IPv6 single-stack (experimental)
 - [Migrate clusters to IPv6](migration.md) - Migrate existing clusters from IPv4 to IPv6
 - [Troubleshoot IPv6 networking issues](troubleshooting.md) - Diagnose and resolve common problems

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/index.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/index.md
@@ -1,13 +1,133 @@
 # IPv6 networking
 
-Configure IPv6 networking for ScyllaDB clusters, including dual-stack and single-stack deployments.
+IPv6 networking support enables you to run ScyllaDB clusters on IPv6 networks, with options for IPv6-only, IPv4-only, or dual-stack (both protocols) configurations.
 
-:::{toctree}
-:maxdepth: 1
+:::{note}
+IPv6-only configurations are experimental. All other configurations are production-ready. See [Production readiness](../../../reference/ipv6-configuration.md#production-readiness) for details.
+:::
+
+## Tutorials
+
+Start here if you're new to IPv6 networking in ScyllaDB:
+
+- [Getting started with IPv6 networking](get-started.md) - Your first IPv6-enabled cluster with step-by-step guidance
+
+## How-to guides
+
+Practical guides for specific tasks:
+
+- [Configure dual-stack with IPv4](configure-dual-stack.md) - IPv4-first dual-stack (recommended)
+- [Configure dual-stack with IPv6](configure-dual-stack.md#configure-dual-stack-networking-with-ipv6) - IPv6-first dual-stack
+- [Configure IPv6-only](configure-single-stack.md) - IPv6 single-stack (experimental)
+- [Migrate clusters to IPv6](migration.md) - Migrate existing clusters from IPv4 to IPv6
+- [Troubleshoot IPv6 networking issues](troubleshooting.md) - Diagnose and resolve common problems
+
+## Reference
+
+Technical specifications and API details:
+
+- [IPv6 configuration reference](../../../reference/ipv6-configuration.md) - Complete API reference for IPv6 settings
+
+## Concepts
+
+Deep explanations of how IPv6 networking works:
+
+- [IPv6 networking concepts](ipv6-concepts.md) - Understand how IPv6 support works in ScyllaDB
+
+## Configuration examples
+
+Quick examples for common scenarios:
+
+**Dual-stack (recommended for production)**:
+```yaml
+network:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4  # ScyllaDB uses IPv4
+    - IPv6  # Services also support IPv6
+  dnsPolicy: ClusterFirst
+```
+
+**IPv6-only (experimental)**:
+```yaml
+network:
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv6
+  dnsPolicy: ClusterFirst
+```
+
+**IPv4-only (default)**:
+```yaml
+network:
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4
+```
+
+For complete examples, see the [how-to guides](configure-dual-stack.md).
+
+## Key concepts
+
+### IP family selection
+
+The **first** IP family in `network.ipFamilies` determines which protocol ScyllaDB uses internally:
+
+- `[IPv6]` → ScyllaDB uses IPv6
+- `[IPv4, IPv6]` → ScyllaDB uses IPv4, services support both
+- `[IPv6, IPv4]` → ScyllaDB uses IPv6, services support both
+
+Learn more in [IPv6 networking concepts](ipv6-concepts.md).
+
+### Dual-stack behavior
+
+"Dual-stack" refers to Kubernetes services having both IPv4 and IPv6 addresses. ScyllaDB itself always runs on a single IP family (the first one configured).
+
+This provides client flexibility while maintaining internal consistency.
+
+### DNS configuration
+
+For IPv6, `dnsPolicy: ClusterFirst` is essential to ensure proper DNS resolution of IPv6 addresses.
+
+## Prerequisites
+
+Before configuring IPv6:
+
+- **Network**: Cluster must have IPv6 networking configured
+
+## Feature status
+
+| Configuration | Status | Production Ready |
+|---------------|--------|------------------|
+| Dual-stack (IPv4 + IPv6) | Stable | Yes |
+| IPv6-only | Experimental | No |
+| IPv4-only | Stable | Yes |
+
+For IPv6-only production support progress, see [#3211](https://github.com/scylladb/scylla-operator/issues/3211).
+
+## Getting help
+
+If you need assistance:
+
+1. **Check documentation**: Review the troubleshooting guide and concepts
+2. **Search issues**: Look for similar problems in [GitHub issues](https://github.com/scylladb/scylla-operator/issues)
+3. **Ask the community**: Join [ScyllaDB Slack](https://scylladb-users.slack.com/)
+4. **Open an issue**: Report bugs or request features on [GitHub](https://github.com/scylladb/scylla-operator/issues/new)
+
+## Related documentation
+
+- [Networking overview](../index.md)
+- [ScyllaCluster API Reference](../../../reference/api/groups/scylla.scylladb.com/scyllaclusters)
+- [Kubernetes IPv6 Documentation](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
+
+```{toctree}
+:hidden:
+:maxdepth: 2
 
 get-started
 configure-dual-stack
 configure-single-stack
 migration
 troubleshooting
-:::
+ipv6-concepts
+```

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/ipv6-concepts.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/ipv6-concepts.md
@@ -1,0 +1,323 @@
+# IPv6 networking concepts
+
+This document explains how IPv6 networking works in ScyllaDB clusters, including the design decisions and behaviors.
+
+## Overview
+
+IPv6 networking support in ScyllaDB Operator enables you to run ScyllaDB clusters on modern IPv6 networks. Understanding how IPv6 works in ScyllaDB helps you make informed decisions about network configuration.
+
+## How IPv6 support works
+
+### Operator orchestration
+
+When you configure IPv6 networking via the `network.ipFamilies` field in the ScyllaCluster CRD, ScyllaDB Operator automatically orchestrates several components:
+
+1. **ScyllaDB configuration**: Enables IPv6 DNS lookup, sets listen and broadcast addresses
+2. **Service configuration**: Creates Kubernetes services with appropriate IP families
+3. **Manager Agent**: Configures scylla-manager-agent for IPv6 connectivity
+4. **Health probes**: Sets up readiness and liveness probes on IPv6 addresses
+5. **Network policies**: Ensures proper IPv6 traffic flow
+
+This automated configuration ensures all components work together correctly without manual intervention.
+
+### Automatic vs manual configuration
+
+The operator handles all IPv6 configuration automatically. You don't need to:
+- Set ScyllaDB command-line arguments directly
+- Configure listen or broadcast addresses manually
+- Modify manager agent configuration
+- Adjust health probe settings
+
+**You only configure**:
+- `network.ipFamilies` - Which IP protocol(s) to use
+- `network.ipFamilyPolicy` - How to handle dual-stack
+- `network.dnsPolicy` - DNS resolution strategy
+
+The operator translates these high-level settings into appropriate low-level configurations.
+
+## IP family selection behavior
+
+### Primary IP family determines ScyllaDB protocol
+
+The **first** IP family in `network.ipFamilies` is critical - it determines which protocol ScyllaDB uses for **all** internal operations:
+
+```yaml
+# Example 1: ScyllaDB uses IPv6
+network:
+  ipFamilies:
+    - IPv6  # ← ScyllaDB uses this
+    - IPv4  # Services also support this
+```
+
+```yaml
+# Example 2: ScyllaDB uses IPv4
+network:
+  ipFamilies:
+    - IPv4  # ← ScyllaDB uses this
+    - IPv6  # Services also support this
+```
+
+### Why first IP family matters
+
+ScyllaDB requires consistent addressing for:
+
+**Gossip protocol**: Nodes exchange cluster membership information using a single protocol. Mixed protocols would break gossip.
+
+**Data replication**: When nodes replicate data, they must use the same IP protocol to establish connections.
+
+**Broadcast addresses**: All nodes must be able to reach each other's broadcast addresses using the same protocol.
+
+**Token ring**: The consistent hash ring requires uniform addressing across all nodes.
+
+### Service IP families
+
+While ScyllaDB uses a single IP family, Kubernetes services can support multiple:
+
+```yaml
+network:
+  ipFamilies:
+    - IPv4  # ScyllaDB protocol
+    - IPv6  # Additional service accessibility
+```
+
+**Result**:
+- Services get both IPv4 and IPv6 addresses
+- Clients can discover services via either protocol
+- ScyllaDB nodes communicate using IPv4 (the first family)
+- Actual database connections still use IPv4
+
+This provides client flexibility while maintaining internal consistency.
+
+## Dual-stack behavior explained
+
+Understanding dual-stack is key to successful IPv6 adoption.
+
+### What dual-stack means
+
+"Dual-stack" refers to **Kubernetes services** having both IPv4 and IPv6 addresses, not ScyllaDB itself.
+
+**Dual-stack components**:
+- Kubernetes Services: Have both IPv4 and IPv6 ClusterIPs
+- DNS records: Have both A (IPv4) and AAAA (IPv6) records
+- Client access: Clients can connect via either protocol
+
+**Single-stack components**:
+- ScyllaDB nodes: Use one IP protocol (the first in `ipFamilies`)
+- Inter-node communication: Uses one protocol
+- Data replication: Uses one protocol
+
+### How dual-stack works
+
+![Dual-stack architecture diagram showing Kubernetes Service with both IPv4 and IPv6 ClusterIPs, IPv4 and IPv6 clients connecting to it, and ScyllaDB cluster using IPv4 for internal communication](ipv6-dual-stack-architecture.svg)
+
+**Key insight**: Services provide protocol translation, allowing diverse clients to reach a cluster running on a single protocol.
+
+## Client connectivity patterns
+
+### Single-stack IPv4
+
+```yaml
+network:
+  ipFamilies:
+    - IPv4
+```
+
+**Behavior**:
+- Services: IPv4 only
+- ScyllaDB: IPv4 protocol
+- Clients: Must support IPv4
+
+**Use when**: Standard deployments, maximum compatibility
+
+### Single-stack IPv6
+
+```yaml
+network:
+  ipFamilies:
+    - IPv6
+```
+
+**Behavior**:
+- Services: IPv6 only
+- ScyllaDB: IPv6 protocol
+- Clients: Must support IPv6
+
+**Use when**: IPv6-only networks (experimental)
+
+### Dual-stack IPv4-primary
+
+```yaml
+network:
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+**Behavior**:
+- Services: Both IPv4 and IPv6
+- ScyllaDB: IPv4 protocol
+- Clients: Can use either IPv4 or IPv6
+
+**Use when**: Supporting diverse clients while keeping ScyllaDB on IPv4
+
+### Dual-stack IPv6-primary
+
+```yaml
+network:
+  ipFamilies:
+    - IPv6
+    - IPv4
+```
+
+**Behavior**:
+- Services: Both IPv6 and IPv4
+- ScyllaDB: IPv6 protocol
+- Clients: Can use either IPv6 or IPv4
+
+**Use when**: Migrating to IPv6 while supporting legacy IPv4 clients
+
+## DNS configuration and IPv6
+
+DNS configuration is critical for IPv6 networking.
+
+### Why ClusterFirst matters
+
+```yaml
+network:
+  dnsPolicy: ClusterFirst  # Essential for IPv6
+```
+
+**ClusterFirst ensures**:
+- Kubernetes DNS (CoreDNS) handles name resolution
+- AAAA records (IPv6) are correctly resolved
+- Service discovery works for IPv6 addresses
+- Pod-to-pod DNS works across IP families
+
+### Without ClusterFirst
+
+If `dnsPolicy` is not `ClusterFirst`:
+- DNS may use node's resolver instead of cluster DNS
+- AAAA records might not be resolved correctly
+- ScyllaDB nodes may fail to discover each other
+- Service names may resolve to wrong IP family
+
+## Default behavior and fallbacks
+
+Understanding defaults helps when troubleshooting.
+
+### When network configuration is omitted
+
+```yaml
+# No network configuration
+spec:
+  datacenter:
+    # ...
+```
+
+**Defaults**:
+- `ipFamilies`: `[IPv4]`
+- `ipFamilyPolicy`: Cluster default (usually `SingleStack`)
+- `dnsPolicy`: `ClusterFirst`
+
+**Result**: IPv4-only cluster (backward compatible)
+
+### When ipFamilyPolicy is PreferDualStack
+
+```yaml
+network:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+**If cluster supports dual-stack**: Services get both IP families
+
+**If cluster doesn't support dual-stack**: Services get first IP family only (IPv4)
+
+**Advantage**: Graceful degradation without configuration changes
+
+## Multi-datacenter considerations
+
+Multi-datacenter deployments have additional requirements.
+
+### IP family consistency requirement
+
+All datacenters **must** use the same IP family:
+
+```yaml
+# Datacenter 1
+network:
+  ipFamilies:
+    - IPv6
+
+# Datacenter 2 (must match)
+network:
+  ipFamilies:
+    - IPv6  # ✓ Same as DC1
+```
+
+**Why this is required**:
+
+**Cross-datacenter replication**: Nodes in different datacenters must replicate data. They need compatible addressing to establish connections.
+
+**Gossip synchronization**: Gossip information must propagate across datacenters. Mixed protocols break gossip.
+
+**Broadcast address reachability**: Each node's broadcast address must be reachable from all datacenters.
+
+**Token ring consistency**: The global token ring spans all datacenters and requires uniform addressing.
+
+### Multi-datacenter services
+
+Each datacenter's services can be dual-stack even if ScyllaDB uses single-stack:
+
+```yaml
+# Datacenter 1
+network:
+  ipFamilies:
+    - IPv6  # ScyllaDB protocol
+    - IPv4  # Service accessibility
+
+# Datacenter 2
+network:
+  ipFamilies:
+    - IPv6  # Same ScyllaDB protocol
+    - IPv4  # Service accessibility
+```
+
+This provides local client flexibility while maintaining cluster consistency.
+
+## Production readiness
+
+For authoritative information about production readiness and experimental status, see [Production readiness](../../../reference/ipv6-configuration.md#production-readiness) in the configuration reference.
+
+### Recommendation
+
+Use **dual-stack** for production:
+- Well-tested in CI/CD
+- Provides fallback options
+- Supports diverse clients
+- Easier troubleshooting
+
+For production IPv6-only support progress, see [#3211](https://github.com/scylladb/scylla-operator/issues/3211).
+
+## Common misconceptions
+
+### Misconception: Dual-stack means ScyllaDB uses both protocols
+
+**Reality**: ScyllaDB uses the first IP family only. Services support both protocols.
+
+### Misconception: Can mix IP families across datacenters
+
+**Reality**: All datacenters must use the same IP family for ScyllaDB.
+
+### Misconception: Can't use IPv6 without IPv6-only networking
+
+**Reality**: Dual-stack (IPv4 + IPv6) is recommended and well-supported.
+
+## Related documentation
+
+- [IPv6 configuration reference](../../../reference/ipv6-configuration.md)
+- [How to configure IPv6](configure-dual-stack.md)
+- [Getting started with IPv6](get-started.md)
+- [Troubleshoot IPv6 issues](troubleshooting.md)

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/ipv6-dual-stack-architecture.svg
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/ipv6-dual-stack-architecture.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 450" width="700" height="450">
+  <defs>
+    <style>
+      .service-box { fill: #e3f2fd; stroke: #1976d2; stroke-width: 2; }
+      .client-box { fill: #fff3e0; stroke: #f57c00; stroke-width: 2; }
+      .pod-box { fill: #e8f5e9; stroke: #388e3c; stroke-width: 2; }
+      .text { font-family: Arial, sans-serif; font-size: 14px; fill: #333; }
+      .text-bold { font-family: Arial, sans-serif; font-size: 15px; font-weight: bold; fill: #333; }
+      .text-small { font-family: Arial, sans-serif; font-size: 12px; fill: #666; }
+      .arrow { stroke: #666; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="#666" />
+    </marker>
+  </defs>
+  
+  <!-- Clients at the top -->
+  <rect class="client-box" x="50" y="30" width="180" height="70" rx="5"/>
+  <text class="text-bold" x="140" y="55" text-anchor="middle">IPv4-only Client</text>
+  <text class="text-small" x="140" y="75" text-anchor="middle">Uses IPv4: 10.96.10.20</text>
+  <text class="text-small" x="140" y="90" text-anchor="middle">to connect to service</text>
+  
+  <rect class="client-box" x="470" y="30" width="180" height="70" rx="5"/>
+  <text class="text-bold" x="560" y="55" text-anchor="middle">IPv6-only Client</text>
+  <text class="text-small" x="560" y="75" text-anchor="middle">Uses IPv6: fd00:10:96::1234</text>
+  <text class="text-small" x="560" y="90" text-anchor="middle">to connect to service</text>
+  
+  <!-- Arrows from clients to service -->
+  <path class="arrow" d="M 140 100 L 275 180"/>
+  <path class="arrow" d="M 560 100 L 425 180"/>
+  
+  <!-- Kubernetes Service in the middle -->
+  <rect class="service-box" x="200" y="180" width="300" height="90" rx="5"/>
+  <text class="text-bold" x="350" y="205" text-anchor="middle">Kubernetes Service (Dual-Stack)</text>
+  <text class="text-small" x="350" y="227" text-anchor="middle">ClusterIP (IPv4): 10.96.10.20</text>
+  <text class="text-small" x="350" y="245" text-anchor="middle">ClusterIP (IPv6): fd00:10:96::1234</text>
+  <text class="text-small" x="350" y="263" text-anchor="middle">Routes to pods using IPv4</text>
+  
+  <!-- Arrows from service to pods -->
+  <path class="arrow" d="M 280 270 L 180 320"/>
+  <path class="arrow" d="M 350 270 L 350 320"/>
+  <path class="arrow" d="M 420 270 L 520 320"/>
+  
+  <!-- ScyllaDB Pods at the bottom -->
+  <rect class="pod-box" x="80" y="320" width="160" height="90" rx="5"/>
+  <text class="text-bold" x="160" y="345" text-anchor="middle">ScyllaDB Pod 1</text>
+  <text class="text-small" x="160" y="365" text-anchor="middle">IPv4: 10.244.1.5</text>
+  <text class="text-small" x="160" y="383" text-anchor="middle">Gossip, replication,</text>
+  <text class="text-small" x="160" y="398" text-anchor="middle">CQL all use IPv4</text>
+  
+  <rect class="pod-box" x="270" y="320" width="160" height="90" rx="5"/>
+  <text class="text-bold" x="350" y="345" text-anchor="middle">ScyllaDB Pod 2</text>
+  <text class="text-small" x="350" y="365" text-anchor="middle">IPv4: 10.244.2.6</text>
+  <text class="text-small" x="350" y="383" text-anchor="middle">Gossip, replication,</text>
+  <text class="text-small" x="350" y="398" text-anchor="middle">CQL all use IPv4</text>
+  
+  <rect class="pod-box" x="460" y="320" width="160" height="90" rx="5"/>
+  <text class="text-bold" x="540" y="345" text-anchor="middle">ScyllaDB Pod 3</text>
+  <text class="text-small" x="540" y="365" text-anchor="middle">IPv4: 10.244.3.7</text>
+  <text class="text-small" x="540" y="383" text-anchor="middle">Gossip, replication,</text>
+  <text class="text-small" x="540" y="398" text-anchor="middle">CQL all use IPv4</text>
+</svg>

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/migration.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/migration.md
@@ -37,7 +37,7 @@ This is the recommended migration path because:
 
 ### Step 1: Backup your data
 
-Before making any changes, ensure you have recent backups. See [Configuring backup tasks](../../../understand/manager.md#configuring-backup-and-repair-tasks-for-a-scyllacluster) for details on setting up backups for your ScyllaCluster.
+Before making any changes, ensure you have recent backups. See [Configuring backup tasks](../../../understand/manager.md) for details on setting up backups for your ScyllaCluster.
 
 ### Step 2: Update cluster configuration
 
@@ -185,7 +185,7 @@ Update all client applications to support IPv6 before migrating the cluster.
 
 ### Step 3: Backup your data
 
-Create a backup before proceeding. See [Configuring backup tasks](../../../understand/manager.md#configuring-backup-and-repair-tasks-for-a-scyllacluster) for details on setting up backups for your ScyllaCluster.
+Create a backup before proceeding. See [Configuring backup tasks](../../../understand/manager.md) for details on setting up backups for your ScyllaCluster.
 
 ### Step 4: Update cluster configuration
 

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/migration.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/migration.md
@@ -1,5 +1,354 @@
 # Migrate clusters to IPv6
 
-:::{todo}
-This page is not yet written.
+This guide shows you how to migrate existing ScyllaDB clusters to IPv6 networking.
+
+## Before you begin
+
+### Prerequisites
+
+- Existing ScyllaDB cluster running on IPv4
+- Kubernetes cluster with IPv6 support enabled
+- Administrative access to the cluster
+
+### Important considerations
+
+- **Downtime**: Migration requires a rolling restart of all pods
+- **Data safety**: Data is preserved during migration
+- **Client updates**: Client applications need updated connection strings after migration
+- **Testing**: Test the migration process in a non-production environment first
+
+:::{warning}
+Migration involves a rolling restart of your cluster. Plan the migration during a maintenance window.
 :::
+
+## Choose your migration path
+
+Select the migration approach that fits your needs:
+
+1. [Migrate from IPv4 to dual-stack](#migrate-from-ipv4-to-dual-stack): Add IPv6 support while keeping IPv4 (recommended)
+2. [Migrate from IPv4 to IPv6-only](#migrate-from-ipv4-to-ipv6-only): Completely migrate to IPv6 (experimental)
+
+## Migrate from IPv4 to dual-stack
+
+This is the recommended migration path because:
+- Minimizes disruption to existing clients
+- Allows gradual client migration
+- Provides fallback to IPv4 if issues arise
+
+### Step 1: Backup your data
+
+Before making any changes, ensure you have recent backups. See [Configuring backup tasks](../../../understand/manager.md#configuring-backup-and-repair-tasks-for-a-scyllacluster) for details on setting up backups for your ScyllaCluster.
+
+### Step 2: Update cluster configuration
+
+Edit your ScyllaCluster manifest to add dual-stack support:
+
+```yaml
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: your-cluster-name
+  namespace: scylla
+spec:
+  # ... existing configuration ...
+  
+  # Add network configuration
+  network:
+    ipFamilyPolicy: PreferDualStack
+    ipFamilies:
+      - IPv4  # Keep IPv4 as primary
+      - IPv6  # Add IPv6 support
+    dnsPolicy: ClusterFirst
+```
+
+### Step 3: Apply the configuration
+
+Apply the updated configuration:
+
+```bash
+kubectl apply -f scylla-cluster.yaml
+```
+
+The operator will perform a rolling update of all pods.
+
+### Step 4: Monitor the migration
+
+Watch the rolling update progress:
+
+```bash
+# Check cluster status
+kubectl exec -it <pod-name> -n scylla -c scylla -- nodetool status
+```
+
+**Expected output:**
+```
+Datacenter: dc
+===================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address           Load      Tokens  Owns  Host ID                              Rack
+UN  10.244.2.7        501.79 KB 256     ?     4583fff5-2aa6-4041-9be8-c74bcabaff8c rack
+UN  10.244.2.8        494.49 KB 256     ?     b1f889b4-80e7-4685-a3c5-1b81797c2ce4 rack
+UN  10.244.2.9        494.96 KB 256     ?     7a4bb6da-415e-4fc3-a6ca-0369c0e76bf0 rack
+```
+
+Wait for all nodes to show `UN` (Up/Normal) status.
+
+### Step 5: Verify dual-stack configuration
+
+Confirm services have both IP families:
+
+```bash
+kubectl get svc -n scylla -o custom-columns=NAME:.metadata.name,IP-FAMILIES:.spec.ipFamilies,POLICY:.spec.ipFamilyPolicy
+```
+
+**Expected output:**
+```
+NAME                            IP-FAMILIES        POLICY
+scylla-dual-stack-client        [IPv4 IPv6]        PreferDualStack
+scylla-dual-stack-us-east-1a-0  [IPv4 IPv6]        PreferDualStack
+```
+
+### Step 6: Test connectivity
+
+Test that clients can connect via both protocols:
+
+```bash
+# Get service IPs
+kubectl get svc your-cluster-name-client -n scylla -o jsonpath='{.spec.clusterIPs}'
+```
+
+**Example output**
+```
+[
+  "10.96.136.229",
+  "fd00:10:96::6277"
+]
+```
+Test connection using service name:
+
+```bash
+kubectl run -it --rm cqlsh --image=scylladb/scylla-cqlsh:latest --restart=Never -n scylla-test -- \
+    your-cluster-name-client.scylla.svc.cluster.local 9042 \
+  -e "SELECT cluster_name,broadcast_address FROM system.local;"  
+```
+
+**Example output**
+```
+-------------------+---------------------
+ cluster_name      | scylla-cluster
+ broadcast_address | 10.244.2.42
+
+(1 rows)
+pod "cqlsh" deleted
+```
+
+### Step 7: Update client applications
+
+Update your client applications to use the dual-stack service. Most clients will automatically work with dual-stack services without changes.
+
+### Step 8: Verify cluster health
+
+After migration completes:
+
+```bash
+# Verify all nodes are up
+kubectl exec -it <pod-name> -n scylla -c scylla -- nodetool status
+```
+
+## Migrate from IPv4 to IPv6-only
+
+:::{warning}
+**Experimental Feature**: IPv6-only configurations are experimental. See [Production readiness](../../../reference/ipv6-configuration.md#production-readiness) for details. This migration path requires careful planning and testing.
+:::
+
+### Step 1: Verify IPv6-only readiness
+
+Ensure your environment supports IPv6-only:
+
+```bash
+# Check that all nodes have IPv6 addresses
+kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' | tr ' ' '\n' | grep ':'
+```
+
+**Example output**
+```
+fc00:f853:ccd:e793::2
+fc00:f853:ccd:e793::4
+fc00:f853:ccd:e793::3
+fc00:f853:ccd:e793::5
+```
+
+### Step 2: Update client applications
+
+Update all client applications to support IPv6 before migrating the cluster.
+
+### Step 3: Backup your data
+
+Create a backup before proceeding. See [Configuring backup tasks](../../../understand/manager.md#configuring-backup-and-repair-tasks-for-a-scyllacluster) for details on setting up backups for your ScyllaCluster.
+
+### Step 4: Update cluster configuration
+
+Edit your ScyllaCluster manifest for IPv6-only:
+
+```yaml
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: your-cluster-name
+  namespace: scylla
+spec:
+  # ... existing configuration ...
+  
+  # Update network configuration
+  network:
+    ipFamilyPolicy: SingleStack
+    ipFamilies:
+      - IPv6  # IPv6 only
+    dnsPolicy: ClusterFirst
+```
+
+### Step 5: Apply and monitor
+
+Apply the configuration and monitor the migration:
+
+```bash
+kubectl apply -f scylla-cluster.yaml
+
+# Monitor the rolling update
+kubectl get pods -n scylla -w
+```
+
+### Step 6: Verify IPv6-only operation
+
+Check that cluster is using IPv6:
+
+```bash
+# Verify pod IPv6 addresses
+kubectl get pods -n scylla -o wide
+
+# Check cluster status
+kubectl exec -it <pod-name> -n scylla -c scylla -- nodetool status
+```
+
+**Expected output with IPv6 addresses:**
+```
+Datacenter: datacenter
+===================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address           Load      Tokens  Owns  Host ID                              Rack
+UN  fd00:10:244:1::7f 501.79 KB 256     ?     4583fff5-2aa6-4041-9be8-c74bcabaff8c rack
+UN  fd00:10:244:2::6d 494.49 KB 256     ?     b1f889b4-80e7-4685-a3c5-1b81797c2ce4 rack
+UN  fd00:10:244:3::6c 494.96 KB 256     ?     7a4bb6da-415e-4fc3-a6ca-0369c0e76bf0 rack
+```
+
+### Step 7: Test client connectivity
+
+Test that clients can connect:
+
+```bash
+kubectl run -it --rm cqlsh --image=scylladb/scylla-cqlsh:latest --restart=Never -n scylla-test -- \
+    your-cluster-name-client.scylla.svc.cluster.local 9042 \
+  -e "SELECT cluster_name,broadcast_address FROM system.local;"  
+```
+
+**Expected output:**
+```
+-------------------+---------------------
+ cluster_name      | scylla-cluster
+ broadcast_address | fd00:10:244:2::25
+
+(1 rows)
+pod "cqlsh" deleted
+```
+
+### Step 8: Verify cluster health
+
+Check cluster health:
+
+```bash
+# Verify all nodes are up
+kubectl exec -it <pod-name> -n scylla -c scylla -- nodetool status
+```
+
+## Rollback to IPv4
+
+If you encounter issues during migration, you can roll back to the previous IPv4-only configuration.
+
+Update your ScyllaCluster manifest:
+
+```yaml
+network:
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4
+```
+
+Apply the rollback:
+
+```bash
+kubectl apply -f scylla-cluster.yaml
+```
+
+The operator will perform a rolling update back to IPv4.
+
+## Troubleshooting
+
+If you encounter problems during migration:
+
+### Nodes not joining cluster
+
+**Symptom**: Pods are running but nodes show as down
+
+**Solution**:
+1. Check DNS resolution:
+   ```bash
+   kubectl exec -it <pod-name> -n scylla -- nslookup <service-name>
+   ```
+
+2. Verify network configuration:
+   ```bash
+   kubectl get svc -n scylla -o yaml | grep -A 5 -i family
+   ```
+
+3. Review pod logs:
+   ```bash
+   kubectl logs <pod-name> -n scylla -c scylla
+   ```
+
+### Connection failures
+
+**Symptom**: Clients cannot connect after migration
+
+**Solution**:
+1. Verify service IPs:
+   ```bash
+   kubectl get svc -n scylla -o wide
+   ```
+
+2. Check client configuration for IPv6 support
+
+For more troubleshooting steps, see [Troubleshoot IPv6 issues](troubleshooting.md).
+
+## Migration best practices
+
+1. **Test first**: Always test migration in a non-production environment
+2. **Backup**: Create backups before starting migration
+3. **Monitoring**: Set up alerts for cluster health during migration
+4. **Gradual approach**: Use dual-stack first, then migrate to IPv6-only if needed
+5. **Client coordination**: Coordinate with application teams before migration
+6. **Documentation**: Document your specific migration steps and any customizations
+
+## Next steps
+
+- [Troubleshoot IPv6 issues](troubleshooting.md)
+- [Configure IPv6 networking](configure-dual-stack.md)
+- [Understand IPv6 networking concepts](ipv6-concepts.md)
+
+## Related documentation
+
+- [How to configure IPv6 networking](configure-dual-stack.md)
+- [Troubleshoot IPv6 networking](troubleshooting.md)
+- [IPv6 networking concepts](ipv6-concepts.md)
+- [IPv6 configuration reference](../../../reference/ipv6-configuration.md)

--- a/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/troubleshooting.md
+++ b/docs-staging/source/deploy-scylladb/set-up-networking/ipv6/troubleshooting.md
@@ -1,5 +1,49 @@
-# Troubleshoot IPv6 issues
+# Troubleshoot IPv6 networking issues
 
-:::{todo}
-This page is not yet written.
-:::
+This guide helps you diagnose and resolve common IPv6 networking issues in ScyllaDB clusters.
+
+## Quick diagnostics
+
+Run these commands to quickly assess your IPv6 configuration:
+
+```bash
+# Check pod IPv6 addresses
+kubectl get pods -n scylla -l scylla-operator.scylladb.com/pod-type=scylladb-node -o wide
+```
+
+**Expected output for dual-stack:**
+```
+NAME                            READY   STATUS    IP
+scylla-dual-stack-us-east-1a-0  2/2     Running   10.244.2.42
+scylla-dual-stack-us-east-1a-1  2/2     Running   10.244.2.43
+```
+
+Pods show IPv4 addresses. IPv6 addresses are assigned but not displayed in `kubectl get pods`. To verify IPv6, check services or use the address detection command from the migration guide.
+
+```bash
+# Verify service IP families
+kubectl get svc -o custom-columns=NAME:.metadata.name,IP-FAMILIES:.spec.ipFamilies,POLICY:.spec.ipFamilyPolicy -n scylla
+```
+
+**Expected output for dual-stack:**
+```
+NAME                            IP-FAMILIES        POLICY
+scylla-dual-stack-client        [IPv4 IPv6]        PreferDualStack
+scylla-dual-stack-us-east-1a-0  [IPv4 IPv6]        PreferDualStack
+```
+
+**Expected output for IPv6-only:**
+```
+NAME                          IP-FAMILIES   POLICY
+scylla-ipv6-client            [IPv6]        SingleStack
+scylla-ipv6-us-east-1a-0      [IPv6]        SingleStack
+```
+
+Services should show the expected IP families based on your configuration.
+
+## Related documentation
+
+- [Configure IPv6 networking](configure-dual-stack.md)
+- [Migrate to IPv6](migration.md)
+- [IPv6 networking concepts](ipv6-concepts.md)
+- [IPv6 configuration reference](../../../reference/ipv6-configuration.md)

--- a/docs-staging/source/reference/ipv6-configuration.md
+++ b/docs-staging/source/reference/ipv6-configuration.md
@@ -106,3 +106,36 @@ Complete example manifests are available in the repository:
 - [`examples/ipv6/scylla-cluster-dual-stack.yaml`](https://github.com/scylladb/scylla-operator/blob/master/examples/ipv6/scylla-cluster-dual-stack.yaml) — production-ready dual-stack setup
 - [`examples/ipv6/scylla-cluster-minimal-dual-stack.yaml`](https://github.com/scylladb/scylla-operator/blob/master/examples/ipv6/scylla-cluster-minimal-dual-stack.yaml) — minimal dual-stack example
 - [`examples/ipv6/scylla-cluster-ipv6.yaml`](https://github.com/scylladb/scylla-operator/blob/master/examples/ipv6/scylla-cluster-ipv6.yaml) — IPv6 single-stack setup
+
+## Version requirements
+
+### Minimum versions
+
+- **ScyllaDB**: 2024.1 or newer
+- **ScyllaDB Operator**: 1.20 or newer
+
+## Production readiness
+
+### Production-ready configurations
+
+The following configurations are **production-ready**:
+- **IPv4-only single-stack**: Fully supported (default Kubernetes behavior)
+- **IPv4-first dual-stack**: Fully supported and recommended for IPv6 adoption
+- **IPv6-first dual-stack**: Fully supported
+
+### Experimental configurations
+
+The following configurations are **experimental** and not recommended for production use:
+- **IPv6-only single-stack**: Currently under development
+
+:::{note}
+**Experimental status**: IPv6-only configurations work but have not undergone the same level of testing and validation as dual-stack configurations. For production IPv6 deployments, use dual-stack configurations instead.
+
+Track progress on productionizing IPv6-only: [#3211](https://github.com/scylladb/scylla-operator/issues/3211)
+:::
+
+## Related documentation
+
+- [IPv6 networking concepts](../deploy-scylladb/set-up-networking/ipv6/ipv6-concepts.md)
+- [Configure dual-stack networking](../deploy-scylladb/set-up-networking/ipv6/configure-dual-stack.md)
+- [Get started with IPv6](../deploy-scylladb/set-up-networking/ipv6/get-started.md)


### PR DESCRIPTION
_Heads up: This is a non-standard transplant. Since the IPv6 docs were written in Diataxis already and peer-reviewed in #2956, I'm using that as transplant source instead of #3305._

Copy verbatim content from `docs/source/management/networking/ipv6/` into `docs-staging/source/deploy-scylladb/set-up-networking/ipv6/`, rewiring cross-references for the new flat directory structure.

**Files transplanted:**

| Staging file | Source |
|---|---|
| `get-started.md` | `tutorials/ipv6-getting-started.md` |
| `configure-dual-stack.md` | `ipv6-configure.md` + `ipv6-configure-ipv6-first.md` |
| `configure-single-stack.md` | `ipv6-configure-ipv6-only.md` |
| `migration.md` | `ipv6-migrate.md` |
| `troubleshooting.md` | `ipv6-troubleshoot.md` |
| `ipv6-concepts.md` | `concepts/ipv6-networking.md` (new file) |
| `ipv6-dual-stack-architecture.svg` | (new file) |
| `index.md` | Replaced minimal toctree with rich landing page |

### `reference/ipv6-configuration.md`

This file was **not overwritten**. The staging version already had well-structured content (field-by-field documentation with defaults and allowed values, auto-config table, validation rules, example configs) written for the staging directory structure with correct cross-links. The old version covered the same topics in a more narrative style but had three sections the staging version lacked. Those sections were **appended verbatim**:

- **Version requirements** — minimum ScyllaDB (2024.1) and Operator (1.20) versions
- **Production readiness** — lists which configurations are production-ready vs experimental, with a note linking to the tracking issue (#3211)
- **Related documentation** — links to the newly transplanted IPv6 pages (concepts, configure, get-started)

The existing 108 lines of staging content were left untouched.

Also fixes an issue where the [source docs had a bug](https://operator.docs.scylladb.com/stable/management/networking/ipv6/tutorials/ipv6-getting-started.html#step-3-create-your-first-ipv6-enabled-cluster) - `{{repository}}` and `{{revision}}` are not expanded. This is fixed in the transplanted version. The source problem tracked in [OPERATOR-112](https://scylladb.atlassian.net/browse/OPERATOR-112).

Part of [OPERATOR-32](https://github.com/scylladb/scylla-operator/issues/OPERATOR-32)

/kind documentation
/priority important-longterm
/cc czeslavo

[OPERATOR-32]: https://scylladb.atlassian.net/browse/OPERATOR-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OPERATOR-112]: https://scylladb.atlassian.net/browse/OPERATOR-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ