### PR TITLE
test(e2e): decouple ScyllaDB Manager task property update verification from backup, restore, and repair tests

### DIFF
--- a/test/e2e/set/scyllacluster/scyllamanager.go
+++ b/test/e2e/set/scyllacluster/scyllamanager.go
@@ -25,37 +25,42 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
+var _ = g.Describe("ScyllaCluster integration with global ScyllaDB Manager", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
+
+	var (
+		sc               *scyllav1.ScyllaCluster
+		managerClient    *managerclient.Client
+		managerClusterID string
+	)
 
 	g.BeforeEach(func(ctx context.Context) {
 		f = framework.NewFramework(ctx, "scyllacluster")
 	})
 
-	g.DescribeTable("should register and deregister a ScyllaCluster", func(ctx g.SpecContext, deregistrationHook func(context.Context, *scyllav1.ScyllaCluster)) {
-		ns, nsClient, ok := f.DefaultNamespaceIfAny()
-		o.Expect(ok).To(o.BeTrue())
+	g.JustBeforeEach(func(ctx context.Context) {
+		sc = f.GetDefaultScyllaCluster()
+		sc.Spec.Datacenter.Racks[0].Members = 1
 
-		sc := f.GetDefaultScyllaCluster()
-
-		framework.By(`Creating a ScyllaCluster`)
-		sc, err := nsClient.ScyllaClient().ScyllaV1().ScyllaClusters(ns.Name).Create(ctx, sc, metav1.CreateOptions{})
+		framework.By("Creating a ScyllaCluster")
+		var err error
+		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
 		rolloutCtx, rolloutCtxCancel := utils.ContextForRollout(ctx, sc)
 		defer rolloutCtxCancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(rolloutCtx, nsClient.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		sc, err = controllerhelpers.WaitForScyllaClusterState(rolloutCtx, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		scyllaclusterverification.Verify(ctx, nsClient.KubeClient(), nsClient.ScyllaClient(), sc)
-		scyllaclusterverification.WaitForFullQuorum(ctx, nsClient.KubeClient().CoreV1(), sc)
+		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
-		hosts, err := utils.GetBroadcastRPCAddresses(ctx, nsClient.KubeClient().CoreV1(), sc)
+		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(1))
 		di := verification.InsertAndVerifyCQLData(ctx, hosts)
-		defer di.Close()
+		g.DeferCleanup(di.Close)
 
 		framework.By("Waiting for ScyllaDB Manager cluster ID to propagate to ScyllaCluster's status")
 		registrationCtx, registrationCtxCancel := context.WithTimeoutCause(
@@ -67,17 +72,17 @@ var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framew
 
 		sc, err = controllerhelpers.WaitForScyllaClusterState(
 			registrationCtx,
-			nsClient.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace),
+			f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace),
 			sc.Name,
 			controllerhelpers.WaitForStateOptions{},
 			utils.IsScyllaClusterRegisteredWithManager,
 		)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(sc.Status.ManagerID).NotTo(o.BeNil())
-		managerClusterID := *sc.Status.ManagerID
+		managerClusterID = *sc.Status.ManagerID
 		o.Expect(managerClusterID).NotTo(o.BeEmpty())
 
-		managerClient, err := utils.GetManagerClient(ctx, f.KubeAdminClient().CoreV1())
+		managerClient, err = utils.GetManagerClient(ctx, f.KubeAdminClient().CoreV1())
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Verifying that ScyllaCluster is registered with ScyllaDB Manager")
@@ -89,7 +94,9 @@ var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framew
 			WithTimeout(utils.ScyllaDBManagerClusterSyncTimeout).
 			WithPolling(5 * time.Second).
 			Should(o.Succeed())
+	})
 
+	g.DescribeTable("should register and deregister a cluster", func(ctx g.SpecContext, deregistrationHook func(context.Context, *scyllav1.ScyllaCluster)) {
 		deregistrationHook(ctx, sc)
 
 		framework.By("Verifying that the cluster was removed from the global ScyllaDB Manager state")
@@ -145,8 +152,8 @@ var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framew
 				utils.ScyllaDBTerminationTimeout,
 				fmt.Errorf("ScyllaCluster %q has not been deleted in time", naming.ObjRef(sc)),
 			)
-
 			defer deletionCtxCancel()
+
 			err = framework.WaitForObjectDeletion(
 				deletionCtx,
 				f.DynamicClient(),
@@ -159,289 +166,279 @@ var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framew
 		}),
 	)
 
-	type repairTaskTableEntry struct {
-		taskDeletionHook             func(context.Context, *scyllav1.ScyllaCluster)
-		managerStateVerificationHook func(context.Context, *managerclient.Client, string)
-	}
+	g.Context("with a repair task", func() {
+		const (
+			repairTaskInitialParallel = int64(1)
+			repairTaskUpdatedParallel = int64(2)
+		)
 
-	g.DescribeTable("should register cluster, sync repair tasks, and delete them", func(ctx g.SpecContext, e repairTaskTableEntry) {
-		sc := f.GetDefaultScyllaCluster()
-		sc.Spec.Datacenter.Racks[0].Members = 1
+		var repairTask *managerclient.TaskListItem
 
-		framework.By("Creating a ScyllaCluster")
-		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
+		type repairTaskTableEntry struct {
+			taskDeletionHook             func(context.Context, *scyllav1.ScyllaCluster)
+			managerStateVerificationHook func(context.Context, *managerclient.Client, string)
+		}
 
-		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
-		rolloutCtx, rolloutCtxCancel := utils.ContextForRollout(ctx, sc)
-		defer rolloutCtxCancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(rolloutCtx, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
-		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
-
-		hosts, err := utils.GetBroadcastRPCAddresses(ctx, f.KubeClient().CoreV1(), sc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(hosts).To(o.HaveLen(1))
-		di := verification.InsertAndVerifyCQLData(ctx, hosts)
-		defer di.Close()
-
-		framework.By("Scheduling a repair task")
-		scCopy := sc.DeepCopy()
-		scCopy.Spec.Repairs = append(scCopy.Spec.Repairs, scyllav1.RepairTaskSpec{
-			TaskSpec: scyllav1.TaskSpec{
-				SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
-					NumRetries: pointer.Ptr[int64](3),
-					RetryWait: &metav1.Duration{
-						Duration: 30 * time.Second,
+		g.JustBeforeEach(func(ctx context.Context) {
+			framework.By("Scheduling a repair task")
+			scCopy := sc.DeepCopy()
+			scCopy.Spec.Repairs = append(scCopy.Spec.Repairs, scyllav1.RepairTaskSpec{
+				TaskSpec: scyllav1.TaskSpec{
+					SchedulerTaskSpec: scyllav1.SchedulerTaskSpec{
+						NumRetries: pointer.Ptr[int64](3),
+						RetryWait: &metav1.Duration{
+							Duration: 30 * time.Second,
+						},
 					},
+					Name: "repair",
 				},
-				Name: "repair",
-			},
-			Parallel: 2,
+				Parallel: repairTaskInitialParallel,
+			})
+
+			patchData, err := controllerhelpers.GenerateMergePatch(sc, scCopy)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(ctx, sc.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(sc.Spec.Repairs).To(o.HaveLen(1))
+			o.Expect(sc.Spec.Repairs[0].Name).To(o.Equal("repair"))
+			o.Expect(sc.Spec.Repairs[0].Parallel).To(o.Equal(repairTaskInitialParallel))
+			o.Expect(sc.Spec.Backups).To(o.BeEmpty())
+
+			framework.By("Waiting for ScyllaCluster to sync repair task with Scylla Manager")
+			repairTaskScheduledCond := func(cluster *scyllav1.ScyllaCluster) (bool, error) {
+				for _, r := range cluster.Status.Repairs {
+					if r.Name == sc.Spec.Repairs[0].Name {
+						if r.ID == nil || len(*r.ID) == 0 {
+							return false, nil
+						}
+
+						if r.Error != nil {
+							return false, errors.New(*r.Error)
+						}
+
+						return true, nil
+					}
+				}
+				return false, nil
+			}
+
+			taskSchedulingCtx, taskSchedulingCtxCancel := context.WithTimeoutCause(
+				ctx,
+				utils.ScyllaDBManagerTaskSyncTimeout,
+				fmt.Errorf("task has not been scheduled in ScyllaDB Manager in time"),
+			)
+			defer taskSchedulingCtxCancel()
+
+			sc, err = controllerhelpers.WaitForScyllaClusterState(
+				taskSchedulingCtx,
+				f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace),
+				sc.Name,
+				controllerhelpers.WaitForStateOptions{},
+				repairTaskScheduledCond,
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(sc.Status.Repairs).To(o.HaveLen(1))
+			o.Expect(sc.Status.Repairs[0].ID).NotTo(o.BeNil())
+			o.Expect(sc.Status.Repairs[0].Name).To(o.Equal(sc.Spec.Repairs[0].Name))
+			o.Expect(sc.Status.Repairs[0].Parallel).NotTo(o.BeNil())
+			o.Expect(*sc.Status.Repairs[0].Parallel).To(o.Equal(sc.Spec.Repairs[0].Parallel))
+			o.Expect(sc.Status.Backups).To(o.BeEmpty())
+
+			framework.By("Verifying that repair task status was synchronized")
+			tasks, err := managerClient.ListTasks(ctx, managerClusterID, "repair", false, "", "")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(tasks.TaskListItemSlice).To(o.HaveLen(1))
+			repairTask = tasks.TaskListItemSlice[0]
+			o.Expect(repairTask.Name).To(o.Equal(sc.Status.Repairs[0].Name))
+			o.Expect(repairTask.ID).To(o.Equal(*sc.Status.Repairs[0].ID))
+			o.Expect(repairTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(repairTaskInitialParallel))
+
+			framework.By("Waiting for the repair task to finish")
+			repairTaskCompletionCtx, repairTaskCompletionCtxCancel := context.WithTimeoutCause(
+				ctx,
+				utils.ScyllaDBManagerTaskCompletionTimeout,
+				fmt.Errorf("repair task has not completed in time"),
+			)
+			defer repairTaskCompletionCtxCancel()
+
+			o.Eventually(verification.VerifyScyllaDBManagerRepairTaskCompleted).
+				WithContext(repairTaskCompletionCtx).
+				WithPolling(5*time.Second).
+				WithArguments(managerClient, managerClusterID, repairTask.ID).
+				Should(o.Succeed())
 		})
 
-		patchData, err := controllerhelpers.GenerateMergePatch(sc, scCopy)
-		o.Expect(err).NotTo(o.HaveOccurred())
+		g.DescribeTable("should delete a task", func(ctx g.SpecContext, e repairTaskTableEntry) {
+			e.taskDeletionHook(ctx, sc)
 
-		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(ctx, sc.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Spec.Repairs).To(o.HaveLen(1))
-		o.Expect(sc.Spec.Repairs[0].Name).To(o.Equal("repair"))
-		o.Expect(sc.Spec.Repairs[0].Parallel).To(o.Equal(int64(2)))
-		o.Expect(sc.Spec.Backups).To(o.BeEmpty())
-
-		framework.By("Waiting for ScyllaCluster to sync repair tasks with Scylla Manager")
-		repairTaskScheduledCond := func(cluster *scyllav1.ScyllaCluster) (bool, error) {
-			for _, r := range cluster.Status.Repairs {
-				if r.Name == sc.Spec.Repairs[0].Name {
-					if r.ID == nil || len(*r.ID) == 0 {
-						return false, nil
-					}
-
-					if r.Error != nil {
-						return false, errors.New(*r.Error)
-					}
-
-					return true, nil
-				}
+			framework.By("Waiting for ScyllaCluster to sync repair task deletion with Scylla Manager")
+			repairTaskDeletedCond := func(cluster *scyllav1.ScyllaCluster) (bool, error) {
+				return len(cluster.Status.Repairs) == 0, nil
 			}
-			return false, nil
-		}
 
-		taskSchedulingCtx, taskSchedulingCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("task has not been scheduled in ScyllaDB Manager in time"),
+			taskDeletionCtx, taskDeletionCtxCancel := context.WithTimeoutCause(
+				ctx,
+				utils.ScyllaDBManagerTaskSyncTimeout,
+				fmt.Errorf("repair task deletion has not been reconciled in time"),
+			)
+			defer taskDeletionCtxCancel()
+
+			var err error
+			sc, err = controllerhelpers.WaitForScyllaClusterState(
+				taskDeletionCtx,
+				f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace),
+				sc.Name,
+				controllerhelpers.WaitForStateOptions{},
+				repairTaskDeletedCond,
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// Progressing conditions of the underlying ScyllaDBManagerTasks are not propagated to ScyllaClusters by the migration controller,
+			// neither does the controller await the deletion of ScyllaDBManagerTasks.
+			// Task deletion from ScyllaDB Manager state is asynchronous to ScyllaCluster state update.
+			e.managerStateVerificationHook(ctx, managerClient, managerClusterID)
+		},
+			g.Entry("when manager integration is disabled", repairTaskTableEntry{
+				taskDeletionHook: func(ctx context.Context, sc *scyllav1.ScyllaCluster) {
+					framework.By(`Annotating ScyllaCluster to disable ScyllaDB Manager integration`)
+					scCopy := sc.DeepCopy()
+					metav1.SetMetaDataAnnotation(&scCopy.ObjectMeta, naming.DisableGlobalScyllaDBManagerIntegrationAnnotation, naming.LabelValueTrue)
+
+					patch, err := controllerhelpers.GenerateMergePatch(sc, scCopy)
+					o.Expect(err).NotTo(o.HaveOccurred())
+
+					sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace).Patch(
+						ctx,
+						sc.Name,
+						types.MergePatchType,
+						patch,
+						metav1.PatchOptions{},
+					)
+					o.Expect(err).NotTo(o.HaveOccurred())
+				},
+				managerStateVerificationHook: func(ctx context.Context, managerClient *managerclient.Client, managerClusterID string) {
+					framework.By("Verifying that the cluster was removed from the manager state")
+					scyllaDBManagerClusterDeletionCtx, scyllaDBManagerClusterDeletionCtxCancel := context.WithTimeoutCause(
+						ctx,
+						utils.ScyllaDBManagerClusterSyncTimeout,
+						fmt.Errorf("ScyllaCluster with manager cluster ID %q has not been deleted from ScyllaDB Manager state in time", managerClusterID),
+					)
+					defer scyllaDBManagerClusterDeletionCtxCancel()
+
+					o.Eventually(func(eo o.Gomega, ctx context.Context) {
+						_, err := managerClient.GetCluster(ctx, managerClusterID)
+						eo.Expect(err).To(o.HaveOccurred())
+						eo.Expect(err).To(o.Satisfy(managerclienterrors.IsNotFound))
+					}).
+						WithContext(scyllaDBManagerClusterDeletionCtx).
+						WithPolling(5 * time.Second).
+						Should(o.Succeed())
+				},
+			}),
+			g.Entry("when repair task is deleted", repairTaskTableEntry{
+				taskDeletionHook: func(ctx context.Context, sc *scyllav1.ScyllaCluster) {
+					framework.By("Deleting the repair task")
+					sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+						ctx,
+						sc.Name,
+						types.JSONPatchType,
+						[]byte(`[{"op":"remove","path":"/spec/repairs/0"}]`),
+						metav1.PatchOptions{},
+					)
+					o.Expect(err).NotTo(o.HaveOccurred())
+					o.Expect(sc.Spec.Repairs).To(o.BeEmpty())
+				},
+				managerStateVerificationHook: func(ctx context.Context, managerClient *managerclient.Client, managerClusterID string) {
+					framework.By("Verifying that the repair task was removed from the manager state")
+					repairTaskDeletionCtx, repairTaskDeletionCtxCancel := context.WithTimeoutCause(
+						ctx,
+						utils.ScyllaDBManagerTaskSyncTimeout,
+						fmt.Errorf("repair task has not been deleted from ScyllaDB Manager state in time"),
+					)
+					defer repairTaskDeletionCtxCancel()
+
+					o.Eventually(func(eo o.Gomega, ctx context.Context) {
+						tasks, err := managerClient.ListTasks(ctx, managerClusterID, "repair", false, "", "")
+						eo.Expect(err).NotTo(o.HaveOccurred())
+						eo.Expect(tasks.TaskListItemSlice).To(o.BeEmpty())
+					}).
+						WithContext(repairTaskDeletionCtx).
+						WithPolling(5 * time.Second).
+						Should(o.Succeed())
+				},
+			}),
 		)
-		defer taskSchedulingCtxCancel()
 
-		sc, err = controllerhelpers.WaitForScyllaClusterState(
-			taskSchedulingCtx,
-			f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace),
-			sc.Name,
-			controllerhelpers.WaitForStateOptions{},
-			repairTaskScheduledCond,
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Status.Repairs).To(o.HaveLen(1))
-		o.Expect(sc.Status.Repairs[0].ID).NotTo(o.BeNil())
-		o.Expect(sc.Status.Repairs[0].Name).To(o.Equal(sc.Spec.Repairs[0].Name))
-		o.Expect(sc.Status.Repairs[0].Parallel).NotTo(o.BeNil())
-		o.Expect(*sc.Status.Repairs[0].Parallel).To(o.Equal(sc.Spec.Repairs[0].Parallel))
-		o.Expect(sc.Status.Backups).To(o.BeEmpty())
+		g.It("should update task properties and complete with updated properties", func(ctx g.SpecContext) {
+			framework.By("Updating the repair task")
+			sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
+				ctx,
+				sc.Name,
+				types.JSONPatchType,
+				[]byte(fmt.Sprintf(`[{"op":"replace","path":"/spec/repairs/0/parallel","value":%d}]`, repairTaskUpdatedParallel)),
+				metav1.PatchOptions{},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(sc.Spec.Repairs[0].Parallel).To(o.Equal(repairTaskUpdatedParallel))
 
-		// Sanity check to avoid panics.
-		o.Expect(sc.Status.ManagerID).NotTo(o.BeNil())
-		managerClusterID := *sc.Status.ManagerID
-		o.Expect(managerClusterID).NotTo(o.BeEmpty())
+			framework.By("Waiting for ScyllaCluster to sync repair task update with Scylla Manager")
+			repairTaskUpdatedCond := func(cluster *scyllav1.ScyllaCluster) (bool, error) {
+				for _, r := range cluster.Status.Repairs {
+					if r.Name == sc.Spec.Repairs[0].Name {
+						if r.ID == nil || len(*r.ID) == 0 {
+							return false, fmt.Errorf("got unexpected empty task ID in status")
+						}
 
-		managerClient, err := utils.GetManagerClient(ctx, f.KubeAdminClient().CoreV1())
-		o.Expect(err).NotTo(o.HaveOccurred())
+						if r.Error != nil {
+							return false, errors.New(*r.Error)
+						}
 
-		framework.By("Verifying that repair task status was synchronized")
-		tasks, err := managerClient.ListTasks(ctx, managerClusterID, "repair", false, "", "")
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(tasks.TaskListItemSlice).To(o.HaveLen(1))
-		repairTask := tasks.TaskListItemSlice[0]
-		o.Expect(repairTask.Name).To(o.Equal(sc.Status.Repairs[0].Name))
-		o.Expect(repairTask.ID).To(o.Equal(*sc.Status.Repairs[0].ID))
-		o.Expect(repairTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(*sc.Status.Repairs[0].Parallel))
-
-		framework.By("Updating the repair task")
-		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-			ctx,
-			sc.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op":"replace","path":"/spec/repairs/0/parallel","value":1}]`),
-			metav1.PatchOptions{},
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Spec.Repairs).To(o.HaveLen(1))
-		o.Expect(sc.Spec.Repairs[0].Name).To(o.Equal("repair"))
-		o.Expect(sc.Spec.Repairs[0].Parallel).To(o.Equal(int64(1)))
-		o.Expect(sc.Spec.Backups).To(o.BeEmpty())
-
-		framework.By("Waiting for ScyllaCluster to sync repair task update with Scylla Manager")
-		repairTaskUpdatedCond := func(cluster *scyllav1.ScyllaCluster) (bool, error) {
-			for _, r := range cluster.Status.Repairs {
-				if r.Name == sc.Spec.Repairs[0].Name {
-					if r.ID == nil || len(*r.ID) == 0 {
-						return false, fmt.Errorf("got unexpected empty task ID in status")
+						return r.Parallel != nil && *r.Parallel == repairTaskUpdatedParallel, nil
 					}
-
-					if r.Error != nil {
-						return false, errors.New(*r.Error)
-					}
-
-					return r.Parallel != nil && *r.Parallel == int64(1), nil
 				}
+				return false, nil
 			}
-			return false, nil
-		}
 
-		taskUpdateCtx, taskUpdateCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("task update has not been reconciled in time"),
-		)
-		defer taskUpdateCtxCancel()
+			taskUpdateCtx, taskUpdateCtxCancel := context.WithTimeoutCause(
+				ctx,
+				utils.ScyllaDBManagerTaskSyncTimeout,
+				fmt.Errorf("task update has not been reconciled in time"),
+			)
+			defer taskUpdateCtxCancel()
 
-		sc, err = controllerhelpers.WaitForScyllaClusterState(
-			taskUpdateCtx,
-			f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace),
-			sc.Name,
-			controllerhelpers.WaitForStateOptions{},
-			repairTaskUpdatedCond,
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Status.Repairs).To(o.HaveLen(1))
-		o.Expect(sc.Status.Repairs[0].Name).To(o.Equal(sc.Spec.Repairs[0].Name))
-		o.Expect(sc.Status.Repairs[0].ID).NotTo(o.BeNil())
-		o.Expect(*sc.Status.Repairs[0].ID).To(o.Equal(repairTask.ID))
-		o.Expect(sc.Status.Repairs[0].Parallel).NotTo(o.BeNil())
-		o.Expect(*sc.Status.Repairs[0].Parallel).To(o.Equal(sc.Spec.Repairs[0].Parallel))
-		o.Expect(sc.Status.Backups).To(o.BeEmpty())
+			sc, err = controllerhelpers.WaitForScyllaClusterState(
+				taskUpdateCtx,
+				f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace),
+				sc.Name,
+				controllerhelpers.WaitForStateOptions{},
+				repairTaskUpdatedCond,
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(sc.Status.Repairs[0].Parallel).NotTo(o.BeNil())
+			o.Expect(*sc.Status.Repairs[0].Parallel).To(o.Equal(repairTaskUpdatedParallel))
 
-		framework.By("Verifying that updated repair task status was synchronized")
-		tasks, err = managerClient.ListTasks(ctx, managerClusterID, "repair", false, "", "")
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(tasks.TaskListItemSlice).To(o.HaveLen(1))
-		repairTask = tasks.TaskListItemSlice[0]
-		o.Expect(repairTask.Name).To(o.Equal(sc.Status.Repairs[0].Name))
-		o.Expect(repairTask.ID).To(o.Equal(*sc.Status.Repairs[0].ID))
-		o.Expect(repairTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(*sc.Status.Repairs[0].Parallel))
+			framework.By("Verifying that updated repair task status was synchronized")
+			tasks, err := managerClient.ListTasks(ctx, managerClusterID, "repair", false, "", "")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(tasks.TaskListItemSlice).To(o.HaveLen(1))
+			updatedRepairTask := tasks.TaskListItemSlice[0]
+			o.Expect(updatedRepairTask.ID).To(o.Equal(repairTask.ID))
+			o.Expect(updatedRepairTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(repairTaskUpdatedParallel))
 
-		framework.By("Waiting for repair to finish")
+			framework.By("Waiting for repair with updated properties to finish")
+			repairTaskSecondCompletionCtx, repairTaskSecondCompletionCtxCancel := context.WithTimeoutCause(
+				ctx,
+				utils.ScyllaDBManagerTaskCompletionTimeout,
+				fmt.Errorf("repair task has not completed in time after property update"),
+			)
+			defer repairTaskSecondCompletionCtxCancel()
 
-		repairTaskCompletionCtx, repairTaskCompletionCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskCompletionTimeout,
-			fmt.Errorf("repair task has not completed in time"),
-		)
-		defer repairTaskCompletionCtxCancel()
-		o.Eventually(verification.VerifyScyllaDBManagerRepairTaskCompleted).
-			WithContext(repairTaskCompletionCtx).
-			WithPolling(5*time.Second).
-			WithArguments(managerClient, managerClusterID, repairTask.ID).
-			Should(o.Succeed())
-
-		e.taskDeletionHook(ctx, sc)
-
-		framework.By("Waiting for ScyllaCluster to sync repair task deletion with Scylla Manager")
-		repairTaskDeletedCond := func(cluster *scyllav1.ScyllaCluster) (bool, error) {
-			return len(cluster.Status.Repairs) == 0, nil
-		}
-
-		taskDeletionCtx, taskDeletionCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("repair task deletion has not been reconciled in time"),
-		)
-		defer taskDeletionCtxCancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(
-			taskDeletionCtx,
-			f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace),
-			sc.Name,
-			controllerhelpers.WaitForStateOptions{},
-			repairTaskDeletedCond,
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Progressing conditions of the underlying ScyllaDBManagerTasks are not propagated to ScyllaClusters by the migration controller,
-		// neither does the controller await the deletion of ScyllaDBManagerTasks.
-		// Task deletion from ScyllaDB Manager state is asynchronous to ScyllaCluster state update.
-		e.managerStateVerificationHook(ctx, managerClient, managerClusterID)
-	},
-		g.Entry("when manager integration is disabled", repairTaskTableEntry{
-			taskDeletionHook: func(ctx context.Context, sc *scyllav1.ScyllaCluster) {
-				framework.By(`Annotating ScyllaCluster to disable ScyllaDB Manager integration`)
-				scCopy := sc.DeepCopy()
-				metav1.SetMetaDataAnnotation(&scCopy.ObjectMeta, naming.DisableGlobalScyllaDBManagerIntegrationAnnotation, naming.LabelValueTrue)
-
-				patch, err := controllerhelpers.GenerateMergePatch(sc, scCopy)
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace).Patch(
-					ctx,
-					sc.Name,
-					types.MergePatchType,
-					patch,
-					metav1.PatchOptions{},
-				)
-				o.Expect(err).NotTo(o.HaveOccurred())
-			},
-			managerStateVerificationHook: func(ctx context.Context, managerClient *managerclient.Client, managerClusterID string) {
-				framework.By("Verifying that the cluster was removed from the manager state")
-				scyllaDBManagerClusterDeletionCtx, scyllaDBManagerClusterDeletionCtxCancel := context.WithTimeoutCause(
-					ctx,
-					utils.ScyllaDBManagerClusterSyncTimeout,
-					fmt.Errorf("ScyllaCluster with manager cluster ID %q has not been deleted from ScyllaDB Manager state in time", managerClusterID),
-				)
-				defer scyllaDBManagerClusterDeletionCtxCancel()
-
-				o.Eventually(func(eo o.Gomega, ctx context.Context) {
-					_, err := managerClient.GetCluster(ctx, managerClusterID)
-					eo.Expect(err).To(o.HaveOccurred())
-					eo.Expect(err).To(o.Satisfy(managerclienterrors.IsNotFound))
-				}).
-					WithContext(scyllaDBManagerClusterDeletionCtx).
-					WithPolling(5 * time.Second).
-					Should(o.Succeed())
-			},
-		}),
-		g.Entry("when repair task is deleted", repairTaskTableEntry{
-			taskDeletionHook: func(ctx context.Context, sc *scyllav1.ScyllaCluster) {
-				framework.By("Deleting the repair task")
-				sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-					ctx,
-					sc.Name,
-					types.JSONPatchType,
-					[]byte(`[{"op":"remove","path":"/spec/repairs/0"}]`),
-					metav1.PatchOptions{},
-				)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(sc.Spec.Repairs).To(o.BeEmpty())
-			},
-			managerStateVerificationHook: func(ctx context.Context, managerClient *managerclient.Client, managerClusterID string) {
-				framework.By("Verifying that the repair task was removed from the manager state")
-				repairTaskDeletionCtx, repairTaskDeletionCtxCancel := context.WithTimeoutCause(
-					ctx,
-					utils.ScyllaDBManagerTaskSyncTimeout,
-					fmt.Errorf("repair task has not been deleted from ScyllaDB Manager state in time"),
-				)
-				defer repairTaskDeletionCtxCancel()
-
-				o.Eventually(func(eo o.Gomega, ctx context.Context) {
-					tasks, err := managerClient.ListTasks(ctx, managerClusterID, "repair", false, "", "")
-					eo.Expect(err).NotTo(o.HaveOccurred())
-					eo.Expect(tasks.TaskListItemSlice).To(o.BeEmpty())
-				}).
-					WithContext(repairTaskDeletionCtx).
-					WithPolling(5 * time.Second).
-					Should(o.Succeed())
-			},
-		}),
-	)
+			o.Eventually(verification.VerifyScyllaDBManagerRepairTaskCompleted).
+				WithContext(repairTaskSecondCompletionCtx).
+				WithPolling(5*time.Second).
+				WithArguments(managerClient, managerClusterID, updatedRepairTask.ID).
+				Should(o.Succeed())
+		})
+	})
 })

