### PR TITLE
docs(staging): port must-gather documentation from Confluence

### DIFF
--- a/docs-staging/source/troubleshoot/collect-debugging-information/must-gather-contents.md
+++ b/docs-staging/source/troubleshoot/collect-debugging-information/must-gather-contents.md
@@ -1,5 +1,187 @@
 # must-gather contents
 
-:::{todo}
-This page is not yet written.
+This page describes the structure of a must-gather archive and how to find specific information within it.
+
+## Archive structure
+
+### Collection log
+
+`/scylla-operator-must-gather.log` describes collection success or failure on the resource level.
+
+### ScyllaCluster objects
+
+Find them with:
+
+```bash
+grep -rl "^kind: ScyllaCluster" <must-gather-directory>
+```
+
+Each file contains:
+
+- Status conditions (`Available` / `Progressing` / `Degraded`) and their details.
+- ScyllaDB configuration.
+- Rack configurations (number of nodes, resource requests).
+
+### ScyllaDB racks
+
+Racks are represented by StatefulSets in the same namespace as the ScyllaCluster object:
+
+```
+/namespaces/<namespace>/statefulsets.apps/<cluster>-<datacenter>-<rack>
+```
+
+### ScyllaDB nodes
+
+Each node is represented by several Kubernetes resources in the same namespace as the ScyllaCluster:
+
+**Pod** — `/namespaces/<namespace>/pods/<cluster>-<datacenter>-<rack>-<ordinal>.yaml`
+
+The corresponding directory `/namespaces/<namespace>/pods/<cluster>-<datacenter>-<rack>-<ordinal>/` includes items collected from the ScyllaDB node:
+
+- `nodetool-status.log` — output of `nodetool status`
+- `nodetool-gossipinfo.log` — output of `nodetool gossipinfo`
+- `df.log` — disk usage
+- `io_properties.yaml` — ScyllaDB IO properties configuration
+- `scylla-rlimits.log` — resource limits of the ScyllaDB process
+- `scylla.current` and `scylla.previous` — ScyllaDB logs
+
+**Service** — `/namespaces/<namespace>/services/<cluster>-<datacenter>-<rack>-<ordinal>.yaml`
+
+Contains:
+
+- The state of a node replace in progress.
+- The HostID as seen by Operator.
+- Network configuration, including IP addresses.
+
+**PersistentVolumeClaim** — `/namespaces/<namespace>/persistentvolumeclaims/...`
+
+Contains:
+
+- The type of storage (StorageClass) in use.
+- A reference to the PersistentVolume that maps to an actual directory on the disk.
+
+**Jobs** — `/namespaces/<namespace>/jobs.batch/...`
+
+Contains references to Pods (for example, cleanup Jobs).
+
+## Structure of a Kubernetes object
+
+A typical object is located at `/namespaces/<namespace>/<resource-type>/<object-name>.yaml`:
+
+```yaml
+apiVersion: <group>/v1
+kind: <Kind>
+metadata:
+  name: <object-name>
+  namespace: <namespace>
+  creationTimestamp: ...
+  # deletionTimestamp and finalizers are present when deletion is in progress
+  # (useful for investigating why `kubectl delete` is hanging)
+spec:
+  # Declarative configuration
+status:
+  # This is the interesting part most of the time
+  conditions:
+    # Contains Available/Progressing/Degraded details
+```
+
+## Find information in the archive
+
+### Diagnose a stuck resource
+
+Look at status conditions:
+
+```bash
+grep -rl '^kind: ScyllaCluster' <must-gather-directory>
+grep -rl '^kind: NodeConfig' <must-gather-directory>
+grep -rl '^kind: ScyllaDBManagerTask' <must-gather-directory>
+grep -rl '^kind: ScyllaOperatorConfig' <must-gather-directory>
+```
+
+Open the files and look under `.status.conditions`. Each condition has a `type` (`Available`, `Progressing`, `Degraded`, or something more granular).
+See [Conditions](../../reference/conditions.md) for a detailed reference.
+
+- **Available**: Everything should be up and running. Check `Progressing` for any non-disruptive operations in progress.
+- **Progressing**: Operator is trying to make a change. If stuck, look at the Operator logs.
+- **Degraded**: Something failed. Look at the `reason` and the Operator logs.
+
+Pay attention to conditions where `reason` is not `AsExpected`.
+
+### Find Operator logs
+
+```
+/namespaces/scylla-operator/pods/scylla-operator-<hash>/scylla-operator.current
+```
+
+:::{note}
+There will typically be more than one Operator Pod (in an active-standby configuration).
 :::
