### PR TITLE
docs: override User-Agent for docs.openshift.com linkcheck instead of ignoring

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,9 +173,6 @@ linkcheck_ignore = [
     "https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
     # Ignore anchor that works as expected in the browser (probably a matter of the JS page rendering).
     "https://www.scylladb.com/product/support/#enterprise-support",
-    # docs.openshift.com redirects to docs.redhat.com which blocks automated link checkers with 403.
-    "https://docs.openshift.com/container-platform/.*",
-    "https://docs.openshift.com/rosa/.*",
 ]
 
 linkcheck_anchors_ignore_for_url = [
@@ -195,6 +192,10 @@ linkcheck_retries = (
 # Overriding with a plain non-browser UA bypasses the restriction.
 linkcheck_request_headers = {
     "https://docs.redhat.com/": {
+        "User-Agent": "python-requests/2.32.5",
+    },
+    # docs.openshift.com redirects to docs.redhat.com.
+    "https://docs.openshift.com/": {
         "User-Agent": "python-requests/2.32.5",
     },
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:** 
docs.openshift.com redirects to docs.redhat.com, which blocks automated link checkers with 403. bc4f503e2 worked around this by adding docs.openshift.com URLs to linkcheck_ignore, but 4954628e4 introduced a User-Agent override for docs.redhat.com that addresses the root cause.
Apply the same User-Agent override for docs.openshift.com and remove it from linkcheck_ignore.

**Which issue is resolved by this Pull Request:**
Resolves #

/kind machinery
/priority important-soon
/cc