### PR TITLE
docs(staging): transplant the upgrade chapter verbatim from old docs

### DIFF
--- a/docs-staging/source/.internal/wait-for-all-nodes-un.md
+++ b/docs-staging/source/.internal/wait-for-all-nodes-un.md
@@ -1,0 +1,29 @@
+To verify the cluster state, execute `nodetool status` in each of the ScyllaDB cluster pods:
+:::{code-block} bash
+NAMESPACE=<namespace>
+CLUSTER_NAME=<cluster-name>
+
+# List all ScyllaDB pods in the cluster.
+pods=$(kubectl -n "${NAMESPACE}" get pods \
+    -l scylla/cluster="${CLUSTER_NAME}" \
+    -l scylla-operator.scylladb.com/pod-type=scylladb-node \
+    -o name)
+
+# Execute nodetool status in each pod.
+for pod in $pods; do
+    kubectl -n "${NAMESPACE}" exec "${pod}" -c scylla -- nodetool status
+done
+:::
+
+All nodes should report all other nodes as `UN` (Up and Normal) in the output, e.g.:
+
+:::{code-block} console
+Datacenter: us-east-1
+===========================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+-- Address        Load    Tokens Owns Host ID                              Rack      
+UN 10.221.135.48  3.30 KB 256    ?    5dd7f301-62d7-4ab7-986a-e7ea9d21be4d us-east-1a
+UN 10.221.140.203 3.48 KB 256    ?    2f725f88-33fa-4ca7-b366-fa35e63e7c72 us-east-1b
+UN 10.221.150.121 3.67 KB 256    ?    7063a262-fa3f-4f69-8a60-720f464b1483 us-east-1c
+:::

--- a/docs-staging/source/.internal/wait-for-status-conditions.scyllacluster.code-block.md
+++ b/docs-staging/source/.internal/wait-for-status-conditions.scyllacluster.code-block.md
@@ -1,0 +1,5 @@
+:::{code-block} bash
+kubectl wait --for='condition=Progressing=False' scyllacluster.scylla.scylladb.com/scylladb
+kubectl wait --for='condition=Degraded=False' scyllacluster.scylla.scylladb.com/scylladb
+kubectl wait --for='condition=Available=True' scyllacluster.scylla.scylladb.com/scylladb
+:::

--- a/docs-staging/source/.internal/wait-for-status-conditions.scylladbcluster.code-block.md
+++ b/docs-staging/source/.internal/wait-for-status-conditions.scylladbcluster.code-block.md
@@ -1,0 +1,5 @@
+:::{code-block} bash
+kubectl --context=${CONTROL_PLANE_CONTEXT} wait --for='condition=Progressing=False' scylladbcluster.scylla.scylladb.com/dev-cluster
+kubectl --context=${CONTROL_PLANE_CONTEXT} wait --for='condition=Degraded=False' scylladbcluster.scylla.scylladb.com/dev-cluster
+kubectl --context=${CONTROL_PLANE_CONTEXT} wait --for='condition=Available=True' scylladbcluster.scylla.scylladb.com/dev-cluster
+:::

--- a/docs-staging/source/upgrade/index.md
+++ b/docs-staging/source/upgrade/index.md
@@ -1,11 +1,10 @@
 # Upgrade
 
-Guides for upgrading ScyllaDB Operator, ScyllaDB, and the underlying Kubernetes infrastructure.
+Guides for upgrading ScyllaDB Operator and ScyllaDB.
 
 :::{toctree}
 :maxdepth: 1
 
 upgrade-operator
 upgrade-scylladb
-upgrade-kubernetes
 :::

--- a/docs-staging/source/upgrade/upgrade-kubernetes.md
+++ b/docs-staging/source/upgrade/upgrade-kubernetes.md
@@ -1,5 +1,0 @@
-# Upgrade Kubernetes
-
-:::{todo}
-This page is not yet written.
-:::

--- a/docs-staging/source/upgrade/upgrade-operator.md
+++ b/docs-staging/source/upgrade/upgrade-operator.md
@@ -1,5 +1,182 @@
-# Upgrade ScyllaDB Operator
+# Upgrading ScyllaDB Operator
 