--- a/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
+++ b/test/e2e/set/scyllacluster/scyllamanager_object_storage.go
@@ -78,7 +78,7 @@ var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framew
 				Name: "backup",
 			},
 			Location:  []string{objectStorageLocation},
-			Retention: 2,
+			Retention: 1,
 		})
 
 		patchData, err := controllerhelpers.GenerateMergePatch(sourceSC, sourceSCCopy)
@@ -90,7 +90,7 @@ var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framew
 		o.Expect(sourceSC.Spec.Backups).To(o.HaveLen(1))
 		o.Expect(sourceSC.Spec.Backups[0].Name).To(o.Equal("backup"))
 		o.Expect(sourceSC.Spec.Backups[0].Location).To(o.Equal([]string{objectStorageLocation}))
-		o.Expect(sourceSC.Spec.Backups[0].Retention).To(o.Equal(int64(2)))
+		o.Expect(sourceSC.Spec.Backups[0].Retention).To(o.Equal(int64(1)))
 
 		framework.By("Waiting for source ScyllaCluster to sync backups with Scylla Manager")
 		backupTaskScheduledCond := func(cluster *scyllav1.ScyllaCluster) (bool, error) {
@@ -135,69 +135,6 @@ var _ = g.Describe("Scylla Manager integration", framework.SuiteParallel, framew
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(tasks.TaskListItemSlice).To(o.HaveLen(1))
 		backupTask := tasks.TaskListItemSlice[0]
-		o.Expect(backupTask.Name).To(o.Equal(sourceSC.Status.Backups[0].Name))
-		o.Expect(backupTask.ID).To(o.Equal(*sourceSC.Status.Backups[0].ID))
-		o.Expect(backupTask.Properties.(map[string]interface{})["location"]).To(o.ConsistOf(sourceSC.Status.Backups[0].Location))
-		o.Expect(backupTask.Properties.(map[string]interface{})["retention"].(json.Number).Int64()).To(o.Equal(*sourceSC.Status.Backups[0].Retention))
-
-		framework.By("Updating the backup task for ScyllaCluster")
-		sourceSC, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-			ctx,
-			sourceSC.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op":"replace","path":"/spec/backups/0/retention","value":1}]`),
-			metav1.PatchOptions{},
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sourceSC.Spec.Backups[0].Retention).To(o.Equal(int64(1)))
-
-		framework.By("Waiting for source ScyllaCluster to sync backup task update with Scylla Manager")
-		backupTaskUpdatedCond := func(cluster *scyllav1.ScyllaCluster) (bool, error) {
-			for _, b := range cluster.Status.Backups {
-				if b.Name == sourceSC.Spec.Backups[0].Name {
-					if b.ID == nil || len(*b.ID) == 0 {
-						return false, errors.New("got unexpected empty task ID in status")
-					}
-
-					if b.Error != nil {
-						return false, errors.New(*b.Error)
-					}
-
-					return b.Retention != nil && *b.Retention == int64(1), nil
-				}
-			}
-
-			return false, nil
-		}
-
-		taskUpdateCtx, taskUpdateCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("backup task %q update has not been reconciled in time", sourceSC.Spec.Backups[0].Name),
-		)
-		defer taskUpdateCtxCancel()
-
-		sourceSC, err = controllerhelpers.WaitForScyllaClusterState(
-			taskUpdateCtx,
-			f.ScyllaClient().ScyllaV1().ScyllaClusters(sourceSC.Namespace),
-			sourceSC.Name,
-			controllerhelpers.WaitForStateOptions{},
-			backupTaskUpdatedCond,
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		o.Expect(sourceSC.Status.Backups).To(o.HaveLen(1))
-		o.Expect(sourceSC.Status.Backups[0].Name).To(o.Equal(sourceSC.Spec.Backups[0].Name))
-		o.Expect(sourceSC.Status.Backups[0].Location).To(o.Equal(sourceSC.Spec.Backups[0].Location))
-		o.Expect(sourceSC.Status.Backups[0].Retention).NotTo(o.BeNil())
-		o.Expect(*sourceSC.Status.Backups[0].Retention).To(o.Equal(sourceSC.Spec.Backups[0].Retention))
-		o.Expect(sourceSC.Status.Repairs).To(o.BeEmpty())
-
-		framework.By("Verifying that updated backups task properties were synchronized")
-		tasks, err = managerClient.ListTasks(ctx, *sourceSC.Status.ManagerID, "backup", false, "", "")
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(tasks.TaskListItemSlice).To(o.HaveLen(1))
-		backupTask = tasks.TaskListItemSlice[0]
 		o.Expect(backupTask.Name).To(o.Equal(sourceSC.Status.Backups[0].Name))
 		o.Expect(backupTask.ID).To(o.Equal(*sourceSC.Status.Backups[0].ID))
 		o.Expect(backupTask.Properties.(map[string]interface{})["location"]).To(o.ConsistOf(sourceSC.Status.Backups[0].Location))

--- a/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
+++ b/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
@@ -27,15 +27,30 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	repairTaskInitialParallel = int64(1)
+	repairTaskUpdatedParallel = int64(2)
+)
+
 var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with global ScyllaDB Manager", framework.SuiteMultiDatacenterParallel, func() {
 	var f *framework.Framework
