### PR TITLE
fix(crypto): fall back to a live GET on cache miss in ManageCertificates

### DIFF
--- a/pkg/kubecrypto/certmanager.go
+++ b/pkg/kubecrypto/certmanager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -143,12 +144,17 @@ func NewCertificateManager(
 // recreated when their desired config changes. Certificates are automatically refreshed when they reach their refresh
 // interval, or 80% of their lifetime, whichever comes sooner.
 func (cm *CertificateManager) ManageCertificates(ctx context.Context, nowFunc func() time.Time, controller *metav1.ObjectMeta, controllerGVK schema.GroupVersionKind, caConfig *CAConfig, caBundleConfig *CABundleConfig, certConfigs []*CertificateConfig, existingSecrets map[string]*corev1.Secret, existingConfigMaps map[string]*corev1.ConfigMap) error {
+	existingCASecret, err := getSecretWithCache(ctx, cm.secretsClient, controller.GetNamespace(), caConfig.Name, existingSecrets)
+	if err != nil {
+		return fmt.Errorf("can't get CA secret %q: %w", caConfig.Name, err)
+	}
+
 	caCertCreatorConfig := &ocrypto.CACertCreatorConfig{
 		Subject: pkix.Name{
 			CommonName: caConfig.Name,
 		},
 	}
-	caTLSSecret, err := MakeSelfSignedCA(ctx, caConfig.Name, caCertCreatorConfig.ToCreator(), cm.keyGetter, nowFunc, caConfig.Validity, caConfig.Refresh, controller, controllerGVK, existingSecrets[caConfig.Name])
+	caTLSSecret, err := MakeSelfSignedCA(ctx, caConfig.Name, caCertCreatorConfig.ToCreator(), cm.keyGetter, nowFunc, caConfig.Validity, caConfig.Refresh, controller, controllerGVK, existingCASecret)
 	if err != nil {
 		return fmt.Errorf("can't make selfsigned CA %q: %w", caConfig.Name, err)
 	}
@@ -165,7 +171,12 @@ func (cm *CertificateManager) ManageCertificates(ctx context.Context, nowFunc fu
 		caTLSSecret.Refresh(updatedCASecret)
 	}
 
-	caBundleCM, err := caTLSSecret.MakeCABundle(caBundleConfig.Name, controller, controllerGVK, existingConfigMaps[caBundleConfig.Name], nowFunc())
+	existingBundleCM, err := getConfigMapWithCache(ctx, cm.configMapClient, controller.GetNamespace(), caBundleConfig.Name, existingConfigMaps)
+	if err != nil {
+		return fmt.Errorf("can't get CA bundle ConfigMap %q: %w", caBundleConfig.Name, err)
+	}
+
+	caBundleCM, err := caTLSSecret.MakeCABundle(caBundleConfig.Name, controller, controllerGVK, existingBundleCM, nowFunc())
 	if err != nil {
 		return fmt.Errorf("can't make ca bundle ConfigMap %q: %w", caBundleConfig.Name, err)
 	}
@@ -179,7 +190,12 @@ func (cm *CertificateManager) ManageCertificates(ctx context.Context, nowFunc fu
 	}
 
 	for _, cc := range certConfigs {
-		tlsSecret, err := caTLSSecret.MakeCertificate(ctx, cc.Name, cc.CertCreator, cm.keyGetter, controller, controllerGVK, existingSecrets[cc.Name], cc.Validity, cc.Refresh)
+		existingCertSecret, err := getSecretWithCache(ctx, cm.secretsClient, controller.GetNamespace(), cc.Name, existingSecrets)
+		if err != nil {
+			return fmt.Errorf("can't get certificate secret %q: %w", cc.Name, err)
+		}
+
+		tlsSecret, err := caTLSSecret.MakeCertificate(ctx, cc.Name, cc.CertCreator, cm.keyGetter, controller, controllerGVK, existingCertSecret, cc.Validity, cc.Refresh)
 		if err != nil {
 			return fmt.Errorf("can't make certificate %q: %w", cc.Name, err)
 		}
@@ -199,4 +215,39 @@ func (cm *CertificateManager) ManageCertificates(ctx context.Context, nowFunc fu
 
 func (cm *CertificateManager) ManageCertificateChain(ctx context.Context, nowFunc func() time.Time, controller *metav1.ObjectMeta, controllerGVK schema.GroupVersionKind, certChainConfig *CertChainConfig, existingSecrets map[string]*corev1.Secret, existingConfigMaps map[string]*corev1.ConfigMap) error {
 	return cm.ManageCertificates(ctx, nowFunc, controller, controllerGVK, certChainConfig.CAConfig, certChainConfig.CABundleConfig, certChainConfig.CertConfigs, existingSecrets, existingConfigMaps)
+}
+
+// getSecretWithCache returns the named Secret from cache, falling back to a live GET on a cache miss.
+// Returns nil, nil if the Secret does not exist.
+func getSecretWithCache(ctx context.Context, client corev1client.SecretsGetter, namespace, name string, cache map[string]*corev1.Secret) (*corev1.Secret, error) {
+	return getWithCache(ctx, namespace, name, cache, func(ctx context.Context, name string) (*corev1.Secret, error) {
+		return client.Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	})
+}
+
+// getConfigMapWithCache returns the named ConfigMap from cache, falling back to a live GET on a cache miss.
+// Returns nil, nil if the ConfigMap does not exist.
+func getConfigMapWithCache(ctx context.Context, client corev1client.ConfigMapsGetter, namespace, name string, cache map[string]*corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return getWithCache(ctx, namespace, name, cache, func(ctx context.Context, name string) (*corev1.ConfigMap, error) {
+		return client.ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	})
+}
+
+// getWithCache returns the named object from cache, falling back to a live GET on a cache miss.
+// Returns nil, nil if the object does not exist.
+func getWithCache[T any](ctx context.Context, namespace, name string, cache map[string]*T, get func(context.Context, string) (*T, error)) (*T, error) {
+	if obj, ok := cache[name]; ok {
+		return obj, nil
+	}
+
+	obj, err := get(ctx, name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("can't get object %q: %w", naming.ManualRef(namespace, name), err)
+	}
+
+	return obj, nil
 }

--- a/pkg/kubecrypto/certmanager_test.go
+++ b/pkg/kubecrypto/certmanager_test.go
@@ -1,0 +1,192 @@
+package kubecrypto
+
+import (
+	"context"
+	"crypto/elliptic"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"reflect"
+	"testing"
+	"time"
+
+	ocrypto "github.com/scylladb/scylla-operator/pkg/crypto"
+	testcrypto "github.com/scylladb/scylla-operator/pkg/test/crypto"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+)
+
+func Test_ManageCertificates_staleCacheDoesNotRegenerateCA(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace        = "default"
+		caName           = "test-ca"
+		caBundleName     = "test-ca"
+		servingCertName  = "test-serving-certs"
+		testCertValidity = 30 * 24 * time.Hour
+		testCertRefresh  = 15 * 24 * time.Hour
+		testCAValidity   = 10 * 365 * 24 * time.Hour
+		testCARefresh    = 8 * 365 * 24 * time.Hour
+	)
+
+	currentTime := time.Now()
+	nowFunc := func() time.Time { return currentTime }
+
+	keygen, err := ocrypto.NewECDSAKeyGenerator(1, 1, elliptic.P256(), 42*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testcrypto.StartKeyGenerator(t, keygen)
+
+	controller := &metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      "test-controller",
+		UID:       "test-uid",
+	}
+	controllerGVK := schema.GroupVersionKind{
+		Group:   "scylla.scylladb.com",
+		Version: "v1alpha1",
+		Kind:    "ScyllaDBMonitoring",
+	}
+
+	caConfig := &CAConfig{
+		MetaConfig: MetaConfig{
+			Name: caName,
+		},
+		Validity: testCAValidity,
+		Refresh:  testCARefresh,
+	}
+	caBundleConfig := &CABundleConfig{
+		MetaConfig: MetaConfig{
+			Name: caBundleName,
+		},
+	}
+	certConfigs := []*CertificateConfig{
+		{
+			MetaConfig: MetaConfig{
+				Name: servingCertName,
+			},
+			Validity: testCertValidity,
+			Refresh:  testCertRefresh,
+			CertCreator: (&ocrypto.ServingCertCreatorConfig{
+				Subject: pkix.Name{
+					CommonName: "",
+				},
+				DNSNames: []string{"test.example.com"},
+			}).ToCreator(),
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fakeClient := fake.NewSimpleClientset()
+
+	secretCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	secretLister := corev1listers.NewSecretLister(secretCache)
+	configMapCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	configMapLister := corev1listers.NewConfigMapLister(configMapCache)
+	recorder := record.NewFakeRecorder(10)
+
+	cm := NewCertificateManager(
+		keygen,
+		fakeClient.CoreV1(),
+		secretLister,
+		fakeClient.CoreV1(),
+		configMapLister,
+		recorder,
+	)
+
+	// First call: no existing objects anywhere. Creates CA, bundle, and serving cert.
+	err = cm.ManageCertificates(ctx, nowFunc, controller, controllerGVK, caConfig, caBundleConfig, certConfigs, map[string]*corev1.Secret{}, map[string]*corev1.ConfigMap{})
+	if err != nil {
+		t.Fatalf("first ManageCertificates call failed: %v", err)
+	}
+
+	// Record the state after the first call.
+	caSecretAfterFirst, err := fakeClient.CoreV1().Secrets(namespace).Get(ctx, caName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("can't get CA secret after first call: %v", err)
+	}
+	servingSecretAfterFirst, err := fakeClient.CoreV1().Secrets(namespace).Get(ctx, servingCertName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("can't get serving secret after first call: %v", err)
+	}
+	bundleCMAfterFirst, err := fakeClient.CoreV1().ConfigMaps(namespace).Get(ctx, caBundleName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("can't get CA bundle ConfigMap after first call: %v", err)
+	}
+
+	firstBundleCerts, err := ocrypto.DecodeCertificates([]byte(bundleCMAfterFirst.Data[CABundleKey]))
+	if err != nil {
+		t.Fatalf("can't decode CA bundle after first call: %v", err)
+	}
+	if len(firstBundleCerts) != 1 {
+		t.Fatalf("expected 1 cert in CA bundle after first call, got %d", len(firstBundleCerts))
+	}
+
+	// Populate the listers with the objects from the fake client, simulating the informer
+	// having caught up by the time ApplySecret/ApplyConfigMap runs inside ManageCertificates.
+	for _, s := range []*corev1.Secret{caSecretAfterFirst, servingSecretAfterFirst} {
+		if err := secretCache.Add(s); err != nil {
+			t.Fatalf("can't add secret %q to cache: %v", s.Name, err)
+		}
+	}
+	if err := configMapCache.Add(bundleCMAfterFirst); err != nil {
+		t.Fatalf("can't add ConfigMap %q to cache: %v", bundleCMAfterFirst.Name, err)
+	}
+
+	// Second call: empty existingSecrets/existingConfigMaps (simulating a stale snapshot taken
+	// before the informer delivered the objects created in the first call), but the listers
+	// are populated (the informer caught up between the snapshot and the ApplySecret calls).
+	// Without the live-GET fallback this would mint a new CA, producing a 2-cert bundle.
+	err = cm.ManageCertificates(ctx, nowFunc, controller, controllerGVK, caConfig, caBundleConfig, certConfigs, map[string]*corev1.Secret{}, map[string]*corev1.ConfigMap{})
+	if err != nil {
+		t.Fatalf("second ManageCertificates call failed: %v", err)
+	}
+
+	// Verify CA Secret data is unchanged.
+	caSecretAfterSecond, err := fakeClient.CoreV1().Secrets(namespace).Get(ctx, caName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("can't get CA secret after second call: %v", err)
+	}
+	if !reflect.DeepEqual(caSecretAfterFirst.Data, caSecretAfterSecond.Data) {
+		t.Errorf("CA secret was regenerated on the second call (stale cache should not cause regeneration)")
+	}
+
+	// Verify serving cert Secret data is unchanged.
+	servingSecretAfterSecond, err := fakeClient.CoreV1().Secrets(namespace).Get(ctx, servingCertName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("can't get serving secret after second call: %v", err)
+	}
+	if !reflect.DeepEqual(servingSecretAfterFirst.Data, servingSecretAfterSecond.Data) {
+		t.Errorf("serving cert secret was regenerated on the second call (stale cache should not cause regeneration)")
+	}
+
+	// Verify CA bundle still has exactly 1 cert.
+	bundleCMAfterSecond, err := fakeClient.CoreV1().ConfigMaps(namespace).Get(ctx, caBundleName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("can't get CA bundle ConfigMap after second call: %v", err)
+	}
+	secondBundleCerts, err := ocrypto.DecodeCertificates([]byte(bundleCMAfterSecond.Data[CABundleKey]))
+	if err != nil {
+		t.Fatalf("can't decode CA bundle after second call: %v", err)
+	}
+	if len(secondBundleCerts) != 1 {
+		t.Fatalf("expected 1 cert in CA bundle after second call, got %d", len(secondBundleCerts))
+	}
+
+	// Verify the single cert in the bundle is the same CA cert, not a new one.
+	if !certEqual(firstBundleCerts[0], secondBundleCerts[0]) {
+		t.Errorf("CA cert in bundle changed between calls")
+	}
+}
+
+func certEqual(a, b *x509.Certificate) bool {
+	return reflect.DeepEqual(a.Raw, b.Raw)
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
The existingSecrets and existingConfigMaps maps passed to ManageCertificates are point-in-time snapshots from the informer cache, taken at the start of the reconcile loop. When a second reconcile fires before the informer delivers objects created by the first one, the snapshot is stale and the map lookup returns nothing. This causes ManageCertificates to mint a new CA with a different key, which then accumulates in the CA bundle alongside the original - MakeCABundle retains all still-valid CAs, which is correct for rotation but means the duplicate is never dropped.

In practice this surfaces as a flake in the ScyllaDBMonitoring e2e test ("with Platform type with external Prometheus with TLS"), which asserts the grafana serving CA bundle has exactly one cert.

On a cache miss, fall back to a live GET via the API client before deciding to generate. Only mint a new cert when the live GET returns NotFound. This covers the CA Secret, the CA bundle ConfigMap, and leaf cert Secrets.

**Which issue is resolved by this Pull Request:**
Resolves OPERATOR-129

/kind bug
/priority important-soon