### PR TITLE
chore(release): pin tags to 1.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL :=/bin/bash -euEo pipefail -O inherit_errexit
 
 comma :=,
 
-IMAGE_TAG ?= latest
+IMAGE_TAG ?= 1.21
 IMAGE_REF ?= docker.io/scylladb/scylla-operator:$(IMAGE_TAG)
 BUNDLE_IMAGE_REF ?= docker.io/scylladb/scylla-operator-bundle:$(IMAGE_TAG)
 

--- a/bundle/manifests/scylladb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/scylladb-operator.clusterserviceversion.yaml
@@ -418,8 +418,8 @@ spec:
                       - --loglevel=2
                     env:
                       - name: SCYLLA_OPERATOR_IMAGE
-                        value: docker.io/scylladb/scylla-operator:latest
-                    image: docker.io/scylladb/scylla-operator:latest
+                        value: docker.io/scylladb/scylla-operator:1.21
+                    image: docker.io/scylladb/scylla-operator:1.21
                     imagePullPolicy: IfNotPresent
                     name: scylla-operator
                     resources:
@@ -463,7 +463,7 @@ spec:
                       - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
                       - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
                       - --port=5000
-                    image: docker.io/scylladb/scylla-operator:latest
+                    image: docker.io/scylladb/scylla-operator:1.21
                     imagePullPolicy: IfNotPresent
                     lifecycle:
                       preStop:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -49324,11 +49324,11 @@ spec:
       serviceAccountName: scylla-operator
       containers:
       - name: scylla-operator
-        image: docker.io/scylladb/scylla-operator:latest
+        image: docker.io/scylladb/scylla-operator:1.21
         imagePullPolicy: IfNotPresent
         env:
         - name: SCYLLA_OPERATOR_IMAGE
-          value: docker.io/scylladb/scylla-operator:latest
+          value: docker.io/scylladb/scylla-operator:1.21
         args:
         - operator
         - --loglevel=2
@@ -49374,7 +49374,7 @@ spec:
       serviceAccountName: "webhook-server"
       containers:
       - name: webhook-server
-        image: docker.io/scylladb/scylla-operator:latest
+        image: docker.io/scylladb/scylla-operator:1.21
         imagePullPolicy: IfNotPresent
         args:
         - run-webhook-server

--- a/deploy/operator/50_operator.deployment.yaml
+++ b/deploy/operator/50_operator.deployment.yaml
@@ -23,11 +23,11 @@ spec:
       serviceAccountName: scylla-operator
       containers:
       - name: scylla-operator
-        image: docker.io/scylladb/scylla-operator:latest
+        image: docker.io/scylladb/scylla-operator:1.21
         imagePullPolicy: IfNotPresent
         env:
         - name: SCYLLA_OPERATOR_IMAGE
-          value: docker.io/scylladb/scylla-operator:latest
+          value: docker.io/scylladb/scylla-operator:1.21
         args:
         - operator
         - --loglevel=2

--- a/deploy/operator/50_webhookserver.deployment.yaml
+++ b/deploy/operator/50_webhookserver.deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: "webhook-server"
       containers:
       - name: webhook-server
-        image: docker.io/scylladb/scylla-operator:latest
+        image: docker.io/scylladb/scylla-operator:1.21
         imagePullPolicy: IfNotPresent
         args:
         - run-webhook-server

--- a/helm/scylla-manager/Chart.yaml
+++ b/helm/scylla-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scylla-manager
 description: Scylla Manager automates database operations.
 version: 0.0.0 # overwritten during publishing
-appVersion: latest # overwritten during publishing
+appVersion: "1.21" # overwritten during publishing
 dependencies:
   - name: scylla
     version: 1.0.0

--- a/helm/scylla-operator/Chart.yaml
+++ b/helm/scylla-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scylla-operator
 description: Scylla Operator is a Kubernetes Operator for managing and automating tasks related to managing a Scylla clusters.
 version: 0.0.0 # overwritten during publishing
-appVersion: latest # overwritten during publishing
+appVersion: "1.21" # overwritten during publishing
 keywords:
   - scylla
   - scylladb


### PR DESCRIPTION
Executes a step of the release checklist.

Linked issue: OPERATOR-109
/kind machinery
/priority important-soon
/cc czeslavo