+
+	var (
+		nsClient         framework.Client
+		smt              *scyllav1alpha1.ScyllaDBManagerTask
+		managerClient    *managerclient.Client
+		managerClusterID string
+		managerTaskID    uuid.UUID
+		managerTask      *managerclient.Task
+	)
 
 	g.BeforeEach(func(ctx context.Context) {
 		f = framework.NewFramework(ctx, "scylladbmanagertask")
 	})
 
-	g.It("should synchronise a repair task", func(ctx g.SpecContext) {
-		ns, nsClient := f.CreateUserNamespace(ctx)
+	g.JustBeforeEach(func(ctx context.Context) {
+		ns, nc := f.CreateUserNamespace(ctx)
+		nsClient = nc
 
 		workerClusters := f.WorkerClusters()
 		o.Expect(workerClusters).NotTo(o.BeEmpty(), "At least 1 worker cluster is required")
@@ -69,9 +84,9 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 		o.Expect(allHosts).To(o.HaveLen(int(controllerhelpers.GetScyllaDBClusterNodeCount(sc))))
 
 		di := verification.InsertAndVerifyCQLDataByDC(ctx, hostsByDC)
-		defer di.Close()
+		g.DeferCleanup(di.Close)
 
-		smt := &scyllav1alpha1.ScyllaDBManagerTask{
+		smt = &scyllav1alpha1.ScyllaDBManagerTask{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "repair",
 				Namespace: ns.Name,
@@ -89,7 +104,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 							Duration: utils.ScyllaDBManagerTaskRetryWait,
 						},
 					},
-					Parallel: pointer.Ptr[int64](2),
+					Parallel: pointer.Ptr(repairTaskInitialParallel),
 				},
 			},
 		}
@@ -117,7 +132,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(smt.Status.TaskID).NotTo(o.BeNil())
 		o.Expect(*smt.Status.TaskID).NotTo(o.BeEmpty())
-		managerTaskID, err := uuid.Parse(*smt.Status.TaskID)
+		managerTaskID, err = uuid.Parse(*smt.Status.TaskID)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		smcrName, err := naming.ScyllaDBManagerClusterRegistrationNameForScyllaDBCluster(sc)
@@ -126,13 +141,13 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(smcr.Status.ClusterID).NotTo(o.BeNil())
 		o.Expect(*smcr.Status.ClusterID).NotTo(o.BeEmpty())
-		managerClusterID := *smcr.Status.ClusterID
+		managerClusterID = *smcr.Status.ClusterID
 
-		managerClient, err := utils.GetManagerClient(ctx, f.KubeAdminClient().CoreV1())
+		managerClient, err = utils.GetManagerClient(ctx, f.KubeAdminClient().CoreV1())
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Verifying that ScyllaDBManagerTask was registered with global ScyllaDB Manager")
-		managerTask, err := managerClient.GetTask(ctx, managerClusterID, managerclient.RepairTask, managerTaskID)
+		managerTask, err = managerClient.GetTask(ctx, managerClusterID, managerclient.RepairTask, managerTaskID)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(managerTask.Labels).NotTo(o.BeNil())
 		o.Expect(managerTask.Labels[naming.OwnerUIDLabel]).To(o.Equal(string(smt.UID)))
@@ -140,50 +155,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 		framework.By("Verifying that ScyllaDBManagerTask properties were propagated to ScyllaDB Manager state")
 		o.Expect(managerTask.Schedule).NotTo(o.BeNil())
 		o.Expect(managerTask.Schedule.NumRetries).To(o.Equal(*smt.Spec.Repair.NumRetries))
-		o.Expect(managerTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(*smt.Spec.Repair.Parallel))
-
-		framework.By("Updating the ScyllaDBManagerTask")
-		smt, err = nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name).Patch(
-			ctx,
-			smt.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op":"replace","path":"/spec/repair/parallel","value":1}]`),
-			metav1.PatchOptions{},
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(smt.Spec.Repair).NotTo(o.BeNil())
-		o.Expect(smt.Spec.Repair.Parallel).NotTo(o.BeNil())
-		o.Expect(*smt.Spec.Repair.Parallel).To(o.Equal(int64(1)))
-
-		framework.By("Waiting for ScyllaDBManagerTask update to propagate")
-		updateCtx, updateCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("ScyllaDBManagerTask %q update has not been reconciled in time", naming.ObjRef(smt)),
-		)
-		defer updateCtxCancel()
-
-		smt, err = controllerhelpers.WaitForScyllaDBManagerTaskState(
-			updateCtx,
-			nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name),
-			smt.Name,
-			controllerhelpers.WaitForStateOptions{},
-			utilsv1alpha1.IsScyllaDBManagerTaskRolledOut,
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		framework.By("Verifying that the ScyllaDBManagerTask update propagated to ScyllaDB Manager state")
-		updatePropagationCtx, updatePropagationCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("ScyllaDBManagerTask %q update has not propagated to global ScyllaDB Manager instance in time", naming.ObjRef(smt)),
-		)
-
-		defer updatePropagationCtxCancel()
-
-		managerTask, err = managerClient.GetTask(updatePropagationCtx, managerClusterID, managerclient.RepairTask, managerTaskID)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(managerTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(*smt.Spec.Repair.Parallel))
+		o.Expect(managerTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(repairTaskInitialParallel))
 
 		framework.By("Waiting for the repair task to finish")
 		repairTaskCompletionCtx, repairTaskCompletionCtxCancel := context.WithTimeoutCause(
@@ -198,9 +170,11 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, managerClusterID, managerTask.ID).
 			Should(o.Succeed())