+
+### Find ScyllaDB logs by rack name and node number
+
+List all ScyllaDB logs:
+
+```bash
+find <must-gather-directory> -type f -name scylla.current
+```
+
+To find logs for a specific node, first identify the ScyllaCluster:
+
+```bash
+grep -rl "^kind: ScyllaCluster" <must-gather-directory>
+# Example output: namespaces/scylla/scyllaclusters.scylla.scylladb.com/my-cluster.yaml
+```
+
+Then find the logs at:
+
+```
+namespaces/<namespace>/pods/<cluster>-<datacenter>-<rack>-<ordinal>/scylla.current
+```
+
+### Find ScyllaDB logs by HostID
+
+Look at the HostIDs of node Services:
+
+```bash
+grep "internal.scylla-operator.scylladb.com/host-id" \
+    <must-gather-directory>/namespaces/<namespace>/services/<cluster>*.yaml
+```
+
+Example output:
+
+```
+namespaces/scylla/services/my-cluster-dc-rack-0.yaml:    internal.scylla-operator.scylladb.com/host-id: 1849fd66-13ef-490e-846d-fabe55e08000
+namespaces/scylla/services/my-cluster-dc-rack-1.yaml:    internal.scylla-operator.scylladb.com/host-id: d2241fb5-1cf0-4c2e-86fb-b21cfd936f91
+```
+
+Find the Service matching your HostID, then look at the corresponding Pod logs:
+
+```
+namespaces/<namespace>/pods/<matching-pod-name>/scylla.current
+```
+
+### Find ScyllaDB configuration
+
+- Look at `.spec` of the ScyllaCluster object, particularly the ConfigMap referenced by `.spec.datacenter.racks[].scyllaConfig`.
+- Look at the ScyllaDB command line arguments in the ScyllaDB node logs.
+
+:::{note}
+Operator generates `scylla.yaml` from settings in the ScyllaCluster spec.
+must-gather does not currently collect the resulting effective `scylla.yaml`.
+:::
+
+## Too much data collected?
+
+- [Limit collection to a particular namespace](must-gather.md#limit-collection-to-a-particular-namespace) by passing the `--namespace` flag.
+- [Exclude resources](must-gather.md#exclude-resources) by passing the `--exclude-resource` flag.
+- Manually curate the archive to remove information you do not want to include.
+
+## Missing information?
+
+The information collected from ScyllaDB Pods is implemented in [podcollector.go](https://github.com/scylladb/scylla-operator/blob/master/pkg/gather/collect/podcollector.go).
+If must-gather does not collect information you need, [file a feature request](https://github.com/scylladb/scylla-operator/issues/new) or submit a PR.
+
+## Related pages
+
+- [Collect data with must-gather](must-gather.md)
+- [Query system tables](system-tables.md)

--- a/docs-staging/source/troubleshoot/collect-debugging-information/must-gather.md
+++ b/docs-staging/source/troubleshoot/collect-debugging-information/must-gather.md
@@ -1,5 +1,168 @@
 # Collect data with must-gather
 
-:::{todo}
-This page is not yet written.
+`must-gather` is a tool embedded in ScyllaDB Operator that collects diagnostic information equivalent to a debugging session, including:
+
+- A snapshot of ScyllaDB configuration.
+- A snapshot of Operator runtime state (status conditions, node service labels).
+- A snapshot of Operator and ScyllaDB logs.
+- A snapshot of the sequence of events (Kubernetes Events, object creation/deletion information).
+
+## Prerequisites
+
+All examples assume you have exported the `KUBECONFIG` environment variable pointing to a kubeconfig file on your machine.
+If not, export the common default location:
+
+```bash
+export KUBECONFIG=~/.kube/config
+ls -l "${KUBECONFIG}"
+```
+
+:::{note}
+There can be slight deviations in the arguments for your container tool, depending on the container runtime, whether you use SELinux, or similar factors.
+
+As an example, the need for the `Z` option on volume mounts depends on whether you use SELinux and what context is applied on your file or directory.
+If you get an error mentioning `Error: lsetxattr <path>: operation not supported`, try it without the `Z` option.
 :::
+
+### Use an external authentication plugin
+
+Check whether your kubeconfig uses an [external authentication plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins) by running:
+
+```bash
+kubectl config view --minify
+```
+
+Look for this pattern (containing the `exec` key):
+
+```yaml
+users:
+- name: <user_name>
+  user:
+    exec:
+```
+
+If your kubeconfig does not use an external exec plugin, skip the rest of this section.
+
+If your kubeconfig depends on external binaries, the external binary will not be available within the container to authenticate requests.
+Create a dedicated ServiceAccount for must-gather and use it to run the tool:
+
+```bash
+kubectl create namespace must-gather
+kubectl -n must-gather create serviceaccount must-gather
+kubectl create clusterrolebinding must-gather --clusterrole=cluster-admin --serviceaccount=must-gather:must-gather
+export MUST_GATHER_TOKEN
+MUST_GATHER_TOKEN=$( kubectl -n must-gather create token must-gather --duration=1h )
+kubeconfig=$( mktemp )
+# Create a copy of the existing kubeconfig and
+# replace user authentication using yq, or by adjusting the fields manually.
+kubectl config view --minify --raw -o yaml | yq -e '.users[0].user = {"token": env(MUST_GATHER_TOKEN)}' > "${kubeconfig}"
+KUBECONFIG="${kubeconfig}"
+```
+
+:::{note}
+If you do not have `yq` installed, you can get it at https://github.com/mikefarah/yq/#install or replace the user authentication settings manually.
+:::
+
+When you are done using must-gather, remove the Kubernetes resources created for that purpose.
+
+## Run must-gather
+
+Run the must-gather container image, mounting your kubeconfig and a local directory for the output:
+
+::::::{tabs}
+
+:::::{group-tab} Docker
+```bash
+docker run -it --pull=always --rm \
+    -v="${KUBECONFIG}:/kubeconfig:ro" \
+    -v="$( pwd ):/workspace" \
+    --workdir=/workspace \
+    docker.io/scylladb/scylla-operator:latest must-gather \
+    --kubeconfig=/kubeconfig
+```
+:::::
+
+:::::{group-tab} Podman
+```bash
+podman run -it --pull=always --rm \
+    -v="${KUBECONFIG}:/kubeconfig:ro,Z" \
+    -v="$( pwd ):/workspace:Z" \
+    --workdir=/workspace \
+    docker.io/scylladb/scylla-operator:latest must-gather \
+    --kubeconfig=/kubeconfig
+```
+:::::
+
+::::::
+
+Expected output (similar to):
+
+```
+I1029 11:40:59.708164       1 operator/gatherbase.go:119] "Created destination directory" Path="scylla-operator-must-gather-kns4cpxtnwmg"
+I1029 11:40:59.708640       1 cmdutil/helpers.go:106] "Starting must-gather" GitCommit="\"2621bad4d\""
+I1029 11:40:59.709003       1 operator/mustgather.go:253] "Gathering artifacts" DestDir="scylla-operator-must-gather-kns4cpxtnwmg"
+I1029 11:41:06.549330       1 operator/mustgather.go:255] "Finished gathering artifacts" Duration="6.840317591s"
+```
+
+The output directory (here `scylla-operator-must-gather-kns4cpxtnwmg`) contains the collected archive.
+See [must-gather contents](must-gather-contents.md) for details on navigating the archive.
+
+## Inspect the archive for sensitive information
+
+By default, sensitive resources (`Secrets` and `bitnami.com.SealedSecrets`) are omitted from the collection.
+However, before sharing the archive, inspect it on your own to ensure nothing unexpected is included:
+
+```bash
+grep -r -l '^kind: Secret' <must-gather-directory>
+```
+
+Redact or delete sensitive information if necessary.
+
+## Limit collection to a particular namespace
+
+If you are running a large Kubernetes cluster with many ScyllaClusters, limit the collection to a particular namespace:
+
+```bash
+scylla-operator must-gather --namespace="<namespace>"
+```
+
+:::{note}
+The `--namespace` flag affects only ScyllaClusters.
+Other resources related to the Operator installation or cluster state are still collected from other namespaces.
+:::
+
+## Collect every resource in the cluster
+
+By default, must-gather collects only a predefined subset of resources.
+Request collecting every resource in the Kubernetes API if the default set is not sufficient:
+
+```bash
+scylla-operator must-gather --all-resources
+```
+
+## Include sensitive resources
+
+Override the default behavior of omitting sensitive resources by passing the `--include-sensitive-resources` flag:
+
+```bash
+scylla-operator must-gather --all-resources --include-sensitive-resources
+```
+
+## Exclude resources
+
+Exclude specific resources from the collection by passing the `--exclude-resource` flag:
+
+```bash
+scylla-operator must-gather --all-resources \
+    --exclude-resource="LimitRange" \
+    --exclude-resource="DeviceClass.resource.k8s.io"
+```
+
+:::{note}
+The format for the resource is `kind` (for core resources) or `kind.group`. Examples: `LimitRange` or `DeviceClass.resource.k8s.io`.
+:::
+
+## Related pages
+
+- [must-gather contents](must-gather-contents.md)
+- [Query system tables](system-tables.md)


### PR DESCRIPTION
## Summary

Port must-gather documentation into `docs-staging/source/troubleshoot/collect-debugging-information/`, based on the internal Confluence page "Collecting Data with must-gather" and the existing `docs/source/support/must-gather.md`.

## Key decisions

### Split into "Collect" and "Contents"

- **Collect data with must-gather** — how to run must-gather (Docker/Podman tabs), prerequisites (kubeconfig, external auth plugin with ServiceAccount workaround), inspecting the archive for sensitive info, and flags (`--namespace`, `--all-resources`, `--include-sensitive-resources`, `--exclude-resource`).
- **must-gather contents** — archive structure, how to find specific information (stuck resources, Operator logs, ScyllaDB logs by rack or HostID, ScyllaDB configuration), with cross-links between the two pages.

### Pod directory file names verified against real must-gather output

Listed actual file names (`nodetool-status.log`, `nodetool-gossipinfo.log`, `df.log`, `io_properties.yaml`, `scylla-rlimits.log`, `scylla.current`, `scylla.previous`) instead of generic descriptions from Confluence.

### Tab syntax uses `group-tab` pattern

Matches the convention used in `reference/feature-gates.md` and `upgrade/upgrade-scylladb.md`.

### Sensitive resources note moved to "Inspect the archive"

Rather than stating the exclusion upfront, it's now in context — explaining that secrets are excluded by default but users should still inspect before sharing.

### Cross-linking between the two pages

- "Collect" links to "Contents" after the run command output.
- "Contents" links back to "Collect" for narrowing scope (specific flag sections).
- Both link to "Query system tables" and reference conditions.

## Testing

Ran must-gather on a kind cluster (`kind-scylla-operator-e2e`, 4 nodes, ScyllaDB 2026.1.3 with 3-node ScyllaCluster) and verified:

- `scylla-operator must-gather --kubeconfig=...` completes successfully.
- `--namespace=scylla` flag works (limits ScyllaCluster collection).
- Archive structure matches documented paths (ScyllaCluster yamls, StatefulSets, Pod yamls and directories, Services with host-id annotations, PVCs).
- Pod directory contains the documented files: `nodetool-status.log`, `nodetool-gossipinfo.log`, `df.log`, `scylla.current`, `scylla.previous`.
- `grep -rl "^kind: ScyllaCluster"` returns expected results.
- `grep "internal.scylla-operator.scylladb.com/host-id"` on Services returns HostIDs.
- `find -type f -name scylla.current` lists all ScyllaDB log files.
- `grep -r -l '^kind: Secret'` returns nothing (secrets excluded by default).
- Operator logs present at `namespaces/scylla-operator/pods/<pod>/scylla-operator.current`.