### PR TITLE
fix(test): avoid nil pointer dereference in coredump test cleanup

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_coredumps.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_coredumps.go
@@ -60,9 +60,14 @@ var _ = g.Describe("ScyllaCluster coredumps", framework.SuiteSerial, func() {
 		ds, err = f.KubeAdminClient().AppsV1().DaemonSets(coredumpSetupNamespace).Create(ctx, ds, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		// Record the DaemonSet name and namespace before registering DeferCleanup,
+		// because ds may be reassigned to nil if WaitForDaemonSetState times out.
+		dsName := ds.Name
+		dsNamespace := ds.Namespace
+
 		g.DeferCleanup(func(ctx context.Context) {
 			framework.By("Deleting the coredump setup DaemonSet")
-			err := f.KubeAdminClient().AppsV1().DaemonSets(coredumpSetupNamespace).Delete(ctx, ds.Name, metav1.DeleteOptions{
+			err := f.KubeAdminClient().AppsV1().DaemonSets(dsNamespace).Delete(ctx, dsName, metav1.DeleteOptions{
 				PropagationPolicy: pointer.Ptr(metav1.DeletePropagationForeground),
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -72,8 +77,8 @@ var _ = g.Describe("ScyllaCluster coredumps", framework.SuiteSerial, func() {
 				ctx,
 				f.DynamicAdminClient(),
 				appsv1.SchemeGroupVersion.WithResource("daemonsets"),
-				ds.Namespace,
-				ds.Name,
+				dsNamespace,
+				dsName,
 				nil,
 			)
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
**Description of your changes:**
The coredump E2E test panicked in OKE serial CI because the `DeferCleanup` closure
captured the `ds` variable by reference, which was later reassigned to `nil` when
`WaitForDaemonSetState` timed out. The cleanup then dereferenced `nil` when accessing
`ds.Name`.

The underlying timeout was caused by the coredump setup DaemonSet (from
`examples/gke/coredumps/`) running `apt-get` via `nsenter` on the host. OKE nodes run
Oracle Linux, which doesn't have `apt-get`, so the container crash-looped and the
DaemonSet never rolled out.

This PR fixes the panic by recording `ds.Name` and `ds.Namespace` in local variables
before registering `DeferCleanup`, so the closure no longer depends on the mutable `ds`
variable. The OKE platform incompatibility of the coredump setup DaemonSet is a separate
issue.

Linked issue: https://scylladb.atlassian.net/browse/OPERATOR-80

/kind bug
/priority important-soon