+	})
 
+	g.It("should delete a repair task", func(ctx g.SpecContext) {
 		framework.By("Deleting ScyllaDBManagerTask")
-		err = nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name).Delete(
+		err := nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(smt.Namespace).Delete(
 			ctx,
 			smt.Name,
 			metav1.DeleteOptions{
@@ -239,5 +213,63 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 		o.Expect(slices.ContainsFunc(tasks.TaskListItemSlice, func(t *managerclient.TaskListItem) bool {
 			return t.ID == managerTaskID.String()
 		})).To(o.BeFalse())
+	})
+
+	g.It("should update repair task properties and complete with updated properties", func(ctx g.SpecContext) {
+		framework.By("Updating the ScyllaDBManagerTask")
+		updatedSmt, err := nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(smt.Namespace).Patch(
+			ctx,
+			smt.Name,
+			types.JSONPatchType,
+			[]byte(fmt.Sprintf(`[{"op":"replace","path":"/spec/repair/parallel","value":%d}]`, repairTaskUpdatedParallel)),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(updatedSmt.Spec.Repair).NotTo(o.BeNil())
+		o.Expect(updatedSmt.Spec.Repair.Parallel).NotTo(o.BeNil())
+		o.Expect(*updatedSmt.Spec.Repair.Parallel).To(o.Equal(repairTaskUpdatedParallel))
+
+		framework.By("Waiting for ScyllaDBManagerTask update to be reconciled")
+		updateCtx, updateCtxCancel := context.WithTimeoutCause(
+			ctx,
+			utils.ScyllaDBManagerTaskSyncTimeout,
+			fmt.Errorf("ScyllaDBManagerTask %q update has not been reconciled in time", naming.ObjRef(updatedSmt)),
+		)
+		defer updateCtxCancel()
+
+		updatedSmt, err = controllerhelpers.WaitForScyllaDBManagerTaskState(
+			updateCtx,
+			nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(updatedSmt.Namespace),
+			updatedSmt.Name,
+			controllerhelpers.WaitForStateOptions{},
+			utilsv1alpha1.IsScyllaDBManagerTaskRolledOut,
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Verifying that the ScyllaDBManagerTask update propagated to ScyllaDB Manager state")
+		updatePropagationCtx, updatePropagationCtxCancel := context.WithTimeoutCause(
+			ctx,
+			utils.ScyllaDBManagerTaskSyncTimeout,
+			fmt.Errorf("ScyllaDBManagerTask %q update has not propagated to global ScyllaDB Manager instance in time", naming.ObjRef(updatedSmt)),
+		)
+		defer updatePropagationCtxCancel()
+
+		updatedManagerTask, err := managerClient.GetTask(updatePropagationCtx, managerClusterID, managerclient.RepairTask, managerTaskID)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(updatedManagerTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(repairTaskUpdatedParallel))
+
+		framework.By("Waiting for repair with updated properties to finish")
+		repairTaskSecondCompletionCtx, repairTaskSecondCompletionCtxCancel := context.WithTimeoutCause(
+			ctx,
+			utils.ScyllaDBManagerMultiDatacenterTaskCompletionTimeout,
+			fmt.Errorf("repair task %q has not completed in time after property update", managerTaskID),
+		)
+		defer repairTaskSecondCompletionCtxCancel()
+
+		o.Eventually(verification.VerifyScyllaDBManagerRepairTaskCompleted).
+			WithContext(repairTaskSecondCompletionCtx).
+			WithPolling(5*time.Second).
+			WithArguments(managerClient, managerClusterID, updatedManagerTask.ID).
+			Should(o.Succeed())
 	})
 })

--- a/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager_object_storage.go
+++ b/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager_object_storage.go
@@ -26,7 +26,6 @@ import (
 	scylladbclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scylladbcluster"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -102,7 +101,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 						},
 					},
 					Location:  backupLocations,
-					Retention: pointer.Ptr[int64](2),
+					Retention: pointer.Ptr[int64](1),
 				},
 			},
 		}
