### PR TITLE
docs(deploy-scylladb): add Install ScyllaDB Manager page

### DIFF
--- a/docs-staging/source/deploy-scylladb/index.md
+++ b/docs-staging/source/deploy-scylladb/index.md
@@ -7,6 +7,7 @@ before-you-deploy/index
 deploy-your-first-cluster
 reference-deployments/index
 deploy-multi-dc-cluster
+install-scylladb-manager
 set-up-networking/index
 set-up-monitoring
 expose-grafana

--- a/docs-staging/source/deploy-scylladb/install-scylladb-manager.md
+++ b/docs-staging/source/deploy-scylladb/install-scylladb-manager.md
@@ -1,0 +1,76 @@
+# Install ScyllaDB Manager
+
+[ScyllaDB Manager](https://manager.docs.scylladb.com/) provides automated repair and backup scheduling for ScyllaDB clusters.
+With Manager installed, ScyllaDB Operator can:
+
+- **Schedule backups** — automatically snapshot your data and upload it to object storage.
+  See [Schedule backups](../operate/schedule-backups.md).
+- **Schedule repairs** — run automated anti-entropy repairs to keep data consistent across replicas.
+- **Restore from backup** — recover a ScyllaDB cluster from a previously created backup snapshot.
+  See [Restore from backup](../operate/restore-from-backup.md).
+
+For details on how Manager integrates with the Operator, see [ScyllaDB Manager](../understand/manager.md).
+
+## Prerequisites
+
+- ScyllaDB Operator installed and running.
+  See [Install with Helm](../install-operator/install-with-helm.md) or [Install with GitOps](../install-operator/install-with-gitops.md).
+- Nodes configured with the local CSI driver installed.
+  Manager deploys a small internal ScyllaCluster that uses the storage class provided by the local CSI driver.
+  See [Configure nodes](before-you-deploy/configure-nodes.md).
+
+## Install ScyllaDB Manager
+
+ScyllaDB Manager deploys into the `scylla-manager` namespace.
+It runs a small internal ScyllaCluster for its own state.
+
+:::{note}
+ScyllaDB Manager must be installed in the `scylla-manager` namespace.
+The Operator expects Manager in this namespace and will not discover it otherwise.
+:::
+
+::::{tabs}
+:::{tab} GitOps (manifests)
+
+Apply the manifest:
+
+```{code-block} shell
+:substitutions:
+kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/manager-prod.yaml
+```
+
+:::
+
+:::{tab} Helm
+
+Install the Helm chart:
+
+```shell
+helm install scylla-manager scylla/scylla-manager \
+  --create-namespace \
+  --namespace scylla-manager
+```
+
+:::
+::::
+
+Wait for Manager to become available:
+
+```shell
+kubectl -n=scylla-manager rollout status --timeout=10m deployment.apps/scylla-manager
+```
+
+## Verify the installation
+
+Check that the Manager Pod is running:
+
+```shell
+kubectl -n=scylla-manager get pods
+```
+
+You should see the `scylla-manager` Deployment Pod and one or more Pods for the internal Manager ScyllaCluster.
+
+## Next steps
+
+- [Schedule backups](../operate/schedule-backups.md) — configure object storage credentials and schedule automated backups.
+- [ScyllaDB Manager](../understand/manager.md) — understand Manager architecture, task synchronization, and security.

--- a/docs-staging/source/deploy-scylladb/overview.md
+++ b/docs-staging/source/deploy-scylladb/overview.md
@@ -22,6 +22,7 @@ For production, complete the [Before you deploy](before-you-deploy/overview.md) 
 After your cluster is running, see these guides for additional setup:
 
 - [Set up networking](set-up-networking/index.md) — expose ScyllaDB outside the Kubernetes cluster.
+- [Install ScyllaDB Manager](install-scylladb-manager.md) — enable automated backups, repairs, and restore.
 - [Set up monitoring](set-up-monitoring.md) — integrate with Prometheus and Grafana.
 - [Deploy a multi-datacenter cluster](deploy-multi-dc-cluster.md) — span ScyllaDB across multiple Kubernetes clusters.
 - [Production checklist](production-checklist.md) — verify your deployment is production-ready.


### PR DESCRIPTION
## Summary

Add a standalone "Install ScyllaDB Manager" page under the Deploy ScyllaDB section.

## Why a separate page?

The existing install guides (Install with Helm, Install with GitOps) cover Manager installation as one of their steps. However, Manager depends on node configuration (specifically the local CSI driver) because it deploys a small internal ScyllaCluster for its own state. Node configuration is covered in the Deploy ScyllaDB section as a deployment prerequisite, not in the install guides. A dedicated page under Deploy ScyllaDB makes this dependency explicit and places Manager installation in the correct order within the deployment flow — after nodes are configured and a cluster is deployed.

## Notes

- The licensing note was intentionally omitted pending clarification from the Manager team.

/cc @mflendrich 