### PR TITLE
docs(staging): port Install on OpenShift and Install with Helm

### DIFF
--- a/docs-staging/source/install-operator/install-on-openshift.md
+++ b/docs-staging/source/install-operator/install-on-openshift.md
@@ -10,17 +10,15 @@ ScyllaDB Operator is a Red Hat OpenShift Certified Operator. It is available in 
 
 ## Prerequisites
 
-- An OpenShift Container Platform cluster (see the supported version range in [Releases](../reference/releases.md))
-- An account with `cluster-admin` permissions
-- `kubectl` or OpenShift CLI (`oc`) installed
-
-Ensure that your cluster meets the [general prerequisites](prerequisites.md) for ScyllaDB Operator installation.
+- An OpenShift Container Platform cluster meeting the [infrastructure requirements](provision-infrastructure/overview.md).
+- An account with `cluster-admin` permissions.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) or OpenShift CLI (`oc`) configured to communicate with the cluster.
 
 :::{tip}
 All `kubectl` commands in this guide can be executed using the OpenShift CLI (`oc`) instead.
 :::
 
-## Step 1: Install ScyllaDB Operator
+## Install ScyllaDB Operator
 
 ScyllaDB Operator can be installed from the OpenShift software catalog using either the web console or the CLI.
 
@@ -235,106 +233,12 @@ deployment "scylla-operator" successfully rolled out
 deployment "webhook-server" successfully rolled out
 ```
 
-## Step 2: Set up NodeConfig
-
-NodeConfig configures local storage (RAID, filesystem, mount points) and performance tuning on the Kubernetes nodes where ScyllaDB will run.
-
-:::{caution}
-Local storage configuration depends on the OpenShift deployment model and the underlying platform and infrastructure. Review the examples below and adjust the manifest to your specific environment. See [Configure nodes](../deploy-scylladb/before-you-deploy/configure-nodes.md) for details.
-:::
-
-:::{note}
-Performance tuning is enabled for all nodes that are selected by `NodeConfig` by default, unless explicitly opted-out of.
-:::
-
-::::::{tabs}
-::::{group-tab} ROSA (NVMe)
-
-The following manifest creates a RAID0 array from the available NVMe devices, formats it with the XFS filesystem, and enables performance tuning recommended for production-grade ScyllaDB deployments on the selected nodes.
-
-:::{literalinclude} ../../../examples/openshift/rosa/nodeconfig.yaml
-:language: yaml
-:::
-
-:::{code-block} shell
-:substitutions:
-kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/openshift/rosa/nodeconfig.yaml
-:::
-
-::::
-
-::::{group-tab} Any platform (loop devices — dev only)
-
-The following manifest creates a loop device, formats it with the XFS filesystem, and enables performance tuning on the selected nodes.
-
-:::{caution}
-This configuration is only intended for development purposes in environments with no local NVMe disks available. Do not expect production-level performance.
-:::
-
-:::{code-block} shell
-:substitutions:
-kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/generic/nodeconfig-alpha.yaml
-:::
-
-::::
-::::::
-
-Wait for NodeConfig to finish applying changes:
-
-```shell
-kubectl wait --timeout=10m --for='condition=Progressing=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
-kubectl wait --timeout=10m --for='condition=Degraded=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
-kubectl wait --timeout=10m --for='condition=Available=True' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
-```
-
-**Expected output:** All three conditions are satisfied. If `Degraded` is `True` or `Available` is `False` after the timeout, check the NodeConfig status and node events for errors.
-
-## Step 3: Install the Local CSI Driver
-
-The Local CSI Driver dynamically provisions PersistentVolumes from the local storage set up by NodeConfig.
-
-The OpenShift installation includes an additional ClusterRole definition (`00_clusterrole_def_openshift`) that grants the CSI driver access to the `privileged` SecurityContextConstraints required to manage local disks.
-
-:::{code-block} shell
-:substitutions:
-kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
-:::
-
-```shell
-kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-csi-driver
-```
-
-**Expected output:** The DaemonSet reports all Pods ready. The `scylladb-local-xfs` StorageClass is now available.
-
-## Step 4: Install ScyllaDB Manager
-
-ScyllaDB Manager provides automated repair and backup scheduling. It deploys a small internal ScyllaDB cluster for its own database.
-
-:::{code-block} shell
-:substitutions:
-kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/manager-prod.yaml
-:::
-
-```shell
-kubectl -n=scylla-manager rollout status --timeout=10m deployment.apps/scylla-manager
-```
-
-**Expected output:** The Deployment reports `successfully rolled out`.
-
-## Step 5: Set up monitoring (optional)
-
-On OpenShift, you can use the built-in User Workload Monitoring with Prometheus instead of deploying a standalone instance. See [Set up monitoring](../deploy-scylladb/set-up-monitoring.md#openshift-user-workload-monitoring) for OpenShift-specific instructions.
-
 ## Next steps
 
-You now have ScyllaDB Operator, storage, and Manager installed. To deploy your first ScyllaDB cluster, see [Deploy your first cluster](../deploy-scylladb/deploy-your-first-cluster.md).
-
-For production environments, review the [Production checklist](../deploy-scylladb/production-checklist.md) to verify that all recommended settings are in place.
+- [Deploy ScyllaDB](../deploy-scylladb/overview.md) — choose a platform-specific reference deployment or deploy your first cluster.
 
 ## Related pages
 
-- [Prerequisites](prerequisites.md) — Kubernetes and OpenShift version requirements, platform-specific setup.
 - [Install with GitOps](install-with-gitops.md) — alternative installation path using manifests (generic Kubernetes).
 - [Install with Helm](install-with-helm.md) — alternative installation path using Helm charts.
-- [Configure nodes](../deploy-scylladb/before-you-deploy/configure-nodes.md) — customizing NodeConfig for your environment.
 - [Upgrade ScyllaDB Operator](../upgrade/upgrade-operator.md) — version-specific upgrade steps.

--- a/docs-staging/source/install-operator/install-on-openshift.md
+++ b/docs-staging/source/install-operator/install-on-openshift.md
@@ -1,5 +1,344 @@
 # Install on OpenShift
 
-:::{todo}
-This page is not yet written.
+This page walks you through installing ScyllaDB Operator and all its dependencies on Red Hat OpenShift using the Operator Lifecycle Manager (OLM) software catalog. If you are running on a generic Kubernetes distribution, see [Install with GitOps](install-with-gitops.md) or [Install with Helm](install-with-helm.md) instead.
+
+ScyllaDB Operator is a Red Hat OpenShift Certified Operator. It is available in the embedded software catalog and can be installed through the OpenShift web console or CLI.
+
+:::{note}
+**ScyllaDB Operator must run in the `scylla-operator` namespace** and **ScyllaDB Manager must run in the `scylla-manager` namespace**. Using different namespaces for these components is [not currently supported](https://github.com/scylladb/scylla-operator/issues/2563).
 :::
+
+## Prerequisites
+
+- An OpenShift Container Platform cluster (see the supported version range in [Releases](../reference/releases.md))
+- An account with `cluster-admin` permissions
+- `kubectl` or OpenShift CLI (`oc`) installed
+
+Ensure that your cluster meets the [general prerequisites](prerequisites.md) for ScyllaDB Operator installation.
+
+:::{tip}
+All `kubectl` commands in this guide can be executed using the OpenShift CLI (`oc`) instead.
+:::
+
+## Step 1: Install ScyllaDB Operator
+
+ScyllaDB Operator can be installed from the OpenShift software catalog using either the web console or the CLI.
+
+:::::{tabs}
+
+::::{group-tab} Web Console
+
+This procedure follows the generic Operator installation steps outlined in the upstream documentation: [Installing from the software catalog by using the web console](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-installing-from-software-catalog-using-web-console_olm-adding-operators-to-a-cluster).
+
+### Procedure
+
+1. Navigate to **Ecosystem** → **Software Catalog**.
+2. Search for **ScyllaDB Operator** and select the **Certified** version by setting the **Source** filter to **Certified**, or by verifying that the ScyllaDB Operator tile has the **Certified** tag.
+3. Read the description and click **Install**.
+4. In the **Install Operator** dialog, configure the installation:
+   - For clusters on AWS with Security Token Service (STS): enter the Amazon Resource Name (ARN) of the AWS IAM role for your service account in the role ARN field.
+   - Select the **stable** Update Channel.
+   - Select the **All namespaces on the cluster** installation mode.
+   - Select the Operator recommended installed namespace: **scylla-operator**.
+   - Select the **Manual** update approval strategy to manually approve ScyllaDB Operator upgrades when new versions are available.
+
+   :::{caution}
+   Always review the [Upgrade ScyllaDB Operator](../upgrade/upgrade-operator.md) guide before approving a new version.
+   :::
+
+5. Click **Install**.
+6. In the **Install Plan** dialog, review the manual install plan and click **Approve**.
+7. Log in to the OpenShift cluster in the terminal. Ensure that `kubectl` is configured to communicate with your cluster.
+
+::::
+
+::::{group-tab} CLI
+
+This procedure follows the generic Operator installation steps outlined in the upstream documentation: [Installing from the software catalog by using the CLI](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-installing-operator-from-software-catalog-using-cli_olm-adding-operators-to-a-cluster).
+
+### Procedure
+
+1. Log in to the OpenShift cluster in the terminal. Ensure that `kubectl` is configured to communicate with your cluster.
+
+2. Verify that the ScyllaDB Operator package is available:
+
+    ```shell
+    kubectl get -n=openshift-marketplace packagemanifest scylladb-operator
+    ```
+
+    **Expected output:**
+
+    ```console
+    NAME                CATALOG               AGE
+    scylladb-operator   Certified Operators   2d22h
+    ```
+
+3. Create the `scylla-operator` namespace:
+
+    ```shell
+    kubectl create namespace scylla-operator
+    ```
+
+4. Create an `OperatorGroup` in the `scylla-operator` namespace:
+
+    ```shell
+    kubectl apply --server-side -n=scylla-operator -f=- <<EOF
+    apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: scylladb-operator
+      namespace: scylla-operator
+    EOF
+    ```
+
+5. Create a `Subscription` to install ScyllaDB Operator.
+
+    Clusters on cloud providers with token-based authentication require additional fields in the `Subscription` config section. Apply the appropriate manifest based on your environment:
+
+    :::::{tabs}
+    ::::{group-tab} AWS STS
+
+    If the cluster uses AWS Security Token Service (STS), include the role ARN in the `Subscription` manifest:
+
+    :::{code-block} shell
+    :substitutions:
+    kubectl apply --server-side -n=scylla-operator -f=- <<EOF
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: scylladb-operator
+      namespace: scylla-operator
+    spec:
+      channel: stable
+      installPlanApproval: Manual
+      name: scylladb-operator
+      source: certified-operators
+      sourceNamespace: openshift-marketplace
+      startingCSV: scylladb-operator.{{latestStableRelease}}
+      config:
+        env:
+        - name: ROLEARN
+          value: "<role_arn>"
+    EOF
+    :::
+
+    Replace `<role_arn>` with the ARN of the AWS IAM role for your service account.
+
+    ::::
+
+    ::::{group-tab} Generic
+
+    :::{code-block} shell
+    :substitutions:
+    kubectl apply --server-side -n=scylla-operator -f=- <<EOF
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: scylladb-operator
+      namespace: scylla-operator
+    spec:
+      channel: stable
+      installPlanApproval: Manual
+      name: scylladb-operator
+      source: certified-operators
+      sourceNamespace: openshift-marketplace
+      startingCSV: scylladb-operator.{{latestStableRelease}}
+    EOF
+    :::
+
+    ::::
+    :::::
+
+6. Locate, review, and approve the generated `InstallPlan`:
+
+    ```shell
+    kubectl -n=scylla-operator get installplan -l=operators.coreos.com/scylladb-operator.scylla-operator=""
+    ```
+
+    **Example expected output:**
+
+    :::{code-block} console
+    :substitutions:
+    NAME            CSV                                    APPROVAL   APPROVED
+    install-tw6bv   scylladb-operator.{{latestStableRelease}}   Manual     false
+    :::
+
+    Review the `InstallPlan`:
+
+    ```shell
+    kubectl -n=scylla-operator describe installplan <install-plan-name>
+    ```
+
+    Approve it to start the installation:
+
+    ```shell
+    kubectl -n=scylla-operator patch installplan --type=merge -p='{"spec":{"approved":true}}' <install-plan-name>
+    ```
+
+    **Example expected output:**
+
+    ```console
+    installplan.operators.coreos.com/install-tw6bv patched
+    ```
+
+7. Wait for the `ClusterServiceVersion` to reach `Succeeded` phase:
+
+    :::{code-block} shell
+    :substitutions:
+    kubectl -n=scylla-operator wait --for=create --timeout=10m csv/scylladb-operator.{{latestStableRelease}}
+    kubectl -n=scylla-operator wait --timeout=5m --for=jsonpath='{.status.phase}'=Succeeded clusterserviceversions.operators.coreos.com/scylladb-operator.{{latestStableRelease}}
+    :::
+
+    **Expected output:**
+
+    :::{code-block} console
+    :substitutions:
+    clusterserviceversion.operators.coreos.com/scylladb-operator.{{latestStableRelease}} condition met
+    clusterserviceversion.operators.coreos.com/scylladb-operator.{{latestStableRelease}} condition met
+    :::
+
+::::
+:::::
+
+### Verify the installation
+
+Wait for CRDs to propagate to all API servers:
+
+```shell
+kubectl wait --for='condition=established' --timeout=60s \
+  crd/scyllaclusters.scylla.scylladb.com \
+  crd/nodeconfigs.scylla.scylladb.com \
+  crd/scyllaoperatorconfigs.scylla.scylladb.com \
+  crd/scylladbmonitorings.scylla.scylladb.com
+```
+
+**Expected output:**
+
+```console
+customresourcedefinition.apiextensions.k8s.io/scyllaclusters.scylla.scylladb.com condition met
+customresourcedefinition.apiextensions.k8s.io/nodeconfigs.scylla.scylladb.com condition met
+customresourcedefinition.apiextensions.k8s.io/scyllaoperatorconfigs.scylla.scylladb.com condition met
+customresourcedefinition.apiextensions.k8s.io/scylladbmonitorings.scylla.scylladb.com condition met
+```
+
+Wait for the Operator and webhook server deployments:
+
+```shell
+kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/scylla-operator
+kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/webhook-server
+```
+
+**Expected output:**
+
+```console
+deployment "scylla-operator" successfully rolled out
+deployment "webhook-server" successfully rolled out
+```
+
+## Step 2: Set up NodeConfig
+
+NodeConfig configures local storage (RAID, filesystem, mount points) and performance tuning on the Kubernetes nodes where ScyllaDB will run.
+
+:::{caution}
+Local storage configuration depends on the OpenShift deployment model and the underlying platform and infrastructure. Review the examples below and adjust the manifest to your specific environment. See [Configure nodes](../deploy-scylladb/before-you-deploy/configure-nodes.md) for details.
+:::
+
+:::{note}
+Performance tuning is enabled for all nodes that are selected by `NodeConfig` by default, unless explicitly opted-out of.
+:::
+
+:::::{tabs}
+::::{group-tab} ROSA (NVMe)
+
+The following manifest creates a RAID0 array from the available NVMe devices, formats it with the XFS filesystem, and enables performance tuning recommended for production-grade ScyllaDB deployments on the selected nodes.
+
+:::{literalinclude} ../../../examples/openshift/rosa/nodeconfig.yaml
+:language: yaml
+:::
+
+:::{code-block} shell
+:substitutions:
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/openshift/rosa/nodeconfig.yaml
+:::
+
+::::
+
+::::{group-tab} Any platform (loop devices — dev only)
+
+The following manifest creates a loop device, formats it with the XFS filesystem, and enables performance tuning on the selected nodes.
+
+:::{caution}
+This configuration is only intended for development purposes in environments with no local NVMe disks available. Do not expect production-level performance.
+:::
+
+:::{code-block} shell
+:substitutions:
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/generic/nodeconfig-alpha.yaml
+:::
+
+::::
+:::::
+
+Wait for NodeConfig to finish applying changes:
+
+```shell
+kubectl wait --timeout=10m --for='condition=Progressing=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
+kubectl wait --timeout=10m --for='condition=Degraded=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
+kubectl wait --timeout=10m --for='condition=Available=True' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
+```
+
+**Expected output:** All three conditions are satisfied. If `Degraded` is `True` or `Available` is `False` after the timeout, check the NodeConfig status and node events for errors.
+
+## Step 3: Install the Local CSI Driver
+
+The Local CSI Driver dynamically provisions PersistentVolumes from the local storage set up by NodeConfig.
+
+The OpenShift installation includes an additional ClusterRole definition (`00_clusterrole_def_openshift`) that grants the CSI driver access to the `privileged` SecurityContextConstraints required to manage local disks.
+
+:::{code-block} shell
+:substitutions:
+kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
+:::
+
+```shell
+kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-csi-driver
+```
+
+**Expected output:** The DaemonSet reports all pods ready. The `scylladb-local-xfs` StorageClass is now available.
+
+## Step 4: Install ScyllaDB Manager
+
+ScyllaDB Manager provides automated repair and backup scheduling. It deploys a small internal ScyllaDB cluster for its own database.
+
+:::{note}
+ScyllaDB Manager is available for ScyllaDB Enterprise customers and ScyllaDB users. With ScyllaDB, ScyllaDB Manager is limited to 5 nodes. See the ScyllaDB Manager [Proprietary Software License Agreement](https://www.scylladb.com/scylla-manager-software-license-agreement/) for details.
+:::
+
+:::{code-block} shell
+:substitutions:
+kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/deploy/manager-prod.yaml
+:::
+
+```shell
+kubectl -n=scylla-manager rollout status --timeout=10m deployment.apps/scylla-manager
+```
+
+**Expected output:** The deployment reports `successfully rolled out`.
+
+## Step 5: Set up monitoring (optional)
+
+On OpenShift, you can use the built-in User Workload Monitoring with Prometheus instead of deploying a standalone instance. See [Set up monitoring](../deploy-scylladb/set-up-monitoring.md#openshift-user-workload-monitoring) for OpenShift-specific instructions.
+
+## Next steps
+
+You now have ScyllaDB Operator, storage, and Manager installed. To deploy your first ScyllaDB cluster, see [Deploy your first cluster](../deploy-scylladb/deploy-your-first-cluster.md).
+
+For production environments, review the [Production checklist](../deploy-scylladb/production-checklist.md) to verify that all recommended settings are in place.
+
+## Related pages
+
+- [Prerequisites](prerequisites.md) — Kubernetes and OpenShift version requirements, platform-specific setup.
+- [Install with GitOps](install-with-gitops.md) — alternative installation path using manifests (generic Kubernetes).
+- [Install with Helm](install-with-helm.md) — alternative installation path using Helm charts.
+- [Configure nodes](../deploy-scylladb/before-you-deploy/configure-nodes.md) — customizing NodeConfig for your environment.
+- [Upgrade ScyllaDB Operator](../upgrade/upgrade-operator.md) — version-specific upgrade steps.

--- a/docs-staging/source/install-operator/install-on-openshift.md
+++ b/docs-staging/source/install-operator/install-on-openshift.md
@@ -24,9 +24,9 @@ All `kubectl` commands in this guide can be executed using the OpenShift CLI (`o
 
 ScyllaDB Operator can be installed from the OpenShift software catalog using either the web console or the CLI.
 
