### PR TITLE
[v1.20] docs: fix broken Manager link

### DIFF
--- a/docs/source/resources/scyllaclusters/nodeoperations/restore.md
+++ b/docs/source/resources/scyllaclusters/nodeoperations/restore.md
@@ -146,7 +146,7 @@ Snapshot Tag:   sm_20240105115931UTC
 As suggested in the progress output, you will need to execute a rolling restart of the ScyllaCluster **if you are using ScyllaDB 5.4/2024.1 or older**. For ScyllaDB 2024.2 and newer, a rolling restart is not required after restoring the schema.
 
 For more details, refer to the ScyllaDB Manager Restore documentation:
-- [Old Restore Schema Documentation](https://manager.docs.scylladb.com/stable/restore/old-restore-schema.html) (for ScyllaDB 5.4/2024.1 or older)
+- [Old Restore Schema Documentation](https://manager.docs.scylladb.com/branch-3.9/restore/old-restore-schema.html) (for ScyllaDB 5.4/2024.1 or older)
 - [New Restore Schema Documentation](https://manager.docs.scylladb.com/stable/restore/restore-schema.html) (for ScyllaDB 2024.2 and newer)
 
 ```console

--- a/pkg/admissionreview/handler.go
+++ b/pkg/admissionreview/handler.go
@@ -3,7 +3,7 @@ package admissionreview
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -44,7 +44,7 @@ func NewHandler(f HandleFunc) *handler {
 func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var body []byte
 	if req.Body != nil {
-		data, err := ioutil.ReadAll(req.Body)
+		data, err := io.ReadAll(req.Body)
 		if err == nil {
 			body = data
 		}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -4,7 +4,7 @@ package auth
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -101,7 +101,7 @@ func TestValidateTokenFailure(t *testing.T) {
 		if w.Code != http.StatusUnauthorized {
 			t.Error("expected status 401 got", w)
 		}
-		responseBody, err := ioutil.ReadAll(ioutil.NopCloser(w.Result().Body))
+		responseBody, err := io.ReadAll(io.NopCloser(w.Result().Body))
 		if err != nil {
 			t.Error("expected nil err, got", err)
 		}

--- a/pkg/resource/helpers.go
+++ b/pkg/resource/helpers.go
@@ -37,7 +37,7 @@ func GetObjectGVKOrUnknown(obj runtime.Object) *schema.GroupVersionKind {
 	kinds, _, err := Scheme.ObjectKinds(obj)
 	if err != nil || len(kinds) == 0 {
 		t := reflect.TypeOf(obj)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			t = t.Elem()
 		}
 		return &schema.GroupVersionKind{

--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"maps"
 	"os"
 	"os/exec"
@@ -341,7 +340,7 @@ func mergeYAMLs(initialYAML []byte, overrideYAMLs ...[]byte) ([]byte, error) {
 }
 
 func getCPUsAllowedList(procFile string) (string, error) {
-	statusFile, err := ioutil.ReadFile(procFile)
+	statusFile, err := os.ReadFile(procFile)
 	if err != nil {
 		return "", errors.Wrapf(err, "error reading proc status file '%s'", procFile)
 	}

--- a/pkg/util/cloud/eks.go
+++ b/pkg/util/cloud/eks.go
@@ -5,7 +5,7 @@ package cloud
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -49,7 +49,7 @@ func (c *eksMetadataClient) readString(ctx context.Context, path string) (string
 		return "", fmt.Errorf("get metadata at path %q: %w", path, err)
 	}
 
-	buf, err := ioutil.ReadAll(resp.Content)
+	buf, err := io.ReadAll(resp.Content)
 	if err != nil {
 		return "", fmt.Errorf("read response: %w", err)
 	}


### PR DESCRIPTION
**Description of your changes:**
Fixes a broken Manager docs link. Since 1.20 formally supports 2024.1, simply backporting the master [fix](https://github.com/scylladb/scylla-operator/pull/3463) will not do it.

Also delints deprecated code since the CI runners updated to a 1.26 toolchain linter

**Which issue is resolved by this Pull Request:**
Part of https://scylladb.atlassian.net/browse/OPERATOR-135