### PR TITLE
fix: address default SA existence race conditions in e2e.sh

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -96,6 +96,9 @@ function gather-artifacts {
   kubectl create namespace gather-artifacts --dry-run=client -o=yaml | kubectl_apply -f=-
   kubectl create clusterrolebinding gather-artifacts --clusterrole=cluster-admin --serviceaccount=gather-artifacts:default --dry-run=client -o=yaml | kubectl_apply -f=-
   kubectl create -n=gather-artifacts pdb must-gather --selector='app=must-gather' --max-unavailable=0 --dry-run=client -o=yaml | kubectl_apply -f=-
+  # Wait until SA is created - eliminates an existing race condition; there is a potential further race if
+  # RBAC is not yet propagated to k8s API servers - in which case more hardening is due.
+  kubectl -n=gather-artifacts wait --for=jsonpath='{.metadata.name}'=default serviceaccount/default --timeout=60s
 
   kubectl_create -n=gather-artifacts -f=- <<EOF
 apiVersion: v1
@@ -401,6 +404,10 @@ function run-e2e {
   if [[ -n "${SCYLLADB_IMAGE_REF}" ]]; then
     e2e_command_args+=( "--scylladb-image-ref=${SCYLLADB_IMAGE_REF}" )
   fi
+
+  # Wait until SA is created - eliminates an existing race condition; there is a potential further race if
+  # RBAC is not yet propagated to k8s API servers - in which case more hardening is due.
+  kubectl -n=e2e wait --for=jsonpath='{.metadata.name}'=default serviceaccount/default --timeout=60s
 
   kubectl_create -n=e2e -f=- <<EOF
 apiVersion: v1


### PR DESCRIPTION
**Description of your changes:**
Kubernetes creates a default SA for new namespaces, but this process is async. e2e tests rely on the default SA in e2e and must-gather namespaces, and there are no guard rails.

This leads to situations where the e2e tests can [occasionally](https://jenkins.scylladb.com/job/scylla-master/job/docker/1309/) [fail](https://jenkins.scylladb.com/job/scylla-master/job/docker/1310/)

```
 Error from server (Forbidden): pods "e2e" is forbidden: error looking up service account e2e/default: serviceaccount "default" not found
 Error from server (Forbidden): pods "must-gather" is forbidden: error looking up service account gather-artifacts/default: serviceaccount "default" not found
```

Normally SA is created near-instantly, however on Jenkins runners it can occasionally jitter, introducing a race condition for e2e and must-gather pods. This PR ensures that the SA exists.

Added an acknowledgement to a potential further RBAC race (if RBAC is not yet propagated to API servers) - this did not float up so far; will be handled in a follow-up ticket if necessary.

**Which issue is resolved by this Pull Request:**
Fixes https://scylladb.atlassian.net/browse/OPERATOR-115

**Testing**
See ticket