-:::::{tabs}
+::::::::{tabs}
 
-::::{group-tab} Web Console
+:::::::{group-tab} Web Console
 
 This procedure follows the generic Operator installation steps outlined in the upstream documentation: [Installing from the software catalog by using the web console](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-installing-from-software-catalog-using-web-console_olm-adding-operators-to-a-cluster).
 
@@ -50,9 +50,9 @@ This procedure follows the generic Operator installation steps outlined in the u
 6. In the **Install Plan** dialog, review the manual install plan and click **Approve**.
 7. Log in to the OpenShift cluster in the terminal. Ensure that `kubectl` is configured to communicate with your cluster.
 
-::::
+:::::::
 
-::::{group-tab} CLI
+:::::::{group-tab} CLI
 
 This procedure follows the generic Operator installation steps outlined in the upstream documentation: [Installing from the software catalog by using the CLI](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-installing-operator-from-software-catalog-using-cli_olm-adding-operators-to-a-cluster).
 
@@ -197,8 +197,8 @@ This procedure follows the generic Operator installation steps outlined in the u
     clusterserviceversion.operators.coreos.com/scylladb-operator.{{latestStableRelease}} condition met
     :::
 
-::::
-:::::
+:::::::
+::::::::
 
 ### Verify the installation
 
@@ -221,7 +221,7 @@ customresourcedefinition.apiextensions.k8s.io/scyllaoperatorconfigs.scylla.scyll
 customresourcedefinition.apiextensions.k8s.io/scylladbmonitorings.scylla.scylladb.com condition met
 ```
 
-Wait for the Operator and webhook server deployments:
+Wait for ScyllaDB Operator and webhook server Deployments:
 
 ```shell
 kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/scylla-operator