@@ -154,48 +153,6 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 		o.Expect(managerTask.Schedule).NotTo(o.BeNil())
 		o.Expect(managerTask.Schedule.NumRetries).To(o.Equal(*smt.Spec.Backup.NumRetries))
 		o.Expect(managerTask.Properties.(map[string]interface{})["location"]).To(o.ConsistOf(smt.Spec.Backup.Location))
-		o.Expect(managerTask.Properties.(map[string]interface{})["retention"].(json.Number).Int64()).To(o.Equal(*smt.Spec.Backup.Retention))
-
-		framework.By("Updating the ScyllaDBManagerTask")
-		smt, err = nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name).Patch(
-			ctx,
-			smt.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op":"replace","path":"/spec/backup/retention","value":1}]`),
-			metav1.PatchOptions{},
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(smt.Spec.Backup).NotTo(o.BeNil())
-		o.Expect(smt.Spec.Backup.Retention).NotTo(o.BeNil())
-		o.Expect(*smt.Spec.Backup.Retention).To(o.Equal(int64(1)))
-
-		framework.By("Waiting for ScyllaDBManagerTask update to be reconciled")
-		updateCtx, updateCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("ScyllaDBManagerTask %q update has not been reconciled in time", naming.ObjRef(smt)),
-		)
-		defer updateCtxCancel()
-
-		smt, err = controllerhelpers.WaitForScyllaDBManagerTaskState(
-			updateCtx,
-			nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name),
-			smt.Name,
-			controllerhelpers.WaitForStateOptions{},
-			utilsv1alpha1.IsScyllaDBManagerTaskRolledOut,
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		framework.By("Verifying that the ScyllaDBManagerTask update propagated to ScyllaDB Manager state")
-		updatePropagationCtx, updatePropagationCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("ScyllaDBManagerTask %q update has not propagated to global ScyllaDB Manager instance in time", naming.ObjRef(smt)),
-		)
-		defer updatePropagationCtxCancel()
-
-		managerTask, err = managerClient.GetTask(updatePropagationCtx, sourceManagerClusterID, managerclient.BackupTask, managerTaskID)
-		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(managerTask.Properties.(map[string]interface{})["retention"].(json.Number).Int64()).To(o.Equal(*smt.Spec.Backup.Retention))
 
 		framework.By("Waiting for the backup task to finish")

