### PR TITLE
fix: update deprecated pointer for linter to pass

### DIFF
--- a/pkg/resource/helpers.go
+++ b/pkg/resource/helpers.go
@@ -37,7 +37,7 @@ func GetObjectGVKOrUnknown(obj runtime.Object) *schema.GroupVersionKind {
 	kinds, _, err := Scheme.ObjectKinds(obj)
 	if err != nil || len(kinds) == 0 {
 		t := reflect.TypeOf(obj)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			t = t.Elem()
 		}
 		return &schema.GroupVersionKind{


### PR DESCRIPTION
**Description of your changes:**
Fixes a failing test in master, updates a deprecated pointer assignment in Go 1.26

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-136
