### PR TITLE
chore(release): update supported k8s versions

### DIFF
--- a/assets/metadata/metadata.yaml
+++ b/assets/metadata/metadata.yaml
@@ -7,11 +7,11 @@ operator:
   # This value is propagated the ClusterServiceVersion and must be a valid semver version in the format "X.Y.Z".
   # It is also used in the compatibility matrix to determine which Kubernetes versions are supported by the operator.
   # Conventionally, we only specify the major and minor versions, and always set the patch version to 0.
-  minKubernetesVersion: "1.32.0"
+  minKubernetesVersion: "1.33.0"
   # maxKubernetesVersion specifies the maximum Kubernetes version that the operator supports.
   # This value is used in the compatibility matrix to determine which Kubernetes versions are supported by the operator.
   # Conventionally, we only specify the major and minor versions.
-  maxKubernetesVersion: "1.35"
+  maxKubernetesVersion: "1.36"
   redHatCertificationProjectID: "678641799dbe477195796c15"
 operatorTests:
   olm:

--- a/bundle/manifests/scylladb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/scylladb-operator.clusterserviceversion.yaml
@@ -562,4 +562,4 @@ spec:
       targetPort: 5000
       type: ValidatingAdmissionWebhook
       webhookPath: /validate
-  minKubeVersion: 1.32.0
+  minKubeVersion: 1.33.0

--- a/bundle/patches/manifests/versions.clusterserviceversion.yaml
+++ b/bundle/patches/manifests/versions.clusterserviceversion.yaml
@@ -3,4 +3,4 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 spec:
-  minKubeVersion: 1.32.0
+  minKubeVersion: 1.33.0


### PR DESCRIPTION
Linked issue: https://scylladb.atlassian.net/browse/OPERATOR-109

Executes the "Compatible versions" part of the release checklist.

Note about openshift versions: the newest available is 4.21 but updating the tested/supported OCP is out of scope of this release proceeding.

/kind cleanup
/priority important-soon