--- a/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager.go
+++ b/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager.go
@@ -26,16 +26,31 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	repairTaskInitialParallel = int64(1)
+	repairTaskUpdatedParallel = int64(2)
+)
+
 var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with global ScyllaDB Manager", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
 	var f *framework.Framework
+
+	var (
+		nsClient         framework.Client
+		smt              *scyllav1alpha1.ScyllaDBManagerTask
+		managerClient    *managerclient.Client
+		managerClusterID string
+		managerTaskID    uuid.UUID
+		managerTask      *managerclient.Task
+	)
 
 	g.BeforeEach(func(ctx context.Context) {
 		f = framework.NewFramework(ctx, "scylladbmanagertask")
 	})
 
-	g.It("should synchronise a repair task", func(ctx g.SpecContext) {
-		ns, nsClient, ok := f.DefaultNamespaceIfAny()
+	g.JustBeforeEach(func(ctx context.Context) {
+		ns, nc, ok := f.DefaultNamespaceIfAny()
 		o.Expect(ok).To(o.BeTrue())
+		nsClient = nc
 
 		sdc := f.GetDefaultScyllaDBDatacenter()
 		metav1.SetMetaDataLabel(&sdc.ObjectMeta, naming.GlobalScyllaDBManagerRegistrationLabel, naming.LabelValueTrue)
@@ -57,9 +72,9 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(1))
 		di := verification.InsertAndVerifyCQLData(ctx, hosts)
-		defer di.Close()
+		g.DeferCleanup(di.Close)
 
-		smt := &scyllav1alpha1.ScyllaDBManagerTask{
+		smt = &scyllav1alpha1.ScyllaDBManagerTask{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "repair",
 				Namespace: ns.Name,
@@ -77,7 +92,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 							Duration: 30 * time.Second,
 						},
 					},
-					Parallel: pointer.Ptr[int64](2),
+					Parallel: pointer.Ptr(repairTaskInitialParallel),
 				},
 			},
 		}
