### PR TITLE
feat: switch to scylladb-node-exporter sidecar for ScyllaDB >=2026.3 

### DIFF
--- a/.opencode/skills/release-notes-generator/SKILL.md
+++ b/.opencode/skills/release-notes-generator/SKILL.md
@@ -28,12 +28,13 @@ Your release notes must be strictly limited to the following sections (omit a se
 * **Deprecations**: Mention deprecated features/functionalities and recommend alternatives.
 * **Features & Enhancements**: List brand-new features, or enhancements made to existing features or performance.
 * **Bug Fixes**: List fixed bugs, briefly describing the issue and the resolution.
+* **Other changes**: List user-facing behavior changes that do not fit features, bug fixes, deprecations, upgrade requirements, or dependency updates. Use this sparingly; prefer a more specific category when one applies.
 * **Dependencies**: List dependency updates and their new versions.
     * *High-Priority:* List user-facing/important dependencies first (e.g., Kubernetes client libraries, ScyllaDB client go mod dependencies, items in `assets/config/config.yaml`). Explain *why* it was updated and how it affects users.
     * *Low-Priority:* List minor bumps in a collapsible `<details><summary>Other dependencies updates</summary>...` block using a bulleted list, without detailed explanations (add only the PR link and the version change).
 
 **Important Constraints**:
-* Never add any other sections. If you encounter a change that does not fit into the above categories, list it separately in your agent response so we can discuss where it belongs before finalizing the notes.
+* Never add any sections other than the ones listed above. If you encounter a change that does not fit into the above categories, list it separately in your agent response so we can discuss where it belongs before finalizing the notes.
 * Updates to documentation should NOT be included in the release notes. If there are articles added or updated in the `docs/` that are relevant to other items in the release notes, you can link to those articles when describing the relevant item. Link to https://operator.docs.scylladb.com/ for general documentation references.
 
 ### List of dependencies that are not considered "user-facing/important" (not exhaustive):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ## Unreleased
 
+### Other changes
+
+- ScyllaDB Operator now runs `scylladb-node-exporter` as a dedicated sidecar container for ScyllaDB clusters running
+  version 2026.3 or later, since these versions no longer bundle node-exporter. The node-exporter container image is configurable via
+  `ScyllaOperatorConfig.spec.scyllaDBNodeExporterImage`.
+  [#3482](https://github.com/scylladb/scylla-operator/pull/3482)
+
 ## [1.21.0](https://github.com/scylladb/scylla-operator/releases/tag/v1.21.0)
 
 Release date: 2026-05-20

--- a/assets/config/config.go
+++ b/assets/config/config.go
@@ -20,6 +20,7 @@ var (
 type OperatorConfig struct {
 	ScyllaDBVersion                 string `json:"scyllaDBVersion"`
 	ScyllaDBUtilsImage              string `json:"scyllaDBUtilsImage"`
+	ScyllaDBNodeExporterImage       string `json:"scyllaDBNodeExporterImage"`
 	ScyllaDBManagerVersion          string `json:"scyllaDBManagerVersion"`
 	ScyllaDBManagerAgentVersion     string `json:"scyllaDBManagerAgentVersion"`
 	BashToolsImage                  string `json:"bashToolsImage"`

--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -2,6 +2,8 @@ operator:
   # renovate: datasource=docker depName=scylladb packageName=docker.io/scylladb/scylla versioning=semver
   scyllaDBVersion: "2026.2.1"
   scyllaDBUtilsImage: "docker.io/scylladb/scylla:2026.1.0@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a"
+  # FIXME: switch to scylladb-node-exporter image once https://scylladb.atlassian.net/browse/RELENG-711 is completed.
+  scyllaDBNodeExporterImage: "quay.io/prometheus/node-exporter:v1.11.1"
   # renovate: datasource=docker depName=scylla-manager packageName=docker.io/scylladb/scylla-manager versioning=semver
   scyllaDBManagerVersion: "3.11.2@sha256:61ec1396d438945abf3db46db893d7e4d2324acb5523d143077f8fdfea05779d"
   # renovate: datasource=docker depName=scylla-manager-agent packageName=docker.io/scylladb/scylla-manager-agent versioning=semver

--- a/assets/config/config_test.go
+++ b/assets/config/config_test.go
@@ -114,6 +114,14 @@ func TestProjectConfig(t *testing.T) {
 			),
 		},
 		{
+			name:        "scyllaDBNodeExporterImage",
+			configField: Project.Operator.ScyllaDBNodeExporterImage,
+			testFn: composeValidators(
+				validateRequired,
+				validateMultiPlatformImage(ctx),
+			),
+		},
+		{
 			name:        "scyllaDBManagerVersion",
 			configField: Project.Operator.ScyllaDBManagerVersion,
 			testFn: composeValidators(

--- a/bundle/manifests/scylla.scylladb.com_scyllaoperatorconfigs.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scyllaoperatorconfigs.yaml
@@ -48,6 +48,10 @@ spec:
                   Kubernetes cluster domain explicitly, instead of letting Scylla
                   Operator automatically discover it.
                 type: string
+              scyllaDBNodeExporterImage:
+                description: scyllaDBNodeExporterImage is the node-exporter image
+                  used by the operator to collect node metrics from ScyllaDB Pods.
+                type: string
               scyllaUtilsImage:
                 description: scyllaUtilsImage is a ScyllaDB image used for running
                   ScyllaDB utilities.
@@ -153,6 +157,10 @@ spec:
               prometheusVersion:
                 description: prometheusVersion is the Prometheus version used by the
                   operator to create a Prometheus instance.
+                type: string
+              scyllaDBNodeExporterImage:
+                description: scyllaDBNodeExporterImage is the node-exporter image
+                  used by the operator to collect node metrics from ScyllaDB Pods.
                 type: string
               scyllaDBUtilsImage:
                 description: scyllaDBUtilsImage is the ScyllaDB image used for running

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -48819,6 +48819,9 @@ spec:
                 configuredClusterDomain:
                   description: configuredClusterDomain allows users to set the configured Kubernetes cluster domain explicitly, instead of letting Scylla Operator automatically discover it.
                   type: string
+                scyllaDBNodeExporterImage:
+                  description: scyllaDBNodeExporterImage is the node-exporter image used by the operator to collect node metrics from ScyllaDB Pods.
+                  type: string
                 scyllaUtilsImage:
                   description: scyllaUtilsImage is a ScyllaDB image used for running ScyllaDB utilities.
                   type: string
@@ -48917,6 +48920,9 @@ spec:
                   type: integer
                 prometheusVersion:
                   description: prometheusVersion is the Prometheus version used by the operator to create a Prometheus instance.
+                  type: string
+                scyllaDBNodeExporterImage:
+                  description: scyllaDBNodeExporterImage is the node-exporter image used by the operator to collect node metrics from ScyllaDB Pods.
                   type: string
                 scyllaDBUtilsImage:
                   description: scyllaDBUtilsImage is the ScyllaDB image used for running ScyllaDB utilities.

--- a/docs/source/deploy-scylladb/before-you-deploy/configure-operator.md
+++ b/docs/source/deploy-scylladb/before-you-deploy/configure-operator.md
@@ -27,6 +27,7 @@ The `status` section shows the resolved values that are actually in use, includi
 ```yaml
 status:
   scyllaDBUtilsImage: docker.io/scylladb/scylla:2025.1.9@sha256:...
+  scyllaDBNodeExporterImage: quay.io/prometheus/node-exporter:v1.11.1
   bashToolsImage: registry.access.redhat.com/ubi9/ubi:9.5-...@sha256:...
   grafanaImage: docker.io/grafana/grafana:12.2.0@sha256:...
   prometheusVersion: v3.6.0
@@ -35,7 +36,7 @@ status:
 
 ## Configurable fields
 
-```{list-table}
+:::{list-table}
 :header-rows: 1
 
 * - Spec field
@@ -44,6 +45,9 @@ status:
 * - `scyllaUtilsImage`
   - ScyllaDB image used for running utility scripts (perftune, sysctl). Determines which tuning scripts are used for performance optimization.
   - Latest ScyllaDB image.
+* - `scyllaDBNodeExporterImage`
+  - `scylladb-node-exporter` image that ScyllaDB Operator runs as a sidecar to expose node-level OS metrics for ScyllaDB clusters. For versions before 2026.3.0, this field is ineffective because node-exporter is bundled and run directly within `scyllaDBImage`.
+  - Latest scylladb-node-exporter image.
 * - `configuredClusterDomain`
   - Kubernetes cluster domain. Must be a fully qualified domain name.
   - Auto-discovered via DNS lookup of `kubernetes.default.svc`.
@@ -56,7 +60,7 @@ status:
 * - `unsupportedPrometheusVersionOverride`
   - Override the Prometheus version. **Unsupported** — for advanced use only.
   - Latest tested Prometheus version.
-```
+:::
 
 :::{caution}
 Fields prefixed with `unsupported` are not covered by the regular support policy. Use them only if you have a specific reason and understand the implications.
@@ -103,16 +107,18 @@ The cluster domain is used internally for Kubernetes DNS resolution. Most users 
 
 ScyllaOperatorConfig settings are consumed by several Operator controllers:
 
-```{list-table}
+:::{list-table}
 :header-rows: 1
 
 * - Consumer
   - Setting used
 * - NodeConfig controller
   - `scyllaDBUtilsImage` — configures the tuning DaemonSet with the correct ScyllaDB image for `perftune.py` and resource limits.
+* - ScyllaDBDatacenter controller
+  - `scyllaDBNodeExporterImage` — configures the `scylladb-node-exporter` sidecar for ScyllaDB clusters running version 2026.3 or later.
 * - ScyllaDBMonitoring controller
   - `grafanaImage`, `prometheusVersion` — configures the monitoring stack.
-```
+:::
 
 Changes to `ScyllaOperatorConfig` trigger reconciliation in all dependent controllers. You do not need to restart Operator.
 

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scyllaoperatorconfigs.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scyllaoperatorconfigs.rst
@@ -78,6 +78,9 @@ object
    * - configuredClusterDomain
      - string
      - configuredClusterDomain allows users to set the configured Kubernetes cluster domain explicitly, instead of letting Scylla Operator automatically discover it.
+   * - scyllaDBNodeExporterImage
+     - string
+     - scyllaDBNodeExporterImage is the node-exporter image used by the operator to collect node metrics from ScyllaDB Pods.
    * - scyllaUtilsImage
      - string
      - scyllaUtilsImage is a ScyllaDB image used for running ScyllaDB utilities.
@@ -130,6 +133,9 @@ object
    * - prometheusVersion
      - string
      - prometheusVersion is the Prometheus version used by the operator to create a Prometheus instance.
+   * - scyllaDBNodeExporterImage
+     - string
+     - scyllaDBNodeExporterImage is the node-exporter image used by the operator to collect node metrics from ScyllaDB Pods.
    * - scyllaDBUtilsImage
      - string
      - scyllaDBUtilsImage is the ScyllaDB image used for running ScyllaDB utilities.

--- a/docs/source/understand/sidecar.md
+++ b/docs/source/understand/sidecar.md
@@ -35,41 +35,40 @@ A ScyllaDB pod contains init containers that run sequentially before the main wo
 
 ### Long-running containers
 
-```{list-table}
+:::{list-table}
 :header-rows: 1
 
-* - #
-  - Name
+* - Name
   - Image
   - Purpose
   - Conditional
-* - 1
-  - `scylla`
+* - `scylla`
   - ScyllaDB
   - The main container. Waits for the ignition signal, then execs the sidecar binary which configures and starts ScyllaDB.
   - Always present
-* - 2
-  - `scylladb-api-status-probe`
+* - `scylladb-api-status-probe`
   - Operator
   - Translates ScyllaDB's native HTTP API status into Kubernetes health-check endpoints (`/healthz`, `/readyz`) on port 8080.
   - Always present
-* - 3
-  - `scylladb-ignition`
+* - `scylladb-ignition`
   - Operator
   - Evaluates startup prerequisites (tuning done, IPs assigned, container running) and creates the ignition signal file when all are met. See [Ignition](ignition.md).
   - Always present
-* - 4
-  - `scylla-manager-agent`
+* - `scylla-manager-agent`
   - Manager Agent
   - Runs the ScyllaDB Manager Agent for backup, repair, and health-check operations. Waits for the ignition signal and for the ScyllaDB REST API to become available before starting.
-  - Only when Manager integration is configured
-```
+  - Always present
+* - `scylladb-node-exporter`
+  - ScyllaDB Node Exporter
+  - Exposes node-level OS metrics (CPU, disk, network) for Prometheus to scrape.
+  - Only when ScyllaDB version is ≥ 2026.3
+:::
 
 ## Shared volumes
 
 Containers coordinate through volumes mounted into the pod:
 
-```{list-table}
+:::{list-table}
 :header-rows: 1
 
 * - Volume
@@ -80,7 +79,7 @@ Containers coordinate through volumes mounted into the pod:
   - Carries the Operator binary (injected by init container 1) and the ignition signal file (`/mnt/shared/ignition.done`). Shared by all containers.
 * - Data PVC
   - `/var/lib/scylla`
-  - Persistent storage for ScyllaDB data files. Mounted read-write in the main container, read-only in the bootstrap barrier.
+  - Persistent storage for ScyllaDB data files. Mounted read-write in the main container, read-only in the bootstrap barrier and scylladb-node-exporter sidecars.
 * - Managed ScyllaDB config (ConfigMap)
   - `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/managed-config/scylladb-managed-config.yaml`
   - Operator-generated `scylla.yaml` with cluster name, snitch, TLS, and other managed settings.
@@ -93,7 +92,7 @@ Containers coordinate through volumes mounted into the pod:
 * - Agent auth token (Secret)
   - Agent config path
   - Manager Agent authentication token.
-```
+:::
 
 Additional TLS-related volumes (serving certificates, client CA, admin user credentials, Alternator certificates) are mounted when the `AutomaticTLSCertificates` feature gate is enabled or when Alternator is configured.
 

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scyllaoperatorconfigs.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scyllaoperatorconfigs.yaml
@@ -46,6 +46,9 @@ spec:
                 configuredClusterDomain:
                   description: configuredClusterDomain allows users to set the configured Kubernetes cluster domain explicitly, instead of letting Scylla Operator automatically discover it.
                   type: string
+                scyllaDBNodeExporterImage:
+                  description: scyllaDBNodeExporterImage is the node-exporter image used by the operator to collect node metrics from ScyllaDB Pods.
+                  type: string
                 scyllaUtilsImage:
                   description: scyllaUtilsImage is a ScyllaDB image used for running ScyllaDB utilities.
                   type: string
@@ -144,6 +147,9 @@ spec:
                   type: integer
                 prometheusVersion:
                   description: prometheusVersion is the Prometheus version used by the operator to create a Prometheus instance.
+                  type: string
+                scyllaDBNodeExporterImage:
+                  description: scyllaDBNodeExporterImage is the node-exporter image used by the operator to collect node metrics from ScyllaDB Pods.
                   type: string
                 scyllaDBUtilsImage:
                   description: scyllaDBUtilsImage is the ScyllaDB image used for running ScyllaDB utilities.

--- a/pkg/api/scylla/v1alpha1/types_operatorconfig.go
+++ b/pkg/api/scylla/v1alpha1/types_operatorconfig.go
@@ -29,6 +29,10 @@ type ScyllaOperatorConfigSpec struct {
 	// configuredClusterDomain allows users to set the configured Kubernetes cluster domain explicitly, instead of letting Scylla Operator automatically discover it.
 	// +optional
 	ConfiguredClusterDomain *string `json:"configuredClusterDomain,omitempty"`
+
+	// scyllaDBNodeExporterImage is the node-exporter image used by the operator to collect node metrics from ScyllaDB Pods.
+	// +optional
+	ScyllaDBNodeExporterImage *string `json:"scyllaDBNodeExporterImage,omitempty"`
 }
 
 type ScyllaOperatorConfigStatus struct {
@@ -58,6 +62,10 @@ type ScyllaOperatorConfigStatus struct {
 
 	// clusterDomain is the Kubernetes cluster domain used by the Scylla Operator.
 	ClusterDomain *string `json:"clusterDomain,omitempty"`
+
+	// scyllaDBNodeExporterImage is the node-exporter image used by the operator to collect node metrics from ScyllaDB Pods.
+	// +optional
+	ScyllaDBNodeExporterImage *string `json:"scyllaDBNodeExporterImage,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
@@ -2917,6 +2917,11 @@ func (in *ScyllaOperatorConfigSpec) DeepCopyInto(out *ScyllaOperatorConfigSpec) 
 		*out = new(string)
 		**out = **in
 	}
+	if in.ScyllaDBNodeExporterImage != nil {
+		in, out := &in.ScyllaDBNodeExporterImage, &out.ScyllaDBNodeExporterImage
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -2967,6 +2972,11 @@ func (in *ScyllaOperatorConfigStatus) DeepCopyInto(out *ScyllaOperatorConfigStat
 	}
 	if in.ClusterDomain != nil {
 		in, out := &in.ClusterDomain, &out.ClusterDomain
+		*out = new(string)
+		**out = **in
+	}
+	if in.ScyllaDBNodeExporterImage != nil {
+		in, out := &in.ScyllaDBNodeExporterImage, &out.ScyllaDBNodeExporterImage
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -340,6 +340,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		kubeInformers.Batch().V1().Jobs(),
 		scyllaInformers.Scylla().V1alpha1().ScyllaDBDatacenters(),
 		scyllaInformers.Scylla().V1alpha1().ScyllaDBDatacenterNodesStatusReports(),
+		scyllaOperatorConfigInformers.Scylla().V1alpha1().ScyllaOperatorConfigs(),
 		o.OperatorImage,
 		o.CQLSIngressPort,
 		keyGenerator,

--- a/pkg/controller/scylladbdatacenter/controller.go
+++ b/pkg/controller/scylladbdatacenter/controller.go
@@ -77,6 +77,7 @@ type Controller struct {
 	scyllaDBDatacenterLister                  scyllav1alpha1listers.ScyllaDBDatacenterLister
 	jobLister                                 batchv1listers.JobLister
 	scyllaDBDatacenterNodesStatusReportLister scyllav1alpha1listers.ScyllaDBDatacenterNodesStatusReportLister
+	scyllaOperatorConfigLister                scyllav1alpha1listers.ScyllaOperatorConfigLister
 
 	cachesToSync []cache.InformerSynced
 
@@ -103,6 +104,7 @@ func NewController(
 	jobInformer batchv1informers.JobInformer,
 	scyllaDBDatacenterInformer scyllav1alpha1informers.ScyllaDBDatacenterInformer,
 	scyllaDBDatacenterNodesStatusReportInformer scyllav1alpha1informers.ScyllaDBDatacenterNodesStatusReportInformer,
+	scyllaOperatorConfigInformer scyllav1alpha1informers.ScyllaOperatorConfigInformer,
 	operatorImage string,
 	cqlsIngressPort int,
 	keyGetter crypto.KeyGenerator,
@@ -130,6 +132,7 @@ func NewController(
 		scyllaDBDatacenterLister: scyllaDBDatacenterInformer.Lister(),
 		jobLister:                jobInformer.Lister(),
 		scyllaDBDatacenterNodesStatusReportLister: scyllaDBDatacenterNodesStatusReportInformer.Lister(),
+		scyllaOperatorConfigLister:                scyllaOperatorConfigInformer.Lister(),
 
 		cachesToSync: []cache.InformerSynced{
 			podInformer.Informer().HasSynced,
@@ -144,6 +147,7 @@ func NewController(
 			scyllaDBDatacenterInformer.Informer().HasSynced,
 			jobInformer.Informer().HasSynced,
 			scyllaDBDatacenterNodesStatusReportInformer.Informer().HasSynced,
+			scyllaOperatorConfigInformer.Informer().HasSynced,
 		},
 
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "scylladbdatacenter-controller"}),
@@ -250,6 +254,12 @@ func NewController(
 		AddFunc:    sdcc.addScyllaDBDatacenterNodesStatusReport,
 		UpdateFunc: sdcc.updateScyllaDBDatacenterNodesStatusReport,
 		DeleteFunc: sdcc.deleteScyllaDBDatacenterNodesStatusReport,
+	})
+
+	scyllaOperatorConfigInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    sdcc.addScyllaOperatorConfig,
+		UpdateFunc: sdcc.updateScyllaOperatorConfig,
+		DeleteFunc: sdcc.deleteScyllaOperatorConfig,
 	})
 
 	return sdcc, nil
@@ -676,5 +686,28 @@ func (sdcc *Controller) deleteScyllaDBDatacenterNodesStatusReport(obj interface{
 	sdcc.handlers.HandleDelete(
 		obj,
 		sdcc.handlers.EnqueueOwner,
+	)
+}
+
+func (sdcc *Controller) addScyllaOperatorConfig(obj interface{}) {
+	sdcc.handlers.HandleAdd(
+		obj.(*scyllav1alpha1.ScyllaOperatorConfig),
+		sdcc.handlers.EnqueueAll,
+	)
+}
+
+func (sdcc *Controller) updateScyllaOperatorConfig(old, cur interface{}) {
+	sdcc.handlers.HandleUpdate(
+		old.(*scyllav1alpha1.ScyllaOperatorConfig),
+		cur.(*scyllav1alpha1.ScyllaOperatorConfig),
+		sdcc.handlers.EnqueueAll,
+		sdcc.deleteScyllaOperatorConfig,
+	)
+}
+
+func (sdcc *Controller) deleteScyllaOperatorConfig(obj interface{}) {
+	sdcc.handlers.HandleDelete(
+		obj,
+		sdcc.handlers.EnqueueAll,
 	)
 }

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -65,6 +65,9 @@ const (
 	alternatorInsecurePortName = "alternator"
 	alternatorTLSPort          = 8043
 	alternatorTLSPortName      = "alternator-tls"
+
+	nodeExporterPort     = 9100
+	nodeExporterPortName = "node-exporter"
 )
 
 var (
@@ -283,8 +286,8 @@ func getServicePorts(sdc *scyllav1alpha1.ScyllaDBDatacenter) ([]corev1.ServicePo
 			Port: scylla.DefaultScyllaDBManagerAgentMetricsPort,
 		},
 		{
-			Name: "node-exporter",
-			Port: 9100,
+			Name: nodeExporterPortName,
+			Port: nodeExporterPort,
 		},
 		{
 			Name: portNameThrift,
@@ -334,7 +337,7 @@ func getServicePorts(sdc *scyllav1alpha1.ScyllaDBDatacenter) ([]corev1.ServicePo
 
 // StatefulSetForRack make a StatefulSet for the rack.
 // existingSts may be nil if it doesn't exist yet.
-func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.ScyllaDBDatacenter, existingSts *appsv1.StatefulSet, sidecarImage string, rackOrdinal int, inputsHash string) (*appsv1.StatefulSet, error) {
+func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.ScyllaDBDatacenter, existingSts *appsv1.StatefulSet, sidecarImage string, nodeExporterImage string, rackOrdinal int, inputsHash string) (*appsv1.StatefulSet, error) {
 	selectorLabels, err := naming.RackSelectorLabels(rack, sdc)
 	if err != nil {
 		return nil, fmt.Errorf("can't get selector labels: %w", err)
@@ -344,6 +347,7 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 	if err != nil {
 		return nil, fmt.Errorf("can't get version of image %q: %w", sdc.Spec.ScyllaDB.Image, err)
 	}
+	scyllaDBSemver := semver.NewScyllaVersion(scyllaDBVersion)
 
 	if sdc.Spec.RackTemplate != nil {
 		rack = applyRackTemplateOnRackSpec(sdc.Spec.RackTemplate, rack)
@@ -469,7 +473,7 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 		minReadySeconds = int(*sdc.Spec.MinReadySeconds)
 	}
 
-	scyllaContainerPorts, err := containerPorts(sdc)
+	scyllaContainerPorts, err := containerPorts(sdc, scyllaDBSemver)
 	if err != nil {
 		return nil, fmt.Errorf("can't get scylla container ports: %w", err)
 	}
@@ -1109,10 +1113,14 @@ wait
 		sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, *agentContainer)
 	}
 
+	if nodeExporterContainer := getScyllaDBNodeExporterContainer(nodeExporterImage, scyllaDBSemver); nodeExporterContainer != nil {
+		sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, *nodeExporterContainer)
+	}
+
 	return sts, nil
 }
 
-func containerPorts(sdc *scyllav1alpha1.ScyllaDBDatacenter) ([]corev1.ContainerPort, error) {
+func containerPorts(sdc *scyllav1alpha1.ScyllaDBDatacenter, sv semver.ScyllaVersion) ([]corev1.ContainerPort, error) {
 	ports := []corev1.ContainerPort{
 		{
 			Name:          "intra-node",
@@ -1139,13 +1147,16 @@ func containerPorts(sdc *scyllav1alpha1.ScyllaDBDatacenter) ([]corev1.ContainerP
 			ContainerPort: scylla.DefaultScyllaDBMetricsPort,
 		},
 		{
-			Name:          "node-exporter",
-			ContainerPort: 9100,
-		},
-		{
 			Name:          "thrift",
 			ContainerPort: 9160,
 		},
+	}
+
+	if !sv.SupportFeatureSafe(semver.ScyllaDBVersionWithoutNodeExporter) {
+		ports = append(ports, corev1.ContainerPort{
+			Name:          nodeExporterPortName,
+			ContainerPort: nodeExporterPort,
+		})
 	}
 
 	if sdc.Spec.ScyllaDB.AlternatorOptions != nil {
@@ -1459,6 +1470,48 @@ exec scylla-manager-agent \
 	}
 
 	return cnt, nil
+}
+
+func getScyllaDBNodeExporterContainer(image string, sv semver.ScyllaVersion) *corev1.Container {
+	if !sv.SupportFeatureSafe(semver.ScyllaDBVersionWithoutNodeExporter) {
+		return nil
+	}
+
+	return &corev1.Container{
+		Name:            naming.ScyllaDBNodeExporterContainerName,
+		Image:           image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          nodeExporterPortName,
+				ContainerPort: nodeExporterPort,
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: apimachineryutilintstr.FromInt32(nodeExporterPort),
+				},
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      naming.PVCTemplateName,
+				MountPath: naming.DataDir,
+				ReadOnly:  true,
+			},
+		},
+	}
 }
 
 func MakePodDisruptionBudget(sdc *scyllav1alpha1.ScyllaDBDatacenter) *policyv1.PodDisruptionBudget {

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -699,7 +699,7 @@ func runTestStatefulSetForRack(t *testing.T) {
 			"scylla/cluster":                        "basic",
 			"scylla/datacenter":                     "dc",
 			"scylla/rack":                           "rack",
-			"scylla/scylla-version":                 "latest",
+			"scylla/scylla-version":                 unit.ScyllaDBImageTag,
 			"scylla/rack-ordinal":                   fmt.Sprintf("%d", ordinal),
 			"scylla-operator.scylladb.com/pod-type": "scylladb-node",
 		}
@@ -870,7 +870,7 @@ func runTestStatefulSetForRack(t *testing.T) {
 								{
 									Name:            "sidecar-injection",
 									ImagePullPolicy: "IfNotPresent",
-									Image:           "scylladb/scylla-operator:latest",
+									Image:           unit.ScyllaDBOperatorImage,
 									Command: []string{
 										"/bin/sh",
 										"-c",
@@ -1173,7 +1173,7 @@ wait`),
 							},
 							{
 								Name:            "scylladb-api-status-probe",
-								Image:           "scylladb/scylla-operator:latest",
+								Image:           unit.ScyllaDBOperatorImage,
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Command: []string{
 									"/usr/bin/scylla-operator",
@@ -1217,7 +1217,7 @@ wait`),
 							},
 							{
 								Name:            "scylladb-ignition",
-								Image:           "scylladb/scylla-operator:latest",
+								Image:           unit.ScyllaDBOperatorImage,
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Command: []string{
 									"/usr/bin/scylla-operator",
@@ -1710,9 +1710,9 @@ exec scylla-manager-agent \
 					"scylla/cluster":                        "basic",
 					"scylla/datacenter":                     "dc",
 					"scylla/rack":                           "rack",
-					"scylla/rack-ordinal":                   "0",
-					"scylla/scylla-version":                 "latest",
-					"scylla-operator.scylladb.com/pod-type": "scylladb-node",
+				"scylla/rack-ordinal":                   "0",
+				"scylla/scylla-version":                 unit.ScyllaDBImageTag,
+				"scylla-operator.scylladb.com/pod-type": "scylladb-node",
 				}
 
 				return sts
@@ -1890,16 +1890,16 @@ exec scylla-manager-agent \
 			rack: newBasicRack(),
 			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newBasicScyllaDBDatacenter()
-				sdc.Spec.ScyllaDB.Image = "scylla/scylla:2025.1.0"
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageBelowBootstrapSynchronisationThreshold
 				return sdc
 			}(),
 			existingStatefulSet: nil,
 			expectedStatefulSet: func() *appsv1.StatefulSet {
 				sts := newBasicStatefulSet()
 
-				sts.Labels["scylla/scylla-version"] = "2025.1.0"
-				sts.Spec.Template.Labels["scylla/scylla-version"] = "2025.1.0"
-				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Image = "scylla/scylla:2025.1.0"
+			sts.Labels["scylla/scylla-version"] = unit.ScyllaDBImageBelowBootstrapSynchronisationThresholdTag
+			sts.Spec.Template.Labels["scylla/scylla-version"] = unit.ScyllaDBImageBelowBootstrapSynchronisationThresholdTag
+			sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Image = unit.ScyllaDBImageBelowBootstrapSynchronisationThreshold
 
 				if utilfeature.DefaultMutableFeatureGate.Enabled(features.BootstrapSynchronisation) {
 					sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers[:runBootstrapBarrierInitContainerIndex],
@@ -2046,7 +2046,7 @@ exec scylla-manager-agent \
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := StatefulSetForRack(tc.rack, tc.scyllaDBDatacenter, tc.existingStatefulSet, "scylladb/scylla-operator:latest", 0, "")
+			got, err := StatefulSetForRack(tc.rack, tc.scyllaDBDatacenter, tc.existingStatefulSet, unit.ScyllaDBOperatorImage, 0, "")
 
 			if !reflect.DeepEqual(err, tc.expectedError) {
 				t.Fatalf("expected and actual errors differ: %s",
@@ -3075,7 +3075,7 @@ func TestMakeJobs(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:            naming.CleanupContainerName,
-										Image:           "scylladb/scylla-operator:latest",
+										Image:           unit.ScyllaDBOperatorImage,
 										ImagePullPolicy: corev1.PullIfNotPresent,
 										Args: []string{
 											"cleanup-job",
@@ -3344,7 +3344,7 @@ func TestMakeJobs(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:            naming.CleanupContainerName,
-										Image:           "scylladb/scylla-operator:latest",
+										Image:           unit.ScyllaDBOperatorImage,
 										ImagePullPolicy: corev1.PullIfNotPresent,
 										Args: []string{
 											"cleanup-job",
@@ -3473,7 +3473,7 @@ func TestMakeJobs(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:            naming.CleanupContainerName,
-										Image:           "scylladb/scylla-operator:latest",
+										Image:           unit.ScyllaDBOperatorImage,
 										ImagePullPolicy: corev1.PullIfNotPresent,
 										Args: []string{
 											"cleanup-job",
@@ -3582,7 +3582,7 @@ func TestMakeJobs(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:            naming.CleanupContainerName,
-										Image:           "scylladb/scylla-operator:latest",
+										Image:           unit.ScyllaDBOperatorImage,
 										ImagePullPolicy: corev1.PullIfNotPresent,
 										Args: []string{
 											"cleanup-job",
@@ -3700,7 +3700,7 @@ func TestMakeJobs(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:            naming.CleanupContainerName,
-										Image:           "scylladb/scylla-operator:latest",
+										Image:           unit.ScyllaDBOperatorImage,
 										ImagePullPolicy: corev1.PullIfNotPresent,
 										Args: []string{
 											"cleanup-job",
@@ -3818,7 +3818,7 @@ func TestMakeJobs(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:            naming.CleanupContainerName,
-										Image:           "scylladb/scylla-operator:latest",
+										Image:           unit.ScyllaDBOperatorImage,
 										ImagePullPolicy: corev1.PullIfNotPresent,
 										Args: []string{
 											"cleanup-job",
@@ -3914,7 +3914,7 @@ func TestMakeJobs(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:            naming.CleanupContainerName,
-										Image:           "scylladb/scylla-operator:latest",
+										Image:           unit.ScyllaDBOperatorImage,
 										ImagePullPolicy: corev1.PullIfNotPresent,
 										Args: []string{
 											"cleanup-job",
@@ -3964,7 +3964,7 @@ func TestMakeJobs(t *testing.T) {
 
 			podLister := corev1listers.NewPodLister(podCache)
 
-			gotJobs, gotConditions, err := MakeJobs(tc.scyllaDBDatacenter, tc.services, podLister, "scylladb/scylla-operator:latest")
+			gotJobs, gotConditions, err := MakeJobs(tc.scyllaDBDatacenter, tc.services, podLister, unit.ScyllaDBOperatorImage)
 			if err != nil {
 				t.Errorf("expected nil err, got: %v", err)
 			}

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -133,8 +133,8 @@ func TestMemberService(t *testing.T) {
 			Port: 5090,
 		},
 		{
-			Name: "node-exporter",
-			Port: 9100,
+			Name: nodeExporterPortName,
+			Port: nodeExporterPort,
 		},
 		{
 			Name: "thrift",
@@ -980,12 +980,12 @@ func runTestStatefulSetForRack(t *testing.T) {
 										ContainerPort: 9180,
 									},
 									{
-										Name:          "node-exporter",
-										ContainerPort: 9100,
-									},
-									{
 										Name:          "thrift",
 										ContainerPort: 9160,
+									},
+									{
+										Name:          nodeExporterPortName,
+										ContainerPort: nodeExporterPort,
 									},
 								},
 								Command: func() []string {
@@ -1710,9 +1710,9 @@ exec scylla-manager-agent \
 					"scylla/cluster":                        "basic",
 					"scylla/datacenter":                     "dc",
 					"scylla/rack":                           "rack",
-				"scylla/rack-ordinal":                   "0",
-				"scylla/scylla-version":                 unit.ScyllaDBImageTag,
-				"scylla-operator.scylladb.com/pod-type": "scylladb-node",
+					"scylla/rack-ordinal":                   "0",
+					"scylla/scylla-version":                 unit.ScyllaDBImageTag,
+					"scylla-operator.scylladb.com/pod-type": "scylladb-node",
 				}
 
 				return sts
@@ -1897,9 +1897,9 @@ exec scylla-manager-agent \
 			expectedStatefulSet: func() *appsv1.StatefulSet {
 				sts := newBasicStatefulSet()
 
-			sts.Labels["scylla/scylla-version"] = unit.ScyllaDBImageBelowBootstrapSynchronisationThresholdTag
-			sts.Spec.Template.Labels["scylla/scylla-version"] = unit.ScyllaDBImageBelowBootstrapSynchronisationThresholdTag
-			sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Image = unit.ScyllaDBImageBelowBootstrapSynchronisationThreshold
+				sts.Labels["scylla/scylla-version"] = unit.ScyllaDBImageBelowBootstrapSynchronisationThresholdTag
+				sts.Spec.Template.Labels["scylla/scylla-version"] = unit.ScyllaDBImageBelowBootstrapSynchronisationThresholdTag
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Image = unit.ScyllaDBImageBelowBootstrapSynchronisationThreshold
 
 				if utilfeature.DefaultMutableFeatureGate.Enabled(features.BootstrapSynchronisation) {
 					sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers[:runBootstrapBarrierInitContainerIndex],
@@ -2040,13 +2040,102 @@ exec scylla-manager-agent \
 			}(),
 			expectedError: nil,
 		},
+		{
+			name: "new StatefulSet with ScyllaDB version requiring node-exporter sidecar",
+			rack: newBasicRack(),
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newBasicScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAboveNodeExporterThreshold
+				return sdc
+			}(),
+			existingStatefulSet: nil,
+			expectedStatefulSet: func() *appsv1.StatefulSet {
+				sts := newBasicStatefulSet()
+
+				sts.Labels["scylla/scylla-version"] = unit.ScyllaDBImageAboveNodeExporterThresholdTag
+				sts.Spec.Template.Labels["scylla/scylla-version"] = unit.ScyllaDBImageAboveNodeExporterThresholdTag
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Image = unit.ScyllaDBImageAboveNodeExporterThreshold
+
+				if utilfeature.DefaultMutableFeatureGate.Enabled(features.BootstrapSynchronisation) {
+					sts.Spec.Template.Spec.InitContainers[runBootstrapBarrierInitContainerIndex].Image = unit.ScyllaDBImageAboveNodeExporterThreshold
+				}
+
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Ports = slices.DeleteFunc(
+					sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Ports,
+					func(p corev1.ContainerPort) bool { return p.Name == nodeExporterPortName },
+				)
+
+				sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, corev1.Container{
+					Name:            naming.ScyllaDBNodeExporterContainerName,
+					Image:           unit.ScyllaDBNodeExporterImage,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          nodeExporterPortName,
+							ContainerPort: nodeExporterPort,
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Port: apimachineryutilintstr.FromInt32(nodeExporterPort),
+							},
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      naming.PVCTemplateName,
+							MountPath: naming.DataDir,
+							ReadOnly:  true,
+						},
+					},
+				})
+
+				return sts
+			}(),
+			expectedError: nil,
+		},
+		{
+			name: "new StatefulSet with ScyllaDB version below node-exporter threshold",
+			rack: newBasicRack(),
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newBasicScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageBelowNodeExporterThreshold
+				return sdc
+			}(),
+			existingStatefulSet: nil,
+			expectedStatefulSet: func() *appsv1.StatefulSet {
+				sts := newBasicStatefulSet()
+
+				sts.Labels["scylla/scylla-version"] = unit.ScyllaDBImageBelowNodeExporterThresholdTag
+				sts.Spec.Template.Labels["scylla/scylla-version"] = unit.ScyllaDBImageBelowNodeExporterThresholdTag
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Image = unit.ScyllaDBImageBelowNodeExporterThreshold
+
+				if utilfeature.DefaultMutableFeatureGate.Enabled(features.BootstrapSynchronisation) {
+					sts.Spec.Template.Spec.InitContainers[runBootstrapBarrierInitContainerIndex].Image = unit.ScyllaDBImageBelowNodeExporterThreshold
+				}
+
+				return sts
+			}(),
+			expectedError: nil,
+		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := StatefulSetForRack(tc.rack, tc.scyllaDBDatacenter, tc.existingStatefulSet, unit.ScyllaDBOperatorImage, 0, "")
+			got, err := StatefulSetForRack(tc.rack, tc.scyllaDBDatacenter, tc.existingStatefulSet, unit.ScyllaDBOperatorImage, unit.ScyllaDBNodeExporterImage, 0, "")
 
 			if !reflect.DeepEqual(err, tc.expectedError) {
 				t.Fatalf("expected and actual errors differ: %s",
@@ -2835,7 +2924,7 @@ func TestIdentityService(t *testing.T) {
 				{Name: "agent-api", Port: 10001},
 				{Name: "prometheus", Port: 9180},
 				{Name: "agent-prometheus", Port: 5090},
-				{Name: "node-exporter", Port: 9100},
+				{Name: nodeExporterPortName, Port: nodeExporterPort},
 				{Name: "thrift", Port: 9160},
 			},
 		},

--- a/pkg/controller/scylladbdatacenter/sync.go
+++ b/pkg/controller/scylladbdatacenter/sync.go
@@ -44,6 +44,11 @@ func (sdcc *Controller) sync(ctx context.Context, key string) error {
 		return err
 	}
 
+	soc, err := sdcc.scyllaOperatorConfigLister.Get(naming.SingletonName)
+	if err != nil {
+		return fmt.Errorf("can't get ScyllaOperatorConfig %q: %w", naming.SingletonName, err)
+	}
+
 	sdcSelector := labels.SelectorFromSet(labels.Set{
 		naming.ClusterNameLabel: sdc.Name,
 	})
@@ -295,7 +300,7 @@ func (sdcc *Controller) sync(ctx context.Context, key string) error {
 		statefulSetControllerDegradedCondition,
 		sdc.Generation,
 		func() ([]metav1.Condition, error) {
-			return sdcc.syncStatefulSets(ctx, key, sdc, status, statefulSetMap, serviceMap, configMapMap)
+			return sdcc.syncStatefulSets(ctx, key, sdc, soc, status, statefulSetMap, serviceMap, configMapMap)
 		},
 	)
 	if err != nil {

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -38,11 +38,11 @@ func snapshotTag(prefix string, t time.Time) string {
 	return fmt.Sprintf("so_%s_%sUTC", prefix, t.UTC().Format(time.RFC3339))
 }
 
-func (sdcc *Controller) makeRacks(sdc *scyllav1alpha1.ScyllaDBDatacenter, statefulSets map[string]*appsv1.StatefulSet, inputsHash string) ([]*appsv1.StatefulSet, error) {
+func (sdcc *Controller) makeRacks(sdc *scyllav1alpha1.ScyllaDBDatacenter, statefulSets map[string]*appsv1.StatefulSet, nodeExporterImage string, inputsHash string) ([]*appsv1.StatefulSet, error) {
 	sets := make([]*appsv1.StatefulSet, 0, len(sdc.Spec.Racks))
 	for i, rack := range sdc.Spec.Racks {
 		oldSts := statefulSets[naming.StatefulSetNameForRack(rack, sdc)]
-		sts, err := StatefulSetForRack(rack, sdc, oldSts, sdcc.operatorImage, i, inputsHash)
+		sts, err := StatefulSetForRack(rack, sdc, oldSts, sdcc.operatorImage, nodeExporterImage, i, inputsHash)
 		if err != nil {
 			return nil, err
 		}
@@ -474,6 +474,7 @@ func (sdcc *Controller) syncStatefulSets(
 	ctx context.Context,
 	key string,
 	sdc *scyllav1alpha1.ScyllaDBDatacenter,
+	soc *scyllav1alpha1.ScyllaOperatorConfig,
 	status *scyllav1alpha1.ScyllaDBDatacenterStatus,
 	statefulSets map[string]*appsv1.StatefulSet,
 	services map[string]*corev1.Service,
@@ -481,6 +482,18 @@ func (sdcc *Controller) syncStatefulSets(
 ) ([]metav1.Condition, error) {
 	var err error
 	var progressingConditions []metav1.Condition
+
+	if soc.Status.ScyllaDBNodeExporterImage == nil {
+		progressingConditions = append(progressingConditions, metav1.Condition{
+			Type:               statefulSetControllerProgressingCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "WaitingForScyllaDBNodeExporterImage",
+			Message:            "Waiting for ScyllaOperatorConfig to have scylladb-node-exporter image available in the status.",
+			ObservedGeneration: sdc.Generation,
+		})
+		return progressingConditions, nil
+	}
+	nodeExporterImage := *soc.Status.ScyllaDBNodeExporterImage
 
 	managedScyllaDBConfigCMName := naming.GetScyllaDBManagedConfigCMName(sdc.Name)
 	managedScyllaDBConfigCM, found := configMaps[managedScyllaDBConfigCMName]
@@ -501,7 +514,7 @@ func (sdcc *Controller) syncStatefulSets(
 		return progressingConditions, fmt.Errorf("can't hash inputs: %w", err)
 	}
 
-	requiredStatefulSets, err := sdcc.makeRacks(sdc, statefulSets, inputsHash)
+	requiredStatefulSets, err := sdcc.makeRacks(sdc, statefulSets, nodeExporterImage, inputsHash)
 	if err != nil {
 		sdcc.eventRecorder.Eventf(
 			sdc,

--- a/pkg/controller/scyllaoperatorconfig/status.go
+++ b/pkg/controller/scyllaoperatorconfig/status.go
@@ -5,7 +5,6 @@ import (
 
 	configassests "github.com/scylladb/scylla-operator/assets/config"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
-	"github.com/scylladb/scylla-operator/pkg/pointer"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -36,30 +35,36 @@ func (opc *Controller) updateStatus(ctx context.Context, currentSOC *scyllav1alp
 // If a particular object can be missing, it should be reflected in the value itself, like "Unknown" or "".
 func (opc *Controller) calculateStatus(soc *scyllav1alpha1.ScyllaOperatorConfig) *scyllav1alpha1.ScyllaOperatorConfigStatus {
 	status := soc.Status.DeepCopy()
-	status.ObservedGeneration = pointer.Ptr(soc.Generation)
+	status.ObservedGeneration = new(soc.Generation)
 
 	if len(soc.Spec.ScyllaUtilsImage) != 0 {
-		status.ScyllaDBUtilsImage = pointer.Ptr(soc.Spec.ScyllaUtilsImage)
+		status.ScyllaDBUtilsImage = new(soc.Spec.ScyllaUtilsImage)
 	} else {
-		status.ScyllaDBUtilsImage = pointer.Ptr(configassests.Project.Operator.ScyllaDBUtilsImage)
+		status.ScyllaDBUtilsImage = new(configassests.Project.Operator.ScyllaDBUtilsImage)
 	}
 
 	if soc.Spec.UnsupportedBashToolsImageOverride != nil {
-		status.BashToolsImage = pointer.Ptr(*soc.Spec.UnsupportedBashToolsImageOverride)
+		status.BashToolsImage = new(*soc.Spec.UnsupportedBashToolsImageOverride)
 	} else {
-		status.BashToolsImage = pointer.Ptr(configassests.Project.Operator.BashToolsImage)
+		status.BashToolsImage = new(configassests.Project.Operator.BashToolsImage)
 	}
 
 	if soc.Spec.UnsupportedGrafanaImageOverride != nil {
-		status.GrafanaImage = pointer.Ptr(*soc.Spec.UnsupportedGrafanaImageOverride)
+		status.GrafanaImage = new(*soc.Spec.UnsupportedGrafanaImageOverride)
 	} else {
-		status.GrafanaImage = pointer.Ptr(configassests.Project.Operator.GrafanaImage)
+		status.GrafanaImage = new(configassests.Project.Operator.GrafanaImage)
 	}
 
 	if soc.Spec.UnsupportedPrometheusVersionOverride != nil {
-		status.PrometheusVersion = pointer.Ptr(*soc.Spec.UnsupportedPrometheusVersionOverride)
+		status.PrometheusVersion = new(*soc.Spec.UnsupportedPrometheusVersionOverride)
 	} else {
-		status.PrometheusVersion = pointer.Ptr(configassests.Project.Operator.PrometheusVersion)
+		status.PrometheusVersion = new(configassests.Project.Operator.PrometheusVersion)
+	}
+
+	if soc.Spec.ScyllaDBNodeExporterImage != nil {
+		status.ScyllaDBNodeExporterImage = new(*soc.Spec.ScyllaDBNodeExporterImage)
+	} else {
+		status.ScyllaDBNodeExporterImage = new(configassests.Project.Operator.ScyllaDBNodeExporterImage)
 	}
 
 	return status

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -146,14 +146,15 @@ const (
 
 // Configuration Values
 const (
-	ScyllaContainerName             = "scylla"
-	ScyllaDBIgnitionContainerName   = "scylladb-ignition"
-	ScyllaManagerAgentContainerName = "scylla-manager-agent"
-	SidecarInjectorContainerName    = "sidecar-injection"
-	PerftuneContainerName           = "perftune"
-	SysctlsContainerName            = "sysctls"
-	CleanupContainerName            = "cleanup"
-	RLimitsContainerName            = "rlimits"
+	ScyllaContainerName               = "scylla"
+	ScyllaDBIgnitionContainerName     = "scylladb-ignition"
+	ScyllaManagerAgentContainerName   = "scylla-manager-agent"
+	ScyllaDBNodeExporterContainerName = "scylladb-node-exporter"
+	SidecarInjectorContainerName      = "sidecar-injection"
+	PerftuneContainerName             = "perftune"
+	SysctlsContainerName              = "sysctls"
+	CleanupContainerName              = "cleanup"
+	RLimitsContainerName              = "rlimits"
 
 	PVCTemplateName = "data"
 

--- a/pkg/semver/version.go
+++ b/pkg/semver/version.go
@@ -23,6 +23,10 @@ import (
 var (
 	ScyllaVersionThatSupportsDisablingWritebackCache   = semver.MustParse("2021.0.0")
 	ScyllaDBVersionRequiredForBootstrapSynchronisation = semver.MustParse("2025.2.0")
+	// ScyllaDBVersionWithoutNodeExporter is "2026.3.0-0", not "2026.3.0": per semver precedence a pre-release
+	// version is always lower than the same version without one, so a plain "2026.3.0" threshold would reject
+	// pre-GA nightly builds that already ship without node-exporter.
+	ScyllaDBVersionWithoutNodeExporter = semver.MustParse("2026.3.0-0")
 )
 
 // ScyllaVersion contains the version of a cluster with unkown version support

--- a/pkg/test/unit/const.go
+++ b/pkg/test/unit/const.go
@@ -6,4 +6,9 @@ const (
 	ScyllaDBImageRepository = "scylladb/scylla"
 	ScyllaDBImageTag        = "latest"
 	ScyllaDBImage           = ScyllaDBImageRepository + ":" + ScyllaDBImageTag
+
+	ScyllaDBOperatorImage = "scylladb/scylla-operator:latest"
+
+	ScyllaDBImageBelowBootstrapSynchronisationThresholdTag = "2025.1.0"
+	ScyllaDBImageBelowBootstrapSynchronisationThreshold    = ScyllaDBImageRepository + ":" + ScyllaDBImageBelowBootstrapSynchronisationThresholdTag
 )

--- a/pkg/test/unit/const.go
+++ b/pkg/test/unit/const.go
@@ -9,6 +9,14 @@ const (
 
 	ScyllaDBOperatorImage = "scylladb/scylla-operator:latest"
 
+	ScyllaDBNodeExporterImage = "scylladb/scylladb-node-exporter:latest"
+
 	ScyllaDBImageBelowBootstrapSynchronisationThresholdTag = "2025.1.0"
 	ScyllaDBImageBelowBootstrapSynchronisationThreshold    = ScyllaDBImageRepository + ":" + ScyllaDBImageBelowBootstrapSynchronisationThresholdTag
+
+	ScyllaDBImageBelowNodeExporterThresholdTag = "2026.2.0"
+	ScyllaDBImageBelowNodeExporterThreshold    = ScyllaDBImageRepository + ":" + ScyllaDBImageBelowNodeExporterThresholdTag
+
+	ScyllaDBImageAboveNodeExporterThresholdTag = "2026.3.0"
+	ScyllaDBImageAboveNodeExporterThreshold    = ScyllaDBImageRepository + ":" + ScyllaDBImageAboveNodeExporterThresholdTag
 )


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Starting with ScyllaDB 2026.3, supervisord no longer launches the internal scylladb-node-exporter process within the ScyllaDB container. It silently breaks cluster monitoring and alert routing in the operator, as Prometheus can no longer scrape node metrics from port 9100 on the ScyllaDB container.

To restore monitoring parity for ScyllaDB >=2026.3, this PR adds an operator-managed scylladb-node-exporter  sidecar container.
The changes follow the design proposed in the RFC: https://scylladb.atlassian.net/browse/OPERATOR-200.

Sidecar injection is behind `ScyllaDBVersionWithoutNodeExporter` semver gate. If the target cluster version is lower, the operator exposes port 9100 on the main container as before. For versions 2026.3 and newer, the operator appends a separate scylladb-node-exporter container.
The sidecar mounts the `/var/lib/scylla` persistent volume as read-only. This grants the exporter access to the mount path so it can track local disk usage and capacity metrics.

`scyllaDBNodeExporterImage` field is added to `ScyllaOperatorConfig`. This allows operators to override the exporter image cluster-wide while falling back to a default defined in the operator assets.
This PR configures it with the upstream image in place of the scylladb-node-exporter as the container image is not being built yet. The switch is tracked in https://scylladb.atlassian.net/browse/OPERATOR-219.

This PR only extends the existing documentation with information about the new sidecar and config options.
Documenting the inconsistencies in node-exporter metric collection is tracked in https://scylladb.atlassian.net/browse/OPERATOR-218.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-130.

/cc 