@@ -247,7 +247,7 @@ Local storage configuration depends on the OpenShift deployment model and the un
 Performance tuning is enabled for all nodes that are selected by `NodeConfig` by default, unless explicitly opted-out of.
 :::
 
-:::::{tabs}
+::::::{tabs}
 ::::{group-tab} ROSA (NVMe)
 
 The following manifest creates a RAID0 array from the available NVMe devices, formats it with the XFS filesystem, and enables performance tuning recommended for production-grade ScyllaDB deployments on the selected nodes.
@@ -277,7 +277,7 @@ kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/
 :::
 
 ::::
-:::::
+::::::
 
 Wait for NodeConfig to finish applying changes:
 
@@ -304,15 +304,11 @@ kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent
 kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-csi-driver
 ```
 
-**Expected output:** The DaemonSet reports all pods ready. The `scylladb-local-xfs` StorageClass is now available.
+**Expected output:** The DaemonSet reports all Pods ready. The `scylladb-local-xfs` StorageClass is now available.
 
 ## Step 4: Install ScyllaDB Manager
 
 ScyllaDB Manager provides automated repair and backup scheduling. It deploys a small internal ScyllaDB cluster for its own database.
-
-:::{note}
-ScyllaDB Manager is available for ScyllaDB Enterprise customers and ScyllaDB users. With ScyllaDB, ScyllaDB Manager is limited to 5 nodes. See the ScyllaDB Manager [Proprietary Software License Agreement](https://www.scylladb.com/scylla-manager-software-license-agreement/) for details.
-:::
 
 :::{code-block} shell
 :substitutions:
@@ -323,7 +319,7 @@ kubectl -n=scylla-manager apply --server-side -f=https://raw.githubusercontent.c
 kubectl -n=scylla-manager rollout status --timeout=10m deployment.apps/scylla-manager
 ```
 
