### PR TITLE
chore(kind): enable nftables for kind suite

### DIFF
--- a/hack/kind/cluster-config.yaml
+++ b/hack/kind/cluster-config.yaml
@@ -6,6 +6,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   ipFamily: ipv4
+  kubeProxyMode: "nftables"
 nodes:
   - role: control-plane
     kubeadmConfigPatches:


### PR DESCRIPTION
**Description of your changes:**
Switch kind setup to use nftables instead of iptables

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-137

/kind machinery
/priority important-soon