### PR TITLE
docs: switch standard syntax docs' tables to list-table directives

### DIFF
--- a/docs/source/connect-your-app/alternator.md
+++ b/docs/source/connect-your-app/alternator.md
@@ -20,12 +20,25 @@ This enables the Alternator API with HTTPS on port `8043` and authorization enab
 
 ### Configuration options
 
-| Field | Description | Default |
-|-------|-------------|---------|
-| `writeIsolation` | Write isolation level for Alternator operations. | `""` (ScyllaDB default) |
-| `insecureEnableHTTP` | Also serve Alternator on the unencrypted HTTP port. | `false` |
-| `insecureDisableAuthorization` | Disable Alternator authorization. | `false` |
-| `servingCertificate.type` | TLS certificate configuration (`OperatorManaged` or `UserManaged`). | `OperatorManaged` |
+```{list-table}
+:header-rows: 1
+
+* - Field
+  - Description
+  - Default
+* - `writeIsolation`
+  - Write isolation level for Alternator operations.
+  - `""` (ScyllaDB default)
+* - `insecureEnableHTTP`
+  - Also serve Alternator on the unencrypted HTTP port.
+  - `false`
+* - `insecureDisableAuthorization`
+  - Disable Alternator authorization.
+  - `false`
+* - `servingCertificate.type`
+  - TLS certificate configuration (`OperatorManaged` or `UserManaged`).
+  - `OperatorManaged`
+```
 
 :::{note}
 Unlike CQL clients, Alternator clients do not need to connect to every ScyllaDB node directly or discover individual node IP addresses. The Alternator protocol is HTTP-based, so you can also expose it through an Ingress or other HTTP networking concepts.
@@ -103,9 +116,16 @@ TABLENAMES      SeaMonsters
 
 The Operator creates these resources for Alternator:
 
-| Resource | Name | Contents |
-|----------|------|----------|
-| Serving CA | `configmap/<cluster-name>-alternator-local-serving-ca` | `ca-bundle.crt` — CA to validate Alternator HTTPS. |
+```{list-table}
+:header-rows: 1
+
+* - Resource
+  - Name
+  - Contents
+* - Serving CA
+  - `configmap/<cluster-name>-alternator-local-serving-ca`
+  - `ca-bundle.crt` — CA to validate Alternator HTTPS.
+```
 
 ### Troubleshoot
 
@@ -116,10 +136,16 @@ The Operator creates these resources for Alternator:
 
 When using Alternator with a multi-datacenter ScyllaDB deployment (multiple `ScyllaCluster` resources connected via `externalSeeds`), the following constraints apply:
 
-| Limitation | Detail |
-|---|---|
-| No built-in cross-DC routing | Alternator endpoints are per-datacenter. There is no built-in load balancer that routes DynamoDB API requests across datacenters. Connect your application to the Alternator endpoint in the datacenter closest to it. |
-| Authentication tokens are DC-local | Each `ScyllaCluster` has its own Alternator authentication credentials. If you require the same credentials across DCs, you must configure the same `alternatorWriteIsolation` and authentication settings on each cluster independently. |
+```{list-table}
+:header-rows: 1
+
+* - Limitation
+  - Detail
+* - No built-in cross-DC routing
+  - Alternator endpoints are per-datacenter. There is no built-in load balancer that routes DynamoDB API requests across datacenters. Connect your application to the Alternator endpoint in the datacenter closest to it.
+* - Authentication tokens are DC-local
+  - Each `ScyllaCluster` has its own Alternator authentication credentials. If you require the same credentials across DCs, you must configure the same `alternatorWriteIsolation` and authentication settings on each cluster independently.
+```
 
 ## Related pages
 

--- a/docs/source/connect-your-app/connect-via-cql.md
+++ b/docs/source/connect-your-app/connect-via-cql.md
@@ -149,13 +149,28 @@ docker run -it --rm --entrypoint=cqlsh \
 
 When using a ScyllaDB or Cassandra driver in your application:
 
-| Setting | Recommended value | Why |
-|---------|-------------------|-----|
-| Contact points | `<cluster-name>-client.<namespace>.svc` (DNS) or the Service ClusterIP | Use the discovery Service, not individual Pod IPs. The driver discovers all nodes automatically. |
-| Local datacenter | Your `datacenter.name` value (e.g., `us-east-1`) | Required for `DCAwareRoundRobinPolicy`. Prevents cross-DC queries. |
-| Load balancing | Token-aware + DC-aware round robin | Sends queries directly to the replica owning the partition. |
-| TLS | Enabled, with CA verification | Use the serving CA from `configmap/<cluster-name>-local-serving-ca`. |
-| Reconnection | Exponential backoff | Handles node restarts during rolling updates. |
+```{list-table}
+:header-rows: 1
+
+* - Setting
+  - Recommended value
+  - Why
+* - Contact points
+  - `<cluster-name>-client.<namespace>.svc` (DNS) or the Service ClusterIP
+  - Use the discovery Service, not individual Pod IPs. The driver discovers all nodes automatically.
+* - Local datacenter
+  - Your `datacenter.name` value (e.g., `us-east-1`)
+  - Required for `DCAwareRoundRobinPolicy`. Prevents cross-DC queries.
+* - Load balancing
+  - Token-aware + DC-aware round robin
+  - Sends queries directly to the replica owning the partition.
+* - TLS
+  - Enabled, with CA verification
+  - Use the serving CA from `configmap/<cluster-name>-local-serving-ca`.
+* - Reconnection
+  - Exponential backoff
+  - Handles node restarts during rolling updates.
+```
 
 ## Related pages
 

--- a/docs/source/deploy-scylladb/before-you-deploy/configure-cpu-pinning.md
+++ b/docs/source/deploy-scylladb/before-you-deploy/configure-cpu-pinning.md
@@ -16,11 +16,18 @@ CPU pinning ensures:
 
 CPU pinning requires three things to work together:
 
-| Requirement | Who configures it |
-|-------------|-------------------|
-| Kubelet static CPU manager policy | Platform administrator (node pool configuration) |
-| Guaranteed QoS class on the ScyllaDB Pod | `ScyllaCluster` author |
-| Performance tuning enabled in `NodeConfig` | `NodeConfig` author (enabled by default) |
+```{list-table}
+:header-rows: 1
+
+* - Requirement
+  - Who configures it
+* - Kubelet static CPU manager policy
+  - Platform administrator (node pool configuration)
+* - Guaranteed QoS class on the ScyllaDB Pod
+  - `ScyllaCluster` author
+* - Performance tuning enabled in `NodeConfig`
+  - `NodeConfig` author (enabled by default)
+```
 
 If any of these is missing, CPU pinning silently does not apply.
 

--- a/docs/source/deploy-scylladb/before-you-deploy/configure-operator.md
+++ b/docs/source/deploy-scylladb/before-you-deploy/configure-operator.md
@@ -35,13 +35,28 @@ status:
 
 ## Configurable fields
 
-| Spec field | Description | Default |
-|------------|-------------|---------|
-| `scyllaUtilsImage` | ScyllaDB image used for running utility scripts (perftune, sysctl). Determines which tuning scripts are used for performance optimization. | Latest ScyllaDB image. |
-| `configuredClusterDomain` | Kubernetes cluster domain. Must be a fully qualified domain name. | Auto-discovered via DNS lookup of `kubernetes.default.svc`. |
-| `unsupportedBashToolsImageOverride` | Override the Bash tools image. **Unsupported** — for advanced use only. | UBI 9 image. |
-| `unsupportedGrafanaImageOverride` | Override the Grafana image. **Unsupported** — for advanced use only. | Official Grafana image. |
-| `unsupportedPrometheusVersionOverride` | Override the Prometheus version. **Unsupported** — for advanced use only. | Latest tested Prometheus version. |
+```{list-table}
+:header-rows: 1
+
+* - Spec field
+  - Description
+  - Default
+* - `scyllaUtilsImage`
+  - ScyllaDB image used for running utility scripts (perftune, sysctl). Determines which tuning scripts are used for performance optimization.
+  - Latest ScyllaDB image.
+* - `configuredClusterDomain`
+  - Kubernetes cluster domain. Must be a fully qualified domain name.
+  - Auto-discovered via DNS lookup of `kubernetes.default.svc`.
+* - `unsupportedBashToolsImageOverride`
+  - Override the Bash tools image. **Unsupported** — for advanced use only.
+  - UBI 9 image.
+* - `unsupportedGrafanaImageOverride`
+  - Override the Grafana image. **Unsupported** — for advanced use only.
+  - Official Grafana image.
+* - `unsupportedPrometheusVersionOverride`
+  - Override the Prometheus version. **Unsupported** — for advanced use only.
+  - Latest tested Prometheus version.
+```
 
 :::{caution}
 Fields prefixed with `unsupported` are not covered by the regular support policy. Use them only if you have a specific reason and understand the implications.
@@ -88,10 +103,16 @@ The cluster domain is used internally for Kubernetes DNS resolution. Most users 
 
 ScyllaOperatorConfig settings are consumed by several Operator controllers:
 
-| Consumer | Setting used |
-|----------|-------------|
-| NodeConfig controller | `scyllaDBUtilsImage` — configures the tuning DaemonSet with the correct ScyllaDB image for `perftune.py` and resource limits. |
-| ScyllaDBMonitoring controller | `grafanaImage`, `prometheusVersion` — configures the monitoring stack. |
+```{list-table}
+:header-rows: 1
+
+* - Consumer
+  - Setting used
+* - NodeConfig controller
+  - `scyllaDBUtilsImage` — configures the tuning DaemonSet with the correct ScyllaDB image for `perftune.py` and resource limits.
+* - ScyllaDBMonitoring controller
+  - `grafanaImage`, `prometheusVersion` — configures the monitoring stack.
+```
 
 Changes to `ScyllaOperatorConfig` trigger reconciliation in all dependent controllers. You do not need to restart Operator.
 

--- a/docs/source/deploy-scylladb/production-checklist.md
+++ b/docs/source/deploy-scylladb/production-checklist.md
@@ -8,19 +8,58 @@ Work through this checklist after your cluster is deployed and functional. Each 
 
 ## Checklist
 