-**Expected output:** The deployment reports `successfully rolled out`.
+**Expected output:** The Deployment reports `successfully rolled out`.
 
 ## Step 5: Set up monitoring (optional)
 

--- a/docs-staging/source/install-operator/install-on-openshift.md
+++ b/docs-staging/source/install-operator/install-on-openshift.md
@@ -12,7 +12,7 @@ ScyllaDB Operator is a Red Hat OpenShift Certified Operator. It is available in 
 
 - An OpenShift Container Platform cluster meeting the [infrastructure requirements](provision-infrastructure/overview.md).
 - An account with `cluster-admin` permissions.
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) or OpenShift CLI (`oc`) configured to communicate with the cluster.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) or [OpenShift CLI (`oc`)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/cli_tools/openshift-cli-oc#installing-openshift-cli) configured to communicate with the cluster.
 
 :::{tip}
 All `kubectl` commands in this guide can be executed using the OpenShift CLI (`oc`) instead.

--- a/docs-staging/source/install-operator/install-with-helm.md
+++ b/docs-staging/source/install-operator/install-with-helm.md
@@ -126,4 +126,3 @@ kubectl delete crd scyllaclusters.scylla.scylladb.com nodeconfigs.scylla.scyllad
 - [Prerequisites](prerequisites.md) — Kubernetes version requirements and platform-specific setup.
 - [Install with GitOps](install-with-gitops.md) — alternative installation path using manifests.
 - [Install on OpenShift](install-on-openshift.md) — installation path for Red Hat OpenShift via OLM.
-- [Configure nodes](../deploy-scylladb/before-you-deploy/configure-nodes.md) — customizing NodeConfig for your environment.

--- a/docs-staging/source/install-operator/install-with-helm.md
+++ b/docs-staging/source/install-operator/install-with-helm.md
@@ -1,5 +1,221 @@
 # Install with Helm
 
-:::{todo}
-This page is not yet written.
+This page walks you through installing ScyllaDB Operator and all its dependencies using Helm charts. If you prefer applying raw manifests, see [Install with GitOps](install-with-gitops.md). For Red Hat OpenShift, see [Install on OpenShift](install-on-openshift.md).
+
+:::{note}
+The Helm installation path supports single-datacenter deployments only.
+For multi-datacenter ScyllaDB clusters, use the [GitOps installation path](install-with-gitops.md) and follow [Deploy a multi-datacenter cluster](../deploy-scylladb/deploy-multi-dc-cluster.md).
 :::
+
+:::{warning}
+Helm does not support managing CustomResourceDefinition resources ([helm#5871](https://github.com/helm/helm/issues/5871), [helm#7735](https://github.com/helm/helm/issues/7735)). Helm only creates CRDs on the first install and **never updates them**. You must update CRDs manually with every Operator upgrade. For this reason, the [Install with GitOps](install-with-gitops.md) path provides a more consistent experience.
+:::
+
+:::{note}
+ScyllaDB clusters can run in any Kubernetes namespace. However, **ScyllaDB Operator must run in the `scylla-operator` namespace** and **ScyllaDB Manager must run in the `scylla-manager` namespace**. Using different namespaces for these components is [not currently supported](https://github.com/scylladb/scylla-operator/issues/2563).
+:::
+
+## Prerequisites
+
+- Kubernetes (see the supported version range in [Releases](../reference/releases.md))
+- Helm 3+
+
+## Step 1: Add the Helm chart repository
+
+```shell
+helm repo add scylla https://scylla-operator-charts.storage.googleapis.com/stable
+helm repo update
+```
+
+Verify the charts are available:
+
+```shell
+helm search repo scylla
+```
+
+**Expected output:** At least three charts: `scylla/scylla-operator`, `scylla/scylla-manager`, `scylla/scylla`.
+
+## Step 2: Install cert-manager
+
+cert-manager provisions the TLS certificate for ScyllaDB Operator's webhook server. If you already have cert-manager installed in your cluster, you can skip this step. If you want to provide your own webhook certificate, set `webhook.createSelfSignedCertificate: false` and provide `webhook.certificateSecretName` when installing the Operator chart.
+
+You can install cert-manager using the bundled manifest:
+
+:::{code-block} shell
+:substitutions:
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/cert-manager.yaml
+:::
+
+Or follow the [upstream cert-manager installation instructions](https://cert-manager.io/docs/install-operator/).
+
+Wait for cert-manager to become available:
+
+```shell
+kubectl wait -n=cert-manager --for='condition=ready' pod -l app=cert-manager --timeout=60s
+kubectl wait -n=cert-manager --for='condition=ready' pod -l app=cainjector --timeout=60s
+kubectl wait -n=cert-manager --for='condition=ready' pod -l app=webhook --timeout=60s
+```
+
+## Step 3: Install Prometheus Operator
+
+:::{note}
+ScyllaDB Operator references Prometheus Operator CRDs in its RBAC rules. If the CRDs are not installed, the Operator may log warnings about missing Prometheus types. These warnings do not affect core functionality. Support for making this dependency fully optional is tracked in [#3075](https://github.com/scylladb/scylla-operator/issues/3075).
+:::
+
+:::{code-block} shell
+:substitutions:
+kubectl apply -n=prometheus-operator --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/prometheus-operator.yaml
+:::
+
+```shell
+kubectl -n=prometheus-operator rollout status --timeout=10m deployment.apps/prometheus-operator
+```
+
+## Step 4: Install ScyllaDB Operator
+
+```shell
+helm install scylla-operator scylla/scylla-operator \
+  --create-namespace \
+  --namespace scylla-operator
+```
+
+To customize the deployment (image, resources, replicas, log level), create a values file and pass it with `--values`:
+
+```shell
+helm install scylla-operator scylla/scylla-operator \
+  --create-namespace \
+  --namespace scylla-operator \
+  --values my-operator-values.yaml
+```
+
+See the chart's {{ '[values.yaml](https://raw.githubusercontent.com/{}/{}/helm/scylla-operator/values.yaml)'.format(repository, revision) }} for all available options.
+
+Wait for the Operator to become available:
+
+```shell
+kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/scylla-operator
+kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/webhook-server
+```
+
+**Expected output:** Both deployments report `successfully rolled out`.
+
+## Step 5: Set up NodeConfig
+
+NodeConfig configures local storage (RAID, filesystem, mount points) and performance tuning on the Kubernetes nodes where ScyllaDB will run. This step is the same as in the [Install with GitOps](install-with-gitops.md#step-4-set-up-nodeconfig).
+
+:::{caution}
+The NodeConfig manifest depends on your platform, machine type, and node pool configuration. Review the example for your platform and adjust it if your disk layout differs. See [Configure nodes](../deploy-scylladb/before-you-deploy/configure-nodes.md) for details.
+:::
+
+::::{tabs}
+:::{group-tab} GKE (NVMe)
+
+:::{caution}
+Starting with GKE version `1.32.1-gke.1002000`, the Ubuntu image no longer provides `xfsprogs` by default. Install it before applying NodeConfig — see [XFS filesystem tools](prerequisites.md#xfs-filesystem-tools).
+:::
+
+:::{code-block} shell
+:substitutions:
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/gke/nodeconfig-alpha.yaml
+:::
+
+:::
+
+:::{group-tab} EKS (NVMe)
+
+:::{code-block} shell
+:substitutions:
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/eks/nodeconfig-alpha.yaml
+:::
+
+:::
+
+:::{group-tab} Any platform (loop devices — dev only)
+
+:::{caution}
+This NodeConfig sets up loop devices instead of NVMe disks and is intended for development and testing only.
+:::
+
+:::{code-block} shell
+:substitutions:
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/generic/nodeconfig-alpha.yaml
+:::
+
+:::
+::::
+
+Wait for NodeConfig to finish applying changes:
+
+```shell
+kubectl wait --timeout=10m --for='condition=Progressing=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
+kubectl wait --timeout=10m --for='condition=Degraded=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
+kubectl wait --timeout=10m --for='condition=Available=True' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
+```
+
+## Step 6: Install the Local CSI Driver
+
+The Local CSI Driver dynamically provisions PersistentVolumes from the local storage set up by NodeConfig. This step is the same as in the [Install with GitOps](install-with-gitops.md#step-5-install-the-local-csi-driver).
+
+:::{code-block} shell
+:substitutions:
+kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
+:::
+
+```shell
+kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-csi-driver
+```
+
+**Expected output:** The DaemonSet reports all pods ready. The `scylladb-local-xfs` StorageClass is now available.
+
+## Step 7: Install ScyllaDB Manager
+
+```shell
+helm install scylla-manager scylla/scylla-manager \
+  --create-namespace \
+  --namespace scylla-manager
+```
+
+:::{note}
+ScyllaDB Manager is available for ScyllaDB Enterprise customers and ScyllaDB users. With ScyllaDB, ScyllaDB Manager is limited to 5 nodes. See the ScyllaDB Manager [Proprietary Software License Agreement](https://www.scylladb.com/scylla-manager-software-license-agreement/) for details.
+:::
+
+Wait for the Manager to become available:
+
+```shell
+kubectl -n=scylla-manager rollout status --timeout=10m deployment.apps/scylla-manager
+```
+
+## Step 8: Set up monitoring (optional)
+
+To deploy managed Prometheus and Grafana instances for ScyllaDB metrics and dashboards, see [Set up monitoring](../deploy-scylladb/set-up-monitoring.md).
+
+## Next steps
+
+You now have ScyllaDB Operator, storage, and Manager installed. To deploy your first ScyllaDB cluster, see [Deploy your first cluster](../deploy-scylladb/deploy-your-first-cluster.md).
+
+For production environments, review the [Production checklist](../deploy-scylladb/production-checklist.md) to verify that all recommended settings are in place.
+
+## Cleanup
+
+To remove the Helm releases:
+
+```shell
+helm uninstall scylla -n scylla
+helm uninstall scylla-manager -n scylla-manager
+helm uninstall scylla-operator -n scylla-operator
+```
+
+:::{note}
+Helm uninstall does not remove CRDs. To fully clean up, delete the CRDs manually after uninstalling:
+
+```shell
+kubectl delete crd scyllaclusters.scylla.scylladb.com nodeconfigs.scylla.scylladb.com scyllaoperatorconfigs.scylla.scylladb.com scylladbmonitorings.scylla.scylladb.com
+```
+:::
+
+## Related pages
+
+- [Prerequisites](prerequisites.md) — Kubernetes version requirements and platform-specific setup.
+- [Install with GitOps](install-with-gitops.md) — alternative installation path using manifests.
+- [Install on OpenShift](install-on-openshift.md) — installation path for Red Hat OpenShift via OLM.
+- [Configure nodes](../deploy-scylladb/before-you-deploy/configure-nodes.md) — customizing NodeConfig for your environment.

--- a/docs-staging/source/install-operator/install-with-helm.md
+++ b/docs-staging/source/install-operator/install-with-helm.md
@@ -17,8 +17,9 @@ ScyllaDB Operator must run in the `scylla-operator` namespace.
 
 ## Prerequisites
 
-- Kubernetes (see the supported version range in [Releases](../reference/releases.md))
-- Helm 3+
+- A Kubernetes cluster meeting the [infrastructure requirements](provision-infrastructure/overview.md).
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) configured to communicate with the cluster.
+- [Helm 3+](https://helm.sh/docs/intro/install/) installed.
 
 ## Add the Helm chart repository
 

--- a/docs-staging/source/install-operator/install-with-helm.md
+++ b/docs-staging/source/install-operator/install-with-helm.md
@@ -46,7 +46,7 @@ You can install cert-manager using the bundled manifest:
 kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/cert-manager.yaml
 :::
 
-Or follow the [upstream cert-manager installation instructions](https://cert-manager.io/docs/install-operator/).
+Or follow the [upstream cert-manager installation instructions](https://cert-manager.io/docs/installation/).
 
 Wait for cert-manager to become available:
 
@@ -59,7 +59,7 @@ kubectl wait -n=cert-manager --for='condition=ready' pod -l app=webhook --timeou
 ## Step 3: Install Prometheus Operator
 
 :::{note}
-ScyllaDB Operator references Prometheus Operator CRDs in its RBAC rules. If the CRDs are not installed, the Operator may log warnings about missing Prometheus types. These warnings do not affect core functionality. Support for making this dependency fully optional is tracked in [#3075](https://github.com/scylladb/scylla-operator/issues/3075).
+ScyllaDB Operator references Prometheus Operator CRDs in its RBAC rules. If the CRDs are not installed, ScyllaDB Operator may log warnings about missing Prometheus types. These warnings do not affect core functionality. Support for making this dependency fully optional is tracked in [#3075](https://github.com/scylladb/scylla-operator/issues/3075).
 :::
 
 :::{code-block} shell
@@ -90,14 +90,14 @@ helm install scylla-operator scylla/scylla-operator \
 
 See the chart's {{ '[values.yaml](https://raw.githubusercontent.com/{}/{}/helm/scylla-operator/values.yaml)'.format(repository, revision) }} for all available options.
 
-Wait for the Operator to become available:
+Wait for ScyllaDB Operator to become available:
 
 ```shell
 kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/scylla-operator
 kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/webhook-server
 ```
 
-**Expected output:** Both deployments report `successfully rolled out`.
+**Expected output:** Both Deployments report `successfully rolled out`.
 
 ## Step 5: Set up NodeConfig
 
@@ -107,8 +107,8 @@ NodeConfig configures local storage (RAID, filesystem, mount points) and perform
 The NodeConfig manifest depends on your platform, machine type, and node pool configuration. Review the example for your platform and adjust it if your disk layout differs. See [Configure nodes](../deploy-scylladb/before-you-deploy/configure-nodes.md) for details.
 :::
 
-::::{tabs}
-:::{group-tab} GKE (NVMe)
+::::::{tabs}
+::::{group-tab} GKE (NVMe)
 
 :::{caution}
 Starting with GKE version `1.32.1-gke.1002000`, the Ubuntu image no longer provides `xfsprogs` by default. Install it before applying NodeConfig — see [XFS filesystem tools](prerequisites.md#xfs-filesystem-tools).
@@ -119,18 +119,18 @@ Starting with GKE version `1.32.1-gke.1002000`, the Ubuntu image no longer provi
 kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/gke/nodeconfig-alpha.yaml
 :::
 
-:::
+::::
 
-:::{group-tab} EKS (NVMe)
+::::{group-tab} EKS (NVMe)
 
 :::{code-block} shell
 :substitutions:
 kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/eks/nodeconfig-alpha.yaml
 :::
 
-:::
+::::
 
-:::{group-tab} Any platform (loop devices — dev only)
+::::{group-tab} Any platform (loop devices — dev only)
 
 :::{caution}
 This NodeConfig sets up loop devices instead of NVMe disks and is intended for development and testing only.
@@ -141,8 +141,8 @@ This NodeConfig sets up loop devices instead of NVMe disks and is intended for d
 kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/generic/nodeconfig-alpha.yaml
 :::
 
-:::
 ::::
+::::::
 
 Wait for NodeConfig to finish applying changes:
 
@@ -165,7 +165,7 @@ kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent
 kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-csi-driver
 ```
 
-**Expected output:** The DaemonSet reports all pods ready. The `scylladb-local-xfs` StorageClass is now available.
+**Expected output:** The DaemonSet reports all Pods ready. The `scylladb-local-xfs` StorageClass is now available.
 
 ## Step 7: Install ScyllaDB Manager
 
@@ -175,11 +175,7 @@ helm install scylla-manager scylla/scylla-manager \
   --namespace scylla-manager
 ```
 
-:::{note}
-ScyllaDB Manager is available for ScyllaDB Enterprise customers and ScyllaDB users. With ScyllaDB, ScyllaDB Manager is limited to 5 nodes. See the ScyllaDB Manager [Proprietary Software License Agreement](https://www.scylladb.com/scylla-manager-software-license-agreement/) for details.
-:::
-
-Wait for the Manager to become available:
+Wait for ScyllaDB Manager to become available:
 
 ```shell
 kubectl -n=scylla-manager rollout status --timeout=10m deployment.apps/scylla-manager
@@ -195,7 +191,7 @@ You now have ScyllaDB Operator, storage, and Manager installed. To deploy your f
 
 For production environments, review the [Production checklist](../deploy-scylladb/production-checklist.md) to verify that all recommended settings are in place.
 
-## Cleanup
+## Clean up
 
 To remove the Helm releases:
 

--- a/docs-staging/source/install-operator/install-with-helm.md
+++ b/docs-staging/source/install-operator/install-with-helm.md
@@ -1,6 +1,6 @@
 # Install with Helm
 
-This page walks you through installing ScyllaDB Operator and all its dependencies using Helm charts. If you prefer applying raw manifests, see [Install with GitOps](install-with-gitops.md). For Red Hat OpenShift, see [Install on OpenShift](install-on-openshift.md).
+This page walks you through installing ScyllaDB Operator and its dependencies using Helm charts. If you prefer applying raw manifests, see [Install with GitOps](install-with-gitops.md). For Red Hat OpenShift, see [Install on OpenShift](install-on-openshift.md).
 
 :::{note}
 The Helm installation path supports single-datacenter deployments only.
@@ -12,7 +12,7 @@ Helm does not support managing CustomResourceDefinition resources ([helm#5871](h
 :::
 
 :::{note}
-ScyllaDB clusters can run in any Kubernetes namespace. However, **ScyllaDB Operator must run in the `scylla-operator` namespace** and **ScyllaDB Manager must run in the `scylla-manager` namespace**. Using different namespaces for these components is [not currently supported](https://github.com/scylladb/scylla-operator/issues/2563).
+ScyllaDB Operator must run in the `scylla-operator` namespace.
 :::
 
 ## Prerequisites
@@ -20,7 +20,7 @@ ScyllaDB clusters can run in any Kubernetes namespace. However, **ScyllaDB Opera
 - Kubernetes (see the supported version range in [Releases](../reference/releases.md))
 - Helm 3+
 
-## Step 1: Add the Helm chart repository
+## Add the Helm chart repository
 
 ```shell
 helm repo add scylla https://scylla-operator-charts.storage.googleapis.com/stable
@@ -35,9 +35,9 @@ helm search repo scylla
 
 **Expected output:** At least three charts: `scylla/scylla-operator`, `scylla/scylla-manager`, `scylla/scylla`.
 
-## Step 2: Install cert-manager
+## Install cert-manager
 
-cert-manager provisions the TLS certificate for ScyllaDB Operator's webhook server. If you already have cert-manager installed in your cluster, you can skip this step. If you want to provide your own webhook certificate, set `webhook.createSelfSignedCertificate: false` and provide `webhook.certificateSecretName` when installing the Operator chart.
+cert-manager provisions the TLS certificate for ScyllaDB Operator's webhook server. If you already have cert-manager installed in your cluster, skip this step. If you want to provide your own webhook certificate, set `webhook.createSelfSignedCertificate: false` and provide `webhook.certificateSecretName` when installing the Operator chart.
 
 You can install cert-manager using the bundled manifest:
 
@@ -56,22 +56,7 @@ kubectl wait -n=cert-manager --for='condition=ready' pod -l app=cainjector --tim
 kubectl wait -n=cert-manager --for='condition=ready' pod -l app=webhook --timeout=60s
 ```
 
-## Step 3: Install Prometheus Operator
-
-:::{note}
-ScyllaDB Operator references Prometheus Operator CRDs in its RBAC rules. If the CRDs are not installed, ScyllaDB Operator may log warnings about missing Prometheus types. These warnings do not affect core functionality. Support for making this dependency fully optional is tracked in [#3075](https://github.com/scylladb/scylla-operator/issues/3075).
-:::
-
-:::{code-block} shell
-:substitutions:
-kubectl apply -n=prometheus-operator --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/prometheus-operator.yaml
-:::
-
-```shell
-kubectl -n=prometheus-operator rollout status --timeout=10m deployment.apps/prometheus-operator
-```
-
-## Step 4: Install ScyllaDB Operator
+## Install ScyllaDB Operator
 
 ```shell
 helm install scylla-operator scylla/scylla-operator \
@@ -99,97 +84,23 @@ kubectl -n=scylla-operator rollout status --timeout=10m deployment.apps/webhook-
 
 **Expected output:** Both Deployments report `successfully rolled out`.
 
-## Step 5: Set up NodeConfig
+## Install Prometheus Operator (optional)
 
-NodeConfig configures local storage (RAID, filesystem, mount points) and performance tuning on the Kubernetes nodes where ScyllaDB will run. This step is the same as in the [Install with GitOps](install-with-gitops.md#step-4-set-up-nodeconfig).
-
-:::{caution}
-The NodeConfig manifest depends on your platform, machine type, and node pool configuration. Review the example for your platform and adjust it if your disk layout differs. See [Configure nodes](../deploy-scylladb/before-you-deploy/configure-nodes.md) for details.
-:::
-
-::::::{tabs}
-::::{group-tab} GKE (NVMe)
-
-:::{caution}
-Starting with GKE version `1.32.1-gke.1002000`, the Ubuntu image no longer provides `xfsprogs` by default. Install it before applying NodeConfig — see [XFS filesystem tools](prerequisites.md#xfs-filesystem-tools).
-:::
+Prometheus Operator is required only if you plan to use ScyllaDB monitoring (`ScyllaDBMonitoring` CRD).
+If you do not need monitoring, skip this step.
 
 :::{code-block} shell
 :substitutions:
-kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/gke/nodeconfig-alpha.yaml
-:::
-
-::::
-
-::::{group-tab} EKS (NVMe)
-
-:::{code-block} shell
-:substitutions:
-kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/eks/nodeconfig-alpha.yaml
-:::
-
-::::
-
-::::{group-tab} Any platform (loop devices — dev only)
-
-:::{caution}
-This NodeConfig sets up loop devices instead of NVMe disks and is intended for development and testing only.
-:::
-
-:::{code-block} shell
-:substitutions:
-kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/generic/nodeconfig-alpha.yaml
-:::
-
-::::
-::::::
-
-Wait for NodeConfig to finish applying changes:
-
-```shell
-kubectl wait --timeout=10m --for='condition=Progressing=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
-kubectl wait --timeout=10m --for='condition=Degraded=False' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
-kubectl wait --timeout=10m --for='condition=Available=True' nodeconfigs.scylla.scylladb.com/scylladb-nodepool-1
-```
-
-## Step 6: Install the Local CSI Driver
-
-The Local CSI Driver dynamically provisions PersistentVolumes from the local storage set up by NodeConfig. This step is the same as in the [Install with GitOps](install-with-gitops.md#step-5-install-the-local-csi-driver).
-
-:::{code-block} shell
-:substitutions:
-kubectl -n=local-csi-driver apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/common/local-volume-provisioner/local-csi-driver/{00_clusterrole_def,00_clusterrole_def_openshift,00_clusterrole,00_namespace,00_scylladb-local-xfs.storageclass,10_csidriver,10_serviceaccount,20_clusterrolebinding,50_daemonset}.yaml
+kubectl apply -n=prometheus-operator --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/third-party/prometheus-operator.yaml
 :::
 
 ```shell
-kubectl -n=local-csi-driver rollout status --timeout=10m daemonset.apps/local-csi-driver
+kubectl -n=prometheus-operator rollout status --timeout=10m deployment.apps/prometheus-operator
 ```
-
-**Expected output:** The DaemonSet reports all Pods ready. The `scylladb-local-xfs` StorageClass is now available.
-
-## Step 7: Install ScyllaDB Manager
-
-```shell
-helm install scylla-manager scylla/scylla-manager \
-  --create-namespace \
-  --namespace scylla-manager
-```
-
-Wait for ScyllaDB Manager to become available:
-
-```shell
-kubectl -n=scylla-manager rollout status --timeout=10m deployment.apps/scylla-manager
-```
-
-## Step 8: Set up monitoring (optional)
-
-To deploy managed Prometheus and Grafana instances for ScyllaDB metrics and dashboards, see [Set up monitoring](../deploy-scylladb/set-up-monitoring.md).
 
 ## Next steps
 
-You now have ScyllaDB Operator, storage, and Manager installed. To deploy your first ScyllaDB cluster, see [Deploy your first cluster](../deploy-scylladb/deploy-your-first-cluster.md).
-
-For production environments, review the [Production checklist](../deploy-scylladb/production-checklist.md) to verify that all recommended settings are in place.
+- [Deploy ScyllaDB](../deploy-scylladb/overview.md) — choose a platform-specific reference deployment or deploy your first cluster.
 
 ## Clean up
 

--- a/docs-staging/source/install-operator/provision-infrastructure/set-up-openshift-cluster.md
+++ b/docs-staging/source/install-operator/provision-infrastructure/set-up-openshift-cluster.md
@@ -1,5 +1,20 @@
 # Set up an OpenShift cluster for ScyllaDB
 
-:::{todo}
-This page is not yet written.
+This guide describes the infrastructure requirements for running ScyllaDB on Red Hat OpenShift.
+
+## Cluster requirements
+
+You need an OpenShift Container Platform cluster in a [supported version](../../reference/releases.md) with:
+
+- **A dedicated machine pool for ScyllaDB** with local NVMe storage and sufficient CPU and memory.
+  See [Set up dedicated node pools](../../deploy-scylladb/before-you-deploy/set-up-dedicated-node-pools.md) for labeling and taint requirements.
+- **Sufficient CPU and memory** — see the [ScyllaDB system requirements](https://docs.scylladb.com/manual/stable/getting-started/system-requirements.html) for minimum and recommended specifications.
+  Plan for at least 2 CPUs reserved for the OS, kubelet, and DaemonSets.
+
+:::{tip}
+[Red Hat OpenShift Service on AWS (ROSA)](https://aws.amazon.com/rosa/) provides a managed OpenShift experience with access to NVMe-backed instance types suitable for ScyllaDB.
 :::
+
+## Next steps
+
+- [Install ScyllaDB Operator on OpenShift](../install-on-openshift.md) — install the operator via OLM.


### PR DESCRIPTION
## Summary

Port "Install on OpenShift", "Install with Helm", and "Set up an OpenShift cluster for ScyllaDB" pages from the `mflendrich/docs-vibecode` branch into `docs-staging/source/install-operator/`.

## Key decisions

### Scope limited to operator installation only

Dropped NodeConfig, Local CSI Driver, ScyllaDB Manager, and Monitoring steps from both guides. These belong to the deploy-scylladb section, consistent with the existing "Install with GitOps" page. Next steps now points to `deploy-scylladb/overview.md`.

### Structure aligned with "Install with GitOps"

- No "Step X:" prefixes in headings.
- Prerequisites use full sentences with links to infrastructure requirements, kubectl, and tool-specific install docs (Helm / oc).
- "Next steps" links to `deploy-scylladb/overview.md` instead of listing individual deployment steps inline.

### Prometheus Operator marked optional and moved after operator install (Helm)

On OpenShift, Prometheus Operator is built-in via User Workload Monitoring, so this step doesn't apply. On Helm, it's now positioned after the operator install and clearly marked as optional, matching GitOps.

### ScyllaDB Enterprise / Manager licensing note removed

Per style guide — no Enterprise mentions.

### MyST tab directive syntax fixed

Used `group-tab` with proper fence depth for nested directives. The OpenShift guide has tabs-within-tabs (Web Console / CLI, then AWS STS / Generic inside CLI) which requires careful colon-fence nesting.

### "ScyllaDB Operator" naming

No bare "the Operator" — uses "ScyllaDB Operator" throughout.

### OpenShift cluster provisioning guide kept minimal

Unlike the OKE guide (which includes a full executable script), the OpenShift provisioning page only covers high-level cluster requirements — dedicated node pool with NVMe, CPU/memory sizing — and links to the "Set up dedicated node pools" guide and ROSA on AWS. There is no setup script to reference.

## Known issues

- `prerequisites.md` does not exist in docs-staging — links are pre-existing broken references.
- `set-up-monitoring.md#openshift-user-workload-monitoring` anchor in the OpenShift guide may not exist depending on what's in that file currently.