### PR TITLE
chore(changelog,docs): add 1.21.0, promote docs to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [1.21.0](#1210)
 - [1.20.2](#1202)
 - [1.20.1](#1201)
 - [1.19.2](#1192)
@@ -7,7 +8,17 @@
 
 ## Unreleased
 
+## [1.21.0](https://github.com/scylladb/scylla-operator/releases/tag/v1.21.0)
+
+Release date: 2026-05-20
+
 ### Highlights
+
+- Oracle Kubernetes Engine (OKE) is now a supported platform. Refer to the [OKE reference deployment](https://operator.docs.scylladb.com/v1.21/deploy-scylladb/reference-deployments/reference-deployment-oke.html) in documentation.
+- Added ECDSA as an alternative to RSA for TLS certificate key generation.
+- Prometheus Operator is now an optional dependency; setups without its CRDs are fully supported.
+- ⚠️  `ScyllaCluster` backup/repair task names not conforming to RFC 1123 are now rejected (previously warned).
+- 🐛 Several bug fixes including identity service selector, monitoring status conditions, and `must-gather` resilience.
 
 ### Upgrade requirements
   

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,12 +84,12 @@ smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
 BRANCHES = ["master", "v1.18", "v1.19", "v1.20", "v1.21"]
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", "v1.21"]
+UNSTABLE_VERSIONS = ["master"]
 DEPRECATED_VERSIONS = ["v1.18", "v1.19"]
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.
-smv_latest_version = "v1.20"
+smv_latest_version = "v1.21"
 smv_rename_latest_version = "stable"
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"


### PR DESCRIPTION
Linked issue: OPERATOR-109

Adds a changelog for 1.21.0.
Also promotes docs to stable.
Setting a release date for 1.22 will come in a separate PR.

/kind cleanup
/priority important-soon