### PR TITLE
chore(kind): enable nftables and tune etcd

### DIFF
--- a/hack/kind/cluster-config.yaml
+++ b/hack/kind/cluster-config.yaml
@@ -6,6 +6,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   ipFamily: ipv4
+  kubeProxyMode: "nftables"
 nodes:
   - role: control-plane
     kubeadmConfigPatches:

--- a/hack/kind/cluster-setup.sh
+++ b/hack/kind/cluster-setup.sh
@@ -52,6 +52,17 @@ else
     echo "Reusing existing KinD cluster: ${CLUSTER_NAME}"
 fi
 
+# Bump etcd CPU request from the kubeadm default of 100m to avoid compaction stalls under high test parallelism.
+podman exec "${CLUSTER_NAME}-control-plane" sed -i 's/cpu: 100m/cpu: 500m/' /etc/kubernetes/manifests/etcd.yaml
+echo "Waiting for API server to become ready after etcd CPU bump..."
+wait_kubeconfig="$(mktemp)"
+kind get kubeconfig --name="${CLUSTER_NAME}" > "${wait_kubeconfig}"
+until KUBECONFIG="${wait_kubeconfig}" kubectl get --raw /readyz >/dev/null 2>&1; do
+    echo "API server not ready yet, retrying..."
+    sleep 2
+done
+rm "${wait_kubeconfig}"
+
 # Set up a local registry for the KinD cluster following https://kind.sigs.k8s.io/docs/user/local-registry/.
 reg_name='kind-registry'
 reg_port='5001'


### PR DESCRIPTION
**Description of your changes:**
- Switch kind suite to nftables routing (much faster than iptables). The [Jenkins](https://jenkins.scylladb.com/job/releng-testing/job/operator/9/) [results](https://jenkins.scylladb.com/job/releng-testing/job/operator/10/) hint at much [improved](https://jenkins.scylladb.com/job/releng-testing/job/operator/13/) [stability](https://jenkins.scylladb.com/job/releng-testing/job/operator/14/).
- Tune etcd to use 500m CPU (and wait for the new instances to spin up before proceeding with the cluster deployment

With these changes we should see fewer flakes in Prow and Jenkins alike

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-137
