### PR TITLE
docs(staging,gke,eks): add reference deployment guides

### DIFF
--- a/docs-staging/source/deploy-scylladb/before-you-deploy/configure-nodes.md
+++ b/docs-staging/source/deploy-scylladb/before-you-deploy/configure-nodes.md
@@ -29,7 +29,7 @@ Both `NodeConfig` placement and `ScyllaCluster` rack placement must reference th
 
 ```{code-block} console
 :substitutions:
-kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/gke/nodeconfig.yaml
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/gke/nodeconfig-alpha.yaml
 ```
 
 :::
@@ -38,7 +38,7 @@ kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/
 
 ```{code-block} console
 :substitutions:
-kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/eks/nodeconfig.yaml
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/eks/nodeconfig-alpha.yaml
 ```
 
 :::

--- a/docs-staging/source/deploy-scylladb/reference-deployments/reference-deployment-eks.md
+++ b/docs-staging/source/deploy-scylladb/reference-deployments/reference-deployment-eks.md
@@ -1,5 +1,214 @@
 # Reference deployment: EKS
 
-:::{todo}
-This page is not yet written.
+This guide deploys a production-ready ScyllaDB cluster on Amazon Elastic Kubernetes Service (EKS).
+By the end, you will have a 3-node ScyllaDB cluster spread across 3 availability zones, with performance tuning and local NVMe storage configured.
+
+## Prerequisites
+
+- An EKS cluster provisioned with a dedicated ScyllaDB node group with local NVMe SSDs.
+  If you do not have one yet, follow [Set up an EKS cluster for ScyllaDB](../../install-operator/provision-infrastructure/set-up-eks-cluster.md).
+- Dedicated nodes labeled and tainted per [Set up dedicated node pools](../before-you-deploy/set-up-dedicated-node-pools.md).
+  The EKS cluster setup guide handles this automatically.
+- ScyllaDB Operator installed.
+  Follow [Install ScyllaDB Operator](../../install-operator/install-with-gitops.md) if you have not done so yet.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) configured and pointed at the cluster.
+- The environment variables from the [EKS cluster setup guide](../../install-operator/provision-infrastructure/set-up-eks-cluster.md#set-environment-variables) exported in your shell (at minimum `AWS_REGION`, `EKS_AZ_1`, `EKS_AZ_2`, `EKS_AZ_3`).
+
+## Work around the ScyllaDB utils image issue
+
+The default ScyllaDB utils image used by the operator for node tuning jobs contains a broken `systemctl` binary that fails on EKS nodes running `irqbalance`.
+Until this is fixed upstream, override the utils image with an older version that includes a working `systemctl`:
+
+:::{code-block} console
+kubectl apply --server-side -f=- <<EOF
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: ScyllaOperatorConfig
+metadata:
+  name: cluster
+spec:
+  scyllaUtilsImage: "docker.io/scylladb/scylla:2025.1"
+EOF
 :::
+
+## Set up nodes
+
+Before deploying a `ScyllaCluster`, the dedicated nodes must be prepared with local disk setup and kernel tuning via `NodeConfig`, and the Local CSI Driver must be installed to provision `PersistentVolumes` from the local NVMe storage.
+Follow [Configure nodes](../before-you-deploy/configure-nodes.md), selecting the **EKS** tab where applicable, then return here to deploy the cluster.
+
+## Deploy a ScyllaDB cluster
+
+:::{include} /_snippets/scyllacluster-namespace-tip.md
+:::
+
+Create a ScyllaDB cluster with one rack per availability zone.
+The resource requests are sized for `i4i.2xlarge` (8 vCPU, 64 GiB RAM), leaving headroom for the OS, kubelet, and `DaemonSets`.
+See the [ScyllaDB system requirements](https://docs.scylladb.com/manual/stable/getting-started/system-requirements.html) for general sizing guidance.
+Adjust if you use a different instance type.
+
+:::{code-block} console
+:substitutions:
+kubectl apply --server-side -f=- <<EOF
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: scylladb
+spec:
+  repository: {{imageRepository}}
+  version: {{scyllaDBImageTag}}
+  agentVersion: {{agentVersion}}
+  automaticOrphanedNodeCleanup: true
+  datacenter:
+    name: ${AWS_REGION}
+    racks:
+    - name: ${EKS_AZ_1}
+      members: 1
+      storage:
+        capacity: 1500Gi
+        storageClassName: scylladb-local-xfs
+      resources:
+        requests:
+          cpu: 6
+          memory: 50Gi
+        limits:
+          cpu: 6
+          memory: 50Gi
+      agentResources:
+        requests:
+          cpu: 100m
+          memory: 20Mi
+        limits:
+          cpu: 100m
+          memory: 20Mi
+      placement:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: scylla.scylladb.com/node-type
+                operator: In
+                values:
+                - scylla
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - ${EKS_AZ_1}
+        tolerations:
+        - key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
+          effect: NoSchedule
+    - name: ${EKS_AZ_2}
+      members: 1
+      storage:
+        capacity: 1500Gi
+        storageClassName: scylladb-local-xfs
+      resources:
+        requests:
+          cpu: 6
+          memory: 50Gi
+        limits:
+          cpu: 6
+          memory: 50Gi
+      agentResources:
+        requests:
+          cpu: 100m
+          memory: 20Mi
+        limits:
+          cpu: 100m
+          memory: 20Mi
+      placement:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: scylla.scylladb.com/node-type
+                operator: In
+                values:
+                - scylla
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - ${EKS_AZ_2}
+        tolerations:
+        - key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
+          effect: NoSchedule
+    - name: ${EKS_AZ_3}
+      members: 1
+      storage:
+        capacity: 1500Gi
+        storageClassName: scylladb-local-xfs
+      resources:
+        requests:
+          cpu: 6
+          memory: 50Gi
+        limits:
+          cpu: 6
+          memory: 50Gi
+      agentResources:
+        requests:
+          cpu: 100m
+          memory: 20Mi
+        limits:
+          cpu: 100m
+          memory: 20Mi
+      placement:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: scylla.scylladb.com/node-type
+                operator: In
+                values:
+                - scylla
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - ${EKS_AZ_3}
+        tolerations:
+        - key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
+          effect: NoSchedule
+EOF
+:::
+
+## Verify the deployment
+
+Wait for the cluster to become ready:
+
+:::{code-block} console
+kubectl wait --for='condition=Progressing=False' scyllacluster.scylla.scylladb.com/scylladb
+kubectl wait --for='condition=Degraded=False' scyllacluster.scylla.scylladb.com/scylladb
+kubectl wait --for='condition=Available=True' scyllacluster.scylla.scylladb.com/scylladb
+:::
+
+Verify the cluster status:
+
+:::{code-block} console
+kubectl get scyllaclusters.scylla.scylladb.com/scylladb
+:::
+
+Expected output:
+
+:::{code-block}
+NAME       READY   MEMBERS   RACKS   AVAILABLE   PROGRESSING   DEGRADED   AGE
+scylladb   3       3         3       True        False         False      5m
+:::
+
+## Clean up
+
+Delete the ScyllaDB cluster first so the underlying `PersistentVolumes` are released cleanly:
+
+:::{code-block} console
+kubectl delete scyllaclusters.scylla.scylladb.com/scylladb
+:::
+
+To tear down the EKS infrastructure, follow the [Clean up](../../install-operator/provision-infrastructure/set-up-eks-cluster.md#clean-up) section of the EKS cluster setup guide.
+
+## Next steps
+
+- [Set up monitoring](../set-up-monitoring.md) with Prometheus and Grafana dashboards.
+- Review the [production checklist](../production-checklist.md) before going live.
+- Learn how to [connect your application](../../connect-your-app/index.md) to ScyllaDB.

--- a/docs-staging/source/deploy-scylladb/reference-deployments/reference-deployment-gke.md
+++ b/docs-staging/source/deploy-scylladb/reference-deployments/reference-deployment-gke.md
@@ -1,5 +1,198 @@
 # Reference deployment: GKE
 
-:::{todo}
-This page is not yet written.
+This guide deploys a production-ready ScyllaDB cluster on Google Kubernetes Engine (GKE).
+By the end, you will have a 3-node ScyllaDB cluster spread across 3 zones, with performance tuning and local NVMe storage configured.
+
+## Prerequisites
+
+- A regional GKE cluster provisioned with a dedicated ScyllaDB node pool with local NVMe SSDs, spread across 3 zones.
+  If you do not have one yet, follow [Set up a GKE cluster for ScyllaDB](../../install-operator/provision-infrastructure/set-up-gke-cluster.md).
+- Dedicated nodes labeled and tainted per [Set up dedicated node pools](../before-you-deploy/set-up-dedicated-node-pools.md).
+  The GKE cluster setup guide handles this automatically.
+- ScyllaDB Operator installed.
+  Follow [Install ScyllaDB Operator](../../install-operator/install-with-gitops.md) if you have not done so yet.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) configured and pointed at the cluster.
+- The environment variables from the [GKE cluster setup guide](../../install-operator/provision-infrastructure/set-up-gke-cluster.md#set-environment-variables) exported in your shell (at minimum `GCP_REGION`, `GKE_ZONE_1`, `GKE_ZONE_2`, `GKE_ZONE_3`).
+
+## Set up nodes
+
+Before deploying a `ScyllaCluster`, the dedicated nodes must be prepared with local disk setup and kernel tuning via `NodeConfig`, and the Local CSI Driver must be installed to provision `PersistentVolumes` from the local NVMe storage.
+Follow [Configure nodes](../before-you-deploy/configure-nodes.md), selecting the **GKE** tab where applicable, then return here to deploy the cluster.
+
+## Deploy a ScyllaDB cluster
+
+:::{include} /_snippets/scyllacluster-namespace-tip.md
 :::
+
+Create a ScyllaDB cluster with one rack per availability zone.
+The resource requests are sized for `n2-highmem-16` (16 vCPU, 128 GiB RAM), leaving headroom for the OS, kubelet, and `DaemonSets`.
+See the [ScyllaDB system requirements](https://docs.scylladb.com/manual/stable/getting-started/system-requirements.html) for general sizing guidance.
+Adjust if you use a different machine type.
+
+:::{code-block} console
+:substitutions:
+kubectl apply --server-side -f=- <<EOF
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: scylladb
+spec:
+  repository: {{imageRepository}}
+  version: {{scyllaDBImageTag}}
+  agentVersion: {{agentVersion}}
+  automaticOrphanedNodeCleanup: true
+  datacenter:
+    name: ${GCP_REGION}
+    racks:
+    - name: ${GKE_ZONE_1}
+      members: 1
+      storage:
+        capacity: 500Gi
+        storageClassName: scylladb-local-xfs
+      resources:
+        requests:
+          cpu: 14
+          memory: 110Gi
+        limits:
+          cpu: 14
+          memory: 110Gi
+      agentResources:
+        requests:
+          cpu: 100m
+          memory: 20Mi
+        limits:
+          cpu: 100m
+          memory: 20Mi
+      placement:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: scylla.scylladb.com/node-type
+                operator: In
+                values:
+                - scylla
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - ${GKE_ZONE_1}
+        tolerations:
+        - key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
+          effect: NoSchedule
+    - name: ${GKE_ZONE_2}
+      members: 1
+      storage:
+        capacity: 500Gi
+        storageClassName: scylladb-local-xfs
+      resources:
+        requests:
+          cpu: 14
+          memory: 110Gi
+        limits:
+          cpu: 14
+          memory: 110Gi
+      agentResources:
+        requests:
+          cpu: 100m
+          memory: 20Mi
+        limits:
+          cpu: 100m
+          memory: 20Mi
+      placement:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: scylla.scylladb.com/node-type
+                operator: In
+                values:
+                - scylla
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - ${GKE_ZONE_2}
+        tolerations:
+        - key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
+          effect: NoSchedule
+    - name: ${GKE_ZONE_3}
+      members: 1
+      storage:
+        capacity: 500Gi
+        storageClassName: scylladb-local-xfs
+      resources:
+        requests:
+          cpu: 14
+          memory: 110Gi
+        limits:
+          cpu: 14
+          memory: 110Gi
+      agentResources:
+        requests:
+          cpu: 100m
+          memory: 20Mi
+        limits:
+          cpu: 100m
+          memory: 20Mi
+      placement:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: scylla.scylladb.com/node-type
+                operator: In
+                values:
+                - scylla
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - ${GKE_ZONE_3}
+        tolerations:
+        - key: scylla-operator.scylladb.com/dedicated
+          operator: Equal
+          value: scyllaclusters
+          effect: NoSchedule
+EOF
+:::
+
+## Verify the deployment
+
+Wait for the cluster to become ready:
+
+:::{code-block} console
+kubectl wait --for='condition=Progressing=False' scyllacluster.scylla.scylladb.com/scylladb
+kubectl wait --for='condition=Degraded=False' scyllacluster.scylla.scylladb.com/scylladb
+kubectl wait --for='condition=Available=True' scyllacluster.scylla.scylladb.com/scylladb
+:::
+
+Verify the cluster status:
+
+:::{code-block} console
+kubectl get scyllaclusters.scylla.scylladb.com/scylladb
+:::
+
+Expected output:
+
+:::{code-block}
+NAME       READY   MEMBERS   RACKS   AVAILABLE   PROGRESSING   DEGRADED   AGE
+scylladb   3       3         3       True        False         False      5m
+:::
+
+## Clean up
+
+Delete the ScyllaDB cluster first so the underlying `PersistentVolumes` are released cleanly:
+
+:::{code-block} console
+kubectl delete scyllaclusters.scylla.scylladb.com/scylladb
+:::
+
+To tear down the GKE infrastructure, follow the [Clean up](../../install-operator/provision-infrastructure/set-up-gke-cluster.md#clean-up) section of the GKE cluster setup guide.
+
+## Next steps
+
+- [Set up monitoring](../set-up-monitoring.md) with Prometheus and Grafana dashboards.
+- Review the [production checklist](../production-checklist.md) before going live.
+- Learn how to [connect your application](../../connect-your-app/index.md) to ScyllaDB.

--- a/docs-staging/source/install-operator/provision-infrastructure/set-up-eks-cluster.md
+++ b/docs-staging/source/install-operator/provision-infrastructure/set-up-eks-cluster.md
@@ -1,5 +1,109 @@
 # Set up an EKS cluster for ScyllaDB
 
-:::{todo}
-This page is not yet written.
+This guide provisions an Amazon Elastic Kubernetes Service (EKS) cluster suitable for running ScyllaDB.
+At the end, you will have:
+
+- An EKS cluster with an infrastructure node group.
+- A dedicated ScyllaDB node group with local NVMe SSDs, static CPU manager policy, and ScyllaDB labels and taints.
+
+:::{tip}
+All the steps in this guide are also available as a single executable script:
+{{ '[`examples/eks/setup-eks-cluster.sh`](https://github.com/{}/blob/{}/examples/eks/setup-eks-cluster.sh)'.format(repository, revision) }}.
+Set `AWS_REGION`, then run the script to provision everything in one go.
 :::
+
+## Prerequisites
+
+- An AWS account with permissions to create EKS clusters, EC2 instances, and VPC resources.
+- The [`eksctl` CLI](https://eksctl.io/installation/) installed.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) installed.
+- AWS credentials configured (`aws configure` or environment variables).
+- Sufficient quota for `i4i.2xlarge` instances in your target region.
+  See [ScyllaDB cloud instance recommendations for AWS](https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#amazon-web-services-aws) for recommended instance types and [system requirements](https://docs.scylladb.com/manual/stable/getting-started/system-requirements.html) for minimum specifications.
+
+## Set environment variables
+
+The rest of the guide refers to the variables defined here.
+
+Set your AWS region — this has no default and must be provided:
+
+:::{code-block} console
+export AWS_REGION="<your-region>"  # e.g. eu-central-1
+:::
+
+The remaining variables have sensible defaults and can be copied as-is.
+Override any value before running if needed:
+
+:::{literalinclude} ../../../../examples/eks/setup-eks-cluster.sh
+:language: bash
+:start-after: "# [START env_defaults]"
+:end-before: "# [END env_defaults]"
+:::
+
+## Create a temporary directory
+
+Create a temporary directory for configuration files used in this guide:
+
+:::{literalinclude} ../../../../examples/eks/setup-eks-cluster.sh
+:language: bash
+:start-after: "# [START tmpdir]"
+:end-before: "# [END tmpdir]"
+:::
+
+## Create the eksctl cluster configuration
+
+`eksctl` uses a declarative `ClusterConfig` to define the cluster and its node groups.
+Generate the configuration file:
+
+:::{literalinclude} ../../../../examples/eks/setup-eks-cluster.sh
+:language: bash
+:start-after: "# [START create_cluster_config]"
+:end-before: "# [END create_cluster_config]"
+:::
+
+The ScyllaDB node group uses `i4i.2xlarge` instances (8 vCPU, 64 GiB RAM, 1x1875 GB NVMe SSD) with:
+
+- `cpuManagerPolicy: static` for CPU pinning.
+- ScyllaDB labels and taints so only ScyllaDB pods are scheduled on these nodes.
+- Nodes spread across 3 availability zones for fault tolerance.
+
+## Create the EKS cluster
+
+:::{literalinclude} ../../../../examples/eks/setup-eks-cluster.sh
+:language: bash
+:start-after: "# [START create_cluster]"
+:end-before: "# [END create_cluster]"
+:::
+
+:::{note}
+Cluster creation typically takes 15–20 minutes.
+`eksctl` automatically configures `kubectl` to use the new cluster.
+:::
+
+Verify connectivity and node readiness:
+
+:::{code-block} console
+kubectl get nodes -L scylla.scylladb.com/node-type
+:::
+
+Example expected output:
+
+:::{code-block} console
+NAME                                              STATUS   ROLES    AGE   VERSION   NODE-TYPE
+ip-192-168-xx-xx.eu-central-1.compute.internal    Ready    <none>   10m   v1.32.1   scylla
+ip-192-168-xx-xx.eu-central-1.compute.internal    Ready    <none>   10m   v1.32.1   scylla
+ip-192-168-xx-xx.eu-central-1.compute.internal    Ready    <none>   10m   v1.32.1   scylla
+ip-192-168-xx-xx.eu-central-1.compute.internal    Ready    <none>   10m   v1.32.1   infra
+:::
+
+## Clean up
+
+Delete the EKS cluster and all associated resources:
+
+:::{code-block} console
+eksctl delete cluster --name="${EKS_CLUSTER_NAME}" --region="${AWS_REGION}" --force --disable-nodegroup-eviction
+:::
+
+## Next steps
+
+- Follow the [Reference deployment: EKS](../../deploy-scylladb/reference-deployments/reference-deployment-eks.md) for a complete ScyllaDB deployment on this cluster.

--- a/docs-staging/source/install-operator/provision-infrastructure/set-up-gke-cluster.md
+++ b/docs-staging/source/install-operator/provision-infrastructure/set-up-gke-cluster.md
@@ -1,5 +1,131 @@
 # Set up a GKE cluster for ScyllaDB
 
-:::{todo}
-This page is not yet written.
+This guide provisions a Google Kubernetes Engine (GKE) cluster suitable for running ScyllaDB.
+At the end, you will have:
+
+- A regional GKE cluster with a system node pool for infrastructure workloads.
+- A dedicated node pool with local NVMe SSDs, static CPU manager policy, and ScyllaDB labels and taints, spread across 3 zones.
+
+:::{tip}
+All the steps in this guide are also available as a single executable script:
+{{ '[`examples/gke/setup-gke-cluster.sh`](https://github.com/{}/blob/{}/examples/gke/setup-gke-cluster.sh)'.format(repository, revision) }}.
+Set `GCP_PROJECT` and `GCP_REGION`, then run the script to provision everything in one go.
 :::
+
+## Prerequisites
+
+- A Google Cloud project with the [Kubernetes Engine API](https://console.cloud.google.com/apis/api/container.googleapis.com) enabled.
+- A GCP account with the [`Kubernetes Engine Admin`](https://cloud.google.com/iam/docs/understanding-roles#container.admin) (`roles/container.admin`) IAM role on the project.
+- The [`gcloud` CLI](https://cloud.google.com/sdk/docs/install) installed and configured (`gcloud init`).
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) installed.
+- Sufficient quota for `n2-highmem-16` instances with local SSDs in your target region.
+  See [ScyllaDB cloud instance recommendations for GCE](https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#google-compute-engine-gce) for recommended machine types and [system requirements](https://docs.scylladb.com/manual/stable/getting-started/system-requirements.html) for minimum specifications.
+
+## Set environment variables
+
+The rest of the guide refers to the variables defined here.
+
+Set your GCP project and region — these have no defaults and must be provided:
+
+:::{code-block} console
+export GCP_PROJECT="<your-project>"  # e.g. my-scylla-project
+export GCP_REGION="<your-region>"    # e.g. us-central1
+:::
+
+The remaining variables have sensible defaults and can be copied as-is.
+Override any value before running if needed:
+
+:::{literalinclude} ../../../../examples/gke/setup-gke-cluster.sh
+:language: bash
+:start-after: "# [START env_defaults]"
+:end-before: "# [END env_defaults]"
+:::
+
+## Create a temporary directory
+
+Create a temporary directory for configuration files used in this guide:
+
+:::{literalinclude} ../../../../examples/gke/setup-gke-cluster.sh
+:language: bash
+:start-after: "# [START tmpdir]"
+:end-before: "# [END tmpdir]"
+:::
+
+## Create the kubelet configuration
+
+The dedicated ScyllaDB node pool requires [static CPU manager policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy) for CPU pinning.
+Create a `systemconfig.yaml` that will be passed to the node pool:
+
+:::{literalinclude} ../../../../examples/gke/setup-gke-cluster.sh
+:language: bash
+:start-after: "# [START systemconfig]"
+:end-before: "# [END systemconfig]"
+:::
+
+## Create the GKE cluster
+
+Create a regional GKE cluster with a system node pool for infrastructure workloads (cert-manager, ScyllaDB Operator, etc.).
+The system pool is placed in a single zone to keep costs down:
+
+:::{literalinclude} ../../../../examples/gke/setup-gke-cluster.sh
+:language: bash
+:start-after: "# [START create_cluster]"
+:end-before: "# [END create_cluster]"
+:::
+
+## Create the dedicated ScyllaDB node pool
+
+This pool is dedicated to ScyllaDB workloads.
+Each node has local NVMe SSDs for storage and the static CPU manager policy enabled via the system config file created earlier.
+The pool spans 3 zones so each ScyllaDB rack can be placed in a separate zone for fault tolerance:
+
+:::{literalinclude} ../../../../examples/gke/setup-gke-cluster.sh
+:language: bash
+:start-after: "# [START create_scylla_pool]"
+:end-before: "# [END create_scylla_pool]"
+:::
+
+:::{note}
+The `--local-nvme-ssd-block` flag provisions raw NVMe block devices that `NodeConfig` will configure as a RAID0 array.
+Do not use `--ephemeral-storage-local-ssd`, which makes the SSDs managed by the kubelet and unavailable for direct RAID setup.
+:::
+
+## Get cluster credentials
+
+:::{literalinclude} ../../../../examples/gke/setup-gke-cluster.sh
+:language: bash
+:start-after: "# [START get_credentials]"
+:end-before: "# [END get_credentials]"
+:::
+
+Verify connectivity and node readiness:
+
+:::{code-block} console
+kubectl get nodes -L scylla.scylladb.com/node-type
+:::
+
+Example expected output:
+
+:::{code-block} console
+NAME                                              STATUS   ROLES    AGE   VERSION   NODE-TYPE
+gke-scylladb-demo-default-pool-xxxxxxxx-xxxx      Ready    <none>   10m   v1.32.1
+gke-scylladb-demo-default-pool-xxxxxxxx-xxxx      Ready    <none>   10m   v1.32.1
+gke-scylladb-demo-scyllaclusters-xxxxxxxx-xxxx    Ready    <none>   5m    v1.32.1   scylla
+gke-scylladb-demo-scyllaclusters-xxxxxxxx-xxxx    Ready    <none>   5m    v1.32.1   scylla
+gke-scylladb-demo-scyllaclusters-xxxxxxxx-xxxx    Ready    <none>   5m    v1.32.1   scylla
+:::
+
+## Clean up
+
+Delete the GKE cluster (this also deletes all node pools):
+
+:::{code-block} console
+gcloud container clusters delete "${GKE_CLUSTER_NAME}" \
+  --project="${GCP_PROJECT}" \
+  --region="${GCP_REGION}" \
+  --quiet
+:::
+
+## Next steps
+
+- Follow the [Reference deployment: GKE](../../deploy-scylladb/reference-deployments/reference-deployment-gke.md) for a complete ScyllaDB deployment on this cluster.

--- a/examples/eks/setup-eks-cluster.sh
+++ b/examples/eks/setup-eks-cluster.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Set up an EKS cluster suitable for running ScyllaDB.
+#
+# This script creates:
+# - An EKS cluster with an infrastructure node group
+# - A dedicated ScyllaDB node group with local NVMe SSDs and static CPU policy
+#
+# Prerequisites:
+# - eksctl CLI installed and configured
+# - kubectl installed
+# - AWS credentials configured
+#
+# Usage:
+#   export AWS_REGION='eu-central-1'
+#   ./setup-eks-cluster.sh
+
+set -euo pipefail
+
+# [START tmpdir]
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+# [END tmpdir]
+
+# Target region.
+: "${AWS_REGION:?'Set AWS_REGION (e.g. eu-central-1)'}"
+
+# [START env_defaults]
+# Cluster name.
+export EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-scylladb-demo}"
+
+# Availability zones — one per ScyllaDB rack.
+export EKS_AZ_1="${EKS_AZ_1:-${AWS_REGION}a}"
+export EKS_AZ_2="${EKS_AZ_2:-${AWS_REGION}b}"
+export EKS_AZ_3="${EKS_AZ_3:-${AWS_REGION}c}"
+
+# Dedicated ScyllaDB node group. i4i.2xlarge provides 8 vCPU, 64 GiB RAM, and 1x1875 GB NVMe.
+# See https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#amazon-web-services-aws
+export SCYLLA_INSTANCE_TYPE="${SCYLLA_INSTANCE_TYPE:-i4i.2xlarge}"
+export SCYLLA_NODE_COUNT="${SCYLLA_NODE_COUNT:-3}"
+
+# Infrastructure node group.
+export INFRA_INSTANCE_TYPE="${INFRA_INSTANCE_TYPE:-i3.large}"
+export INFRA_NODE_COUNT="${INFRA_NODE_COUNT:-1}"
+# [END env_defaults]
+
+# [START create_cluster_config]
+cat > "${TMPDIR}/clusterconfig.eksctl.yaml" <<EOF
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: ${EKS_CLUSTER_NAME}
+  region: ${AWS_REGION}
+availabilityZones:
+- ${EKS_AZ_1}
+- ${EKS_AZ_2}
+- ${EKS_AZ_3}
+nodeGroups:
+- name: scylla-pool
+  instanceType: ${SCYLLA_INSTANCE_TYPE}
+  desiredCapacity: ${SCYLLA_NODE_COUNT}
+  amiFamily: AmazonLinux2023
+  labels:
+    scylla.scylladb.com/node-type: scylla
+  taints:
+    scylla-operator.scylladb.com/dedicated: "scyllaclusters:NoSchedule"
+  kubeletExtraConfig:
+    cpuManagerPolicy: static
+  availabilityZones:
+  - ${EKS_AZ_1}
+  - ${EKS_AZ_2}
+  - ${EKS_AZ_3}
+- name: infra-pool
+  instanceType: ${INFRA_INSTANCE_TYPE}
+  desiredCapacity: ${INFRA_NODE_COUNT}
+  amiFamily: AmazonLinux2023
+  labels:
+    scylla.scylladb.com/node-type: infra
+EOF
+# [END create_cluster_config]
+
+# [START create_cluster]
+eksctl create cluster -f="${TMPDIR}/clusterconfig.eksctl.yaml"
+# [END create_cluster]
+
+# [START cleanup]
+# eksctl delete cluster --name="${EKS_CLUSTER_NAME}" --region="${AWS_REGION}" --force --disable-nodegroup-eviction
+# [END cleanup]

--- a/examples/gke/setup-gke-cluster.sh
+++ b/examples/gke/setup-gke-cluster.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Set up a GKE cluster suitable for running ScyllaDB.
+#
+# This script creates:
+# - A regional GKE cluster with a system node pool
+# - A dedicated ScyllaDB node pool with local NVMe SSDs and static CPU policy,
+#   spread across 3 zones for fault tolerance
+#
+# Prerequisites:
+# - gcloud CLI installed and configured
+# - kubectl installed
+#
+# Usage:
+#   export GCP_PROJECT='my-project'
+#   export GCP_REGION='us-central1'
+#   ./setup-gke-cluster.sh
+
+set -euo pipefail
+
+# [START tmpdir]
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+# [END tmpdir]
+
+# Target project and region.
+: "${GCP_PROJECT:?'Set GCP_PROJECT'}"
+: "${GCP_REGION:?'Set GCP_REGION (e.g. us-central1)'}"
+
+# [START env_defaults]
+# Cluster name.
+export GKE_CLUSTER_NAME="${GKE_CLUSTER_NAME:-scylladb-demo}"
+
+# Availability zones — one per ScyllaDB rack.
+export GKE_ZONE_1="${GKE_ZONE_1:-${GCP_REGION}-a}"
+export GKE_ZONE_2="${GKE_ZONE_2:-${GCP_REGION}-b}"
+export GKE_ZONE_3="${GKE_ZONE_3:-${GCP_REGION}-c}"
+
+# System node pool machine type.
+export SYSTEM_MACHINE_TYPE="${SYSTEM_MACHINE_TYPE:-n2-standard-8}"
+export SYSTEM_NODE_COUNT="${SYSTEM_NODE_COUNT:-2}"
+
+# Dedicated ScyllaDB node pool. n2-highmem-16 provides 16 vCPU and 128 GiB RAM.
+# See https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#google-compute-engine-gce
+export SCYLLA_MACHINE_TYPE="${SCYLLA_MACHINE_TYPE:-n2-highmem-16}"
+# Node count is per zone. With 3 zones this gives 3 nodes total.
+export SCYLLA_NODE_COUNT="${SCYLLA_NODE_COUNT:-1}"
+export SCYLLA_LOCAL_SSD_COUNT="${SCYLLA_LOCAL_SSD_COUNT:-4}"
+# [END env_defaults]
+
+# [START systemconfig]
+cat > "${TMPDIR}/systemconfig.yaml" <<EOF
+kubeletConfig:
+  cpuManagerPolicy: static
+EOF
+# [END systemconfig]
+
+# [START create_cluster]
+gcloud container clusters create "${GKE_CLUSTER_NAME}" \
+  --project="${GCP_PROJECT}" \
+  --region="${GCP_REGION}" \
+  --node-locations="${GKE_ZONE_1}" \
+  --cluster-version="latest" \
+  --machine-type="${SYSTEM_MACHINE_TYPE}" \
+  --num-nodes="${SYSTEM_NODE_COUNT}" \
+  --disk-type='pd-ssd' --disk-size='20' \
+  --image-type='UBUNTU_CONTAINERD' \
+  --no-enable-autoupgrade \
+  --no-enable-autorepair
+# [END create_cluster]
+
+# [START create_scylla_pool]
+gcloud container node-pools create 'scyllaclusters' \
+  --project="${GCP_PROJECT}" \
+  --region="${GCP_REGION}" \
+  --cluster="${GKE_CLUSTER_NAME}" \
+  --node-locations="${GKE_ZONE_1},${GKE_ZONE_2},${GKE_ZONE_3}" \
+  --node-version="latest" \
+  --machine-type="${SCYLLA_MACHINE_TYPE}" \
+  --num-nodes="${SCYLLA_NODE_COUNT}" \
+  --disk-type='pd-ssd' --disk-size='20' \
+  --local-nvme-ssd-block="count=${SCYLLA_LOCAL_SSD_COUNT}" \
+  --image-type='UBUNTU_CONTAINERD' \
+  --system-config-from-file="${TMPDIR}/systemconfig.yaml" \
+  --no-enable-autoupgrade \
+  --no-enable-autorepair \
+  --node-labels='scylla.scylladb.com/node-type=scylla' \
+  --node-taints='scylla-operator.scylladb.com/dedicated=scyllaclusters:NoSchedule'
+# [END create_scylla_pool]
+
+# [START get_credentials]
+gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" \
+  --project="${GCP_PROJECT}" \
+  --region="${GCP_REGION}"
+# [END get_credentials]
+
+# [START cleanup]
+# gcloud container clusters delete "${GKE_CLUSTER_NAME}" \
+#   --project="${GCP_PROJECT}" \
+#   --region="${GCP_REGION}" \
+#   --quiet
+# [END cleanup]


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Adds reference deployment guides for GKE and EKS.

**EKS note**:
During EKS testing, discovered that the fix for systemctl missing in the Scylla image wasn't solved properly (container perftune doesn't complete successfuly). Created a Jira tracker for it: https://scylladb.atlassian.net/browse/OPERATOR-113 and posted a fix already: https://github.com/scylladb/scylladb/pull/29904. Added a workaround `ScyllaOperatorConfig` patch in the EKS guide to mitigate this.

**Which issue is resolved by this Pull Request:**
Part of https://scylladb.atlassian.net/browse/OPERATOR-32.
