### PR TITLE
test(oke): add OKE E2E test scripts and CI manifests

### DIFF
--- a/hack/.ci/manifests/cluster/nodeconfig-oke.yaml
+++ b/hack/.ci/manifests/cluster/nodeconfig-oke.yaml
@@ -1,0 +1,41 @@
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: NodeConfig
+metadata:
+  name: cluster
+spec:
+  localDiskSetup:
+    filesystems:
+    - device: /dev/md/nvmes
+      type: xfs
+    mounts:
+    - device: /dev/md/nvmes
+      mountPoint: /var/lib/persistent-volumes
+      unsupportedOptions:
+      - prjquota
+    raids:
+    - name: nvmes
+      type: RAID0
+      RAID0:
+        devices:
+          nameRegex: ^/dev/nvme\dn\d$
+  sysctls:
+  - name: fs.aio-max-nr
+    value: "4294967295"
+  - name: fs.file-max
+    value: "9223372036854775807"
+  - name: fs.nr_open
+    value: "1073741816"
+  - name: fs.inotify.max_user_instances
+    value: "1200"
+  - name: vm.swappiness
+    value: "1"
+  - name: vm.vfs_cache_pressure
+    value: "2000"
+  placement:
+    nodeSelector:
+      scylla.scylladb.com/node-type: scylla
+    tolerations:
+    - effect: NoSchedule
+      key: scylla-operator.scylladb.com/dedicated
+      operator: Equal
+      value: scyllaclusters

--- a/hack/.ci/oke/cloud-init-scylladb-node.sh
+++ b/hack/.ci/oke/cloud-init-scylladb-node.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+curl --fail -H "Authorization: Bearer Oracle" -L0 \
+  http://169.254.169.254/opc/v2/instance/metadata/oke_init_script \
+  | base64 --decode > /var/run/oke-init.sh
+bash /var/run/oke-init.sh --kubelet-extra-args "--cpu-manager-policy=static"

--- a/hack/.ci/run-e2e-oke-release.sh
+++ b/hack/.ci/run-e2e-oke-release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 ScyllaDB
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+if [ -z "${ARTIFACTS+x}" ]; then
+  echo "ARTIFACTS can't be empty" > /dev/stderr
+  exit 2
+fi
+
+source "$( dirname "${BASH_SOURCE[0]}" )/../lib/kube.sh"
+source "$( dirname "${BASH_SOURCE[0]}" )/lib/e2e.sh"
+source "$( dirname "${BASH_SOURCE[0]}" )/run-e2e-shared.env.sh"
+source "$( dirname "${BASH_SOURCE[0]}" )/run-e2e-oke-shared.env.sh"
+parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
+
+trap gather-artifacts-on-exit EXIT
+trap gracefully-shutdown-e2es INT
+
+run-deploy-script-in-all-clusters "${parent_dir}/../ci-deploy-release.sh"
+
+apply-e2e-workarounds-in-all-clusters
+run-e2e

--- a/hack/.ci/run-e2e-oke-shared.env.sh
+++ b/hack/.ci/run-e2e-oke-shared.env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 ScyllaDB
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+_oke_shared_env_parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
+
+SO_NODECONFIG_PATH="${SO_NODECONFIG_PATH=${_oke_shared_env_parent_dir}/manifests/cluster/nodeconfig-oke.yaml}"
+export SO_NODECONFIG_PATH
+
+SO_CSI_DRIVER_PATH="${SO_CSI_DRIVER_PATH=${_oke_shared_env_parent_dir}/manifests/namespaces/local-csi-driver/}"
+export SO_CSI_DRIVER_PATH
+
+# TODO: Remove object-storage entries from SO_SKIPPED_TESTS when https://scylladb.atlassian.net/browse/OPERATOR-83 is resolved.
+# TODO: Remove coredumps entry from SO_SKIPPED_TESTS when https://scylladb.atlassian.net/browse/OPERATOR-116 is resolved.
+SO_SKIPPED_TESTS="${SO_SKIPPED_TESTS=\
+ScyllaDBManagerTask and ScyllaDBDatacenter integration with global ScyllaDB Manager should synchronise a backup task and support a manual restore procedure|\
+Scylla Manager integration should register cluster, sync backup tasks and support manual restore procedure|\
+Scylla Manager integration should discover cluster and sync errors for invalid tasks and invalid updates to existing tasks|\
+ScyllaCluster coredumps should persist a coredump when ScyllaDB crashes with SIGABRT}"
+export SO_SKIPPED_TESTS

--- a/hack/.ci/run-e2e-oke.sh
+++ b/hack/.ci/run-e2e-oke.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 ScyllaDB
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+if [ -z "${ARTIFACTS+x}" ]; then
+  echo "ARTIFACTS can't be empty" > /dev/stderr
+  exit 2
+fi
+
+source "$( dirname "${BASH_SOURCE[0]}" )/../lib/kube.sh"
+source "$( dirname "${BASH_SOURCE[0]}" )/lib/e2e.sh"
+source "$( dirname "${BASH_SOURCE[0]}" )/run-e2e-shared.env.sh"
+source "$( dirname "${BASH_SOURCE[0]}" )/run-e2e-oke-shared.env.sh"
+parent_dir="$( dirname "${BASH_SOURCE[0]}" )"
+
+trap gather-artifacts-on-exit EXIT
+trap gracefully-shutdown-e2es INT
+
+run-deploy-script-in-all-clusters "${parent_dir}/../ci-deploy.sh"
+
+apply-e2e-workarounds-in-all-clusters
+run-e2e


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** 
This PR adds scripts and manifests for ScyllaDB Operator E2E testing in OKE.

There are 3 test cases in parallel suite failing due to missing object storage and 1 test case in serial suite failing due to not being adjusted to the OKE platform. They are skipped and tracked in dedicated issues linked in the scripts.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-80

/kind machinery
/priority important-soon
/cc