@@ -109,7 +124,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(smt.Status.TaskID).NotTo(o.BeNil())
 		o.Expect(*smt.Status.TaskID).NotTo(o.BeEmpty())
-		managerTaskID, err := uuid.Parse(*smt.Status.TaskID)
+		managerTaskID, err = uuid.Parse(*smt.Status.TaskID)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		smcrName, err := naming.ScyllaDBManagerClusterRegistrationNameForScyllaDBDatacenter(sdc)
@@ -118,13 +133,13 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(smcr.Status.ClusterID).NotTo(o.BeNil())
 		o.Expect(*smcr.Status.ClusterID).NotTo(o.BeEmpty())
-		managerClusterID := *smcr.Status.ClusterID
+		managerClusterID = *smcr.Status.ClusterID
 
-		managerClient, err := utils.GetManagerClient(ctx, f.KubeAdminClient().CoreV1())
+		managerClient, err = utils.GetManagerClient(ctx, f.KubeAdminClient().CoreV1())
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Verifying that ScyllaDBManagerTask was registered with global ScyllaDB Manager")
-		managerTask, err := managerClient.GetTask(ctx, managerClusterID, managerclient.RepairTask, managerTaskID)
+		managerTask, err = managerClient.GetTask(ctx, managerClusterID, managerclient.RepairTask, managerTaskID)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(managerTask.Labels).NotTo(o.BeNil())
 		o.Expect(managerTask.Labels[naming.OwnerUIDLabel]).To(o.Equal(string(smt.UID)))
@@ -132,50 +147,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		framework.By("Verifying that ScyllaDBManagerTask properties were propagated to ScyllaDB Manager state")
 		o.Expect(managerTask.Schedule).NotTo(o.BeNil())
 		o.Expect(managerTask.Schedule.NumRetries).To(o.Equal(*smt.Spec.Repair.NumRetries))
-		o.Expect(managerTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(*smt.Spec.Repair.Parallel))
-
-		framework.By("Updating the ScyllaDBManagerTask")
-		smt, err = nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name).Patch(
-			ctx,
-			smt.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op":"replace","path":"/spec/repair/parallel","value":1}]`),
-			metav1.PatchOptions{},
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(smt.Spec.Repair).NotTo(o.BeNil())
-		o.Expect(smt.Spec.Repair.Parallel).NotTo(o.BeNil())
-		o.Expect(*smt.Spec.Repair.Parallel).To(o.Equal(int64(1)))
-
-		framework.By("Waiting for ScyllaDBManagerTask update to be reconciled")
-		updateCtx, updateCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("ScyllaDBManagerTask %q update has not been reconciled in time", naming.ObjRef(smt)),
-		)
-		defer updateCtxCancel()
-
-		smt, err = controllerhelpers.WaitForScyllaDBManagerTaskState(
-			updateCtx,
-			nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name),
-			smt.Name,
-			controllerhelpers.WaitForStateOptions{},
-			utilsv1alpha1.IsScyllaDBManagerTaskRolledOut,
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		framework.By("Verifying that the ScyllaDBManagerTask update propagated to ScyllaDB Manager state")
-		updatePropagationCtx, updatePropagationCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("ScyllaDBManagerTask %q update has not propagated to global ScyllaDB Manager instance in time", naming.ObjRef(smt)),
-		)
-
-		defer updatePropagationCtxCancel()
-
-		managerTask, err = managerClient.GetTask(updatePropagationCtx, managerClusterID, managerclient.RepairTask, managerTaskID)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(managerTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(*smt.Spec.Repair.Parallel))
+		o.Expect(managerTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(repairTaskInitialParallel))
 
 		framework.By("Waiting for the repair task to finish")
 		repairTaskCompletionCtx, repairTaskCompletionCtxCancel := context.WithTimeoutCause(
@@ -190,9 +162,11 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 			WithPolling(5*time.Second).
 			WithArguments(managerClient, managerClusterID, managerTask.ID).
 			Should(o.Succeed())
+	})
 