-| # | Item | Expected state | Guide |
-|---|------|----------------|-------|
-| 1 | **NodeConfig deployed** | A `NodeConfig` resource is applied and `Available=True` in each cluster running ScyllaDB. NodeConfig configures disk setup, kernel parameters, and performance tuning — without it, ScyllaDB runs on untuned nodes with default kernel settings. | [Node configuration](before-you-deploy/configure-nodes.md) |
-| 2 | **Dedicated node pool** | ScyllaDB runs on isolated nodes with label `scylla.scylladb.com/node-type=scylla` and taint `scylla-operator.scylladb.com/dedicated=scyllaclusters:NoSchedule`. No other workloads are scheduled on these nodes. | [Set up dedicated node pools](before-you-deploy/set-up-dedicated-node-pools.md) |
-| 3 | **Performance tuning co-located** | NodeConfig `placement` targets the same nodes as the ScyllaCluster placement. Both use the same label selector and toleration. If they target different node sets, tuning does not apply to ScyllaDB pods. | [Set up dedicated node pools](before-you-deploy/set-up-dedicated-node-pools.md) |
-| 4 | **`fs.nr_open` set** | The sysctl `fs.nr_open` is set to a high value (e.g., `1073741816`) via NodeConfig. This defines the ceiling for `RLIMIT_NOFILE`, which ScyllaDB Operator raises on each ScyllaDB process. Without it, ScyllaDB may fail to open files under heavy load. | [Configure nodes](before-you-deploy/configure-nodes.md) |
-| 5 | **Coredumps enabled** | `systemd-coredump` is configured on the host with sufficient backing storage. Coredumps are essential for diagnosing crashes. | [Coredumps](../troubleshoot/configure-coredumps.md) |
-| 6 | **Monitoring deployed** | A `ScyllaDBMonitoring` resource is created with Prometheus scraping ScyllaDB metrics and Grafana displaying dashboards. Alerts are configured for key failure modes. | [Set up monitoring](set-up-monitoring/index.md) |
-| 7 | **Resource requests and limits set** | Both `resources` (ScyllaDB container) and `agentResources` (Manager Agent sidecar) have explicit requests and limits. ScyllaDB derives its memory allocation from the container memory limit. Ensure values match your instance type and workload. | [Deploy your first cluster](deploy-your-first-cluster.md) |
-| 8 | **CPU pinning active** | The kubelet uses `cpuManagerPolicy: static`. The ScyllaDB pod has Guaranteed QoS class (requests equal limits for all containers). ScyllaDB starts with `--overprovisioned=0`. | [Configure CPU pinning](before-you-deploy/configure-cpu-pinning.md) |
-| 9 | **XFS online discard enabled** | The `discard` mount option is set on ScyllaDB data volumes via NodeConfig's `unsupportedOptions`. This enables SSD TRIM for consistent write performance. | [Configure nodes](before-you-deploy/configure-nodes.md) |
-| 10 | **I/O properties configured** | Precomputed I/O properties are set to avoid the automatic I/O benchmark that runs on first boot, which can produce inconsistent results in cloud environments. | [Configure precomputed IO properties](../operate/configure-io-properties.md) |
-| 11 | **Backups scheduled** | ScyllaDB Manager backup tasks are configured with object storage (S3, GCS, or Azure Blob) and appropriate IAM credentials. Backup schedules are tested with a restore drill. | [Back up and restore](../operate/back-up-and-restore.md) |
+```{list-table}
+:header-rows: 1
+
+* - #
+  - Item
+  - Expected state
+  - Guide
+* - 1
+  - **NodeConfig deployed**
+  - A `NodeConfig` resource is applied and `Available=True` in each cluster running ScyllaDB. NodeConfig configures disk setup, kernel parameters, and performance tuning — without it, ScyllaDB runs on untuned nodes with default kernel settings.
+  - [Node configuration](before-you-deploy/configure-nodes.md)
+* - 2
+  - **Dedicated node pool**
+  - ScyllaDB runs on isolated nodes with label `scylla.scylladb.com/node-type=scylla` and taint `scylla-operator.scylladb.com/dedicated=scyllaclusters:NoSchedule`. No other workloads are scheduled on these nodes.
+  - [Set up dedicated node pools](before-you-deploy/set-up-dedicated-node-pools.md)
+* - 3
+  - **Performance tuning co-located**
+  - NodeConfig `placement` targets the same nodes as the ScyllaCluster placement. Both use the same label selector and toleration. If they target different node sets, tuning does not apply to ScyllaDB pods.
+  - [Set up dedicated node pools](before-you-deploy/set-up-dedicated-node-pools.md)
+* - 4
+  - **`fs.nr_open` set**
+  - The sysctl `fs.nr_open` is set to a high value (e.g., `1073741816`) via NodeConfig. This defines the ceiling for `RLIMIT_NOFILE`, which ScyllaDB Operator raises on each ScyllaDB process. Without it, ScyllaDB may fail to open files under heavy load.
+  - [Configure nodes](before-you-deploy/configure-nodes.md)
+* - 5
+  - **Coredumps enabled**
+  - `systemd-coredump` is configured on the host with sufficient backing storage. Coredumps are essential for diagnosing crashes.
+  - [Coredumps](../troubleshoot/configure-coredumps.md)
+* - 6
+  - **Monitoring deployed**
+  - A `ScyllaDBMonitoring` resource is created with Prometheus scraping ScyllaDB metrics and Grafana displaying dashboards. Alerts are configured for key failure modes.
+  - [Set up monitoring](set-up-monitoring/index.md)
+* - 7
+  - **Resource requests and limits set**
+  - Both `resources` (ScyllaDB container) and `agentResources` (Manager Agent sidecar) have explicit requests and limits. ScyllaDB derives its memory allocation from the container memory limit. Ensure values match your instance type and workload.
+  - [Deploy your first cluster](deploy-your-first-cluster.md)
+* - 8
+  - **CPU pinning active**
+  - The kubelet uses `cpuManagerPolicy: static`. The ScyllaDB pod has Guaranteed QoS class (requests equal limits for all containers). ScyllaDB starts with `--overprovisioned=0`.
+  - [Configure CPU pinning](before-you-deploy/configure-cpu-pinning.md)
+* - 9
+  - **XFS online discard enabled**
+  - The `discard` mount option is set on ScyllaDB data volumes via NodeConfig's `unsupportedOptions`. This enables SSD TRIM for consistent write performance.
+  - [Configure nodes](before-you-deploy/configure-nodes.md)
+* - 10
+  - **I/O properties configured**
+  - Precomputed I/O properties are set to avoid the automatic I/O benchmark that runs on first boot, which can produce inconsistent results in cloud environments.
+  - [Configure precomputed IO properties](../operate/configure-io-properties.md)
+* - 11
+  - **Backups scheduled**
+  - ScyllaDB Manager backup tasks are configured with object storage (S3, GCS, or Azure Blob) and appropriate IAM credentials. Backup schedules are tested with a restore drill.
+  - [Back up and restore](../operate/back-up-and-restore.md)
+```
 
 ## Verification commands
 

--- a/docs/source/deploy-scylladb/set-up-networking/configure-external-access.md
+++ b/docs/source/deploy-scylladb/set-up-networking/configure-external-access.md
@@ -29,19 +29,37 @@ spec:
 
 ### Node Service types
 
-| Type | Description |
-|------|-------------|
-| `Headless` | No additional IP allocated. DNS resolves to Pod IP. Use when broadcasting Pod IPs. |
-| `ClusterIP` | Allocates a cluster-internal virtual IP. Routable only within the Kubernetes cluster. |
-| `LoadBalancer` | Provisions an external load balancer. Use for internet-facing or cross-VPC access. Supports custom annotations and `loadBalancerClass`. |
+```{list-table}
+:header-rows: 1
+
+* - Type
+  - Description
+* - `Headless`
+  - No additional IP allocated. DNS resolves to Pod IP. Use when broadcasting Pod IPs.
+* - `ClusterIP`
+  - Allocates a cluster-internal virtual IP. Routable only within the Kubernetes cluster.
+* - `LoadBalancer`
+  - Provisions an external load balancer. Use for internet-facing or cross-VPC access. Supports custom annotations and `loadBalancerClass`.
+```
 
 ### Broadcast address types
 
-| Type | Source | Use case |
-|------|--------|----------|
-| `PodIP` | `Pod.status.podIP` | When Pod IPs are routable (same VPC, VPC peering, multi-DC). |
-| `ServiceClusterIP` | `Service.spec.clusterIP` | In-cluster access only. |
-| `ServiceLoadBalancerIngress` | `Service.status.loadBalancer.ingress[0]` | External access via load balancer. |
+```{list-table}
+:header-rows: 1
+
+* - Type
+  - Source
+  - Use case
+* - `PodIP`
+  - `Pod.status.podIP`
+  - When Pod IPs are routable (same VPC, VPC peering, multi-DC).
+* - `ServiceClusterIP`
+  - `Service.spec.clusterIP`
+  - In-cluster access only.
+* - `ServiceLoadBalancerIngress`
+  - `Service.status.loadBalancer.ingress[0]`
+  - External access via load balancer.
+```
 
 ## Common deployment scenarios
 

--- a/docs/source/deploy-scylladb/set-up-networking/ipv6/index.md
+++ b/docs/source/deploy-scylladb/set-up-networking/ipv6/index.md
@@ -96,11 +96,22 @@ Before configuring IPv6:
 
 ## Feature status
 
