### PR TITLE
docs(staging): port troubleshooting guides

### DIFF
--- a/docs-staging/source/reference/known-issues.md
+++ b/docs-staging/source/reference/known-issues.md
@@ -26,12 +26,8 @@ On EKS clusters using a custom CNI plugin, webhook connectivity can break becaus
 
 **Reference**: [aws/containers-roadmap#1215](https://github.com/aws/containers-roadmap/issues/1215)
 
-See [Troubleshoot installation issues](../troubleshoot/troubleshoot-installation.md) for diagnosis steps.
-
 ### GKE: private clusters require a firewall rule
 
 GKE private clusters restrict communication from the API server to node pods. A firewall rule must be added to allow the API server to reach the webhook pod on the serving port.
 
 **Reference**: [GKE private clusters — add firewall rules](https://cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation#add_firewall_rules)
-
-See [Troubleshoot installation issues](../troubleshoot/troubleshoot-installation.md) for the firewall rule configuration.

--- a/docs-staging/source/troubleshoot/change-log-level.md
+++ b/docs-staging/source/troubleshoot/change-log-level.md
@@ -32,7 +32,7 @@ Apply the change:
 kubectl apply --server-side -f scylla-cluster.yaml
 ```
 
-The Operator performs a rolling restart to apply the new argument.
+ScyllaDB Operator performs a rolling restart to apply the new argument.
 
 See [Passing ScyllaDB arguments](../operate/pass-scylladb-arguments.md) for details.
 
@@ -90,7 +90,7 @@ To make the change persistent, update the ScyllaCluster spec as described in [Me
 
 - **Debug and trace levels** generate significantly more log output and can impact performance.
   Revert to `info` once you have collected the needed diagnostics.
-- In a stuck rollout scenario, the Operator cannot process spec changes because the rollout is blocked.
+- In a stuck rollout scenario, ScyllaDB Operator cannot process spec changes because the rollout is blocked.
   The REST API is the only way to change log levels on pods that are already running.
   See [StatefulSets and racks](../understand/statefulsets-and-racks.md) for why a stuck rollout blocks further updates (partition-based rolling updates).
 

--- a/docs-staging/source/troubleshoot/change-log-level.md
+++ b/docs-staging/source/troubleshoot/change-log-level.md
@@ -43,19 +43,26 @@ Use the ScyllaDB REST API to change the log level on running pods without trigge
 ### Change log level on a single pod
 
 ```bash
-kubectl -n scylla exec -it <pod-name> -c scylla -- \
+kubectl -n scylla exec <pod-name> -c scylla -- \
   curl -s -X POST "http://localhost:10000/system/logger/<logger-name>?level=<level>"
 ```
 
 Where:
-- `<logger-name>` is the logger to adjust (e.g., `compaction`, `gossip`, `storage_proxy`, or `default` for all loggers)
+- `<logger-name>` is the logger to adjust (e.g., `compaction`, `gossip`, `storage_proxy`)
 - `<level>` is the desired level: `error`, `warn`, `info`, `debug`, `trace`
+
+To set **all** loggers at once, omit the logger name from the path:
+
+```bash
+kubectl -n scylla exec <pod-name> -c scylla -- \
+  curl -s -X POST "http://localhost:10000/system/logger?level=<level>"
+```
 
 **Example — set all loggers to debug:**
 
 ```bash
-kubectl -n scylla exec -it <pod-name> -c scylla -- \
-  curl -s -X POST "http://localhost:10000/system/logger/default?level=debug"
+kubectl -n scylla exec <pod-name> -c scylla -- \
+  curl -s -X POST "http://localhost:10000/system/logger?level=debug"
 ```
 
 ### Change log level on all pods
@@ -69,17 +76,21 @@ for pod in $(kubectl -n "${NAMESPACE}" get pods \
   -l scylla-operator.scylladb.com/pod-type=scylladb-node \
   -o jsonpath='{.items[*].metadata.name}'); do
   echo "Setting log level on ${pod}..."
-  kubectl -n "${NAMESPACE}" exec -it "${pod}" -c scylla -- \
-    curl -s -X POST "http://localhost:10000/system/logger/default?level=debug"
+  kubectl -n "${NAMESPACE}" exec "${pod}" -c scylla -- \
+    curl -s -X POST "http://localhost:10000/system/logger?level=debug"
 done
 ```
 
 ### Verify the change
 
+Check the level of a specific logger:
+
 ```bash
-kubectl -n scylla exec -it <pod-name> -c scylla -- \
-  curl -s "http://localhost:10000/system/logger" | jq .
+kubectl -n scylla exec <pod-name> -c scylla -- \
+  curl -s "http://localhost:10000/system/logger/compaction"
 ```
+
+The response is the current log level (e.g., `"debug"`).
 
 ### Important notes
 

--- a/docs-staging/source/troubleshoot/change-log-level.md
+++ b/docs-staging/source/troubleshoot/change-log-level.md
@@ -1,5 +1,101 @@
 # Change log level on a live cluster
 
-:::{todo}
-This page is not yet written.
+Change the ScyllaDB log level without a full rolling restart.
+This is useful when a rolling restart is not feasible — for example, when a StatefulSet is stuck mid-rollout or the cluster is degraded.
+
+## When to use each method
+
+| Scenario | Method | Persistent? |
+|---|---|---|
+| Normal operations — rolling restart is acceptable | [Spec change](#method-1-spec-change-rolling-restart) | Yes |
+| StatefulSet stuck mid-rollout | [REST API](#method-2-rest-api-no-restart) | No — lost on pod restart |
+| Cluster degraded — cannot tolerate a rolling restart | [REST API](#method-2-rest-api-no-restart) | No — lost on pod restart |
+
+## Method 1: Spec change (rolling restart)
+
+Add the log level argument to the ScyllaCluster spec:
+
+```yaml
+apiVersion: scylla.scylladb.com/v1
+kind: ScyllaCluster
+metadata:
+  name: my-cluster
+  namespace: scylla
+spec:
+  # ... existing configuration ...
+  scyllaArgs: "--default-log-level=debug"
+```
+
+Apply the change:
+
+```bash
+kubectl apply --server-side -f scylla-cluster.yaml
+```
+
+The Operator performs a rolling restart to apply the new argument.
+
+See [Passing ScyllaDB arguments](../operate/pass-scylladb-arguments.md) for details.
+
+## Method 2: REST API (no restart)
+
+Use the ScyllaDB REST API to change the log level on running pods without triggering a rollout.
+
+### Change log level on a single pod
+
+```bash
+kubectl -n scylla exec -it <pod-name> -c scylla -- \
+  curl -s -X POST "http://localhost:10000/system/logger/<logger-name>?level=<level>"
+```
+
+Where:
+- `<logger-name>` is the logger to adjust (e.g., `compaction`, `gossip`, `storage_proxy`, or `default` for all loggers)
+- `<level>` is the desired level: `error`, `warn`, `info`, `debug`, `trace`
+
+**Example — set all loggers to debug:**
+
+```bash
+kubectl -n scylla exec -it <pod-name> -c scylla -- \
+  curl -s -X POST "http://localhost:10000/system/logger/default?level=debug"
+```
+
+### Change log level on all pods
+
+```bash
+NAMESPACE=scylla
+CLUSTER=my-cluster
+
+for pod in $(kubectl -n "${NAMESPACE}" get pods \
+  -l scylla/cluster="${CLUSTER}" \
+  -l scylla-operator.scylladb.com/pod-type=scylladb-node \
+  -o jsonpath='{.items[*].metadata.name}'); do
+  echo "Setting log level on ${pod}..."
+  kubectl -n "${NAMESPACE}" exec -it "${pod}" -c scylla -- \
+    curl -s -X POST "http://localhost:10000/system/logger/default?level=debug"
+done
+```
+
+### Verify the change
+
+```bash
+kubectl -n scylla exec -it <pod-name> -c scylla -- \
+  curl -s "http://localhost:10000/system/logger" | jq .
+```
+
+### Important notes
+
+:::{caution}
+REST API log level changes are **ephemeral** — they are lost when the pod restarts.
+To make the change persistent, update the ScyllaCluster spec as described in [Method 1](#method-1-spec-change-rolling-restart).
 :::
+
+- **Debug and trace levels** generate significantly more log output and can impact performance.
+  Revert to `info` once you have collected the needed diagnostics.
+- In a stuck rollout scenario, the Operator cannot process spec changes because the rollout is blocked.
+  The REST API is the only way to change log levels on pods that are already running.
+  See [StatefulSets and racks](../understand/statefulsets-and-racks.md) for why a stuck rollout blocks further updates (partition-based rolling updates).
+
+## Related pages
+
+- [Passing ScyllaDB arguments](../operate/pass-scylladb-arguments.md)
+- [StatefulSets and racks](../understand/statefulsets-and-racks.md)
+- [Diagnostic flowchart](diagnostic-flowchart.md)

--- a/docs-staging/source/troubleshoot/change-log-level.md
+++ b/docs-staging/source/troubleshoot/change-log-level.md
@@ -109,4 +109,3 @@ To make the change persistent, update the ScyllaCluster spec as described in [Me
 
 - [Passing ScyllaDB arguments](../operate/pass-scylladb-arguments.md)
 - [StatefulSets and racks](../understand/statefulsets-and-racks.md)
-- [Diagnostic flowchart](diagnostic-flowchart.md)

--- a/docs-staging/source/troubleshoot/collect-debugging-information/system-tables.md
+++ b/docs-staging/source/troubleshoot/collect-debugging-information/system-tables.md
@@ -1,5 +1,190 @@
 # Query system tables for debugging
 
-:::{todo}
-This page is not yet written.
-:::
+Use ScyllaDB system tables to gather diagnostic information that is not captured by `must-gather`.
+
+System tables contain ScyllaDB-internal state — repair history, SSTable activity, large partitions, runtime information, and more.
+
+## When to use system tables
+
+| Use case | Tool |
+|---|---|
+| Kubernetes-level diagnostics (pod status, events, logs) | [must-gather](must-gather.md) |
+| ScyllaDB-internal state (repair history, SSTable stats, large partitions) | System tables (this page) |
+
+Include system table output alongside must-gather archives when filing support tickets for ScyllaDB-level issues (performance, data consistency, repair).
+
+## How to query system tables
+
+Connect to a ScyllaDB pod and use `cqlsh`:
+
+```bash
+kubectl -n scylla exec -it <pod-name> -c scylla -- cqlsh
+```
+
+Or run a single query:
+
+```bash
+kubectl -n scylla exec -it <pod-name> -c scylla -- \
+  cqlsh -e "<CQL query>"
+```
+
+## Useful system tables
+
+### Cluster and node information
+
+```sql
+-- Node-local information (listen address, host ID, cluster name, ScyllaDB version)
+SELECT * FROM system.local;
+
+-- All known peers in the cluster
+SELECT peer, data_center, rack, host_id, schema_version, tokens FROM system.peers;
+```
+
+**Example output (`system.local`):**
+
+```
+ key   | bootstrapped | cluster_name | cql_version | data_center
+-------+--------------+--------------+-------------+-------------
+ local | COMPLETED    | my-cluster   | 3.4.5       | us-east-1
+```
+
+**Example output (`system.peers`):**
+
+```
+ peer      | data_center | host_id                              | rack       | release_version | tokens
+-----------+-------------+--------------------------------------+------------+-----------------+--------
+ 10.0.1.5  | us-east-1   | a1b2c3d4-e5f6-7890-abcd-ef1234567890 | us-east-1a | 2025.1.0        | {-9223372036854775808, ...}
+ 10.0.1.6  | us-east-1   | e5f6a7b8-c9d0-1234-5678-9abcdef01234 | us-east-1b | 2025.1.0        | {-1234567890123456789, ...}
+```
+
+### Large partitions
+
+```sql
+-- Partitions that exceed the large partition threshold
+SELECT * FROM system.large_partitions LIMIT 20;
+
+-- Large rows
+SELECT * FROM system.large_rows LIMIT 20;
+
+-- Large cells
+SELECT * FROM system.large_cells LIMIT 20;
+```
+
+**Example output (`system.large_partitions`):**
+
+```
+ keyspace_name | table_name | sstable_name    | partition_size | partition_key | rows
+---------------+------------+-----------------+----------------+---------------+------
+ mykeyspace    | mytable    | md-123-big-Data | 1048576        | 'mykey'       | 1000
+ mykeyspace    | mytable    | md-124-big-Data | 524288         | 'otherkey'    | 500
+```
+
+**Example output (`system.large_rows`):**
+
+```
+ keyspace_name | table_name | sstable_name    | row_size | partition_key | clustering_key
+---------------+------------+-----------------+----------+---------------+---------------
+ mykeyspace    | mytable    | md-124-big-Data | 524288   | 'mykey'       | 'myrow'
+```
+
+**Example output (`system.large_cells`):**
+
+```
+ keyspace_name | table_name | sstable_name    | cell_size | partition_key | clustering_key | column_name
+---------------+------------+-----------------+-----------+---------------+----------------+------------
+ mykeyspace    | mytable    | md-125-big-Data | 262144    | 'mykey'       | 'myrow'        | 'mycolumn'
+```
+
+Large partitions are a common cause of performance issues and timeouts.
+See the [ScyllaDB documentation on large partitions](https://docs.scylladb.com/stable/troubleshoot/large-partition-table.html).
+
+### Repair history
+
+```sql
+-- Repair history (distributed across nodes)
+SELECT * FROM system_distributed.repair_history LIMIT 20;
+```
+
+**Example output (`system_distributed.repair_history`):**
+
+```
+ id   | completed_at                    | keyspace_name | options | range_end | range_start | status  | table_names
+------+---------------------------------+---------------+---------+-----------+-------------+---------+------------
+ uuid | 2026-04-01 10:30:00.000000+0000 | mykeyspace    | {}      | ...       | ...         | SUCCESS | {'mytable'}
+ uuid | 2026-04-01 09:15:00.000000+0000 | mykeyspace    | {}      | ...       | ...         | SUCCESS | {'mytable'}
+```
+
+### SSTable activity
+
+```sql
+-- SSTable activity statistics
+SELECT * FROM system.sstable_activity LIMIT 20;
+```
+
+**Example output (`system.sstable_activity`):**
+
+```
+ keyspace_name | columnfamily_name | generation | rate_120m | rate_15m
+---------------+-------------------+------------+-----------+---------
+ mykeyspace    | mytable           | 123        |       0.5 |      1.2
+ mykeyspace    | mytable           | 124        |       0.2 |      0.8
+```
+
+### Runtime information
+
+```sql
+-- Runtime configuration and memory usage
+SELECT * FROM system.runtime_info;
+```
+
+**Example output (`system.runtime_info`):**
+
+```
+ group | item            | value
+-------+-----------------+---------
+ cache | entries         |     193
+ cache | hit_rate_recent |      82
+ cache | hit_rate_total  |    0.99
+ cache | hits            |  122282
+ cache | memory_free     | 5950484
+```
+
+### Compaction history
+
+```sql
+-- Recent compaction events
+SELECT * FROM system.compaction_history LIMIT 20;
+```
+
+**Example output (`system.compaction_history`):**
+
+```
+ id   | bytes_in | bytes_out | columnfamily_name | compaction_properties | ended_at                        | keyspace_name | rows_merged
+------+----------+-----------+-------------------+-----------------------+---------------------------------+---------------+------------
+ uuid | 10485760 |   8388608 | mytable           | {}                    | 2026-04-01 09:00:00.000000+0000 | mykeyspace    | {1: 5000}
+ uuid |  5242880 |   4194304 | mytable           | {}                    | 2026-04-01 08:30:00.000000+0000 | mykeyspace    | {1: 2500}
+```
+
+## Include system table output in support tickets
+
+When filing a support ticket, include:
+
+1. Output from `system.local` and `system.peers` — provides cluster topology context.
+2. Output from `system.large_partitions` — if the issue is performance-related.
+3. Output from `system_distributed.repair_history` — if the issue involves data consistency.
+4. Any other tables relevant to the specific issue.
+
+Format the output for readability:
+
+```bash
+kubectl -n scylla exec -it <pod-name> -c scylla -- \
+  cqlsh -e "EXPAND ON; SELECT * FROM system.local;"
+```
+
+The `EXPAND ON` command formats each row vertically, making wide tables easier to read.
+
+## Related pages
+
+- [must-gather](must-gather.md)
+- [must-gather contents](must-gather-contents.md)
+- [Cluster health](../check-cluster-health.md)

--- a/docs-staging/source/troubleshoot/configure-coredumps.md
+++ b/docs-staging/source/troubleshoot/configure-coredumps.md
@@ -1,4 +1,4 @@
-# Collecting core dumps
+# Collect core dumps
 
 This guide explains how to configure core dump collection on Kubernetes nodes running ScyllaDB Operator-managed ScyllaDB clusters and how to retrieve the resulting dump files.
 
@@ -22,7 +22,7 @@ This must be completed **before the anticipated crash**.
 
 A ready-to-use setup for GKE is provided below. On other platforms, apply these four steps using the OS package manager and systemd tooling available on the node.
 
-## Setting up core dump collection on GKE
+## Set up core dump collection on GKE
 
 GKE Ubuntu nodes do not ship `systemd-coredump` by default. The two manifests below handle all four setup steps via a single container on each ScyllaDB node. The container performs the setup once at startup and then sleeps, keeping the pod alive so that the DaemonSet re-applies the settings whenever the pod is evicted or rescheduled.
 
@@ -94,7 +94,7 @@ kubectl debug node/<node-name> -it --profile=sysadmin --image=docker.io/library/
 
 The output must be `active`.
 
-## Verifying that core dump collection works end to end
+## Verify that core dump collection works end to end
 
 The steps below trigger a test crash of a running ScyllaDB process and confirm the dump was captured by `systemd-coredump`.
 
@@ -130,7 +130,7 @@ ScyllaDB logs a backtrace and terminates. The pod stays running because the Scyl
 
 Confirm the dump was captured using coredumpctl list - see [Retrieving core dumps from nodes](#retrieving-core-dumps-from-nodes) for details.
 
-## Retrieving core dumps from nodes
+## Retrieve core dumps from nodes
 
 Core dumps are stored at `/var/lib/systemd/coredump/` on the host.
 

--- a/docs-staging/source/troubleshoot/configure-coredumps.md
+++ b/docs-staging/source/troubleshoot/configure-coredumps.md
@@ -124,7 +124,7 @@ Inside a pod managed by ScyllaDB Operator, the sidecar is PID 1 and the `scylla`
 kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -c scylla -- sh -c 'kill -ABRT $(pgrep -x scylla)'
 :::
 
-ScyllaDB logs a backtrace and terminates. The pod stays running because the Scylla Operator sidecar (PID 1) is unaffected; the Operator will restart the ScyllaDB process automatically. The dump is written to the node's host filesystem before the process exits.
+ScyllaDB logs a backtrace and terminates. The pod stays running because the ScyllaDB Operator sidecar (PID 1) is unaffected; ScyllaDB Operator will restart the ScyllaDB process automatically. The dump is written to the node's host filesystem before the process exits.
 
 ### 3. Confirm the dump was captured
 

--- a/docs-staging/source/troubleshoot/configure-coredumps.md
+++ b/docs-staging/source/troubleshoot/configure-coredumps.md
@@ -1,5 +1,185 @@
-# Collect core dumps
+# Collecting core dumps
 
-:::{todo}
-This page is not yet written.
+This guide explains how to configure core dump collection on Kubernetes nodes running ScyllaDB Operator-managed ScyllaDB clusters and how to retrieve the resulting dump files.
+
+## Background
+
+Core dump handling is controlled by `kernel.core_pattern` (see Linux [man page](https://man7.org/linux/man-pages/man5/core.5.html)). In Kubernetes, writing dumps to an absolute path inside the container means they are lost on pod restart.
+We recommend piping dumps through the `systemd-coredump` tool, which stores them on the host filesystem independently of pod lifetime.
+
+## Platform requirements
+
+Collecting a core dump requires the following prerequisites on the Kubernetes worker node where the process expected to crash is scheduled. To make things simpler, it can be done on all worker nodes.
+This must be completed **before the anticipated crash**.
+
+1. **`systemd-coredump` installed** - the helper binary that receives the core image from the kernel and writes it to disk.
+
+2. **`/etc/systemd/coredump.conf` configured** - controls storage location (`Storage=external`), compression (`Compress=yes`), and disk space limits (`MaxUse`, `KeepFree`, `ProcessSizeMax`, `ExternalSizeMax`). 
+
+3. **`kernel.core_pattern` set** to pipe crashes through `systemd-coredump`.
+
+4. **`systemd-coredump.socket` active**. 
+
+A ready-to-use setup for GKE is provided below. On other platforms, apply these four steps using the OS package manager and systemd tooling available on the node.
+
+## Setting up core dump collection on GKE
+
+GKE Ubuntu nodes do not ship `systemd-coredump` by default. The two manifests below handle all four setup steps via a single container on each ScyllaDB node. The container performs the setup once at startup and then sleeps, keeping the pod alive so that the DaemonSet re-applies the settings whenever the pod is evicted or rescheduled.
+
+### 1. Create the ConfigMap
+
+:::{literalinclude} ../../../examples/gke/coredumps/coredump-conf.configmap.yaml
+:language: yaml
 :::
+
+Download the manifest and edit `MaxUse` and `KeepFree` to match your environment before applying - see [Storage considerations](#storage-considerations).
+
+:::{code-block} bash
+:substitutions:
+curl -fLO https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/gke/coredumps/coredump-conf.configmap.yaml
+:::
+
+:::{code-block} bash
+vi coredump-conf.configmap.yaml
+:::
+
+:::{code-block} bash
+kubectl apply --server-side -f=coredump-conf.configmap.yaml
+:::
+
+### 2. Deploy the setup DaemonSet
+
+:::{literalinclude} ../../../examples/gke/coredumps/setup-systemd-coredump.daemonset.yaml
+:language: yaml
+:::
+
+:::{code-block} bash
+:substitutions:
+kubectl apply --server-side -f=https://raw.githubusercontent.com/{{repository}}/{{revision}}/examples/gke/coredumps/setup-systemd-coredump.daemonset.yaml
+:::
+
+Wait for the DaemonSet to roll out on all ScyllaDB nodes:
+
+:::{code-block} bash
+kubectl -n scylla-operator rollout status daemonset/scylladb-coredump-setup
+:::
+
+### 3. Verify the configuration
+
+After the DaemonSet rolls out, confirm `kernel.core_pattern` is correctly set on each node. List the dedicated ScyllaDB nodes:
+
+:::{code-block} bash
+kubectl get nodes -l scylla.scylladb.com/node-type=scylla -o name
+:::
+
+Run the following command for each node, replacing `<node-name>` with the actual name:
+
+:::{code-block} bash
+kubectl debug node/<node-name> -it --profile=sysadmin --image=docker.io/library/ubuntu:24.04 -- \
+  nsenter --mount=/proc/1/ns/mnt -- sysctl -n kernel.core_pattern
+:::
+
+Expected output:
+
+:::{code-block} console
+|/usr/lib/systemd/systemd-coredump %P %u %g %s %t 9223372036854775808 %h %d
+:::
+
+Also verify that `systemd-coredump.socket` is active:
+
+:::{code-block} bash
+kubectl debug node/<node-name> -it --profile=sysadmin --image=docker.io/library/ubuntu:24.04 -- \
+  nsenter --mount=/proc/1/ns/mnt -- systemctl is-active systemd-coredump.socket
+:::
+
+The output must be `active`.
+
+## Verifying that core dump collection works end to end
+
+The steps below trigger a test crash of a running ScyllaDB process and confirm the dump was captured by `systemd-coredump`.
+
+:::{warning}
+This procedure intentionally crashes a ScyllaDB node. Only run it when the cluster can tolerate losing one member temporarily.
+:::
+
+### 1. Find the pod and its node
+
+:::{code-block} bash
+NAMESPACE=<namespace>
+kubectl get pods -n "${NAMESPACE}" -l scylla-operator.scylladb.com/pod-type=scylladb-node -o wide
+:::
+
+Store the pod name and the node it is scheduled on:
+
+:::{code-block} bash
+POD_NAME=<pod-name>
+NODE_NAME=<node-name>
+:::
+
+### 2. Trigger the crash
+
+Inside a pod managed by ScyllaDB Operator, the sidecar is PID 1 and the `scylla` binary runs as a child process. Send a `SIGABRT` signal to the `scylla` process to trigger a crash and core dump:
+
+:::{code-block} bash
+kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -c scylla -- sh -c 'kill -ABRT $(pgrep -x scylla)'
+:::
+
+ScyllaDB logs a backtrace and terminates. The pod stays running because the Scylla Operator sidecar (PID 1) is unaffected; the Operator will restart the ScyllaDB process automatically. The dump is written to the node's host filesystem before the process exits.
+
+### 3. Confirm the dump was captured
+
+Confirm the dump was captured using coredumpctl list - see [Retrieving core dumps from nodes](#retrieving-core-dumps-from-nodes) for details.
+
+## Retrieving core dumps from nodes
+
+Core dumps are stored at `/var/lib/systemd/coredump/` on the host.
+
+### 1. List available dumps
+
+:::{code-block} bash
+kubectl debug "node/${NODE_NAME}" -it --profile=sysadmin --image=docker.io/library/ubuntu:24.04 -- \
+  nsenter --mount=/proc/1/ns/mnt -- coredumpctl list
+:::
+
+Store the PID of the desired dump from the output:
+
+:::{code-block} bash
+DUMP_PID=<pid>
+:::
+
+### 2. Export a specific dump
+
+Start a debug pod on the node so that we can use `kubectl exec` to retrieve the dump file:
+
+:::{code-block} bash
+kubectl debug "node/${NODE_NAME}" --profile=sysadmin --image=docker.io/library/ubuntu:24.04 -- sleep 3600
+:::
+
+Store the debug pod name:
+
+:::{code-block} bash
+DEBUG_POD_NAME=<debug-pod-name>
+:::
+
+Pull the dump file from the node to your local machine (it can be very large, so this may take some time):
+
+:::{code-block} bash
+kubectl exec "${DEBUG_POD_NAME}" -- \
+    nsenter --mount=/proc/1/ns/mnt -- coredumpctl dump "${DUMP_PID}" \
+    > scylla.core
+:::
+
+You can verify the dump with `file scylla.core` - it should show ELF 64-bit LSB core file.
+
+## Storage considerations
+
+Take into account that ScyllaDB core dumps can be very large. You will need spare disk space larger than that of ScyllaDB’s RAM. Core dump storage is controlled by the `[Coredump]` section of `/etc/systemd/coredump.conf`.
+
+:::{note}
+`systemd-coredump` will automatically delete the oldest dump files when the `MaxUse` or `KeepFree` thresholds are exceeded, so some dumps may be lost if a node generates many crashes in a short period of time and the disk is nearly full.
+:::
+
+To avoid losing dumps due to insufficient disk space, consider the following:
+
+- **Attach a dedicated disk** to each ScyllaDB node at `/var/lib/systemd/coredump/` so core dumps do not compete with the OS for disk space.
+- **Offload dumps to object storage** - the [IBM core-dump-handler](https://github.com/IBM/core-dump-handler) project provides a Helm chart that installs a similar `kernel.core_pattern` pipe handler and automatically uploads dumps to an S3-compatible bucket. This is a good option if you need centralized, long-term dump storage.

--- a/docs-staging/source/troubleshoot/diagnose-node-not-starting.md
+++ b/docs-staging/source/troubleshoot/diagnose-node-not-starting.md
@@ -1,5 +1,0 @@
-# Diagnose a node that is not starting
-
-:::{todo}
-This page is not yet written.
-:::

--- a/docs-staging/source/troubleshoot/diagnostic-flowchart.md
+++ b/docs-staging/source/troubleshoot/diagnostic-flowchart.md
@@ -1,5 +1,0 @@
-# Diagnostic flowchart
-
-:::{todo}
-This page is not yet written.
-:::

--- a/docs-staging/source/troubleshoot/index.md
+++ b/docs-staging/source/troubleshoot/index.md
@@ -2,18 +2,14 @@
 
 Diagnose and resolve issues with ScyllaDB Operator, ScyllaDB clusters, and related infrastructure.
 
-Start with the [diagnostic flowchart](diagnostic-flowchart.md) to narrow down the problem category, then follow the relevant guide.
-
 ## By symptom
 
 | Symptom | Guide |
 |---|---|
-| Pods stuck in `Pending`, `Init`, `CrashLoopBackOff`, or not becoming `Ready` | [Diagnose a node that is not starting](diagnose-node-not-starting.md) |
 | Pods restarting unexpectedly | [Investigate pod restarts](investigate-restarts.md) |
 | Cluster degraded, nodes showing `DN` | [Check cluster health](check-cluster-health.md) |
-| Application cannot connect to ScyllaDB | [Diagnostic flowchart](diagnostic-flowchart.md) — see also [Connect Your App](../connect-your-app/index.md) and [Set up networking](../deploy-scylladb/set-up-networking/index.md) |
-| Operator or webhook installation failures | [Troubleshoot installation issues](troubleshoot-installation.md) |
-| Upgrade failed or stuck | [Diagnostic flowchart](diagnostic-flowchart.md) — see also [Upgrade](../upgrade/index.md) |
+| Application cannot connect to ScyllaDB | [Connect Your App](../connect-your-app/index.md) and [Set up networking](../deploy-scylladb/set-up-networking/index.md) |
+| Upgrade failed or stuck | [Upgrade](../upgrade/index.md) |
 | Node replace stuck or failed | [Recover from a failed node replace](recover-from-failed-replace.md) |
 | Slow queries, throughput degradation, or CPU pinning not working | [Troubleshoot performance](troubleshoot-performance.md) |
 | Need to change log level without a rolling restart | [Change log level](change-log-level.md) |
@@ -24,11 +20,8 @@ Start with the [diagnostic flowchart](diagnostic-flowchart.md) to narrow down th
 :::{toctree}
 :maxdepth: 1
 
-diagnostic-flowchart
-troubleshoot-installation
 check-cluster-health
 investigate-restarts
-diagnose-node-not-starting
 change-log-level
 recover-from-failed-replace
 troubleshoot-performance

--- a/docs-staging/source/troubleshoot/investigate-restarts.md
+++ b/docs-staging/source/troubleshoot/investigate-restarts.md
@@ -1,5 +1,154 @@
 # Investigate pod restarts
 
-:::{todo}
-This page is not yet written.
-:::
+Determine why a ScyllaDB pod or container restarted and collect the evidence needed for diagnosis or a support ticket.
+
+## Identify that a restart occurred
+
+Check the restart count:
+
+```bash
+kubectl -n scylla get pods -l scylla-operator.scylladb.com/pod-type=scylladb-node
+```
+
+A non-zero `RESTARTS` column indicates that one or more containers in the pod have restarted.
+
+You can also compare the container start time against the pod creation time.
+If the container started significantly later than the pod was created, the container has restarted:
+
+```bash
+kubectl -n scylla get pod <pod-name> -o jsonpath='Pod created: {.metadata.creationTimestamp}{"\n"}Container started: {.status.containerStatuses[?(@.name=="scylla")].state.running.startedAt}{"\n"}'
+```
+
+## Determine the restart reason
+
+### Container status
+
+```bash
+kubectl -n scylla get pod <pod-name> -o jsonpath='{.status.containerStatuses}' | jq .
+```
+
+Key fields:
+
+| Field | Description |
+|---|---|
+| `restartCount` | Total number of restarts for this container |
+| `lastState.terminated.reason` | Why the container stopped (`OOMKilled`, `Error`, `Completed`) |
+| `lastState.terminated.exitCode` | Process exit code (`137` = SIGKILL / OOMKilled, `1` = error) |
+| `lastState.terminated.finishedAt` | Timestamp of the last termination |
+
+### Pod events
+
+```bash
+kubectl -n scylla describe pod <pod-name>
+```
+
+Look for these events in the `Events` section:
+
+| Event | Meaning |
+|---|---|
+| `Killing` | Container was killed (by kubelet or OOM killer) |
+| `BackOff` | Container is in `CrashLoopBackOff` — restarting repeatedly |
+| `OOMKilling` | Container exceeded its memory limit |
+| `Unhealthy` | Liveness probe failed — kubelet killed the container |
+| `FailedScheduling` | Pod cannot be placed on any node |
+
+## Distinguish restart causes
+
+### OOMKilled
+
+**Indicators:**
+- `lastState.terminated.reason: OOMKilled`
+- `lastState.terminated.exitCode: 137`
+
+**Common causes:**
+- Memory limit too low for the workload.
+- ScyllaDB memory allocation exceeds the container limit.
+
+**Resolution:**
+- Increase the memory limit in the ScyllaCluster spec.
+- Review ScyllaDB memory usage via monitoring dashboards.
+
+### Liveness probe failure
+
+**Indicators:**
+- Event: `Unhealthy` with `Liveness probe failed`
+- Container restarted without `OOMKilled` reason.
+
+**Common causes:**
+- ScyllaDB unresponsive due to long GC pauses or compaction stalls.
+- Node overloaded — too many concurrent operations.
+
+**Resolution:**
+- Check ScyllaDB logs for compaction or GC warnings.
+- Review resource allocation (CPU, memory).
+- Check for large partition warnings in logs.
+
+### CrashLoopBackOff
+
+**Indicators:**
+- Pod status: `CrashLoopBackOff`
+- Event: `BackOff`
+
+**Common causes:**
+- ScyllaDB fails to start — corrupt SSTables, invalid configuration, wrong seeds.
+- Disk permission issues.
+- Missing or invalid `io_properties.yaml`.
+
+**Resolution:**
+- Check previous container logs: `kubectl -n scylla logs <pod-name> -c scylla --previous`
+- Verify configuration with `kubectl -n scylla describe scyllacluster <cluster-name>`
+
+### Node eviction
+
+**Indicators:**
+- Pod event: `Evicted`
+- Node conditions show `MemoryPressure` or `DiskPressure`.
+
+**Cause:** The Kubernetes node is under resource pressure and the kubelet evicted the pod.
+
+**Resolution:**
+- Check node conditions: `kubectl describe node <node-name>`
+- Ensure dedicated node pools with appropriate taints prevent co-scheduling with other workloads.
+- See [Set up dedicated node pools](../deploy-scylladb/before-you-deploy/set-up-dedicated-node-pools.md).
+
+## Collect evidence
+
+When filing a support ticket or investigating further, collect:
+
+1. **Previous container logs:**
+   ```bash
+   kubectl -n scylla logs <pod-name> -c scylla --previous
+   ```
+
+2. **Full pod YAML with status:**
+   ```bash
+   kubectl -n scylla get pod <pod-name> -o yaml
+   ```
+
+3. **Pod events:**
+   ```bash
+   kubectl -n scylla describe pod <pod-name>
+   ```
+
+4. **must-gather archive:**
+
+   Collect a must-gather archive for escalation or offline analysis:
+
+   ```bash
+   podman run -it --pull=always --rm \
+     -v="${KUBECONFIG}:/kubeconfig:ro,Z" \
+     -v="$(pwd):/workspace:Z" \
+     --workdir=/workspace \
+     docker.io/scylladb/scylla-operator:latest \
+     must-gather --kubeconfig=/kubeconfig
+   ```
+
+   The archive contains the previous pod logs (`logs.previous`) needed to diagnose restarts.
+   See [must-gather](collect-debugging-information/must-gather.md) for full options (including Docker and `--all-resources`) and [must-gather contents](collect-debugging-information/must-gather-contents.md) for a guide to interpreting the files.
+
+## Related pages
+
+- [Diagnostic flowchart](diagnostic-flowchart.md)
+- [Node not starting](diagnose-node-not-starting.md)
+- [Cluster health](check-cluster-health.md)
+- [Collecting debugging information](collect-debugging-information/index.md)

--- a/docs-staging/source/troubleshoot/investigate-restarts.md
+++ b/docs-staging/source/troubleshoot/investigate-restarts.md
@@ -113,38 +113,10 @@ Look for these events in the `Events` section:
 
 ## Collect evidence
 
-When filing a support ticket or investigating further, collect:
+When filing a support ticket or investigating further, collect a must-gather archive.
+It includes previous container logs, full pod status, and events needed to diagnose restarts.
 
-1. **Previous container logs:**
-   ```bash
-   kubectl -n scylla logs <pod-name> -c scylla --previous
-   ```
-
-2. **Full pod YAML with status:**
-   ```bash
-   kubectl -n scylla get pod <pod-name> -o yaml
-   ```
-
-3. **Pod events:**
-   ```bash
-   kubectl -n scylla describe pod <pod-name>
-   ```
-
-4. **must-gather archive:**
-
-   Collect a must-gather archive for escalation or offline analysis:
-
-   ```bash
-   podman run -it --pull=always --rm \
-     -v="${KUBECONFIG}:/kubeconfig:ro,Z" \
-     -v="$(pwd):/workspace:Z" \
-     --workdir=/workspace \
-     docker.io/scylladb/scylla-operator:latest \
-     must-gather --kubeconfig=/kubeconfig
-   ```
-
-   The archive contains the previous pod logs (`logs.previous`) needed to diagnose restarts.
-   See [must-gather](collect-debugging-information/must-gather.md) for full options (including Docker and `--all-resources`) and [must-gather contents](collect-debugging-information/must-gather-contents.md) for a guide to interpreting the files.
+See [Collect debugging information](collect-debugging-information/index.md) for instructions.
 
 ## Related pages
 

--- a/docs-staging/source/troubleshoot/investigate-restarts.md
+++ b/docs-staging/source/troubleshoot/investigate-restarts.md
@@ -120,7 +120,5 @@ See [Collect debugging information](collect-debugging-information/index.md) for 
 
 ## Related pages
 
-- [Diagnostic flowchart](diagnostic-flowchart.md)
-- [Node not starting](diagnose-node-not-starting.md)
 - [Cluster health](check-cluster-health.md)
 - [Collecting debugging information](collect-debugging-information/index.md)

--- a/docs-staging/source/troubleshoot/recover-from-failed-replace.md
+++ b/docs-staging/source/troubleshoot/recover-from-failed-replace.md
@@ -83,7 +83,7 @@ Run `nodetool status` again and note the Host IDs of:
 kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
 ```
 
-Cross-reference with the [ScyllaDB guide for handling failed membership changes](https://docs.scylladb.com/manual/branch-2025.1/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html).
+Cross-reference with the [ScyllaDB guide for handling failed membership changes](https://docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html).
 
 ## Stop the culprit node
 

--- a/docs-staging/source/troubleshoot/recover-from-failed-replace.md
+++ b/docs-staging/source/troubleshoot/recover-from-failed-replace.md
@@ -36,18 +36,8 @@ Note the **Host ID** of the problematic node.
 
 ## Collect a must-gather archive
 
-Before making any changes, capture the current state:
-
-```bash
-docker run -it --pull=always --rm \
-  -v="${KUBECONFIG}:/kubeconfig:ro" \
-  -v="$(pwd):/workspace" \
-  --workdir=/workspace \
-  docker.io/scylladb/scylla-operator:latest \
-  must-gather --kubeconfig=/kubeconfig
-```
-
-See [must-gather](collect-debugging-information/must-gather.md) for details.
+Before making any changes, capture the current state by collecting a must-gather archive.
+See [Collect debugging information](collect-debugging-information/index.md) for instructions.
 
 ## Pause ScyllaDB Operator
 

--- a/docs-staging/source/troubleshoot/recover-from-failed-replace.md
+++ b/docs-staging/source/troubleshoot/recover-from-failed-replace.md
@@ -1,6 +1,6 @@
 # Recover from a failed node replace
 
-Step-by-step procedure to recover when a node replace operation fails and leaves the Operator stuck.
+Step-by-step procedure to recover when a node replace operation fails and leaves ScyllaDB Operator stuck.
 
 :::{warning}
 This procedure involves manual cluster-state manipulation and can cause data loss on the affected node.
@@ -13,14 +13,14 @@ Use this guide when:
 
 - A node replace is stuck — the replacement pod is in `CrashLoopBackOff` or stuck joining.
 - `nodetool status` shows a node with status `DN` or `?N` that was being replaced.
-- The Operator cannot apply further configuration changes because the rollout is blocked.
+- ScyllaDB Operator cannot apply further configuration changes because the rollout is blocked.
 
 For normal node replacement, see [Replace nodes](../operate/replace-nodes.md).
 
 ## Prerequisites
 
 - `kubectl` access to the cluster.
-- Ability to scale the Operator deployment.
+- Ability to scale the ScyllaDB Operator deployment.
 - A recent backup ([Back up and restore](../operate/back-up-and-restore.md)).
 
 ## Step 1: Verify the failure
@@ -49,9 +49,9 @@ docker run -it --pull=always --rm \
 
 See [must-gather](collect-debugging-information/must-gather.md) for details.
 
-## Step 3: Pause the Operator
+## Step 3: Pause ScyllaDB Operator
 
-Note the current replica count, then scale the Operator to zero:
+Note the current replica count, then scale ScyllaDB Operator to zero:
 
 ```bash
 # Note the current replicas
@@ -61,7 +61,7 @@ kubectl -n scylla-operator get deploy scylla-operator -o jsonpath='{.spec.replic
 kubectl -n scylla-operator scale deploy scylla-operator --replicas=0
 ```
 
-Wait for the Operator pods to terminate:
+Wait for ScyllaDB Operator pods to terminate:
 
 ```bash
 kubectl -n scylla-operator get pods -w
@@ -81,7 +81,7 @@ Without this flag, `kubectl delete statefulset` also deletes all pods managed by
 :::
 
 The existing pods continue running.
-The Operator will recreate the StatefulSet when it resumes.
+ScyllaDB Operator will recreate the StatefulSet when it resumes.
 
 ## Step 5: Identify Host IDs to remove
 
@@ -107,7 +107,7 @@ kubectl -n scylla delete pod <culprit-pod-name>
 kubectl -n scylla delete pvc <culprit-pvc-name>
 
 # Delete the per-node Service
-# This signals the Operator to provision a brand-new node instead of retrying the replace
+# This signals ScyllaDB Operator to provision a brand-new node instead of retrying the replace
 kubectl -n scylla delete svc <culprit-service-name>
 ```
 
@@ -133,15 +133,15 @@ kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
 
 All remaining nodes should show `UN`.
 
-## Step 8: Resume the Operator
+## Step 8: Resume ScyllaDB Operator
 
-Scale the Operator back to its original replica count:
+Scale ScyllaDB Operator back to its original replica count:
 
 ```bash
 kubectl -n scylla-operator scale deploy scylla-operator --replicas=<original-count>
 ```
 
-The Operator will:
+ScyllaDB Operator will:
 1. Recreate the rack StatefulSet.
 2. Recreate the per-node Service.
 3. Create a new pod and PVC for the removed node.
@@ -178,7 +178,7 @@ In a multi-datacenter deployment using multiple `ScyllaCluster` resources, perfo
 
 | Situation | Recovery |
 |---|---|
-| Accidentally deleted StatefulSet without `--cascade=orphan` | PVCs survive the deletion. When the Operator resumes and recreates the StatefulSet, new pods are created and reattach to existing PVCs. Data is preserved. |
+| Accidentally deleted StatefulSet without `--cascade=orphan` | PVCs survive the deletion. When ScyllaDB Operator resumes and recreates the StatefulSet, new pods are created and reattach to existing PVCs. Data is preserved. |
 | Operator fails to recreate the StatefulSet | Manually recreate it from the must-gather archive (the StatefulSet YAML is captured). |
 | New node fails to join | Repeat the procedure — verify that all ghost members were removed. Check seed configuration and network connectivity. |
 

--- a/docs-staging/source/troubleshoot/recover-from-failed-replace.md
+++ b/docs-staging/source/troubleshoot/recover-from-failed-replace.md
@@ -177,4 +177,3 @@ In a multi-datacenter deployment using multiple `ScyllaCluster` resources, perfo
 - [Replace nodes](../operate/replace-nodes.md)
 - [StatefulSets and racks](../understand/statefulsets-and-racks.md)
 - [Collect debugging information](collect-debugging-information/index.md)
-- [Diagnostic flowchart](diagnostic-flowchart.md)

--- a/docs-staging/source/troubleshoot/recover-from-failed-replace.md
+++ b/docs-staging/source/troubleshoot/recover-from-failed-replace.md
@@ -23,7 +23,7 @@ For normal node replacement, see [Replace nodes](../operate/replace-nodes.md).
 - Ability to scale the ScyllaDB Operator deployment.
 - A recent backup ([Back up and restore](../operate/back-up-and-restore.md)).
 
-## Step 1: Verify the failure
+## Verify the failure
 
 Run `nodetool status` on a healthy node to confirm the stuck state:
 
@@ -34,7 +34,7 @@ kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
 Look for nodes with status other than `UN` — for example `DN` (Down/Normal) or nodes with `?` status.
 Note the **Host ID** of the problematic node.
 
-## Step 2: Collect a must-gather archive
+## Collect a must-gather archive
 
 Before making any changes, capture the current state:
 
@@ -49,7 +49,7 @@ docker run -it --pull=always --rm \
 
 See [must-gather](collect-debugging-information/must-gather.md) for details.
 
-## Step 3: Pause ScyllaDB Operator
+## Pause ScyllaDB Operator
 
 Note the current replica count, then scale ScyllaDB Operator to zero:
 
@@ -67,7 +67,7 @@ Wait for ScyllaDB Operator pods to terminate:
 kubectl -n scylla-operator get pods -w
 ```
 
-## Step 4: Orphan-delete the rack StatefulSet
+## Orphan-delete the rack StatefulSet
 
 Delete the StatefulSet for the affected rack **without deleting its pods**:
 
@@ -83,7 +83,7 @@ Without this flag, `kubectl delete statefulset` also deletes all pods managed by
 The existing pods continue running.
 ScyllaDB Operator will recreate the StatefulSet when it resumes.
 
-## Step 5: Identify Host IDs to remove
+## Identify Host IDs to remove
 
 Run `nodetool status` again and note the Host IDs of:
 - The **culprit node** (the failed replacement).
@@ -95,7 +95,7 @@ kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
 
 Cross-reference with the [ScyllaDB guide for handling failed membership changes](https://docs.scylladb.com/manual/branch-2025.1/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html).
 
-## Step 6: Stop the culprit node
+## Stop the culprit node
 
 Delete the pod, PVC, and Service for the failed node:
 
@@ -116,7 +116,7 @@ Deleting the PVC permanently destroys the data on that node.
 The data must be replicated on other nodes and will be recovered via streaming when a new node joins.
 :::
 
-## Step 7: Remove ghost members
+## Remove ghost members
 
 For each ghost Host ID, run `nodetool removenode` from a healthy node:
 
@@ -133,7 +133,7 @@ kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
 
 All remaining nodes should show `UN`.
 
-## Step 8: Resume ScyllaDB Operator
+## Resume ScyllaDB Operator
 
 Scale ScyllaDB Operator back to its original replica count:
 
@@ -147,7 +147,7 @@ ScyllaDB Operator will:
 3. Create a new pod and PVC for the removed node.
 4. The new node joins the cluster as a fresh member and streams data from peers.
 
-## Step 9: Verify recovery
+## Verify recovery
 
 Wait for the new pod to become ready:
 

--- a/docs-staging/source/troubleshoot/recover-from-failed-replace.md
+++ b/docs-staging/source/troubleshoot/recover-from-failed-replace.md
@@ -1,5 +1,190 @@
 # Recover from a failed node replace
 
-:::{todo}
-This page is not yet written.
+Step-by-step procedure to recover when a node replace operation fails and leaves the Operator stuck.
+
+:::{warning}
+This procedure involves manual cluster-state manipulation and can cause data loss on the affected node.
+Follow each step carefully and collect a must-gather archive before making any destructive changes.
 :::
+
+## When to use this procedure
+
+Use this guide when:
+
+- A node replace is stuck — the replacement pod is in `CrashLoopBackOff` or stuck joining.
+- `nodetool status` shows a node with status `DN` or `?N` that was being replaced.
+- The Operator cannot apply further configuration changes because the rollout is blocked.
+
+For normal node replacement, see [Replace nodes](../operate/replace-nodes.md).
+
+## Prerequisites
+
+- `kubectl` access to the cluster.
+- Ability to scale the Operator deployment.
+- A recent backup ([Back up and restore](../operate/back-up-and-restore.md)).
+
+## Step 1: Verify the failure
+
+Run `nodetool status` on a healthy node to confirm the stuck state:
+
+```bash
+kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
+```
+
+Look for nodes with status other than `UN` — for example `DN` (Down/Normal) or nodes with `?` status.
+Note the **Host ID** of the problematic node.
+
+## Step 2: Collect a must-gather archive
+
+Before making any changes, capture the current state:
+
+```bash
+docker run -it --pull=always --rm \
+  -v="${KUBECONFIG}:/kubeconfig:ro" \
+  -v="$(pwd):/workspace" \
+  --workdir=/workspace \
+  docker.io/scylladb/scylla-operator:latest \
+  must-gather --kubeconfig=/kubeconfig
+```
+
+See [must-gather](collect-debugging-information/must-gather.md) for details.
+
+## Step 3: Pause the Operator
+
+Note the current replica count, then scale the Operator to zero:
+
+```bash
+# Note the current replicas
+kubectl -n scylla-operator get deploy scylla-operator -o jsonpath='{.spec.replicas}'
+
+# Scale to zero
+kubectl -n scylla-operator scale deploy scylla-operator --replicas=0
+```
+
+Wait for the Operator pods to terminate:
+
+```bash
+kubectl -n scylla-operator get pods -w
+```
+
+## Step 4: Orphan-delete the rack StatefulSet
+
+Delete the StatefulSet for the affected rack **without deleting its pods**:
+
+```bash
+kubectl -n scylla delete statefulset <cluster-name>-<dc>-<rack> --cascade=orphan
+```
+
+:::{warning}
+You **must** use `--cascade=orphan`.
+Without this flag, `kubectl delete statefulset` also deletes all pods managed by the StatefulSet, causing a full outage for that rack.
+:::
+
+The existing pods continue running.
+The Operator will recreate the StatefulSet when it resumes.
+
+## Step 5: Identify Host IDs to remove
+
+Run `nodetool status` again and note the Host IDs of:
+- The **culprit node** (the failed replacement).
+- Any **ghost members** — nodes that appear in the ring but have no corresponding running pod.
+
+```bash
+kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
+```
+
+Cross-reference with the [ScyllaDB guide for handling failed membership changes](https://docs.scylladb.com/manual/branch-2025.1/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html).
+
+## Step 6: Stop the culprit node
+
+Delete the pod, PVC, and Service for the failed node:
+
+```bash
+# Delete the pod
+kubectl -n scylla delete pod <culprit-pod-name>
+
+# Delete the PVC (data loss for this node)
+kubectl -n scylla delete pvc <culprit-pvc-name>
+
+# Delete the per-node Service
+# This signals the Operator to provision a brand-new node instead of retrying the replace
+kubectl -n scylla delete svc <culprit-service-name>
+```
+
+:::{caution}
+Deleting the PVC permanently destroys the data on that node.
+The data must be replicated on other nodes and will be recovered via streaming when a new node joins.
+:::
+
+## Step 7: Remove ghost members
+
+For each ghost Host ID, run `nodetool removenode` from a healthy node:
+
+```bash
+kubectl -n scylla exec -it <healthy-pod> -c scylla -- \
+  nodetool removenode <ghost-host-id>
+```
+
+Verify that only healthy nodes remain:
+
+```bash
+kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
+```
+
+All remaining nodes should show `UN`.
+
+## Step 8: Resume the Operator
+
+Scale the Operator back to its original replica count:
+
+```bash
+kubectl -n scylla-operator scale deploy scylla-operator --replicas=<original-count>
+```
+
+The Operator will:
+1. Recreate the rack StatefulSet.
+2. Recreate the per-node Service.
+3. Create a new pod and PVC for the removed node.
+4. The new node joins the cluster as a fresh member and streams data from peers.
+
+## Step 9: Verify recovery
+
+Wait for the new pod to become ready:
+
+```bash
+kubectl -n scylla get pods -w
+```
+
+Verify cluster health:
+
+```bash
+kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
+```
+
+All nodes should show `UN`.
+
+After recovery, run a repair to ensure data consistency:
+
+```bash
+# If using ScyllaDB Manager, trigger an ad-hoc repair
+kubectl -n scylla get scylladbmanagertask
+```
+
+## Multi-datacenter note
+
+In a multi-datacenter deployment using multiple `ScyllaCluster` resources, perform this procedure in the Kubernetes cluster hosting the failed node's datacenter.
+
+## What if something goes wrong
+
+| Situation | Recovery |
+|---|---|
+| Accidentally deleted StatefulSet without `--cascade=orphan` | PVCs survive the deletion. When the Operator resumes and recreates the StatefulSet, new pods are created and reattach to existing PVCs. Data is preserved. |
+| Operator fails to recreate the StatefulSet | Manually recreate it from the must-gather archive (the StatefulSet YAML is captured). |
+| New node fails to join | Repeat the procedure — verify that all ghost members were removed. Check seed configuration and network connectivity. |
+
+## Related pages
+
+- [Replace nodes](../operate/replace-nodes.md)
+- [StatefulSets and racks](../understand/statefulsets-and-racks.md)
+- [Collect debugging information](collect-debugging-information/index.md)
+- [Diagnostic flowchart](diagnostic-flowchart.md)

--- a/docs-staging/source/troubleshoot/recover-from-failed-replace.md
+++ b/docs-staging/source/troubleshoot/recover-from-failed-replace.md
@@ -15,24 +15,34 @@ Use this guide when:
 - `nodetool status` shows a node with status `DN` or `?N` that was being replaced.
 - ScyllaDB Operator cannot apply further configuration changes because the rollout is blocked.
 
+This guide assumes that all other nodes in the cluster are healthy (`UN`).
+
 For normal node replacement, see [Replace nodes](../operate/replace-nodes.md).
 
 ## Prerequisites
 
 - `kubectl` access to the cluster.
-- Ability to scale the ScyllaDB Operator deployment.
-- A recent backup ([Back up and restore](../operate/back-up-and-restore.md)).
+- Ability to scale the ScyllaDB Operator Deployment.
+- A recent backup — this is a dangerous operation and a data backup is recommended before proceeding.
 
 ## Verify the failure
 
 Run `nodetool status` on a healthy node to confirm the stuck state:
 
-```bash
-kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
+```console
+$ kubectl -n <namespace> exec <healthy-pod> -c scylla -- nodetool status
+
+Datacenter: exampledc
+=====================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+-- Address        Load      Tokens Owns Host ID                              Rack
+UN 10.152.183.112 491.57 KB 256    ?    e7478c73-07a9-4fb2-a435-6603ccc9e6bd examplerack
+DN 10.152.183.214 466.12 KB 256    ?    09d815de-6f6d-4394-8439-bd8d34231835 examplerack
+UN 10.152.183.43  456.25 KB 256    ?    ac4e578d-cc82-4b71-9ba1-0f40aede9e8d examplerack
 ```
 
-Look for nodes with status other than `UN` — for example `DN` (Down/Normal) or nodes with `?` status.
-Note the **Host ID** of the problematic node.
+Ensure that the culprit entry matches either the old (replaced) node's Host ID or the new (attempting to replace) node's Host ID. Check the logs of the failing pod to determine which one it is.
 
 ## Collect a must-gather archive
 
@@ -41,14 +51,14 @@ See [Collect debugging information](collect-debugging-information/index.md) for 
 
 ## Pause ScyllaDB Operator
 
-Note the current replica count, then scale ScyllaDB Operator to zero:
+Note the current replica count, then scale ScyllaDB Operator to zero to prevent reconciliation while you perform manual recovery:
 
 ```bash
-# Note the current replicas
+# Note the current replicas (typically 2)
 kubectl -n scylla-operator get deploy scylla-operator -o jsonpath='{.spec.replicas}'
 
 # Scale to zero
-kubectl -n scylla-operator scale deploy scylla-operator --replicas=0
+kubectl -n scylla-operator scale deploy/scylla-operator --replicas=0 --timeout=5m
 ```
 
 Wait for ScyllaDB Operator pods to terminate:
@@ -59,46 +69,51 @@ kubectl -n scylla-operator get pods -w
 
 ## Orphan-delete the rack StatefulSet
 
-Delete the StatefulSet for the affected rack **without deleting its pods**:
+Delete the StatefulSet for the affected rack **without deleting its pods**.
+This prevents the StatefulSet from recreating the culprit pod when you delete it in the next step.
+ScyllaDB Operator will recreate the StatefulSet in its exact form when it resumes.
 
 ```bash
-kubectl -n scylla delete statefulset <cluster-name>-<dc>-<rack> --cascade=orphan
+kubectl -n <namespace> delete statefulset <cluster>-<dc>-<rack> --cascade=orphan
 ```
 
 :::{warning}
 You **must** use `--cascade=orphan`.
-Without this flag, `kubectl delete statefulset` also deletes all pods managed by the StatefulSet, causing a full outage for that rack.
+Without this flag, `kubectl delete statefulset` also deletes all pods managed by the StatefulSet, causing unavailability for that rack.
+Deletion of a StatefulSet does not delete associated PVCs, so even if you accidentally omit `--cascade=orphan`, data is preserved on the PVCs and Operator will recover the pods when it resumes.
 :::
 
 The existing pods continue running.
-ScyllaDB Operator will recreate the StatefulSet when it resumes.
 
 ## Identify Host IDs to remove
 
-Run `nodetool status` again and note the Host IDs of:
+Follow [Step One: Determining Host IDs of Ghost Members](https://docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html#step-one-determining-host-ids-of-ghost-members) from the ScyllaDB documentation.
+
+Run `nodetool status` and note the Host IDs of:
 - The **culprit node** (the failed replacement).
 - Any **ghost members** — nodes that appear in the ring but have no corresponding running pod.
 
 ```bash
-kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
+kubectl -n <namespace> exec <healthy-pod> -c scylla -- nodetool status
 ```
-
-Cross-reference with the [ScyllaDB guide for handling failed membership changes](https://docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html).
 
 ## Stop the culprit node
 
 Delete the pod, PVC, and Service for the failed node:
 
 ```bash
-# Delete the pod
-kubectl -n scylla delete pod <culprit-pod-name>
+# Stop the node that is failing to join the cluster.
+# The StatefulSet does not exist, so it will not recreate the pod.
+kubectl -n <namespace> delete pod <culprit-pod>
 
-# Delete the PVC (data loss for this node)
-kubectl -n scylla delete pvc <culprit-pvc-name>
+# WARNING: This causes data loss for this node.
+# Delete the PersistentVolumeClaim for the data volume held by the culprit node.
+kubectl -n <namespace> delete pvc <culprit-pvc>
 
-# Delete the per-node Service
-# This signals ScyllaDB Operator to provision a brand-new node instead of retrying the replace
-kubectl -n scylla delete svc <culprit-service-name>
+# Delete the per-node Service.
+# ScyllaDB Operator interprets this as a need to provision a brand-new node
+# instead of attempting to replace the old one in the rack.
+kubectl -n <namespace> delete service <culprit-service>
 ```
 
 :::{caution}
@@ -108,17 +123,28 @@ The data must be replicated on other nodes and will be recovered via streaming w
 
 ## Remove ghost members
 
+Follow [Step Two: Removing the Ghost Members](https://docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html#step-two-removing-the-ghost-members) from the ScyllaDB documentation.
+
 For each ghost Host ID, run `nodetool removenode` from a healthy node:
 
 ```bash
-kubectl -n scylla exec -it <healthy-pod> -c scylla -- \
-  nodetool removenode <ghost-host-id>
+kubectl -n <namespace> exec <healthy-pod> -c scylla -- nodetool removenode <host-id>
 ```
+
+Repeat as necessary for each ghost member.
 
 Verify that only healthy nodes remain:
 
-```bash
-kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
+```console
+$ kubectl -n <namespace> exec <healthy-pod> -c scylla -- nodetool status
+
+Datacenter: exampledc
+=====================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+-- Address        Load      Tokens Owns Host ID                              Rack
+UN 10.152.183.112 491.57 KB 256    ?    e7478c73-07a9-4fb2-a435-6603ccc9e6bd examplerack
+UN 10.152.183.43  456.25 KB 256    ?    ac4e578d-cc82-4b71-9ba1-0f40aede9e8d examplerack
 ```
 
 All remaining nodes should show `UN`.
@@ -128,13 +154,14 @@ All remaining nodes should show `UN`.
 Scale ScyllaDB Operator back to its original replica count:
 
 ```bash
-kubectl -n scylla-operator scale deploy scylla-operator --replicas=<original-count>
+# Replace N with the number of replicas noted earlier (typically 2).
+kubectl -n scylla-operator scale deploy/scylla-operator --replicas=<N> --timeout=5m
 ```
 
 ScyllaDB Operator will:
-1. Recreate the rack StatefulSet.
+1. Recreate the (identical) StatefulSet for the rack.
 2. Recreate the per-node Service.
-3. Create a new pod and PVC for the removed node.
+3. Create a new Pod and PVC for the removed node.
 4. The new node joins the cluster as a fresh member and streams data from peers.
 
 ## Verify recovery
@@ -142,23 +169,25 @@ ScyllaDB Operator will:
 Wait for the new pod to become ready:
 
 ```bash
-kubectl -n scylla get pods -w
+kubectl -n <namespace> get pods -w
 ```
 
 Verify cluster health:
 
-```bash
-kubectl -n scylla exec -it <healthy-pod> -c scylla -- nodetool status
+```console
+$ kubectl -n <namespace> exec <healthy-pod> -c scylla -- nodetool status
+
+Datacenter: exampledc
+=====================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+-- Address        Load      Tokens Owns Host ID                              Rack
+UN 10.152.183.112 491.57 KB 256    ?    e7478c73-07a9-4fb2-a435-6603ccc9e6bd examplerack
+UN 10.152.183.234 493.66 KB 256    ?    NEW-UUID-DIFFERENT-THAN-BEFORE-abcde examplerack
+UN 10.152.183.43  456.25 KB 256    ?    ac4e578d-cc82-4b71-9ba1-0f40aede9e8d examplerack
 ```
 
-All nodes should show `UN`.
-
-After recovery, run a repair to ensure data consistency:
-
-```bash
-# If using ScyllaDB Manager, trigger an ad-hoc repair
-kubectl -n scylla get scylladbmanagertask
-```
+All nodes should show `UN`. Note that the recovered node has a new Host ID.
 
 ## Multi-datacenter note
 
@@ -168,8 +197,8 @@ In a multi-datacenter deployment using multiple `ScyllaCluster` resources, perfo
 
 | Situation | Recovery |
 |---|---|
-| Accidentally deleted StatefulSet without `--cascade=orphan` | PVCs survive the deletion. When ScyllaDB Operator resumes and recreates the StatefulSet, new pods are created and reattach to existing PVCs. Data is preserved. |
-| Operator fails to recreate the StatefulSet | Manually recreate it from the must-gather archive (the StatefulSet YAML is captured). |
+| Accidentally deleted StatefulSet without `--cascade=orphan` | Pods are deleted (causing rack unavailability), but PVCs survive. When ScyllaDB Operator resumes and recreates the StatefulSet, new pods are created and reattach to existing PVCs. Data is preserved. |
+| ScyllaDB Operator fails to recreate the StatefulSet | Manually recreate it from the must-gather archive (the StatefulSet YAML is captured). |
 | New node fails to join | Repeat the procedure — verify that all ghost members were removed. Check seed configuration and network connectivity. |
 
 ## Related pages
@@ -177,3 +206,4 @@ In a multi-datacenter deployment using multiple `ScyllaCluster` resources, perfo
 - [Replace nodes](../operate/replace-nodes.md)
 - [StatefulSets and racks](../understand/statefulsets-and-racks.md)
 - [Collect debugging information](collect-debugging-information/index.md)
+- [ScyllaDB: Handling membership change failures](https://docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html)

--- a/docs-staging/source/troubleshoot/recover-from-failed-replace.md
+++ b/docs-staging/source/troubleshoot/recover-from-failed-replace.md
@@ -87,8 +87,6 @@ The existing pods continue running.
 
 ## Identify Host IDs to remove
 
-Follow [Step One: Determining Host IDs of Ghost Members](https://docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html#step-one-determining-host-ids-of-ghost-members) from the ScyllaDB documentation.
-
 Run `nodetool status` and note the Host IDs of:
 - The **culprit node** (the failed replacement).
 - Any **ghost members** — nodes that appear in the ring but have no corresponding running pod.
@@ -122,8 +120,6 @@ The data must be replicated on other nodes and will be recovered via streaming w
 :::
 
 ## Remove ghost members
-
-Follow [Step Two: Removing the Ghost Members](https://docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html#step-two-removing-the-ghost-members) from the ScyllaDB documentation.
 
 For each ghost Host ID, run `nodetool removenode` from a healthy node:
 
@@ -206,4 +202,3 @@ In a multi-datacenter deployment using multiple `ScyllaCluster` resources, perfo
 - [Replace nodes](../operate/replace-nodes.md)
 - [StatefulSets and racks](../understand/statefulsets-and-racks.md)
 - [Collect debugging information](collect-debugging-information/index.md)
-- [ScyllaDB: Handling membership change failures](https://docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/handling-membership-change-failures.html)

--- a/docs-staging/source/troubleshoot/troubleshoot-installation.md
+++ b/docs-staging/source/troubleshoot/troubleshoot-installation.md
@@ -1,5 +1,0 @@
-# Troubleshoot installation issues
-
-:::{todo}
-This page is not yet written.
-:::

--- a/docs-staging/source/understand/statefulsets-and-racks.md
+++ b/docs-staging/source/understand/statefulsets-and-racks.md
@@ -104,7 +104,7 @@ If a pod fails to become Ready after a rolling update, the rollout stalls. No ot
 - `kubectl get statefulset` shows `READY` count lower than `REPLICAS`.
 - The `ScyllaCluster` status condition reports `WaitingForStatefulSetRollout`.
 
-To diagnose, check the logs of the failing pod and its events. If the problem is with the new configuration, fix the spec and the rollout resumes automatically. If the pod is stuck for other reasons (crash loop, resource issues), see [Node not starting](../troubleshoot/diagnose-node-not-starting.md).
+To diagnose, check the logs of the failing pod and its events. If the problem is with the new configuration, fix the spec and the rollout resumes automatically. If the pod is stuck for other reasons (crash loop, resource issues), see [Investigate pod restarts](../troubleshoot/investigate-restarts.md).
 
 For log-level changes on a stuck cluster where a rolling restart is not feasible, see [Changing log level](../troubleshoot/change-log-level.md).
 


### PR DESCRIPTION
## Summary

Port five troubleshooting guides into `docs-staging/source/troubleshoot/`:

- **Change log level** — from PR branch, covers spec change (rolling restart) and REST API (no restart) methods.
- **Configure coredumps** — from `docs/source/management/coredumps.md`, covers GKE systemd-coredump setup and core dump retrieval.
- **Investigate pod restarts** — from PR branch, covers OOMKilled, liveness probe failure, CrashLoopBackOff, and node eviction.
- **Recover from a failed node replace** — from enhancement proposal `enhancements/proposals/2955-failed-replace-recovery/`, step-by-step recovery with concrete `nodetool status` examples.
- **Query system tables for debugging** — from PR branch, CQL queries for system.local, system.peers, large_partitions, repair_history, sstable_activity, runtime_info, and compaction_history with example outputs.

## Key decisions

### change-log-level REST API corrected

The upstream PR branch used `POST /system/logger/default?level=<level>` to set all loggers. Testing on ScyllaDB 2026.1.3 revealed that the `default` logger does not exist. The correct API is `POST /system/logger?level=<level>` (omitting the logger name). Verified on a kind cluster.

### recover-from-failed-replace rewritten from enhancement proposal

The PR branch version was a simplified skeleton. Rewrote it based on `enhancements/proposals/2955-failed-replace-recovery/failed-replace-recovery.md`, adding:
- Concrete `nodetool status` output examples showing DN nodes and recovery.
- Explicit Host ID verification step (match old vs new node from logs).
- Links to specific ScyllaDB docs sections (Step One / Step Two of the failed membership change guide).
- Better "what if" table explaining PVC survival semantics.

Procedure verified end-to-end on a kind cluster (see testing section below).

### must-gather references simplified

Instead of inline `docker run`/`podman run` commands and manual `kubectl logs`/`kubectl get pod -o yaml` commands, guides link to [Collect debugging information](docs-staging/source/troubleshoot/collect-debugging-information/index.md). must-gather captures all of that.

### Placeholder pages dropped

Removed empty placeholder pages that were never written:
- `diagnostic-flowchart.md`
- `diagnose-node-not-starting.md`
- `troubleshoot-installation.md`

All references updated or removed across the tree (index, related-pages sections, known-issues, statefulsets-and-racks).

### Style conventions applied

- Sentence case headings, imperative verbs.
- "ScyllaDB Operator" naming (no "the Operator").
- ScyllaDB docs links use `/stable/` instead of `/branch-2025.1/`.

## Testing

### Change log level (REST API)

Verified on kind cluster with ScyllaDB 2026.1.3:
- `POST /system/logger/compaction?level=debug` — sets specific logger ✓
- `POST /system/logger?level=debug` — sets all loggers ✓
- `GET /system/logger/compaction` — returns `"debug"` ✓

### Change log level (spec change)

- Patched ScyllaCluster with `scyllaArgs: "--default-log-level=debug"`.
- Operator performed rolling restart, pod came back with `--default-log-level=debug` in process args ✓

### Recover from a failed node replace

Verified on a 3-node kind cluster:

1. Scaled operator to 0.
2. Orphan-deleted the rack StatefulSet — pods survived ✓
3. Deleted pod, PVC, and service for node-2 — node appeared as DN in nodetool status ✓
4. `nodetool removenode <host-id>` — node removed from ring, only 2 UN nodes remaining ✓
5. Scaled operator back to 2 — it recreated StatefulSet, Service, Pod, PVC ✓
6. New node joined with fresh Host ID, all 3 nodes UN ✓

### Query system tables

Verified on kind cluster with ScyllaDB 2026.1.3:
- `system.local` — returns node info ✓
- `system.peers` — returns peer list ✓
- `system.large_partitions` — query works (empty on fresh cluster) ✓
- `system.runtime_info` — returns cache/memory stats ✓
- `system.compaction_history` — returns compaction events ✓

## Known issues

- `troubleshoot/index.md` has overview content in it (symptom table) rather than being a pure toctree. This is consistent with how it existed before this PR and is acceptable for navigation pages.