+	g.It("should delete a repair task", func(ctx g.SpecContext) {
 		framework.By("Deleting ScyllaDBManagerTask")
-		err = nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name).Delete(
+		err := nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(smt.Namespace).Delete(
 			ctx,
 			smt.Name,
 			metav1.DeleteOptions{
@@ -231,5 +205,63 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		o.Expect(slices.ContainsFunc(tasks.TaskListItemSlice, func(t *managerclient.TaskListItem) bool {
 			return t.ID == managerTaskID.String()
 		})).To(o.BeFalse())
+	})
+
+	g.It("should update repair task properties and complete with updated properties", func(ctx g.SpecContext) {
+		framework.By("Updating the ScyllaDBManagerTask")
+		updatedSmt, err := nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(smt.Namespace).Patch(
+			ctx,
+			smt.Name,
+			types.JSONPatchType,
+			[]byte(fmt.Sprintf(`[{"op":"replace","path":"/spec/repair/parallel","value":%d}]`, repairTaskUpdatedParallel)),
+			metav1.PatchOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(updatedSmt.Spec.Repair).NotTo(o.BeNil())
+		o.Expect(updatedSmt.Spec.Repair.Parallel).NotTo(o.BeNil())
+		o.Expect(*updatedSmt.Spec.Repair.Parallel).To(o.Equal(repairTaskUpdatedParallel))
+
+		framework.By("Waiting for ScyllaDBManagerTask update to be reconciled")
+		updateCtx, updateCtxCancel := context.WithTimeoutCause(
+			ctx,
+			utils.ScyllaDBManagerTaskSyncTimeout,
+			fmt.Errorf("ScyllaDBManagerTask %q update has not been reconciled in time", naming.ObjRef(updatedSmt)),
+		)
+		defer updateCtxCancel()
+
+		updatedSmt, err = controllerhelpers.WaitForScyllaDBManagerTaskState(
+			updateCtx,
+			nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(updatedSmt.Namespace),
+			updatedSmt.Name,
+			controllerhelpers.WaitForStateOptions{},
+			utilsv1alpha1.IsScyllaDBManagerTaskRolledOut,
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Verifying that the ScyllaDBManagerTask update propagated to ScyllaDB Manager state")
+		updatePropagationCtx, updatePropagationCtxCancel := context.WithTimeoutCause(
+			ctx,
+			utils.ScyllaDBManagerTaskSyncTimeout,
+			fmt.Errorf("ScyllaDBManagerTask %q update has not propagated to global ScyllaDB Manager instance in time", naming.ObjRef(updatedSmt)),
+		)
+		defer updatePropagationCtxCancel()
+
+		updatedManagerTask, err := managerClient.GetTask(updatePropagationCtx, managerClusterID, managerclient.RepairTask, managerTaskID)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(updatedManagerTask.Properties.(map[string]interface{})["parallel"].(json.Number).Int64()).To(o.Equal(repairTaskUpdatedParallel))
+
+		framework.By("Waiting for repair with updated properties to finish")
+		repairTaskCompletionCtx, repairTaskCompletionCtxCancel := context.WithTimeoutCause(
+			ctx,
+			utils.ScyllaDBManagerTaskCompletionTimeout,
+			fmt.Errorf("repair task %q has not completed in time after property update", managerTaskID),
+		)
+		defer repairTaskCompletionCtxCancel()
+
+		o.Eventually(verification.VerifyScyllaDBManagerRepairTaskCompleted).
+			WithContext(repairTaskCompletionCtx).
+			WithPolling(5*time.Second).
+			WithArguments(managerClient, managerClusterID, updatedManagerTask.ID).
+			Should(o.Succeed())
 	})
 })

--- a/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
+++ b/test/e2e/set/scylladbmanagertask/scylladbmanagertask_scylladbdatacenter_globalmanager_object_storage.go
@@ -25,7 +25,6 @@ import (
 	scylladbdatacenterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scylladbdatacenter"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -89,7 +88,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 					Location: []string{
 						utils.LocationForScyllaManager(objectStorageSettings),
 					},
-					Retention: pointer.Ptr[int64](2),
+					Retention: pointer.Ptr[int64](1),
 				},
 			},
 		}
@@ -145,48 +144,6 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBDatacenter integration with 
 		o.Expect(managerTask.Schedule).NotTo(o.BeNil())
 		o.Expect(managerTask.Schedule.NumRetries).To(o.Equal(*smt.Spec.Backup.NumRetries))
 		o.Expect(managerTask.Properties.(map[string]interface{})["location"]).To(o.ConsistOf(smt.Spec.Backup.Location))
-		o.Expect(managerTask.Properties.(map[string]interface{})["retention"].(json.Number).Int64()).To(o.Equal(*smt.Spec.Backup.Retention))
-
-		framework.By("Updating the ScyllaDBManagerTask")
-		smt, err = nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name).Patch(
-			ctx,
-			smt.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op":"replace","path":"/spec/backup/retention","value":1}]`),
-			metav1.PatchOptions{},
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(smt.Spec.Backup).NotTo(o.BeNil())
-		o.Expect(smt.Spec.Backup.Retention).NotTo(o.BeNil())
-		o.Expect(*smt.Spec.Backup.Retention).To(o.Equal(int64(1)))
-
-		framework.By("Waiting for ScyllaDBManagerTask update to be reconciled")
-		updateCtx, updateCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("ScyllaDBManagerTask %q update has not been reconciled in time", naming.ObjRef(smt)),
-		)
-		defer updateCtxCancel()
-
-		smt, err = controllerhelpers.WaitForScyllaDBManagerTaskState(
-			updateCtx,
-			nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBManagerTasks(ns.Name),
-			smt.Name,
-			controllerhelpers.WaitForStateOptions{},
-			utilsv1alpha1.IsScyllaDBManagerTaskRolledOut,
-		)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		framework.By("Verifying that the ScyllaDBManagerTask update propagated to ScyllaDB Manager state")
-		updatePropagationCtx, updatePropagationCtxCancel := context.WithTimeoutCause(
-			ctx,
-			utils.ScyllaDBManagerTaskSyncTimeout,
-			fmt.Errorf("ScyllaDBManagerTask %q update has not propagated to global ScyllaDB Manager instance in time", naming.ObjRef(smt)),
-		)
-		defer updatePropagationCtxCancel()
-
-		managerTask, err = managerClient.GetTask(updatePropagationCtx, sourceManagerClusterID, managerclient.BackupTask, managerTaskID)
-		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(managerTask.Properties.(map[string]interface{})["retention"].(json.Number).Int64()).To(o.Equal(*smt.Spec.Backup.Retention))
 
 		framework.By("Waiting for the backup task to finish")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
The e2e-gke-parallel check in #3461 failed on a Manager-related test. Ultimately, the failure is caused by scylladb/scylla-manager#4564: if a task fails and is scheduled for retry, a subsequent `PutTask` call - even one that doesn't change the schedule - cancels the pending retry. The task never reruns and the test times out waiting for completion. I couldn't identify the root cause of the initial task failure in a reasonable timeframe, but the investigation was sufficient to say it wasn't a regression from the integration perspective; the upstream bug is tracked in CLOUD-2276.

From an integration testing perspective, verifying that an update mid-run triggers a retry brings no value - it exercises a scylla-manager scheduler edge case rather than operator behaviour. I changed the workflow to: create task -> wait for completion -> update task -> wait for completion. That sequence sidesteps the race entirely.

As part of the same change I decoupled task update verification from task deletion. The tests for "delete repair task" and "disable manager integration" now live in a separate `DescribeTable`, independent of the update test. The same restructuring is applied to the `ScyllaDBManagerTask` single-DC and multi-DC suites, and the backup task update verification is removed from the object storage suite (the update path is covered by the repair task suite and the `ScyllaDBManagerTask` suites). The shared cluster setup (create, rollout, CQL data insertion, manager registration) is moved into `JustBeforeEach` so all sub-tests reuse it without duplication. 
These changes should make future flakes easier to isolate.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-140

/kind flake
/priority important-soon
/cc