### PR TITLE
feat(manager): start agent after scylla API is ready

### DIFF
--- a/docs/source/understand/ignition.md
+++ b/docs/source/understand/ignition.md
@@ -19,7 +19,7 @@ Ignition uses a simple file-based signal on the shared emptyDir volume mounted a
 1. The `scylladb-ignition` sidecar container runs the ignition controller, which continuously evaluates prerequisites.
 2. When **all** prerequisites are met, the controller creates the file `/mnt/shared/ignition.done`.
 3. The `scylla` container's entrypoint polls for this file in a shell loop. Once the file appears, it execs into the sidecar binary that configures and starts ScyllaDB.
-4. The ScyllaDB Manager Agent container (when present) uses the same wait loop, ensuring the agent does not start before ScyllaDB is configured.
+4. The ScyllaDB Manager Agent container (when present) uses the same wait loop for ignition, and additionally polls the ScyllaDB REST API (port 10000) to wait for ScyllaDB to finish IO tuning and become available before starting.
 
 ## Prerequisites evaluated
 

--- a/docs/source/understand/manager.md
+++ b/docs/source/understand/manager.md
@@ -24,7 +24,7 @@ The Agent communicates with Manager to execute operations on the local node (str
 
 The Agent:
 - Listens on port 10001.
-- Waits for [ignition](ignition.md) before starting — it does not run until ScyllaDB itself is ready.
+- Waits for [ignition](ignition.md) and for the ScyllaDB REST API (port 10000) to become available before starting — this covers the gap between ignition completing and ScyllaDB finishing IO tuning on first boot.
 - Is configured through layered YAML config files and an auth token that the Operator manages automatically.
 - Uses the image specified by the `agentVersion` and `agentRepository` fields on the `ScyllaCluster` spec.
 

--- a/docs/source/understand/sidecar.md
+++ b/docs/source/understand/sidecar.md
@@ -21,7 +21,7 @@ A ScyllaDB pod contains init containers that run sequentially before the main wo
 | 1 | `scylla` | ScyllaDB | The main container. Waits for the ignition signal, then execs the sidecar binary which configures and starts ScyllaDB. | Always present |
 | 2 | `scylladb-api-status-probe` | Operator | Translates ScyllaDB's native HTTP API status into Kubernetes health-check endpoints (`/healthz`, `/readyz`) on port 8080. | Always present |
 | 3 | `scylladb-ignition` | Operator | Evaluates startup prerequisites (tuning done, IPs assigned, container running) and creates the ignition signal file when all are met. See [Ignition](ignition.md). | Always present |
-| 4 | `scylla-manager-agent` | Manager Agent | Runs the ScyllaDB Manager Agent for backup, repair, and health-check operations. Waits for the ignition signal before starting. | Only when Manager integration is configured |
+| 4 | `scylla-manager-agent` | Manager Agent | Runs the ScyllaDB Manager Agent for backup, repair, and health-check operations. Waits for the ignition signal and for the ScyllaDB REST API to become available before starting. | Only when Manager integration is configured |
 
 ## Shared volumes
 
@@ -45,7 +45,7 @@ The `/mnt/shared/ignition.done` file is the coordination point between the ignit
 1. The `scylla` container's entrypoint loops, sleeping until the file appears.
 2. The `scylladb-ignition` container evaluates prerequisites and creates the file when all conditions are satisfied.
 3. On container termination, the `scylla` container's shutdown trap removes the file so that on restart the ignition sidecar must re-evaluate.
-4. The Manager Agent container uses the same wait loop before starting the agent process.
+4. The Manager Agent container uses the same wait loop, and additionally polls the ScyllaDB REST API (port 10000) to ensure ScyllaDB has finished IO tuning and is accepting connections before starting the agent process.
 
 This mechanism ensures that ScyllaDB never starts before node-level tuning is complete and network addresses are assigned. See [Ignition](ignition.md) for the full list of prerequisites.
 

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -1371,7 +1371,7 @@ func getScyllaDBManagerAgentContainer(r scyllav1alpha1.RackSpec, sdc *scyllav1al
 		Name:            naming.ScyllaManagerAgentContainerName,
 		Image:           *sdc.Spec.ScyllaDBManagerAgent.Image,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		// There is no point in starting scylla-manager before ScyllaDB is tuned and ignited. The manager agent fails after 60 attempts and hits backoff unnecessarily.
+		// There is no point in starting ScyllaDB Manager Agent before ScyllaDB is ignited and tuned. The manager agent fails after 60 attempts and hits backoff unnecessarily.
 		Command: []string{
 			"/usr/bin/bash",
 			"-euEo",
@@ -1387,7 +1387,13 @@ until [[ -f "/mnt/shared/ignition.done" ]]; do
   sleep 1 &
   wait
 done
-printf '{"L":"INFO","T":"%s","M":"Ignited. Starting ScyllaDB Manager Agent"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
+printf '{"L":"INFO","T":"%s","M":"Ignited. Waiting for ScyllaDB API to become available"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
+
+until curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "" "http://localhost:` + strconv.Itoa(naming.ScyllaAPIPort) + `/"; do
+  sleep 1 &
+  wait
+done
+printf '{"L":"INFO","T":"%s","M":"ScyllaDB API is available. Starting ScyllaDB Manager Agent"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
 
 exec scylla-manager-agent \
 -c ` + fmt.Sprintf("%q ", naming.ScyllaAgentConfigDefaultFile) + `\

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1284,7 +1285,13 @@ until [[ -f "/mnt/shared/ignition.done" ]]; do
   sleep 1 &
   wait
 done
-printf '{"L":"INFO","T":"%s","M":"Ignited. Starting ScyllaDB Manager Agent"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
+printf '{"L":"INFO","T":"%s","M":"Ignited. Waiting for ScyllaDB API to become available"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
+
+until curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "" "http://localhost:` + strconv.Itoa(naming.ScyllaAPIPort) + `/"; do
+  sleep 1 &
+  wait
+done
+printf '{"L":"INFO","T":"%s","M":"ScyllaDB API is available. Starting ScyllaDB Manager Agent"}\n' "$( date -u '+%Y-%m-%dT%H:%M:%S,%3NZ' )" > /dev/stderr
 
 exec scylla-manager-agent \
 -c "/etc/scylla-manager-agent/scylla-manager-agent.yaml" \


### PR DESCRIPTION
**Description of your changes:**
- make SM agent wait until after ScyllaDB API to become available
- adjust the test accordingly

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-199