-| Configuration | Status | Production Ready |
-|---------------|--------|------------------|
-| Dual-stack (IPv4 + IPv6) | Stable | Yes |
-| IPv6-only | Experimental | No |
-| IPv4-only | Stable | Yes |
+```{list-table}
+:header-rows: 1
+
+* - Configuration
+  - Status
+  - Production Ready
+* - Dual-stack (IPv4 + IPv6)
+  - Stable
+  - Yes
+* - IPv6-only
+  - Experimental
+  - No
+* - IPv4-only
+  - Stable
+  - Yes
+```
 
 For IPv6-only production support progress, see [#3211](https://github.com/scylladb/scylla-operator/issues/3211).
 

--- a/docs/source/get-started/concepts-for-k8s-beginners.md
+++ b/docs/source/get-started/concepts-for-k8s-beginners.md
@@ -4,19 +4,46 @@ If you are familiar with ScyllaDB but new to Kubernetes, this page maps the Scyl
 
 ## Concept mapping
 
-| ScyllaDB concept | Kubernetes equivalent | Notes |
-|---|---|---|
-| **ScyllaDB node** | ScyllaDB **Pod**, **node service** and **PVC** | Each ScyllaDB node runs inside a Kubernetes pod. A pod is the smallest deployable unit in Kubernetes and contains one or more containers. The node service is a Kubernetes service that allows connectivity to that node and stores some of its runtime metadata. The PVC (PersistentVolumeClaim) provides persistent storage for keyspaces. |
-| **ScyllaDB process** | **Container** (inside the pod) | The ScyllaDB process runs inside a container within the pod. The pod also contains sidecar containers for monitoring, tuning, and management. |
-| **Datacenter** | **`ScyllaCluster`** | A `ScyllaCluster` resource represents one ScyllaDB datacenter. For multi-DC setups, create one `ScyllaCluster` per datacenter in each Kubernetes cluster and connect them using `externalSeeds`. |
-| **Rack** | **StatefulSet** | Each rack in the ScyllaCluster spec maps to a Kubernetes StatefulSet. The StatefulSet guarantees stable pod names, persistent storage, and ordered startup/shutdown. |
-| **Cluster** | **`ScyllaCluster`** resource (one per datacenter) | You declare the desired cluster state as a YAML resource. The Operator continuously reconciles the actual state to match. For multi-DC clusters, create one `ScyllaCluster` per datacenter and connect them via `externalSeeds`. |
-| **`scylla.yaml` config file** | **ConfigMap** referenced by `scyllaConfig` | ScyllaDB configuration is stored in a Kubernetes ConfigMap and referenced from the ScyllaCluster spec. The Operator also generates configuration automatically. |
-| **Data directory** | **PersistentVolumeClaim (PVC)** | Each ScyllaDB node's data is stored on a PersistentVolume, provisioned via a PVC. Data survives pod restarts. |
-| **Node IP / listen address** | **Service** (per member) | Each ScyllaDB node gets a dedicated Kubernetes Service that provides a stable network identity, independent of pod restarts. |
-| **Seed nodes** | Managed automatically | The Operator selects seed nodes and configures them. You do not need to manage seeds manually. |
-| **`nodetool`** | `kubectl exec` + `nodetool` | Run `nodetool` commands by executing into the ScyllaDB container: `kubectl exec -it <pod> -c scylla -- nodetool status`. Read-only commands are safe; state-changing commands are (mostly) disallowed; see [nodetool alternatives](../reference/nodetool-alternatives.md). |
-| **Repair / Backup tasks** | **ScyllaDBManagerTask** resource or cluster spec fields | Instead of running `sctool` commands, you declare tasks as Kubernetes resources or in the ScyllaCluster spec. |
+```{list-table}
+:header-rows: 1
+
+* - ScyllaDB concept
+  - Kubernetes equivalent
+  - Notes
+* - **ScyllaDB node**
+  - ScyllaDB **Pod**, **node service** and **PVC**
+  - Each ScyllaDB node runs inside a Kubernetes pod. A pod is the smallest deployable unit in Kubernetes and contains one or more containers. The node service is a Kubernetes service that allows connectivity to that node and stores some of its runtime metadata. The PVC (PersistentVolumeClaim) provides persistent storage for keyspaces.
+* - **ScyllaDB process**
+  - **Container** (inside the pod)
+  - The ScyllaDB process runs inside a container within the pod. The pod also contains sidecar containers for monitoring, tuning, and management.
+* - **Datacenter**
+  - **`ScyllaCluster`**
+  - A `ScyllaCluster` resource represents one ScyllaDB datacenter. For multi-DC setups, create one `ScyllaCluster` per datacenter in each Kubernetes cluster and connect them using `externalSeeds`.
+* - **Rack**
+  - **StatefulSet**
+  - Each rack in the ScyllaCluster spec maps to a Kubernetes StatefulSet. The StatefulSet guarantees stable pod names, persistent storage, and ordered startup/shutdown.
+* - **Cluster**
+  - **`ScyllaCluster`** resource (one per datacenter)
+  - You declare the desired cluster state as a YAML resource. The Operator continuously reconciles the actual state to match. For multi-DC clusters, create one `ScyllaCluster` per datacenter and connect them via `externalSeeds`.
+* - **`scylla.yaml` config file**
+  - **ConfigMap** referenced by `scyllaConfig`
+  - ScyllaDB configuration is stored in a Kubernetes ConfigMap and referenced from the ScyllaCluster spec. The Operator also generates configuration automatically.
+* - **Data directory**
+  - **PersistentVolumeClaim (PVC)**
+  - Each ScyllaDB node's data is stored on a PersistentVolume, provisioned via a PVC. Data survives pod restarts.
+* - **Node IP / listen address**
+  - **Service** (per member)
+  - Each ScyllaDB node gets a dedicated Kubernetes Service that provides a stable network identity, independent of pod restarts.
+* - **Seed nodes**
+  - Managed automatically
+  - The Operator selects seed nodes and configures them. You do not need to manage seeds manually.
+* - **`nodetool`**
+  - `kubectl exec` + `nodetool`
+  - Run `nodetool` commands by executing into the ScyllaDB container: `kubectl exec -it <pod> -c scylla -- nodetool status`. Read-only commands are safe; state-changing commands are (mostly) disallowed; see [nodetool alternatives](../reference/nodetool-alternatives.md).
+* - **Repair / Backup tasks**
+  - **ScyllaDBManagerTask** resource or cluster spec fields
+  - Instead of running `sctool` commands, you declare tasks as Kubernetes resources or in the ScyllaCluster spec.
+```
 
 ## Understanding pod names
 
@@ -36,26 +63,60 @@ The ordinal is zero-based. When you scale up a rack, new nodes get the next ordi
 
 ## Key differences from bare-metal ScyllaDB
 
-| Aspect | Bare metal | Kubernetes with Operator |
-|---|---|---|
-| **Starting/stopping nodes** | `systemctl start/stop scylla` | The Operator manages pod lifecycle. Delete a pod to restart it; the Operator recreates it automatically. |
-| **Adding nodes** | Install ScyllaDB on a new machine, configure seeds, start. | Increase `members` in the rack spec. The Operator handles everything. |
-| **Removing nodes** | Run `nodetool decommission`, then shut down. | Decrease `members` in the rack spec. The Operator runs decommission before removing the pod. |
-| **Replacing a dead node** | Start a new node with `replace_address_first_boot`. | Label the node's Service for replacement. The Operator handles the rest. |
-| **Configuration changes** | Edit `scylla.yaml` and restart. | Update the ConfigMap or ScyllaCluster spec. The Operator performs a rolling restart. |
-| **Monitoring** | Deploy monitoring stack manually. | Create a `ScyllaDBMonitoring` resource. |
-| **Upgrades** | Update packages, restart nodes one by one. | Change the `version` field. The Operator performs a rolling upgrade. |
+```{list-table}
+:header-rows: 1
+
+* - Aspect
+  - Bare metal
+  - Kubernetes with Operator
+* - **Starting/stopping nodes**
+  - `systemctl start/stop scylla`
+  - The Operator manages pod lifecycle. Delete a pod to restart it; the Operator recreates it automatically.
+* - **Adding nodes**
+  - Install ScyllaDB on a new machine, configure seeds, start.
+  - Increase `members` in the rack spec. The Operator handles everything.
+* - **Removing nodes**
+  - Run `nodetool decommission`, then shut down.
+  - Decrease `members` in the rack spec. The Operator runs decommission before removing the pod.
+* - **Replacing a dead node**
+  - Start a new node with `replace_address_first_boot`.
+  - Label the node's Service for replacement. The Operator handles the rest.
+* - **Configuration changes**
+  - Edit `scylla.yaml` and restart.
+  - Update the ConfigMap or ScyllaCluster spec. The Operator performs a rolling restart.
+* - **Monitoring**
+  - Deploy monitoring stack manually.
+  - Create a `ScyllaDBMonitoring` resource.
+* - **Upgrades**
+  - Update packages, restart nodes one by one.
+  - Change the `version` field. The Operator performs a rolling upgrade.
+```
 
 ## Kubernetes failure states and what they mean for ScyllaDB
 
 When troubleshooting, you may encounter these Kubernetes-specific states:
 
-| State | What it means | What to check |
-|---|---|---|
-| **Pending** | The pod cannot be scheduled onto a node. Common causes: no nodes match the affinity/toleration rules, or insufficient CPU/memory resources on available nodes. | Node resources, node selectors, taints/tolerations, PVC binding. |
-| **CrashLoopBackOff** | The container keeps crashing and Kubernetes is backing off before restarting. ScyllaDB is starting then crashes repeatedly. Common causes: misconfigured `scylla.yaml`, insufficient memory, corrupt data on the PVC, or init containers not completing. | Container logs (`kubectl logs --previous`), ScyllaDB startup errors. |
-| **ImagePullBackOff** | Kubernetes cannot pull the container image. Check the image tag, registry access from the node, and any pull secrets. | Image name/tag, registry credentials, network connectivity. |
-| **Init:0/N** | Init containers have not completed yet. An init container has not yet completed. Possible causes: the bootstrap barrier is waiting for a prerequisite, or a sidecar init is failing. | Init container logs, NodeConfig status, bootstrap barrier. |
-| **Running but not Ready** | The container is running but the readiness probe is failing. | ScyllaDB may still be starting up, or it may be unhealthy. Check logs. |
+```{list-table}
+:header-rows: 1
+
+* - State
+  - What it means
+  - What to check
+* - **Pending**
+  - The pod cannot be scheduled onto a node. Common causes: no nodes match the affinity/toleration rules, or insufficient CPU/memory resources on available nodes.
+  - Node resources, node selectors, taints/tolerations, PVC binding.
+* - **CrashLoopBackOff**
+  - The container keeps crashing and Kubernetes is backing off before restarting. ScyllaDB is starting then crashes repeatedly. Common causes: misconfigured `scylla.yaml`, insufficient memory, corrupt data on the PVC, or init containers not completing.
+  - Container logs (`kubectl logs --previous`), ScyllaDB startup errors.
+* - **ImagePullBackOff**
+  - Kubernetes cannot pull the container image. Check the image tag, registry access from the node, and any pull secrets.
+  - Image name/tag, registry credentials, network connectivity.
+* - **Init:0/N**
+  - Init containers have not completed yet. An init container has not yet completed. Possible causes: the bootstrap barrier is waiting for a prerequisite, or a sidecar init is failing.
+  - Init container logs, NodeConfig status, bootstrap barrier.
+* - **Running but not Ready**
+  - The container is running but the readiness probe is failing.
+  - ScyllaDB may still be starting up, or it may be unhealthy. Check logs.
+```
 
 For detailed troubleshooting procedures, see the [troubleshooting guide](../troubleshoot/index.md).

--- a/docs/source/get-started/what-is-scylladb-operator.md
+++ b/docs/source/get-started/what-is-scylladb-operator.md
@@ -6,16 +6,37 @@ ScyllaDB Operator is a [Kubernetes Operator](https://kubernetes.io/docs/concepts
 
 Running ScyllaDB on Kubernetes without an operator requires manually handling many tasks that the Operator automates:
 
-| Concern | Without the Operator | With ScyllaDB Operator |
-|---|---|---|
-| **Provisioning** | Manually create StatefulSets, Services, ConfigMaps, PVCs, and configure ScyllaDB seed lists, snitch settings, and rack/DC placement. | Declare a `ScyllaCluster` resource. The Operator creates and configures all Kubernetes objects. |
-| **Scaling** | Manually adjust StatefulSet replicas, update seed lists, and run `nodetool cleanup` on existing nodes after the new node finishes streaming. | Change the `members` count in the spec. The Operator handles the StatefulSet update and runs cleanup automatically when token ownership changes. |
-| **Upgrades** | Manually update the container image, coordinate a rolling restart, and verify each node rejoins before proceeding to the next. | Update the image field in the spec. The Operator performs a rolling upgrade one node at a time, verifying health at each step. |
-| **Node replacement** | Manually drain the node, remove it from the cluster, recreate the pod, and pass the `replace_address_first_boot` flag. | Label the node's Service for replacement. The Operator handles draining, decommissioning, and bootstrapping the replacement. |
-| **Performance tuning** | SSH into each Kubernetes node to run `perftune`, configure IRQ affinity, set sysctls, and prepare RAID/filesystem layouts. | Create a `NodeConfig` resource. The Operator deploys privileged DaemonSets and Jobs that tune each node and prepare disks automatically. |
-| **Repairs and backups** | Install and configure ScyllaDB Manager separately, register clusters manually, and schedule tasks. | Define repair and backup tasks in the cluster spec or as `ScyllaDBManagerTask` resources. The Operator deploys Manager and registers clusters. |
-| **Monitoring** | Deploy and configure Prometheus, Grafana, ServiceMonitors, and dashboards manually. | Create a `ScyllaDBMonitoring` resource. The Operator provisions the monitoring stack with ScyllaDB-specific dashboards. |
-| **TLS** | Generate and distribute certificates, configure ScyllaDB to use them, and handle rotation. | Enable TLS in the spec. The Operator uses cert-manager to provision and rotate certificates automatically. |
+```{list-table}
+:header-rows: 1
+
+* - Concern
+  - Without the Operator
+  - With ScyllaDB Operator
+* - **Provisioning**
+  - Manually create StatefulSets, Services, ConfigMaps, PVCs, and configure ScyllaDB seed lists, snitch settings, and rack/DC placement.
+  - Declare a `ScyllaCluster` resource. The Operator creates and configures all Kubernetes objects.
+* - **Scaling**
+  - Manually adjust StatefulSet replicas, update seed lists, and run `nodetool cleanup` on existing nodes after the new node finishes streaming.
+  - Change the `members` count in the spec. The Operator handles the StatefulSet update and runs cleanup automatically when token ownership changes.
+* - **Upgrades**
+  - Manually update the container image, coordinate a rolling restart, and verify each node rejoins before proceeding to the next.
+  - Update the image field in the spec. The Operator performs a rolling upgrade one node at a time, verifying health at each step.
+* - **Node replacement**
+  - Manually drain the node, remove it from the cluster, recreate the pod, and pass the `replace_address_first_boot` flag.
+  - Label the node's Service for replacement. The Operator handles draining, decommissioning, and bootstrapping the replacement.
+* - **Performance tuning**
+  - SSH into each Kubernetes node to run `perftune`, configure IRQ affinity, set sysctls, and prepare RAID/filesystem layouts.
+  - Create a `NodeConfig` resource. The Operator deploys privileged DaemonSets and Jobs that tune each node and prepare disks automatically.
+* - **Repairs and backups**
+  - Install and configure ScyllaDB Manager separately, register clusters manually, and schedule tasks.
+  - Define repair and backup tasks in the cluster spec or as `ScyllaDBManagerTask` resources. The Operator deploys Manager and registers clusters.
+* - **Monitoring**
+  - Deploy and configure Prometheus, Grafana, ServiceMonitors, and dashboards manually.
+  - Create a `ScyllaDBMonitoring` resource. The Operator provisions the monitoring stack with ScyllaDB-specific dashboards.
+* - **TLS**
+  - Generate and distribute certificates, configure ScyllaDB to use them, and handle rotation.
+  - Enable TLS in the spec. The Operator uses cert-manager to provision and rotate certificates automatically.
+```
 
 ## How it works
 
@@ -49,13 +70,28 @@ The Operator manages each datacenter independently. The following must be manage
 
 The Operator provides the following custom resources:
 
-| Resource | Scope | Purpose |
-|---|---|---|
-| `ScyllaCluster` | Namespaced | A ScyllaDB datacenter (one resource per DC; for multi-DC, create one per Kubernetes cluster and connect via `externalSeeds`) |
-| `NodeConfig` | Cluster | Node-level disk setup, RAID, filesystem, and performance tuning |
-| `ScyllaOperatorConfig` | Cluster | Global Operator configuration (images, cluster domain) |
-| `ScyllaDBMonitoring` | Namespaced | Monitoring stack (Prometheus + Grafana) for ScyllaDB |
-| `ScyllaDBManagerTask` | Namespaced | Backup or repair task managed by ScyllaDB Manager |
+```{list-table}
+:header-rows: 1
+
+* - Resource
+  - Scope
+  - Purpose
+* - `ScyllaCluster`
+  - Namespaced
+  - A ScyllaDB datacenter (one resource per DC; for multi-DC, create one per Kubernetes cluster and connect via `externalSeeds`)
+* - `NodeConfig`
+  - Cluster
+  - Node-level disk setup, RAID, filesystem, and performance tuning
+* - `ScyllaOperatorConfig`
+  - Cluster
+  - Global Operator configuration (images, cluster domain)
+* - `ScyllaDBMonitoring`
+  - Namespaced
+  - Monitoring stack (Prometheus + Grafana) for ScyllaDB
+* - `ScyllaDBManagerTask`
+  - Namespaced
+  - Backup or repair task managed by ScyllaDB Manager
+```
 
 The Operator also uses several internal CRD types under the hood to orchestrate operations such as datacenter management, Manager cluster registration, and bootstrap synchronisation. These are not intended for direct user interaction.
 

--- a/docs/source/operate/configure-io-properties.md
+++ b/docs/source/operate/configure-io-properties.md
@@ -109,12 +109,20 @@ Ensure the values match the actual capabilities of your storage.
 
 ## Key considerations
 
-| Consideration | Detail |
-|---|---|
-| Persistent cache | By default, iotune results are cached on the persistent volume. Precomputed values are only needed if you want to skip or override the benchmark. |
-| Consistent values | All nodes sharing the same storage type should use the same IO properties. Mount the same ConfigMap across all racks that use the same storage class. |
-| Rolling restart | Adding or changing the volume mount triggers a rolling restart. The Operator restarts nodes one at a time. |
-| Storage class changes | If you change the storage class or move to a different disk type, update the IO properties ConfigMap to match the new storage. |
+```{list-table}
+:header-rows: 1
+
+* - Consideration
+  - Detail
+* - Persistent cache
+  - By default, iotune results are cached on the persistent volume. Precomputed values are only needed if you want to skip or override the benchmark.
+* - Consistent values
+  - All nodes sharing the same storage type should use the same IO properties. Mount the same ConfigMap across all racks that use the same storage class.
+* - Rolling restart
+  - Adding or changing the volume mount triggers a rolling restart. The Operator restarts nodes one at a time.
+* - Storage class changes
+  - If you change the storage class or move to a different disk type, update the IO properties ConfigMap to match the new storage.
+```
 
 ## Related pages
 

--- a/docs/source/operate/perform-rolling-restart.md
+++ b/docs/source/operate/perform-rolling-restart.md
@@ -34,12 +34,20 @@ In multi-DC clusters using multiple `ScyllaCluster` resources, restart each data
 
 ## Key considerations
 
-| Consideration | Detail |
-|---|---|
-| One at a time | The Operator restarts one node at a time per rack. Each node is drained before termination, and the replacement must be ready before the next node is restarted. |
-| Unique value | The value of `forceRedeploymentReason` must be different from the current value to trigger a restart. Repeating the same string has no effect. |
-| Impact on availability | A rolling restart temporarily reduces the number of available replicas by one. Ensure your replication factor allows for one node to be unavailable. |
-| PodDisruptionBudget | The PDB (`maxUnavailable: 1`) ensures that at most one node per datacenter is unavailable at any given time, even during a rolling restart. |
+```{list-table}
+:header-rows: 1
+
+* - Consideration
+  - Detail
+* - One at a time
+  - The Operator restarts one node at a time per rack. Each node is drained before termination, and the replacement must be ready before the next node is restarted.
+* - Unique value
+  - The value of `forceRedeploymentReason` must be different from the current value to trigger a restart. Repeating the same string has no effect.
+* - Impact on availability
+  - A rolling restart temporarily reduces the number of available replicas by one. Ensure your replication factor allows for one node to be unavailable.
+* - PodDisruptionBudget
+  - The PDB (`maxUnavailable: 1`) ensures that at most one node per datacenter is unavailable at any given time, even during a rolling restart.
+```
 
 ## Related pages
 

--- a/docs/source/operate/scale-add-remove-racks.md
+++ b/docs/source/operate/scale-add-remove-racks.md
@@ -158,14 +158,24 @@ In multi-DC clusters using multiple `ScyllaCluster` resources, each datacenter i
 
 ## Key considerations
 
-| Consideration | Detail |
-|---|---|
-| One at a time | The Operator scales down one node at a time per rack, ensuring data is streamed away before the next decommission begins. |
-| Automatic cleanup | After scaling completes, the Operator triggers data cleanup Jobs on affected nodes to remove data that no longer belongs to them. |
-| PVC deletion | PVCs are deleted after scale-down. The Operator removes the PVC and Service of each decommissioned node after the replica count is reduced. |
-| Replication factor | Ensure you do not scale below the replication factor of your keyspaces. ScyllaDB will refuse queries if replicas become unavailable. |
-| PodDisruptionBudget | Each datacenter has a PDB with `maxUnavailable: 1`. This does not block Operator-driven scaling but prevents concurrent pod evictions during node drains. |
-| Run repair after scaling | After significant scaling operations, run a repair to ensure data consistency across the new token ranges. |
+```{list-table}
+:header-rows: 1
+
+* - Consideration
+  - Detail
+* - One at a time
+  - The Operator scales down one node at a time per rack, ensuring data is streamed away before the next decommission begins.
+* - Automatic cleanup
+  - After scaling completes, the Operator triggers data cleanup Jobs on affected nodes to remove data that no longer belongs to them.
+* - PVC deletion
+  - PVCs are deleted after scale-down. The Operator removes the PVC and Service of each decommissioned node after the replica count is reduced.
+* - Replication factor
+  - Ensure you do not scale below the replication factor of your keyspaces. ScyllaDB will refuse queries if replicas become unavailable.
+* - PodDisruptionBudget
+  - Each datacenter has a PDB with `maxUnavailable: 1`. This does not block Operator-driven scaling but prevents concurrent pod evictions during node drains.
+* - Run repair after scaling
+  - After significant scaling operations, run a repair to ensure data consistency across the new token ranges.
+```
 
 ## Related pages
 

--- a/docs/source/reference/conditions.md
+++ b/docs/source/reference/conditions.md
@@ -9,11 +9,26 @@ These conditions apply to all Operator-managed custom resources that report stat
 
 Every condition-reporting resource exposes three top-level conditions:
 
-| Condition type | Meaning when `True` | Meaning when `False` | Meaning when `Unknown` |
-|---|---|---|---|
-| `Available` | The resource is functional and can serve its purpose | The resource is not functional | Availability cannot yet be determined |
-| `Progressing` | The Operator is actively reconciling (rolling update, scaling, version change) | Either completed or stuck | Reconciliation state cannot yet be determined |
-| `Degraded` | Something is unhealthy or an error occurred during reconciliation | Resource is healthy | Health cannot yet be determined |
+```{list-table}
+:header-rows: 1
+
+* - Condition type
+  - Meaning when `True`
+  - Meaning when `False`
+  - Meaning when `Unknown`
+* - `Available`
+  - The resource is functional and can serve its purpose
+  - The resource is not functional
+  - Availability cannot yet be determined
+* - `Progressing`
+  - The Operator is actively reconciling (rolling update, scaling, version change)
+  - Either completed or stuck
+  - Reconciliation state cannot yet be determined
+* - `Degraded`
+  - Something is unhealthy or an error occurred during reconciliation
+  - Resource is healthy
+  - Health cannot yet be determined
+```
 
 A fully healthy, quiescent resource shows: `Available=True`, `Progressing=False`, `Degraded=False`.
 
@@ -42,14 +57,24 @@ kubectl -n scylla get scyllacluster <cluster-name> \
 
 Each condition object contains:
 
-| Field | Description |
-|---|---|
-| `type` | Condition name (e.g. `Available`, `StatefulSetControllerDegraded`) |
-| `status` | `True`, `False`, or `Unknown` |
-| `reason` | A CamelCase machine-readable reason string |
-| `message` | A human-readable description of the current state |
-| `lastTransitionTime` | When the condition last changed |
-| `observedGeneration` | The `metadata.generation` the condition was computed from |
+```{list-table}
+:header-rows: 1
+
+* - Field
+  - Description
+* - `type`
+  - Condition name (e.g. `Available`, `StatefulSetControllerDegraded`)
+* - `status`
+  - `True`, `False`, or `Unknown`
+* - `reason`
+  - A CamelCase machine-readable reason string
+* - `message`
+  - A human-readable description of the current state
+* - `lastTransitionTime`
+  - When the condition last changed
+* - `observedGeneration`
+  - The `metadata.generation` the condition was computed from
+```
 
 ## Related pages
 

--- a/docs/source/reference/ipv6-configuration.md
+++ b/docs/source/reference/ipv6-configuration.md
@@ -26,11 +26,26 @@ Sets the DNS resolution policy for ScyllaDB pods. Defaults to `ClusterFirstWithH
 
 When `spec.network.ipFamilies` includes IPv6 as the first entry, the Operator automatically applies the following ScyllaDB arguments. You do not need to set these manually.
 
-| ScyllaDB argument | IPv4 value | IPv6 value | Purpose |
-|---|---|---|---|
-| `--listen-address` | `0.0.0.0` | `::` | Interface ScyllaDB listens on for inter-node communication |
-| `--rpc-address` | not set (ScyllaDB defaults to `0.0.0.0`) | `::` | Interface ScyllaDB listens on for CQL client connections |
-| `--enable-ipv6-dns-lookup` | not set | `1` | Enables AAAA DNS record resolution in ScyllaDB |
+```{list-table}
+:header-rows: 1
+
+* - ScyllaDB argument
+  - IPv4 value
+  - IPv6 value
+  - Purpose
+* - `--listen-address`
+  - `0.0.0.0`
+  - `::`
+  - Interface ScyllaDB listens on for inter-node communication
+* - `--rpc-address`
+  - not set (ScyllaDB defaults to `0.0.0.0`)
+  - `::`
+  - Interface ScyllaDB listens on for CQL client connections
+* - `--enable-ipv6-dns-lookup`
+  - not set
+  - `1`
+  - Enables AAAA DNS record resolution in ScyllaDB
+```
 
 ### Broadcast addresses
 

--- a/docs/source/troubleshoot/change-log-level.md
+++ b/docs/source/troubleshoot/change-log-level.md
@@ -5,11 +5,22 @@ This is useful when a rolling restart is not feasible — for example, when a St
 
 ## When to use each method
 
-| Scenario | Method | Persistent? |
-|---|---|---|
-| Normal operations — rolling restart is acceptable | [Spec change](#method-1-spec-change-rolling-restart) | Yes |
-| StatefulSet stuck mid-rollout | [REST API](#method-2-rest-api-no-restart) | No — lost on pod restart |
-| Cluster degraded — cannot tolerate a rolling restart | [REST API](#method-2-rest-api-no-restart) | No — lost on pod restart |
+```{list-table}
+:header-rows: 1
+
+* - Scenario
+  - Method
+  - Persistent?
+* - Normal operations — rolling restart is acceptable
+  - [Spec change](#method-1-spec-change-rolling-restart)
+  - Yes
+* - StatefulSet stuck mid-rollout
+  - [REST API](#method-2-rest-api-no-restart)
+  - No — lost on pod restart
+* - Cluster degraded — cannot tolerate a rolling restart
+  - [REST API](#method-2-rest-api-no-restart)
+  - No — lost on pod restart
+```
 
 ## Method 1: Spec change (rolling restart)
 

--- a/docs/source/troubleshoot/collect-debugging-information/system-tables.md
+++ b/docs/source/troubleshoot/collect-debugging-information/system-tables.md
@@ -6,10 +6,16 @@ System tables contain ScyllaDB-internal state — repair history, SSTable activi
 
 ## When to use system tables
 
-| Use case | Tool |
-|---|---|
-| Kubernetes-level diagnostics (pod status, events, logs) | [Collect debugging information](index.md) |
-| ScyllaDB-internal state (repair history, SSTable stats, large partitions) | System tables (this page) |
+```{list-table}
+:header-rows: 1
+
+* - Use case
+  - Tool
+* - Kubernetes-level diagnostics (pod status, events, logs)
+  - [Collect debugging information](index.md)
+* - ScyllaDB-internal state (repair history, SSTable stats, large partitions)
+  - System tables (this page)
+```
 
 Include system table output alongside debugging information archives when filing support tickets for ScyllaDB-level issues (performance, data consistency, repair).
 

--- a/docs/source/troubleshoot/index.md
+++ b/docs/source/troubleshoot/index.md
@@ -4,16 +4,28 @@ Diagnose and resolve issues with ScyllaDB Operator, ScyllaDB clusters, and relat
 
 ## By symptom
 
-| Symptom | Guide |
-|---|---|
-| Pods restarting unexpectedly | [Investigate pod restarts](investigate-restarts.md) |
-| Application cannot connect to ScyllaDB | [Connect Your App](../connect-your-app/index.md) and [Set up networking](../deploy-scylladb/set-up-networking/index.md) |
-| Upgrade failed or stuck | [Upgrade](../upgrade/index.md) |
-| Node replace stuck or failed | [Recover from a failed node replace](recover-from-failed-replace.md) |
-| Slow queries, throughput degradation, or CPU pinning not working | [Troubleshoot performance](troubleshoot-performance.md) |
-| Need to change log level without a rolling restart | [Change log level](change-log-level.md) |
-| Need to collect data for a support ticket | [Collect debugging information](collect-debugging-information/index.md) |
-| Need to configure or collect core dumps | [Collect core dumps](configure-coredumps.md) |
+```{list-table}
+:header-rows: 1
+
+* - Symptom
+  - Guide
+* - Pods restarting unexpectedly
+  - [Investigate pod restarts](investigate-restarts.md)
+* - Application cannot connect to ScyllaDB
+  - [Connect Your App](../connect-your-app/index.md) and [Set up networking](../deploy-scylladb/set-up-networking/index.md)
+* - Upgrade failed or stuck
+  - [Upgrade](../upgrade/index.md)
+* - Node replace stuck or failed
+  - [Recover from a failed node replace](recover-from-failed-replace.md)
+* - Slow queries, throughput degradation, or CPU pinning not working
+  - [Troubleshoot performance](troubleshoot-performance.md)
+* - Need to change log level without a rolling restart
+  - [Change log level](change-log-level.md)
+* - Need to collect data for a support ticket
+  - [Collect debugging information](collect-debugging-information/index.md)
+* - Need to configure or collect core dumps
+  - [Collect core dumps](configure-coredumps.md)
+```
 
 :::{toctree}
 :maxdepth: 1

--- a/docs/source/troubleshoot/investigate-restarts.md
+++ b/docs/source/troubleshoot/investigate-restarts.md
@@ -29,12 +29,20 @@ kubectl -n scylla get pod <pod-name> -o jsonpath='{.status.containerStatuses}' |
 
 Key fields:
 
-| Field | Description |
-|---|---|
-| `restartCount` | Total number of restarts for this container |
-| `lastState.terminated.reason` | Why the container stopped (`OOMKilled`, `Error`, `Completed`) |
-| `lastState.terminated.exitCode` | Process exit code (`137` = SIGKILL / OOMKilled, `1` = error) |
-| `lastState.terminated.finishedAt` | Timestamp of the last termination |
+```{list-table}
+:header-rows: 1
+
+* - Field
+  - Description
+* - `restartCount`
+  - Total number of restarts for this container
+* - `lastState.terminated.reason`
+  - Why the container stopped (`OOMKilled`, `Error`, `Completed`)
+* - `lastState.terminated.exitCode`
+  - Process exit code (`137` = SIGKILL / OOMKilled, `1` = error)
+* - `lastState.terminated.finishedAt`
+  - Timestamp of the last termination
+```
 
 ### Pod events
 
@@ -44,13 +52,22 @@ kubectl -n scylla describe pod <pod-name>
 
 Look for these events in the `Events` section:
 
-| Event | Meaning |
-|---|---|
-| `Killing` | Container was killed (by kubelet or OOM killer) |
-| `BackOff` | Container is in `CrashLoopBackOff` — restarting repeatedly |
-| `OOMKilling` | Container exceeded its memory limit |
-| `Unhealthy` | Liveness probe failed — kubelet killed the container |
-| `FailedScheduling` | Pod cannot be placed on any node |
+```{list-table}
+:header-rows: 1
+
+* - Event
+  - Meaning
+* - `Killing`
+  - Container was killed (by kubelet or OOM killer)
+* - `BackOff`
+  - Container is in `CrashLoopBackOff` — restarting repeatedly
+* - `OOMKilling`
+  - Container exceeded its memory limit
+* - `Unhealthy`
+  - Liveness probe failed — kubelet killed the container
+* - `FailedScheduling`
+  - Pod cannot be placed on any node
+```
 
 ## Distinguish restart causes
 

--- a/docs/source/troubleshoot/recover-from-failed-replace.md
+++ b/docs/source/troubleshoot/recover-from-failed-replace.md
@@ -191,11 +191,18 @@ In a multi-datacenter deployment using multiple `ScyllaCluster` resources, perfo
 
 ## What if something goes wrong
 
-| Situation | Recovery |
-|---|---|
-| Accidentally deleted StatefulSet without `--cascade=orphan` | Pods are deleted (causing rack unavailability), but PVCs survive. When ScyllaDB Operator resumes and recreates the StatefulSet, new pods are created and reattach to existing PVCs. Data is preserved. |
-| ScyllaDB Operator fails to recreate the StatefulSet | Manually recreate it from the must-gather archive (the StatefulSet YAML is captured). |
-| New node fails to join | Repeat the procedure — verify that all ghost members were removed. Check seed configuration and network connectivity. |
+```{list-table}
+:header-rows: 1
+
+* - Situation
+  - Recovery
+* - Accidentally deleted StatefulSet without `--cascade=orphan`
+  - Pods are deleted (causing rack unavailability), but PVCs survive. When ScyllaDB Operator resumes and recreates the StatefulSet, new pods are created and reattach to existing PVCs. Data is preserved.
+* - ScyllaDB Operator fails to recreate the StatefulSet
+  - Manually recreate it from the must-gather archive (the StatefulSet YAML is captured).
+* - New node fails to join
+  - Repeat the procedure — verify that all ghost members were removed. Check seed configuration and network connectivity.
+```
 
 ## Related pages
 

--- a/docs/source/troubleshoot/troubleshoot-performance.md
+++ b/docs/source/troubleshoot/troubleshoot-performance.md
@@ -30,13 +30,28 @@ kubectl -n scylla-operator-node-tuning get jobs \
 
 ### Common issues
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| `qosClass: Burstable` | `agentResources` has no limits, or requests ≠ limits on any container | Set matching requests and limits on **both** `resources` and `agentResources` |
-| `--overprovisioned=1` in logs | Pod is not Guaranteed QoS, or kubelet lacks static CPU policy | Check QoS class and kubelet configuration |
-| No `ContainerPerftune` job | Pod is Burstable — tuning is skipped for non-Guaranteed Pods | Fix QoS class |
-| `cpuset.cpus.effective` shows all CPUs | Kubelet not using static policy, or CPU request is fractional | Enable `cpuManagerPolicy: static` and use integer CPU values |
-| Latency spikes despite pinning | IRQ affinity not set — perftune job failed or did not run | Verify `NodeConfig` `disableOptimizations` is `false` (default) and check perftune job logs |
+```{list-table}
+:header-rows: 1
+
+* - Symptom
+  - Cause
+  - Fix
+* - `qosClass: Burstable`
+  - `agentResources` has no limits, or requests ≠ limits on any container
+  - Set matching requests and limits on **both** `resources` and `agentResources`
+* - `--overprovisioned=1` in logs
+  - Pod is not Guaranteed QoS, or kubelet lacks static CPU policy
+  - Check QoS class and kubelet configuration
+* - No `ContainerPerftune` job
+  - Pod is Burstable — tuning is skipped for non-Guaranteed Pods
+  - Fix QoS class
+* - `cpuset.cpus.effective` shows all CPUs
+  - Kubelet not using static policy, or CPU request is fractional
+  - Enable `cpuManagerPolicy: static` and use integer CPU values
+* - Latency spikes despite pinning
+  - IRQ affinity not set — perftune job failed or did not run
+  - Verify `NodeConfig` `disableOptimizations` is `false` (default) and check perftune job logs
+```
 
 ## See also
 

--- a/docs/source/understand/bootstrap-sync.md
+++ b/docs/source/understand/bootstrap-sync.md
@@ -65,10 +65,16 @@ If any node is missing a host ID, has not yet reported, does not list another no
 
 ## Feature gate and version requirements
 
-| Requirement | Value |
-|-------------|-------|
-| Feature gate | `BootstrapSynchronisation` (default off since v1.19) |
-| Minimum ScyllaDB version | 2025.2 |
+```{list-table}
+:header-rows: 1
+
+* - Requirement
+  - Value
+* - Feature gate
+  - `BootstrapSynchronisation` (default off since v1.19)
+* - Minimum ScyllaDB version
+  - 2025.2
+```
 
 The feature gate must be enabled in the Operator's command-line flags. The Operator also checks the ScyllaDB container image version and only adds the init container when the version satisfies `≥ 2025.2.0`.
 

--- a/docs/source/understand/ignition.md
+++ b/docs/source/understand/ignition.md
@@ -25,13 +25,28 @@ Ignition uses a simple file-based signal on the shared emptyDir volume mounted a
 
 The ignition controller checks the following conditions. **All** must be true before the signal file is created:
 
-| # | Condition | Why |
-|---|-----------|-----|
-| 1 | **LoadBalancer ingress available** (only when broadcast address type is `ServiceLoadBalancerIngress`) | The broadcast address cannot be resolved until the cloud provider assigns an external IP or hostname to the member Service. |
-| 2 | **Pod has an IP** (`status.podIP` is set) | ScyllaDB needs a listen address. The sidecar cannot resolve `PodIP`-type broadcast addresses without it. |
-| 3 | **ScyllaDB container has a container ID** (`containerStatuses[].containerID` is set) | Per-container tuning (CPU pinning, cgroup settings) targets a specific container ID. Tuning cannot complete until the container exists. |
-| 4 | **Tuning ConfigMap exists** with matching container ID | A ConfigMap labeled for this pod must exist, created by the tuning infrastructure. Its `ContainerID` field must match the current ScyllaDB container ID, confirming that tuning ran for this specific container instance. |
-| 5 | **No blocking NodeConfigs** in the tuning ConfigMap | The ConfigMap must report that all `NodeConfig` resources have completed tuning. If any are still in progress, ignition waits. |
+```{list-table}
+:header-rows: 1
+
+* - #
+  - Condition
+  - Why
+* - 1
+  - **LoadBalancer ingress available** (only when broadcast address type is `ServiceLoadBalancerIngress`)
+  - The broadcast address cannot be resolved until the cloud provider assigns an external IP or hostname to the member Service.
+* - 2
+  - **Pod has an IP** (`status.podIP` is set)
+  - ScyllaDB needs a listen address. The sidecar cannot resolve `PodIP`-type broadcast addresses without it.
+* - 3
+  - **ScyllaDB container has a container ID** (`containerStatuses[].containerID` is set)
+  - Per-container tuning (CPU pinning, cgroup settings) targets a specific container ID. Tuning cannot complete until the container exists.
+* - 4
+  - **Tuning ConfigMap exists** with matching container ID
+  - A ConfigMap labeled for this pod must exist, created by the tuning infrastructure. Its `ContainerID` field must match the current ScyllaDB container ID, confirming that tuning ran for this specific container instance.
+* - 5
+  - **No blocking NodeConfigs** in the tuning ConfigMap
+  - The ConfigMap must report that all `NodeConfig` resources have completed tuning. If any are still in progress, ignition waits.
+```
 
 ## Cleanup on shutdown
 
@@ -47,10 +62,16 @@ This ensures that if the container restarts (due to a crash or rolling update), 
 
 For debugging or recovery scenarios, the annotation `internal.scylla-operator.scylladb.com/force-ignition-value` on the node's member Service can override the ignition decision:
 
-| Value | Effect |
-|-------|--------|
-| `"true"` | Ignition proceeds immediately, bypassing all prerequisite checks. |
-| `"false"` | Ignition is blocked indefinitely, regardless of prerequisite status. |
+```{list-table}
+:header-rows: 1
+
+* - Value
+  - Effect
+* - `"true"`
+  - Ignition proceeds immediately, bypassing all prerequisite checks.
+* - `"false"`
+  - Ignition is blocked indefinitely, regardless of prerequisite status.
+```
 
 :::{caution}
 The force override is an internal mechanism intended for debugging. Forcing ignition to `true` while tuning is incomplete results in degraded performance. Forcing it to `false` prevents the ScyllaDB node from starting.

--- a/docs/source/understand/index.md
+++ b/docs/source/understand/index.md
@@ -24,11 +24,18 @@ To make changes, always modify the custom resource spec.
 
 ScyllaDB Operator installs into three namespaces:
 
-| Namespace | What runs there |
-|---|---|
-| `scylla-operator` | Two Deployments: the **controller manager** (`scylla-operator`) that runs all controllers, and the **webhook server** (`webhook-server`) that validates API requests. Both run with 2 replicas by default and are protected by PodDisruptionBudgets. |
-| `scylla-manager` | **ScyllaDB Manager** — a separate component that coordinates repair and backup tasks. It uses a small internal ScyllaDB cluster as its own database. Deployed optionally. |
-| `scylla-operator-node-tuning` | **Node tuning agents** — privileged DaemonSets and Jobs created by the NodeConfig controller to set up disks, filesystems, and performance tuning on Kubernetes nodes. |
+```{list-table}
+:header-rows: 1
+
+* - Namespace
+  - What runs there
+* - `scylla-operator`
+  - Two Deployments: the **controller manager** (`scylla-operator`) that runs all controllers, and the **webhook server** (`webhook-server`) that validates API requests. Both run with 2 replicas by default and are protected by PodDisruptionBudgets.
+* - `scylla-manager`
+  - **ScyllaDB Manager** — a separate component that coordinates repair and backup tasks. It uses a small internal ScyllaDB cluster as its own database. Deployed optionally.
+* - `scylla-operator-node-tuning`
+  - **Node tuning agents** — privileged DaemonSets and Jobs created by the NodeConfig controller to set up disks, filesystems, and performance tuning on Kubernetes nodes.
+```
 
 Your ScyllaDB clusters run in your own namespaces, separate from the Operator.
 
@@ -40,20 +47,40 @@ The Operator provides the following CRDs, all in the `scylla.scylladb.com` API g
 
 Cluster-scoped resources affect the entire Kubernetes cluster and require elevated privileges.
 
-| Resource | API version | Purpose |
-|---|---|---|
-| `NodeConfig` | `v1alpha1` | Configures Kubernetes nodes for ScyllaDB: RAID setup, filesystem creation, mount points, sysctls, and performance tuning. See [Tuning](tuning.md). |
-| `ScyllaOperatorConfig` | `v1alpha1` | Global Operator configuration: auxiliary images, cluster domain, tuning image overrides. A singleton named `cluster`. |
+```{list-table}
+:header-rows: 1
+
+* - Resource
+  - API version
+  - Purpose
+* - `NodeConfig`
+  - `v1alpha1`
+  - Configures Kubernetes nodes for ScyllaDB: RAID setup, filesystem creation, mount points, sysctls, and performance tuning. See [Tuning](tuning.md).
+* - `ScyllaOperatorConfig`
+  - `v1alpha1`
+  - Global Operator configuration: auxiliary images, cluster domain, tuning image overrides. A singleton named `cluster`.
+```
 
 ### Namespaced resources
 
 Namespaced resources are scoped to a Kubernetes namespace and can be managed by namespace-level RBAC.
 
-| Resource | API version | Purpose |
-|---|---|---|
-| `ScyllaCluster` | `v1` (stable) | Defines a single-datacenter ScyllaDB cluster. The primary resource for most deployments. |
-| `ScyllaDBMonitoring` | `v1alpha1` | Defines a monitoring stack (Prometheus + Grafana) for ScyllaDB. See [Set up monitoring](monitoring.md). |
-| `ScyllaDBManagerTask` | `v1alpha1` | Defines a backup or repair task managed by ScyllaDB Manager. |
+```{list-table}
+:header-rows: 1
+
+* - Resource
+  - API version
+  - Purpose
+* - `ScyllaCluster`
+  - `v1` (stable)
+  - Defines a single-datacenter ScyllaDB cluster. The primary resource for most deployments.
+* - `ScyllaDBMonitoring`
+  - `v1alpha1`
+  - Defines a monitoring stack (Prometheus + Grafana) for ScyllaDB. See [Set up monitoring](monitoring.md).
+* - `ScyllaDBManagerTask`
+  - `v1alpha1`
+  - Defines a backup or repair task managed by ScyllaDB Manager.
+```
 
 :::{tip}
 You can discover the available resources in your cluster by running:
@@ -70,37 +97,72 @@ kubectl explain --api-version='scylla.scylladb.com/v1alpha1' NodeConfig.spec
 
 The controller manager runs the following controllers:
 
-| Controller | What it reconciles |
-|---|---|
-| ScyllaCluster | Primary controller for single-datacenter deployments. Manages a ScyllaDB datacenter — StatefulSets, Services, ConfigMaps, Jobs, PDBs, Ingresses, TLS certificates — and synchronises Manager tasks based on the stable `ScyllaCluster` (v1) API. |
-| ScyllaDBDatacenter | Internal controller that creates and manages the underlying Kubernetes objects for each datacenter. Users do not interact with `ScyllaDBDatacenter` resources directly — the ScyllaCluster controller translates each `ScyllaCluster` into an internal `ScyllaDBDatacenter` resource, which this controller then reconciles. |
-| NodeConfig | Deploys privileged DaemonSets and Jobs that set up RAID, filesystems, mount points, sysctls, and performance tuning on Kubernetes nodes. |
-| NodeConfigPod | Watches ScyllaDB pods and creates per-pod tuning ConfigMaps that tie container-level tuning to a specific container instance. |
-| ScyllaOperatorConfig | Reconciles the global Operator configuration, discovers cluster domain, and resolves auxiliary images. |
-| ScyllaDBMonitoring | Deploys and configures Prometheus, Grafana, ServiceMonitors, PrometheusRules, and dashboards. |
-| OrphanedPV | Detects and cleans up PersistentVolumes that become orphaned when ScyllaDB nodes are removed. |
-| ScyllaDBManager | Coordinates global ScyllaDB Manager state across all clusters. |
-| ScyllaDBManagerClusterRegistration | Registers ScyllaDB clusters with ScyllaDB Manager. |
-| ScyllaDBManagerTask | Reconciles backup and repair task definitions with ScyllaDB Manager. |
+```{list-table}
+:header-rows: 1
+
+* - Controller
+  - What it reconciles
+* - ScyllaCluster
+  - Primary controller for single-datacenter deployments. Manages a ScyllaDB datacenter — StatefulSets, Services, ConfigMaps, Jobs, PDBs, Ingresses, TLS certificates — and synchronises Manager tasks based on the stable `ScyllaCluster` (v1) API.
+* - ScyllaDBDatacenter
+  - Internal controller that creates and manages the underlying Kubernetes objects for each datacenter. Users do not interact with `ScyllaDBDatacenter` resources directly — the ScyllaCluster controller translates each `ScyllaCluster` into an internal `ScyllaDBDatacenter` resource, which this controller then reconciles.
+* - NodeConfig
+  - Deploys privileged DaemonSets and Jobs that set up RAID, filesystems, mount points, sysctls, and performance tuning on Kubernetes nodes.
+* - NodeConfigPod
+  - Watches ScyllaDB pods and creates per-pod tuning ConfigMaps that tie container-level tuning to a specific container instance.
+* - ScyllaOperatorConfig
+  - Reconciles the global Operator configuration, discovers cluster domain, and resolves auxiliary images.
+* - ScyllaDBMonitoring
+  - Deploys and configures Prometheus, Grafana, ServiceMonitors, PrometheusRules, and dashboards.
+* - OrphanedPV
+  - Detects and cleans up PersistentVolumes that become orphaned when ScyllaDB nodes are removed.
+* - ScyllaDBManager
+  - Coordinates global ScyllaDB Manager state across all clusters.
+* - ScyllaDBManagerClusterRegistration
+  - Registers ScyllaDB clusters with ScyllaDB Manager.
+* - ScyllaDBManagerTask
+  - Reconciles backup and repair task definitions with ScyllaDB Manager.
+```
 
 ### Experimental controllers
 
 The following controllers are run by Operator, but there is no current plan to make their respective CRDs generally available. These controllers and CRDs may be removed in a future version.
 
-| Controller | What it reconciles |
-|---|---|
-| ScyllaDBCluster | Orchestrates multi-datacenter clusters by managing `ScyllaDBDatacenter` resources across remote Kubernetes clusters. |
-| RemoteKubernetesCluster | Manages connections and informers for remote Kubernetes clusters used in multi-DC deployments. |
+```{list-table}
+:header-rows: 1
+
+* - Controller
+  - What it reconciles
+* - ScyllaDBCluster
+  - Orchestrates multi-datacenter clusters by managing `ScyllaDBDatacenter` resources across remote Kubernetes clusters.
+* - RemoteKubernetesCluster
+  - Manages connections and informers for remote Kubernetes clusters used in multi-DC deployments.
+```
 
 Additional controllers run **inside ScyllaDB pods** rather than in the Operator deployment:
 
-| Controller | Where it runs | What it does |
-|---|---|---|
-| Sidecar | Main ScyllaDB container | Manages the ScyllaDB process lifecycle, syncs member service annotations with host ID and token ring state. See [Sidecar](sidecar.md). |
-| Ignition | `scylladb-ignition` sidecar container | Evaluates startup prerequisites (tuning done, IP assigned, LB ready) and creates the ignition signal file. See [Ignition](ignition.md). |
-| StatusReport | Main ScyllaDB container | Reports node status to internal status report resources for bootstrap synchronisation. |
-| BootstrapBarrier | `scylladb-bootstrap-barrier` init container | Blocks pod startup until bootstrap preconditions are met (feature-gated). See [Bootstrap Sync](bootstrap-sync.md). |
-| NodeSetup | Node tuning DaemonSet pods | Configures the host machine (runs via the `node-setup-daemon` subcommand). |
+```{list-table}
+:header-rows: 1
+
+* - Controller
+  - Where it runs
+  - What it does
+* - Sidecar
+  - Main ScyllaDB container
+  - Manages the ScyllaDB process lifecycle, syncs member service annotations with host ID and token ring state. See [Sidecar](sidecar.md).
+* - Ignition
+  - `scylladb-ignition` sidecar container
+  - Evaluates startup prerequisites (tuning done, IP assigned, LB ready) and creates the ignition signal file. See [Ignition](ignition.md).
+* - StatusReport
+  - Main ScyllaDB container
+  - Reports node status to internal status report resources for bootstrap synchronisation.
+* - BootstrapBarrier
+  - `scylladb-bootstrap-barrier` init container
+  - Blocks pod startup until bootstrap preconditions are met (feature-gated). See [Bootstrap Sync](bootstrap-sync.md).
+* - NodeSetup
+  - Node tuning DaemonSet pods
+  - Configures the host machine (runs via the `node-setup-daemon` subcommand).
+```
 
 ## Admission webhooks
 

--- a/docs/source/understand/networking.md
+++ b/docs/source/understand/networking.md
@@ -6,10 +6,19 @@ This page explains how ScyllaDB Operator exposes ScyllaDB nodes on the network, 
 
 For every ScyllaDB cluster the Operator manages two kinds of Kubernetes Service:
 
-| Service | Count | Purpose |
-|---------|-------|---------|
-| **Identity** (named `<cluster>-client`) | One per datacenter | Stable DNS names for the StatefulSet. A regular `ClusterIP` Service shared by all racks' StatefulSets as their `serviceName`, so that each pod gets a predictable DNS record (`<pod>.<cluster>-client.<ns>.svc.cluster.local`). Also serves as a client entry point that load-balances across all ScyllaDB pods. |
-| **Member** | One per pod | A dedicated Service whose type is controlled by `exposeOptions.nodeService.type`. Carries the address that is broadcast to clients or other nodes. |
+```{list-table}
+:header-rows: 1
+
+* - Service
+  - Count
+  - Purpose
+* - **Identity** (named `<cluster>-client`)
+  - One per datacenter
+  - Stable DNS names for the StatefulSet. A regular `ClusterIP` Service shared by all racks' StatefulSets as their `serviceName`, so that each pod gets a predictable DNS record (`<pod>.<cluster>-client.<ns>.svc.cluster.local`). Also serves as a client entry point that load-balances across all ScyllaDB pods.
+* - **Member**
+  - One per pod
+  - A dedicated Service whose type is controlled by `exposeOptions.nodeService.type`. Carries the address that is broadcast to clients or other nodes.
+```
 
 The member Service uses a selector that matches exactly one pod, giving every ScyllaDB node its own stable network identity independent of the pod IP lifecycle.
 
@@ -77,11 +86,22 @@ The Operator lets you configure these independently via `exposeOptions.broadcast
 
 ### Broadcast address types
 
-| Type | Address source | When to use |
-|------|---------------|-------------|
-| **`PodIP`** | Pod's IP from `status.podIP` (or a specific entry in `status.podIPs` selected by IP family) | Pod IPs are routable from wherever the consumer lives — for example, within a VPC or across peered VPCs. |
-| **`ServiceClusterIP`** | `spec.clusterIP` of the member Service | Consumers are inside the same Kubernetes cluster. Requires `nodeService.type` to be `ClusterIP` or `LoadBalancer`. |
-| **`ServiceLoadBalancerIngress`** | First entry in `status.loadBalancer.ingress` (IP or hostname) of the member Service | Consumers are outside the Kubernetes cluster and reach nodes through a load balancer. Requires `nodeService.type` to be `LoadBalancer`. |
+```{list-table}
+:header-rows: 1
+
+* - Type
+  - Address source
+  - When to use
+* - **`PodIP`**
+  - Pod's IP from `status.podIP` (or a specific entry in `status.podIPs` selected by IP family)
+  - Pod IPs are routable from wherever the consumer lives — for example, within a VPC or across peered VPCs.
+* - **`ServiceClusterIP`**
+  - `spec.clusterIP` of the member Service
+  - Consumers are inside the same Kubernetes cluster. Requires `nodeService.type` to be `ClusterIP` or `LoadBalancer`.
+* - **`ServiceLoadBalancerIngress`**
+  - First entry in `status.loadBalancer.ingress` (IP or hostname) of the member Service
+  - Consumers are outside the Kubernetes cluster and reach nodes through a load balancer. Requires `nodeService.type` to be `LoadBalancer`.
+```
 
 ### How broadcast addresses reach ScyllaDB
 
@@ -95,11 +115,18 @@ The ScyllaDB process itself listens on all interfaces (`0.0.0.0` for IPv4, `::` 
 
 A `ScyllaCluster` created without explicit `exposeOptions` uses the following defaults:
 
-| Field | Default |
-|-------|---------|
-| `nodeService.type` | `ClusterIP` |
-| `broadcastOptions.nodes.type` | `ServiceClusterIP` |
-| `broadcastOptions.clients.type` | `ServiceClusterIP` |
+```{list-table}
+:header-rows: 1
+
+* - Field
+  - Default
+* - `nodeService.type`
+  - `ClusterIP`
+* - `broadcastOptions.nodes.type`
+  - `ServiceClusterIP`
+* - `broadcastOptions.clients.type`
+  - `ServiceClusterIP`
+```
 
 For multi-datacenter deployments using multiple `ScyllaCluster` resources connected via `externalSeeds`, you typically need to override these defaults to use `Headless` / `PodIP` so that pod IPs are broadcast directly. See the [Multi-VPC / multi-datacenter](#multi-vpc-multi-datacenter) scenario below.
 

--- a/docs/source/understand/pod-disruption-budgets.md
+++ b/docs/source/understand/pod-disruption-budgets.md
@@ -31,10 +31,19 @@ The PDB selector uses the same labels as the ScyllaDB pods but adds a `MatchExpr
 
 The Operator deployment and the webhook server deployment each have their own PDB:
 
-| Component | PDB spec | When created |
-|-----------|----------|-------------|
-| `scylla-operator` | `minAvailable: 1` | When running with more than one replica |
-| `webhook-server` | `minAvailable: 1` | When running with more than one replica |
+```{list-table}
+:header-rows: 1
+
+* - Component
+  - PDB spec
+  - When created
+* - `scylla-operator`
+  - `minAvailable: 1`
+  - When running with more than one replica
+* - `webhook-server`
+  - `minAvailable: 1`
+  - When running with more than one replica
+```
 
 These PDBs ensure that at least one Operator pod and one webhook pod remain available during node drains, preventing a complete loss of the control plane during cluster maintenance.
 

--- a/docs/source/understand/security.md
+++ b/docs/source/understand/security.md
@@ -22,13 +22,28 @@ When the `AutomaticTLSCertificates` feature gate is enabled (default since v1.11
 
 For each ScyllaDB datacenter (that is, each `ScyllaCluster` resource) the operator creates:
 
-| Resource | Type | Purpose |
-|----------|------|---------|
-| `<name>-local-client-ca` | Secret + ConfigMap | Client certificate authority — signs client certificates used for mutual TLS authentication to CQL. The CA bundle ConfigMap is distributed to ScyllaDB nodes as a truststore. |
-| `<name>-local-user-admin` | Secret | Client certificate for the `admin` user — used for mTLS authentication to CQL. |
-| `<name>-local-serving-ca` | Secret + ConfigMap | Serving certificate authority — signs the server certificate used by ScyllaDB for encrypted CQL connections. |
-| `<name>-local-serving-certs` | Secret | Server certificate for ScyllaDB — contains a multi-SAN certificate covering all pod IPs, Service ClusterIPs, LoadBalancer addresses, internal DNS names, and `cql.<domain>` / `<hostID>.cql.<domain>` DNS names for each configured DNS domain. |
-| `<name>-local-cql-connection-configs-admin` | Secret | Pre-built CQL connection configuration file containing the admin client certificate, key, and serving CA bundle for each DNS domain. |
+```{list-table}
+:header-rows: 1
+
+* - Resource
+  - Type
+  - Purpose
+* - `<name>-local-client-ca`
+  - Secret + ConfigMap
+  - Client certificate authority — signs client certificates used for mutual TLS authentication to CQL. The CA bundle ConfigMap is distributed to ScyllaDB nodes as a truststore.
+* - `<name>-local-user-admin`
+  - Secret
+  - Client certificate for the `admin` user — used for mTLS authentication to CQL.
+* - `<name>-local-serving-ca`
+  - Secret + ConfigMap
+  - Serving certificate authority — signs the server certificate used by ScyllaDB for encrypted CQL connections.
+* - `<name>-local-serving-certs`
+  - Secret
+  - Server certificate for ScyllaDB — contains a multi-SAN certificate covering all pod IPs, Service ClusterIPs, LoadBalancer addresses, internal DNS names, and `cql.<domain>` / `<hostID>.cql.<domain>` DNS names for each configured DNS domain.
+* - `<name>-local-cql-connection-configs-admin`
+  - Secret
+  - Pre-built CQL connection configuration file containing the admin client certificate, key, and serving CA bundle for each DNS domain.
+```
 
 The operator watches all member Services and pod IPs and regenerates the serving certificate whenever the set of addresses changes (new pods, LoadBalancer address assignment, etc.).
 
@@ -51,10 +66,16 @@ The `OperatorManaged` / `UserManaged` certificate toggle described below under [
 
 When Alternator is enabled (`spec.alternator` in `ScyllaCluster`), the operator creates a separate serving CA and certificate:
 
-| Resource | Purpose |
-|----------|---------|
-| `<name>-alternator-local-serving-ca` | CA for Alternator serving certificates. |
-| `<name>-alternator-local-serving-certs` | Server certificate for the Alternator HTTPS endpoint (port 8043). |
+```{list-table}
+:header-rows: 1
+
+* - Resource
+  - Purpose
+* - `<name>-alternator-local-serving-ca`
+  - CA for Alternator serving certificates.
+* - `<name>-alternator-local-serving-certs`
+  - Server certificate for the Alternator HTTPS endpoint (port 8043).
+```
 
 The Alternator serving certificate is configured through `spec.alternator.servingCertificate`, which supports two modes:
 
@@ -115,10 +136,19 @@ The member ClusterRole grants the sidecar running inside each ScyllaDB pod the m
 
 The operator installs two ClusterRoles for Kubernetes users who manage ScyllaDB resources:
 
-| ClusterRole | Aggregated to | Permissions |
-|-------------|---------------|-------------|
-| `scyllacluster-view` | `admin`, `edit`, `view` | Read-only access to ScyllaDB CRDs (`ScyllaClusters`, `ScyllaDBMonitorings`, `ScyllaDBManagerClusterRegistrations`, `ScyllaDBManagerTasks`). |
-| `scyllacluster-edit` | `admin`, `edit` | Create, update, patch, and delete ScyllaDB CRDs. |
+```{list-table}
+:header-rows: 1
+
+* - ClusterRole
+  - Aggregated to
+  - Permissions
+* - `scyllacluster-view`
+  - `admin`, `edit`, `view`
+  - Read-only access to ScyllaDB CRDs (`ScyllaClusters`, `ScyllaDBMonitorings`, `ScyllaDBManagerClusterRegistrations`, `ScyllaDBManagerTasks`).
+* - `scyllacluster-edit`
+  - `admin`, `edit`
+  - Create, update, patch, and delete ScyllaDB CRDs.
+```
 
 These ClusterRoles are aggregated into the default Kubernetes `admin`, `edit`, and `view` ClusterRoles. This means any user who has the Kubernetes `edit` role in a namespace can automatically create and manage ScyllaDB clusters in that namespace.
 

--- a/docs/source/understand/sidecar.md
+++ b/docs/source/understand/sidecar.md
@@ -8,33 +8,92 @@ A ScyllaDB pod contains init containers that run sequentially before the main wo
 
 ### Init containers (in order)
 
-| # | Name | Image | Purpose | Conditional |
-|---|------|-------|---------|-------------|
-| 1 | `sidecar-injection` | Operator | Copies the `scylla-operator` binary into the `/mnt/shared` volume so that other containers can use it without bundling the Operator image. | Always present |
-| 2 | `sysctl-buddy` | Operator | Applies sysctl settings from a pod annotation. Used during migration from legacy tuning. | Only when the sysctls annotation is set |
-| 3 | `scylladb-bootstrap-barrier` | ScyllaDB | Blocks until all nodes in the cluster report each other as UP, preventing a new node from bootstrapping into an unhealthy cluster. See [Bootstrap synchronisation](bootstrap-sync.md). | Only when the `BootstrapSynchronisation` feature gate is enabled and the ScyllaDB version is ≥ 2025.2 |
+```{list-table}
+:header-rows: 1
+
+* - #
+  - Name
+  - Image
+  - Purpose
+  - Conditional
+* - 1
+  - `sidecar-injection`
+  - Operator
+  - Copies the `scylla-operator` binary into the `/mnt/shared` volume so that other containers can use it without bundling the Operator image.
+  - Always present
+* - 2
+  - `sysctl-buddy`
+  - Operator
+  - Applies sysctl settings from a pod annotation. Used during migration from legacy tuning.
+  - Only when the sysctls annotation is set
+* - 3
+  - `scylladb-bootstrap-barrier`
+  - ScyllaDB
+  - Blocks until all nodes in the cluster report each other as UP, preventing a new node from bootstrapping into an unhealthy cluster. See [Bootstrap synchronisation](bootstrap-sync.md).
+  - Only when the `BootstrapSynchronisation` feature gate is enabled and the ScyllaDB version is ≥ 2025.2
+```
 
 ### Long-running containers
 
-| # | Name | Image | Purpose | Conditional |
-|---|------|-------|---------|-------------|
-| 1 | `scylla` | ScyllaDB | The main container. Waits for the ignition signal, then execs the sidecar binary which configures and starts ScyllaDB. | Always present |
-| 2 | `scylladb-api-status-probe` | Operator | Translates ScyllaDB's native HTTP API status into Kubernetes health-check endpoints (`/healthz`, `/readyz`) on port 8080. | Always present |
-| 3 | `scylladb-ignition` | Operator | Evaluates startup prerequisites (tuning done, IPs assigned, container running) and creates the ignition signal file when all are met. See [Ignition](ignition.md). | Always present |
-| 4 | `scylla-manager-agent` | Manager Agent | Runs the ScyllaDB Manager Agent for backup, repair, and health-check operations. Waits for the ignition signal and for the ScyllaDB REST API to become available before starting. | Only when Manager integration is configured |
+```{list-table}
+:header-rows: 1
+
+* - #
+  - Name
+  - Image
+  - Purpose
+  - Conditional
+* - 1
+  - `scylla`
+  - ScyllaDB
+  - The main container. Waits for the ignition signal, then execs the sidecar binary which configures and starts ScyllaDB.
+  - Always present
+* - 2
+  - `scylladb-api-status-probe`
+  - Operator
+  - Translates ScyllaDB's native HTTP API status into Kubernetes health-check endpoints (`/healthz`, `/readyz`) on port 8080.
+  - Always present
+* - 3
+  - `scylladb-ignition`
+  - Operator
+  - Evaluates startup prerequisites (tuning done, IPs assigned, container running) and creates the ignition signal file when all are met. See [Ignition](ignition.md).
+  - Always present
+* - 4
+  - `scylla-manager-agent`
+  - Manager Agent
+  - Runs the ScyllaDB Manager Agent for backup, repair, and health-check operations. Waits for the ignition signal and for the ScyllaDB REST API to become available before starting.
+  - Only when Manager integration is configured
+```
 
 ## Shared volumes
 
 Containers coordinate through volumes mounted into the pod:
 
-| Volume | Mount path | Purpose |
-|--------|-----------|---------|
-| `shared` (emptyDir) | `/mnt/shared` | Carries the Operator binary (injected by init container 1) and the ignition signal file (`/mnt/shared/ignition.done`). Shared by all containers. |
-| Data PVC | `/var/lib/scylla` | Persistent storage for ScyllaDB data files. Mounted read-write in the main container, read-only in the bootstrap barrier. |
-| Managed ScyllaDB config (ConfigMap) | `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/managed-config/scylladb-managed-config.yaml` | Operator-generated `scylla.yaml` with cluster name, snitch, TLS, and other managed settings. |
-| User ScyllaDB config (ConfigMap) | `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/config/scylla.yaml` | User-provided `scylla.yaml` overrides. |
-| Rack config (ConfigMap) | Snitch properties path | Datacenter and rack assignment for the gossip endpoint snitch. |
-| Agent auth token (Secret) | Agent config path | Manager Agent authentication token. |
+```{list-table}
+:header-rows: 1
+
+* - Volume
+  - Mount path
+  - Purpose
+* - `shared` (emptyDir)
+  - `/mnt/shared`
+  - Carries the Operator binary (injected by init container 1) and the ignition signal file (`/mnt/shared/ignition.done`). Shared by all containers.
+* - Data PVC
+  - `/var/lib/scylla`
+  - Persistent storage for ScyllaDB data files. Mounted read-write in the main container, read-only in the bootstrap barrier.
+* - Managed ScyllaDB config (ConfigMap)
+  - `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/managed-config/scylladb-managed-config.yaml`
+  - Operator-generated `scylla.yaml` with cluster name, snitch, TLS, and other managed settings.
+* - User ScyllaDB config (ConfigMap)
+  - `/var/run/configmaps/scylla-operator.scylladb.com/scylladb/config/scylla.yaml`
+  - User-provided `scylla.yaml` overrides.
+* - Rack config (ConfigMap)
+  - Snitch properties path
+  - Datacenter and rack assignment for the gossip endpoint snitch.
+* - Agent auth token (Secret)
+  - Agent config path
+  - Manager Agent authentication token.
+```
 
 Additional TLS-related volumes (serving certificates, client CA, admin user credentials, Alternator certificates) are mounted when the `AutomaticTLSCertificates` feature gate is enabled or when Alternator is configured.
 
@@ -108,10 +167,19 @@ Periodically polls the ScyllaDB storage service API and writes the node's gossip
 
 The `scylladb-api-status-probe` container runs an HTTP server on port 8080 that translates ScyllaDB's native HTTP API into Kubernetes probe responses:
 
-| Endpoint | Kubernetes probe | What it checks |
-|----------|-----------------|----------------|
-| `/healthz` | Startup and liveness | ScyllaDB process is alive and responsive. |
-| `/readyz` | Readiness | ScyllaDB node is ready to serve traffic. |
+```{list-table}
+:header-rows: 1
+
+* - Endpoint
+  - Kubernetes probe
+  - What it checks
+* - `/healthz`
+  - Startup and liveness
+  - ScyllaDB process is alive and responsive.
+* - `/readyz`
+  - Readiness
+  - ScyllaDB node is ready to serve traffic.
+```
 
 The `scylla` container's health probes point to these endpoints rather than directly to ScyllaDB, because ScyllaDB's native API is not designed to return the HTTP status codes that Kubernetes expects.
 

--- a/docs/source/understand/storage.md
+++ b/docs/source/understand/storage.md
@@ -8,13 +8,28 @@ This page explains how ScyllaDB Operator integrates with Kubernetes storage, the
 ScyllaDB works with both local and network-attached storage provisioners.
 However, **local NVMe storage provides substantially better performance** and is the recommended choice for production deployments.
 
-| | Local NVMe storage | Network-attached storage (e.g., EBS, Persistent Disk) |
-|---|---|---|
-| **Latency** | Microseconds — direct access to physical drives on the host | Milliseconds — network round-trip to remote block device |
-| **Throughput** | Full drive bandwidth, often multiple NVMes in RAID0 | Limited by network bandwidth and provider throttling |
-| **Data durability on node loss** | Data is lost when the node is lost. ScyllaDB's replication across multiple nodes provides durability. | Data survives node loss. PersistentVolume can be reattached to a new node. |
-| **Dynamic provisioning** | Requires a local provisioner (e.g., ScyllaDB Local CSI Driver) | Natively supported by most cloud providers |
-| **Setup complexity** | Requires NodeConfig for RAID/filesystem setup and a local provisioner | Minimal — use the cloud provider's default StorageClass |
+```{list-table}
+:header-rows: 1
+
+* - 
+  - Local NVMe storage
+  - Network-attached storage (e.g., EBS, Persistent Disk)
+* - **Latency**
+  - Microseconds — direct access to physical drives on the host
+  - Milliseconds — network round-trip to remote block device
+* - **Throughput**
+  - Full drive bandwidth, often multiple NVMes in RAID0
+  - Limited by network bandwidth and provider throttling
+* - **Data durability on node loss**
+  - Data is lost when the node is lost. ScyllaDB's replication across multiple nodes provides durability.
+  - Data survives node loss. PersistentVolume can be reattached to a new node.
+* - **Dynamic provisioning**
+  - Requires a local provisioner (e.g., ScyllaDB Local CSI Driver)
+  - Natively supported by most cloud providers
+* - **Setup complexity**
+  - Requires NodeConfig for RAID/filesystem setup and a local provisioner
+  - Minimal — use the cloud provider's default StorageClass
+```
 
 :::{tip}
 For production workloads, use **local NVMe storage** with the ScyllaDB Local CSI Driver.

--- a/docs/source/understand/tuning.md
+++ b/docs/source/understand/tuning.md
@@ -21,10 +21,16 @@ The NodeConfig controller creates a privileged DaemonSet in the `scylla-operator
 This DaemonSet runs on every node that matches the NodeConfig's placement selectors.
 Inside each DaemonSet pod, a controller creates two types of Jobs:
 
-| Job type | What it does |
-|---|---|
-| **NodePerftune** | Runs the [`perftune.py`](https://github.com/scylladb/seastar/blob/master/scripts/perftune.py) script (from the ScyllaDB utilities image) with `--tune=system --tune-clock`. This tunes kernel parameters, clock settings, network device settings, disk devices, and spreads IRQs across available CPUs. |
-| **NodeSysctls** | Applies the sysctls specified in the NodeConfig spec (e.g., `fs.aio-max-nr`, `fs.nr_open`, `vm.swappiness`) to the host via `sysctl --load`. |
+```{list-table}
+:header-rows: 1
+
+* - Job type
+  - What it does
+* - **NodePerftune**
+  - Runs the [`perftune.py`](https://github.com/scylladb/seastar/blob/master/scripts/perftune.py) script (from the ScyllaDB utilities image) with `--tune=system --tune-clock`. This tunes kernel parameters, clock settings, network device settings, disk devices, and spreads IRQs across available CPUs.
+* - **NodeSysctls**
+  - Applies the sysctls specified in the NodeConfig spec (e.g., `fs.aio-max-nr`, `fs.nr_open`, `vm.swappiness`) to the host via `sysctl --load`.
+```
 
 Both jobs run as privileged containers with access to the host filesystem.
 
@@ -42,10 +48,16 @@ It tunes the host specifically for the CPUs assigned to that ScyllaDB container.
 
 The same DaemonSet controller that creates node-level jobs also creates container-level jobs for each ScyllaDB pod:
 
-| Job type | What it does |
-|---|---|
-| **ContainerPerftune** | Runs `perftune.py` with `--tune=net` (and `--tune=disks` when data host paths are configured), setting IRQ affinity masks so that network and disk IRQs are handled by CPUs **not** assigned to the ScyllaDB container. Also configures per-NIC and per-disk settings. |
-| **ContainerResourceLimits** | Raises OS-level resource limits (such as the maximum number of open file descriptors) for the ScyllaDB process. |
+```{list-table}
+:header-rows: 1
+
+* - Job type
+  - What it does
+* - **ContainerPerftune**
+  - Runs `perftune.py` with `--tune=net` (and `--tune=disks` when data host paths are configured), setting IRQ affinity masks so that network and disk IRQs are handled by CPUs **not** assigned to the ScyllaDB container. Also configures per-NIC and per-disk settings.
+* - **ContainerResourceLimits**
+  - Raises OS-level resource limits (such as the maximum number of open file descriptors) for the ScyllaDB process.
+```
 
 ContainerPerftune runs only for pods with [Guaranteed QoS class](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#guaranteed) — because only Guaranteed pods have pinned CPUs.
 ContainerResourceLimits runs for all ScyllaDB pods regardless of QoS class.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Currently, when making changes to the docs' tables using standard syntax, the diffs are difficult to read and so it's hard to figure out what the changes to the content are. To mitigate this, this PR switches the standard syntax to `list-table` directives as already done in the support matrix: https://github.com/scylladb/scylla-operator/blob/ea13c0ebff361d0966b1424431e619fe590db7e3/docs/source/reference/releases.md?plain=1#L6-L16.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-215

/kind cleanup
/priority important-longterm