### PR TITLE
test: introduce orphan assertions after cluster scale down

### DIFF
--- a/test/e2e/utils/verification/scyllacluster/verify.go
+++ b/test/e2e/utils/verification/scyllacluster/verify.go
@@ -338,6 +338,12 @@ func VerifyWithOptions(ctx context.Context, kubeClient kubernetes.Interface, scy
 
 	verifyPersistentVolumeClaims(ctx, kubeClient.CoreV1(), sc)
 
+	memberServiceList, err := kubeClient.CoreV1().Services(sc.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: utils.GetMemberServiceSelector(sc).String(),
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(memberServiceList.Items).To(o.HaveLen(memberCount), "expected exactly %d member services, got %d", memberCount, len(memberServiceList.Items))
+
 	clusterClient, hosts, err := utils.GetScyllaClient(ctx, kubeClient.CoreV1(), sc)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	defer clusterClient.Close()


### PR DESCRIPTION
**Description of your changes:**
- adds missing orphaned resource assertions (pods and services) to the scale down test
- migrates the missing part of former SCT's `test_orphaned_services_after_shrink_cluster`

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-156

/kind machinery
/priority important-soon