### PR TITLE
PoC - smoke-testing ScyllaDB (+ Helm) on KinD in GH Actions

### DIFF
--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -1,0 +1,61 @@
+name: Setup KinD with ScyllaDB Operator image
+description: >
+  Creates a KinD cluster, builds the operator image from source,
+  loads it into the cluster, and deploys cert-manager.
+
+outputs:
+  image-ref:
+    description: The operator image reference loaded into the cluster.
+    value: ${{ steps.meta.outputs.image-ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set image metadata
+      id: meta
+      shell: bash
+      run: echo "image-ref=localhost/scylladb/scylla-operator:e2e" >> "${GITHUB_OUTPUT}"
+
+    - name: Write KinD cluster config
+      shell: bash
+      run: |
+        cat > /tmp/kind-config.yaml <<'EOF'
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          ipFamily: ipv4
+        nodes:
+          - role: control-plane
+          - role: worker
+        EOF
+
+    - name: Create KinD cluster
+      uses: helm/kind-action@v1
+      with:
+        cluster_name: e2e
+        config: /tmp/kind-config.yaml
+
+    - name: Build operator image
+      shell: bash
+      run: docker build . -t ${{ steps.meta.outputs.image-ref }}
+
+    - name: Load operator image into KinD
+      shell: bash
+      run: kind load docker-image ${{ steps.meta.outputs.image-ref }} --name e2e
+
+    - name: Deploy cert-manager
+      shell: bash
+      run: |
+        kubectl apply --server-side --force-conflicts -f examples/third-party/cert-manager.yaml
+
+        kubectl wait --for=condition=established --timeout=60s \
+          crd/certificates.cert-manager.io \
+          crd/issuers.cert-manager.io
+
+        for deploy in cert-manager cert-manager-cainjector cert-manager-webhook; do
+          kubectl -n cert-manager rollout status --timeout=5m deployment.apps/"${deploy}"
+        done
+
+        # Wait for the webhook CA secret to be created before proceeding,
+        # otherwise the operator's Certificate resource may fail to be issued.
+        kubectl wait --timeout=60s --for=create -n cert-manager secret/cert-manager-webhook-ca

--- a/.github/workflows/e2e-kind-helm.yaml
+++ b/.github/workflows/e2e-kind-helm.yaml
@@ -1,0 +1,113 @@
+name: "E2E: KinD (Helm)"
+
+on:
+  push:
+    branches:
+      - mf/gha-poc
+  workflow_dispatch:
+
+jobs:
+  e2e-kind-helm:
+    name: Deploy ScyllaDB on KinD using Helm
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup KinD cluster
+        id: setup
+        uses: ./.github/actions/setup-kind
+
+      - name: Deploy operator (Helm)
+        env:
+          IMAGE_REF: ${{ steps.setup.outputs.image-ref }}
+        run: |
+          # Extract repository and tag from the full image reference.
+          # "localhost/scylladb/scylla-operator:e2e" -> repo="localhost/scylladb", tag="e2e"
+          repo="${IMAGE_REF%/*}"
+          tag="${IMAGE_REF##*:}"
+
+          helm install scylla-operator helm/scylla-operator \
+            --create-namespace \
+            --namespace scylla-operator \
+            --set "image.repository=${repo}" \
+            --set "image.tag=${tag}" \
+            --set replicas=1 \
+            --set webhookServerReplicas=1
+
+          # Wait for CRDs to be established.
+          kubectl wait --for=condition=established --timeout=60s \
+            crd/scyllaclusters.scylla.scylladb.com
+
+          # Wait for rollout.
+          kubectl -n scylla-operator rollout status --timeout=5m deployment/scylla-operator
+          kubectl -n scylla-operator rollout status --timeout=5m deployment/webhook-server
+
+      - name: Deploy ScyllaDB cluster (Helm)
+        run: |
+          helm install scylla helm/scylla \
+            --create-namespace \
+            --namespace scylla \
+            --set developerMode=true \
+            --set "scyllaArgs=--reactor-backend=io_uring" \
+            --set "exposeOptions.nodeService.type=Headless" \
+            --set "exposeOptions.broadcastOptions.nodes.type=PodIP" \
+            --set "exposeOptions.broadcastOptions.clients.type=PodIP" \
+            --set "racks[0].name=us-east-1a" \
+            --set "racks[0].members=1" \
+            --set "racks[0].storage.storageClassName=standard" \
+            --set "racks[0].storage.capacity=1Gi" \
+            --set "racks[0].resources.requests.cpu=10m" \
+            --set "racks[0].resources.requests.memory=100Mi" \
+            --set "racks[0].resources.limits.cpu=1" \
+            --set "racks[0].resources.limits.memory=1Gi" \
+            --set "racks[0].placement=null"
+
+      - name: Wait for ScyllaCluster to be ready
+        run: |
+          echo "Waiting for ScyllaCluster to roll out..."
+          kubectl -n scylla wait --timeout=10m --for='condition=Progressing=False' \
+            scyllacluster/scylla
+          kubectl -n scylla wait --timeout=10m --for='condition=Degraded=False' \
+            scyllacluster/scylla
+          kubectl -n scylla wait --timeout=10m --for='condition=Available=True' \
+            scyllacluster/scylla
+          echo "ScyllaCluster is available."
+
+      - name: Verify CQL connectivity
+        run: |
+          pod="$(kubectl -n scylla get pods -l "scylla/cluster=scylla" -o jsonpath='{.items[0].metadata.name}')"
+          echo "Running CQL query against pod ${pod}..."
+
+          kubectl -n scylla exec "${pod}" -c scylla -- \
+            cqlsh localhost -e "SELECT key, cluster_name, data_center FROM system.local"
+
+          echo "CQL connectivity verified."
+
+      - name: Collect debug info
+        if: always()
+        run: |
+          echo "=== Cluster-wide pod status ==="
+          kubectl get pods -A -o wide || true
+
+          echo ""
+          echo "=== ScyllaCluster status ==="
+          kubectl -n scylla get scyllaclusters -o yaml || true
+
+          echo ""
+          echo "=== Scylla pods ==="
+          kubectl -n scylla describe pods || true
+
+          echo ""
+          echo "=== Operator logs ==="
+          kubectl -n scylla-operator logs deployment/scylla-operator --tail=100 || true
+
+          echo ""
+          echo "=== Webhook server logs ==="
+          kubectl -n scylla-operator logs deployment/webhook-server --tail=50 || true
+
+          echo ""
+          echo "=== Helm releases ==="
+          helm list -A || true

--- a/.github/workflows/e2e-kind-helm.yaml
+++ b/.github/workflows/e2e-kind-helm.yaml
@@ -47,23 +47,36 @@ jobs:
 
       - name: Deploy ScyllaDB cluster (Helm)
         run: |
+          cat > /tmp/scylla-values.yaml <<'EOF'
+          developerMode: true
+          scyllaArgs: "--reactor-backend=io_uring"
+          exposeOptions:
+            nodeService:
+              type: Headless
+            broadcastOptions:
+              nodes:
+                type: PodIP
+              clients:
+                type: PodIP
+          racks:
+            - name: us-east-1a
+              members: 1
+              storage:
+                storageClassName: standard
+                capacity: 1Gi
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 100Mi
+                limits:
+                  cpu: 1
+                  memory: 1Gi
+          EOF
+
           helm install scylla helm/scylla \
             --create-namespace \
             --namespace scylla \
-            --set developerMode=true \
-            --set "scyllaArgs=--reactor-backend=io_uring" \
-            --set "exposeOptions.nodeService.type=Headless" \
-            --set "exposeOptions.broadcastOptions.nodes.type=PodIP" \
-            --set "exposeOptions.broadcastOptions.clients.type=PodIP" \
-            --set "racks[0].name=us-east-1a" \
-            --set "racks[0].members=1" \
-            --set "racks[0].storage.storageClassName=standard" \
-            --set "racks[0].storage.capacity=1Gi" \
-            --set "racks[0].resources.requests.cpu=10m" \
-            --set "racks[0].resources.requests.memory=100Mi" \
-            --set "racks[0].resources.limits.cpu=1" \
-            --set "racks[0].resources.limits.memory=1Gi" \
-            --set "racks[0].placement=null"
+            -f /tmp/scylla-values.yaml
 
       - name: Wait for ScyllaCluster to be ready
         run: |

--- a/.github/workflows/e2e-kind-helm.yaml
+++ b/.github/workflows/e2e-kind-helm.yaml
@@ -6,6 +6,9 @@ on:
       - mf/gha-poc
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-kind-helm:
     name: Deploy ScyllaDB on KinD using Helm

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -1,0 +1,163 @@
+name: "E2E: KinD"
+
+on:
+  push:
+    branches:
+      - mf/gha-poc
+  workflow_dispatch:
+
+jobs:
+  e2e-kind:
+    name: Deploy ScyllaDB on KinD
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create KinD cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: e2e
+          config: |
+            kind: Cluster
+            apiVersion: kind.x-k8s.io/v1alpha4
+            networking:
+              ipFamily: ipv4
+            nodes:
+              - role: control-plane
+              - role: worker
+
+      - name: Build operator image
+        run: docker build . -t localhost/scylladb/scylla-operator:e2e
+
+      - name: Load operator image into KinD
+        run: kind load docker-image localhost/scylladb/scylla-operator:e2e --name e2e
+
+      - name: Deploy cert-manager
+        run: |
+          kubectl apply --server-side --force-conflicts -f examples/third-party/cert-manager.yaml
+
+          kubectl wait --for=condition=established --timeout=60s \
+            crd/certificates.cert-manager.io \
+            crd/issuers.cert-manager.io
+
+          for deploy in cert-manager cert-manager-cainjector cert-manager-webhook; do
+            kubectl -n cert-manager rollout status --timeout=5m deployment.apps/"${deploy}"
+          done
+
+          # Wait for the webhook CA secret to be created before proceeding,
+          # otherwise the operator's Certificate resource may fail to be issued.
+          kubectl wait --timeout=60s --for=create -n cert-manager secret/cert-manager-webhook-ca
+
+      - name: Deploy operator
+        env:
+          IMAGE_REF: localhost/scylladb/scylla-operator:e2e
+        run: |
+          kubectl apply --server-side --force-conflicts -f deploy/operator.yaml
+
+          # Scale to 1 replica — a 2-node KinD cluster can't satisfy the
+          # pod anti-affinity preferred by the default 2-replica Deployments.
+          kubectl -n scylla-operator scale --replicas=1 \
+            deployment/scylla-operator \
+            deployment/webhook-server
+
+          # Point both Deployments at the locally-built image.
+          kubectl -n scylla-operator set image \
+            deployment/scylla-operator scylla-operator="${IMAGE_REF}"
+          kubectl -n scylla-operator set env \
+            deployment/scylla-operator SCYLLA_OPERATOR_IMAGE="${IMAGE_REF}"
+          kubectl -n scylla-operator set image \
+            deployment/webhook-server webhook-server="${IMAGE_REF}"
+
+          # Wait for CRDs to be established.
+          kubectl wait --for=condition=established --timeout=60s \
+            crd/scyllaclusters.scylla.scylladb.com
+
+          # Wait for rollout.
+          kubectl -n scylla-operator rollout status --timeout=5m deployment/scylla-operator
+          kubectl -n scylla-operator rollout status --timeout=5m deployment/webhook-server
+
+      - name: Create ScyllaCluster
+        run: |
+          kubectl create namespace scylla
+
+          kubectl apply -f - <<'EOF'
+          apiVersion: scylla.scylladb.com/v1
+          kind: ScyllaCluster
+          metadata:
+            name: scylla-test
+            namespace: scylla
+          spec:
+            version: "2026.2.0"
+            agentVersion: "3.11.2@sha256:9fd3ba869f1d610b5f3f635a958ecfd3083c7abb8c9cdb12d0d26c6add0b67d9"
+            developerMode: true
+            scyllaArgs: "--reactor-backend=io_uring"
+            exposeOptions:
+              nodeService:
+                type: Headless
+              broadcastOptions:
+                nodes:
+                  type: PodIP
+                clients:
+                  type: PodIP
+            datacenter:
+              name: us-east-1
+              racks:
+                - name: us-east-1a
+                  members: 1
+                  storage:
+                    capacity: 1Gi
+                    storageClassName: standard
+                  resources:
+                    requests:
+                      cpu: 10m
+                      memory: 100Mi
+                    limits:
+                      cpu: 1
+                      memory: 1Gi
+          EOF
+
+      - name: Wait for ScyllaCluster to be ready
+        run: |
+          echo "Waiting for ScyllaCluster to roll out..."
+          kubectl -n scylla wait --timeout=10m --for='condition=Progressing=False' \
+            scyllacluster/scylla-test
+          kubectl -n scylla wait --timeout=10m --for='condition=Degraded=False' \
+            scyllacluster/scylla-test
+          kubectl -n scylla wait --timeout=10m --for='condition=Available=True' \
+            scyllacluster/scylla-test
+          echo "ScyllaCluster is available."
+
+      - name: Verify CQL connectivity
+        run: |
+          pod="$(kubectl -n scylla get pods -l "scylla/cluster=scylla-test" -o jsonpath='{.items[0].metadata.name}')"
+          echo "Running CQL query against pod ${pod}..."
+
+          kubectl -n scylla exec "${pod}" -c scylla -- \
+            cqlsh localhost -e "SELECT key, cluster_name, data_center FROM system.local"
+
+          echo "CQL connectivity verified."
+
+      - name: Collect debug info
+        if: always()
+        run: |
+          echo "=== Cluster-wide pod status ==="
+          kubectl get pods -A -o wide || true
+
+          echo ""
+          echo "=== ScyllaCluster status ==="
+          kubectl -n scylla get scyllaclusters -o yaml || true
+
+          echo ""
+          echo "=== Scylla pods ==="
+          kubectl -n scylla describe pods || true
+
+          echo ""
+          echo "=== Operator logs ==="
+          kubectl -n scylla-operator logs deployment/scylla-operator --tail=100 || true
+
+          echo ""
+          echo "=== Webhook server logs ==="
+          kubectl -n scylla-operator logs deployment/webhook-server --tail=50 || true

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -16,49 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Write KinD cluster config
-        run: |
-          cat > /tmp/kind-config.yaml <<'EOF'
-          kind: Cluster
-          apiVersion: kind.x-k8s.io/v1alpha4
-          networking:
-            ipFamily: ipv4
-          nodes:
-            - role: control-plane
-            - role: worker
-          EOF
-
-      - name: Create KinD cluster
-        uses: helm/kind-action@v1
-        with:
-          cluster_name: e2e
-          config: /tmp/kind-config.yaml
-
-      - name: Build operator image
-        run: docker build . -t localhost/scylladb/scylla-operator:e2e
-
-      - name: Load operator image into KinD
-        run: kind load docker-image localhost/scylladb/scylla-operator:e2e --name e2e
-
-      - name: Deploy cert-manager
-        run: |
-          kubectl apply --server-side --force-conflicts -f examples/third-party/cert-manager.yaml
-
-          kubectl wait --for=condition=established --timeout=60s \
-            crd/certificates.cert-manager.io \
-            crd/issuers.cert-manager.io
-
-          for deploy in cert-manager cert-manager-cainjector cert-manager-webhook; do
-            kubectl -n cert-manager rollout status --timeout=5m deployment.apps/"${deploy}"
-          done
-
-          # Wait for the webhook CA secret to be created before proceeding,
-          # otherwise the operator's Certificate resource may fail to be issued.
-          kubectl wait --timeout=60s --for=create -n cert-manager secret/cert-manager-webhook-ca
+      - name: Setup KinD cluster
+        id: setup
+        uses: ./.github/actions/setup-kind
 
       - name: Deploy operator
         env:
-          IMAGE_REF: localhost/scylladb/scylla-operator:e2e
+          IMAGE_REF: ${{ steps.setup.outputs.image-ref }}
         run: |
           kubectl apply --server-side --force-conflicts -f deploy/operator.yaml
 

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -16,18 +16,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Write KinD cluster config
+        run: |
+          cat > /tmp/kind-config.yaml <<'EOF'
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          networking:
+            ipFamily: ipv4
+          nodes:
+            - role: control-plane
+            - role: worker
+          EOF
+
       - name: Create KinD cluster
         uses: helm/kind-action@v1
         with:
           cluster_name: e2e
-          config: |
-            kind: Cluster
-            apiVersion: kind.x-k8s.io/v1alpha4
-            networking:
-              ipFamily: ipv4
-            nodes:
-              - role: control-plane
-              - role: worker
+          config: /tmp/kind-config.yaml
 
       - name: Build operator image
         run: docker build . -t localhost/scylladb/scylla-operator:e2e

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -6,6 +6,9 @@ on:
       - mf/gha-poc
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-kind:
     name: Deploy ScyllaDB on KinD


### PR DESCRIPTION
Proof-of-concept of deploying Operator + ScyllaDB on KinD using plain GH Actions.
It turned out that custom runners weren't even necessary for the simplest possible workflow.

Successful runs (their existence resolves OPERATOR-223):
- https://github.com/scylladb/scylla-operator/actions/runs/28967628915/job/85954736574 (without Helm)
- https://github.com/scylladb/scylla-operator/actions/runs/28967628705/job/85954735696 (with Helm).

This PR is not intended to be merged.

Linked issue: OPERATOR-223