-:::{todo}
-This page is not yet written.
+ScyllaDB Operator supports N+1 upgrades only.
+That means to you can only update by 1 minor version at the time and wait for it to successfully roll out and then update
+all ScyllaClusters that also run using the image that's being updated. (ScyllaDB Operator injects it as a sidecar to help run and manage ScyllaDB.)
+
+We value the stability of our APIs and all API changes are backwards compatible.
+
+:::{caution}
+If any additional steps are required for a specific version upgrade, they will be documented in the [Upgrade steps for specific versions](#upgrade-steps-for-specific-versions) section below.
 :::
+
+## Upgrade via GitOps (kubectl)
+
+A typical upgrade flow using GitOps (kubectl) requires re-applying the manifests using ones from the release you want to upgrade to.
+Note that ScyllaDB Operator's dependencies also need to be updated to the versions compatible with the target ScyllaDB Operator version.
+
+Please refer to the [GitOps installation instructions](./../install-operator/install-with-gitops.md) for details.
+
+## Upgrade via Helm
+
+### Prerequisites
+- Update ScyllaDB Operator dependencies to the versions compatible with the target ScyllaDB Operator version.
+  Refer to the [Helm installation instructions](./../install-operator/install-with-helm.md) for details.
+
+- Make sure Helm chart repository is up-to-date:
+  ```
+  helm repo add scylla https://scylla-operator-charts.storage.googleapis.com/stable
+  helm repo update
+  ```
+
+### Upgrade ScyllaDB Manager
+
+Replace `<release_name>` with the name of your Helm release for ScyllaDB Manager and replace `<version>` with the version number you want to install:
+
+```
+helm upgrade --version <version> <release_name> scylla/scylla-manager
+```
+
+### Upgrade ScyllaDB Operator 
+
+Replace `<release_name>` with the name of your Helm release for ScyllaDB Operator and replace `<version>` with the version number you want to install:
+
+1. Update CRD resources. We recommend using `--server-side` flag for `kubectl apply`, if your version supports it.
+   ```
+   tmpdir=$( mktemp -d ) \
+     && helm pull scylla-operator/scylla-operator --version <version> --untar --untardir "${tmpdir}" \
+     && find "${tmpdir}"/scylla-operator/crds/ -name '*.yaml' -printf '-f=%p ' \
+     | xargs kubectl apply
+   ```
+2. Update ScyllaDB Operator.
+   ```
+   helm upgrade --version <version> <release_name> scylla/scylla-operator
+   ```
+
+## Upgrade steps for specific versions
+
+:::{caution}
+The below instructions are **supplementary** to the standard upgrade procedure and don't fully replace it.
+Make sure to familiarize yourself with both the standard upgrade procedure and the additional steps for the specific version you are upgrading to, if applicable, and follow them accordingly.
+:::
+
+### 1.20 to 1.21
+
+#### Ensure ScyllaCluster repair and backup task names are RFC 1123 compliant
+
+Before upgrading, ensure that all `ScyllaCluster` repair (`.spec.repairs[].name`) and backup (`.spec.backups[].name`) task names conform to [RFC 1123 subdomain](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names) requirements:
+- contain no more than 253 characters,
+- contain only lowercase alphanumeric characters, '-' or '.',
+- start with an alphanumeric character,
+- end with an alphanumeric character.
+
+You can run the following snippet to check for such `ScyllaClusters`:
+```bash
+output=$(kubectl get scyllaclusters --all-namespaces -o json | jq -r '
+  def is_rfc1123_subdomain_invalid:
+    (length <= 253) and test("^[a-z0-9]([a-z0-9.-]{0,251}[a-z0-9])?$") | not;
+  .items[] |
+  {
+    namespace: .metadata.namespace,
+    name: .metadata.name,
+    invalid_repairs: [(.spec.repairs // [] | .[].name | select(is_rfc1123_subdomain_invalid))],
+    invalid_backups: [(.spec.backups // [] | .[].name | select(is_rfc1123_subdomain_invalid))]
+  } |
+  select((.invalid_repairs | length > 0) or (.invalid_backups | length > 0)) |
+  "\(.namespace)/\(.name)\n  Invalid repairs: \(if (.invalid_repairs | length) > 0 then (.invalid_repairs | join(", ")) else "(none)" end)\n  Invalid backups: \(if (.invalid_backups | length) > 0 then (.invalid_backups | join(", ")) else "(none)" end)\n"
+') && if [ -z "$output" ]; then echo "All ScyllaCluster repair and backup task names are RFC 1123 compliant."; else echo "$output"; fi
+```
+
+You should get an output similar to the following if there are any `ScyllaClusters` with invalid repair or backup task names:
+
+```console
+scylla/example
+  Invalid repairs: invalid_repair
+  Invalid backups: invalid_backup
+```
+
+or the following if all `ScyllaCluster` repair and backup task names are compliant:
+
+```console
+All ScyllaCluster repair and backup task names are RFC 1123 compliant.
+```
+
+:::{note}
+**Why is this necessary?**
+Starting with v1.20.1, ScyllaDB Operator emitted warnings for `ScyllaCluster` repair and backup task names not conforming to RFC 1123 subdomain requirements.
+In v1.21, these warnings have been replaced with hard validation errors, and the operator will refuse to start if any existing `ScyllaClusters` have non-conforming task names.
+:::
+
+#### Ensure ScyllaCluster spec.version is not empty
+
+`ScyllaCluster` `spec.version` is now a required field. Any create or update request with an empty value will be rejected by the admission webhook.
+You can run the following snippet to check whether any of your existing `ScyllaClusters` have an empty `spec.version`:
+
+```bash
+kubectl get scyllaclusters --all-namespaces -o json | jq -r '
+  .items[] | select((.spec.version // "") == "") |
+  "\(.metadata.namespace)/\(.metadata.name)"
+'
+```
+
+If the command returns no output, all your `ScyllaClusters` are unaffected. If any are listed, set their `spec.version` to a valid ScyllaDB image tag before upgrading.
+
+:::{note}
+**Why is this not a breaking change?**
+A `ScyllaCluster` with an empty `spec.version` was never functional. The migration controller would fail to reconcile it, leaving the cluster in a permanently degraded state. Making the field required only prevents new broken clusters from being created.
+:::
+
+#### Review ScyllaDBMonitoring spec.type default change
+
+The default value of `ScyllaDBMonitoring` `spec.type` has changed from `SaaS` to `Platform`. Any existing `ScyllaDBMonitoring`
+object that omits `spec.type` will render `Platform` dashboards after the upgrade instead of `SaaS`. The `SaaS` value is
+also now deprecated and will be removed in a future release; the admission webhook will emit a warning when it is set explicitly.
+
+You can run the following snippet to list `ScyllaDBMonitoring` objects that will be affected by the default change or that
+still use the deprecated `SaaS` value:
+
+```bash
+output=$(kubectl get scylladbmonitorings --all-namespaces -o json | jq -r '
+  .items[] |
+  select((.spec.type // "SaaS") == "SaaS") |
+  "\(.metadata.namespace)/\(.metadata.name)\t(spec.type=\(.spec.type // "<unset, defaults to SaaS>"))"
+') && if [ -z "$output" ]; then echo "No ScyllaDBMonitoring objects rely on the SaaS type."; else echo "$output"; fi
+```
+
+If the command returns no output, none of your `ScyllaDBMonitoring` objects are affected. Otherwise, for each listed object,
+decide whether you want to:
+- keep the previous behavior by setting `spec.type: SaaS` explicitly before upgrading (the admission webhook will emit a
+  deprecation warning, and you will need to migrate to `Platform` before a future release removes `SaaS`), or
+- adopt the new default by either setting `spec.type: Platform` explicitly or leaving `spec.type` unset.
+
+:::{note}
+**Why is this not a breaking change?**
+The `Platform` dashboards are a superset of the `SaaS` dashboards, so switching from `SaaS` to `Platform` does not remove
+functionality.
+:::
+
+### 1.17 to 1.18
+
+Upgrading from v1.17.x requires extra actions due to the removal of the standalone ScyllaDB Manager controller.
+The controller becomes an integral part of ScyllaDB Operator. As a result, the standalone ScyllaDB Manager controller deployment and its related resources
+need to be removed before upgrading ScyllaDB Operator.
+
+{#steps-1-17-to-1-18-upgrade-via-gitops}
+#### Upgrade via GitOps (kubectl)
+
+```
+kubectl delete -n scylla-manager \
+    clusterrole/scylladb:controller:aggregate-to-manager-controller \
+    clusterrole/scylladb:controller:manager-controller \
+    poddisruptionbudgets.policy/scylla-manager-controller \
+    serviceaccounts/scylla-manager-controller \
+    clusterrolebindings.rbac.authorization.k8s.io/scylladb:controller:manager-controller \
+    deployments.apps/scylla-manager-controller
+```
+
+{#steps-1-17-to-1-18-upgrade-via-helm}
+#### Upgrade via Helm
+
+ScyllaDB Manager Helm installation has to be upgraded before upgrading ScyllaDB Operator Helm installation, following
+the standard [Helm upgrade procedure](#upgrade-via-helm). This will ensure that the ScyllaDB Manager Controller
+is removed before upgrading the ScyllaDB Operator.

--- a/docs-staging/source/upgrade/upgrade-scylladb.md
+++ b/docs-staging/source/upgrade/upgrade-scylladb.md
@@ -1,5 +1,98 @@
-# Upgrade ScyllaDB
+# Upgrading ScyllaDB clusters
 
-:::{todo}
-This page is not yet written.
+Upgrading your ScyllaDB cluster to a newer version is automated by ScyllaDB Operator and performed using a rolling update 
+strategy to maintain availability. It is as simple as updating the ScyllaDB image reference in your ScyllaDB cluster specification.
+
+:::{warning}
+While the cluster remains operational throughout the process, applications requiring strict consistency levels (such as `QUORUM`) 
+may experience transient unavailability. This can occur if the cluster topology view has not yet fully converged across all 
+nodes before the next node is restarted. 
+
+We recommend scheduling upgrades during periods of low application traffic to minimize potential disruptions.
+
+Issue tracking fix for this behavior: [scylla-operator #1077](https://github.com/scylladb/scylla-operator/issues/1077).
+:::
+
+:::{warning}
+ScyllaDB version upgrades must be performed consecutively, meaning **you must not skip any major or minor version on the upgrade path**.
+Before upgrading to the next version, ensure the entire ScyllaDB cluster has been successfully upgraded.
+For details, refer to the [Upgrade procedure in ScyllaDB's documentation](https://enterprise.docs.scylladb.com/stable/upgrade/index.html#upgrade-upgrade-procedures).
+:::
+
+:::{caution}
+Before upgrading ScyllaDB, ensure the target version is supported by the version of ScyllaDB Operator you are using.
+Refer to the [support matrix](./../reference/releases.md#support-matrix) for information on version compatibility.
+:::
+
+## Upgrade via GitOps (kubectl)
+
+To upgrade your ScyllaDB cluster using GitOps (kubectl), adjust the ScyllaDB image tag/reference to the target one in your ScyllaDB cluster specification and re-apply the manifest.
+
+:::::{tabs}
+::::{group-tab} ScyllaCluster
+:::{code-block} yaml
+:substitutions:
+
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: scylladb
+spec:
+  version: {{scyllaDBImageTag}} # Specify the target ScyllaDB image tag.
+  # ...
+:::
+
+After reapplying the manifest, wait for your ScyllaCluster to roll out.
+:::{include} ./../.internal/wait-for-status-conditions.scyllacluster.code-block.md
+:::
+
+::::
+::::{group-tab} ScyllaDBCluster
+:::{code-block} yaml
+:substitutions:
+
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: ScyllaDBCluster
+metadata:
+  name: dev-cluster
+spec:
+  scyllaDB:
+    image: {{imageRepository}}:{{scyllaDBImageTag}} # Specify the target ScyllaDB image reference.
+  # ...
+:::
+
+After reapplying the manifest, wait for your ScyllaDBCluster to roll out.
+:::{include} ./../.internal/wait-for-status-conditions.scylladbcluster.code-block.md
+:::
+
+::::
+:::::
+
+:::{include} ./../.internal/wait-for-all-nodes-un.md
+:::
+
+## Upgrade via Helm
+
+:::{important}
+ScyllaDB Operator does not yet support Helm installation path for managed multi-datacenter ScyllaDB clusters.
+:::
+
+To upgrade your ScyllaDB cluster using Helm, upgrade your Helm release with the target ScyllaDB image tag/reference.
+
+:::::{tabs}
+::::{group-tab} ScyllaCluster
+:::{code-block} shell
+:substitutions:
+
+helm upgrade scylla scylla/scylla --reuse-values --set=scyllaImage.tag={{scyllaDBImageTag}}
+:::
+
+After upgrading the release, wait for your ScyllaCluster to roll out.
+:::{include} ./../.internal/wait-for-status-conditions.scyllacluster.code-block.md
+:::
+
+::::
+::::
+
+:::{include} ./../.internal/wait-for-all-nodes-un.md
 :::


### PR DESCRIPTION
Linked issue: OPERATOR-32

This takes the existing upgrade docs and puts them in the `docs-staging` structure.
Skips the planned Upgrade Kubernetes section as we decided to drop it from scope.

- upgrade-operator.md: verbatim from docs/source/management/upgrading/upgrade.md
- upgrade-scylladb.md: verbatim from docs/source/management/upgrading/upgrade-scylladb.md
- upgrade-kubernetes.md: removed (no old docs equivalent)
- .internal/: created with 3 include files copied from docs/source/.internal/
- Only mechanical path adjustments, no content changes

/kind documentation
/priority important-soon