### PR TITLE
test: collect logs from the replaced node in node replacement E2E test

### DIFF
--- a/pkg/gather/collect/collect.go
+++ b/pkg/gather/collect/collect.go
@@ -216,6 +216,36 @@ func (c *Collector) CollectResourceObject(ctx context.Context, resourceInfo *Res
 	return c.CollectObject(ctx, obj, resourceInfo)
 }
 
+// CollectResourceObjectWithOptionsAndFollowLogs gets the object using the dynamic client and follows its logs.
+func (c *Collector) CollectResourceObjectWithOptionsAndFollowLogs(ctx context.Context, resourceInfo *ResourceInfo, namespace, name string, options CollectObjectOptions, streamOpenCallback func()) error {
+	obj, err := c.dynamicClient.Resource(resourceInfo.Resource).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("can't get resource %q: %w", resourceInfo.Resource, err)
+	}
+
+	return c.CollectObjectWithOptionsAndFollowLogs(ctx, obj, resourceInfo, options, streamOpenCallback)
+}
+
+// CollectObjectWithOptionsAndFollowLogs collects the object's manifest and follows its current container logs until
+// the stream ends. Previous and terminated logs are dumped once without following.
+// Only Pods are supported.
+// streamOpenCallback, if non-nil, is called once all running container log streams are successfully opened.
+func (c *Collector) CollectObjectWithOptionsAndFollowLogs(ctx context.Context, u *unstructured.Unstructured, resourceInfo *ResourceInfo, options CollectObjectOptions, streamOpenCallback func()) error {
+	key := getResourceKey(u, resourceInfo)
+	if c.collectedResources.Has(key) {
+		klog.V(3).InfoS("Skipping already collected resource", "Resource", resourceInfo.Resource, "Ref", naming.ObjRef(u))
+		return nil
+	}
+	c.collectedResources.Insert(key)
+
+	switch resourceInfo.Resource.GroupResource() {
+	case corev1.SchemeGroupVersion.WithResource("pods").GroupResource():
+		return c.podCollector.CollectAndFollowLogs(ctx, u, resourceInfo, options, streamOpenCallback)
+	default:
+		return fmt.Errorf("following logs is only supported for Pods, got %q", resourceInfo.Resource.GroupResource())
+	}
+}
+
 func (c *Collector) CollectResourceObjects(ctx context.Context, resourceInfo *ResourceInfo, namespace string) error {
 	l, err := c.dynamicClient.Resource(resourceInfo.Resource).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {

--- a/pkg/gather/collect/collect.go
+++ b/pkg/gather/collect/collect.go
@@ -171,7 +171,17 @@ func (c *Collector) collectScyllaDBMonitoring(ctx context.Context, u *unstructur
 	return nil
 }
 
+// CollectObjectOptions customizes how a single object is collected.
+type CollectObjectOptions struct {
+	// TransformName, if set, is applied to a resource's name to produce the name used for its filesystem artifact path.
+	TransformName func(name string) string
+}
+
 func (c *Collector) CollectObject(ctx context.Context, u *unstructured.Unstructured, resourceInfo *ResourceInfo) error {
+	return c.CollectObjectWithOptions(ctx, u, resourceInfo, CollectObjectOptions{})
+}
+
+func (c *Collector) CollectObjectWithOptions(ctx context.Context, u *unstructured.Unstructured, resourceInfo *ResourceInfo, options CollectObjectOptions) error {
 	key := getResourceKey(u, resourceInfo)
 	if c.collectedResources.Has(key) {
 		klog.V(3).InfoS("Skipping already collected resource", "Resource", resourceInfo.Resource, "Ref", naming.ObjRef(u))
@@ -181,7 +191,7 @@ func (c *Collector) CollectObject(ctx context.Context, u *unstructured.Unstructu
 
 	switch resourceInfo.Resource.GroupResource() {
 	case corev1.SchemeGroupVersion.WithResource("pods").GroupResource():
-		return c.podCollector.Collect(ctx, u, resourceInfo)
+		return c.podCollector.CollectWithOptions(ctx, u, resourceInfo, options)
 
 	case corev1.SchemeGroupVersion.WithResource("namespaces").GroupResource():
 		return c.collectNamespace(ctx, u, resourceInfo)

--- a/pkg/gather/collect/collect_test.go
+++ b/pkg/gather/collect/collect_test.go
@@ -48,6 +48,7 @@ func TestCollector_CollectObject(t *testing.T) {
 		existingObjects  []runtime.Object
 		relatedResources bool
 		keepGoing        bool
+		collectOptions   CollectObjectOptions
 		expectedDump     *testhelpers.GatherDump
 		expectedError    error
 	}{
@@ -278,6 +279,130 @@ status:
 					},
 					{
 						Name:    "namespaces/test/pods/my-pod/my-init-container.current",
+						Content: "fake logs",
+					},
+				},
+			},
+		},
+		{
+			name: "applies TransformName to the manifest filename and pod log directory",
+			targetedObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "my-container"},
+					},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "my-container",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			existingObjects:  nil,
+			relatedResources: false,
+			keepGoing:        false,
+			collectOptions: CollectObjectOptions{
+				TransformName: func(name string) string {
+					return name + ".suffix"
+				},
+			},
+			expectedError: nil,
+			expectedDump: &testhelpers.GatherDump{
+				Files: []testhelpers.File{
+					{
+						Name: "namespaces/test/pods/my-pod.suffix.yaml",
+						Content: strings.TrimPrefix(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: test
+spec:
+  containers:
+  - name: my-container
+    resources: {}
+status:
+  containerStatuses:
+  - image: ""
+    imageID: ""
+    lastState: {}
+    name: my-container
+    ready: false
+    restartCount: 0
+    state:
+      running:
+        startedAt: null
+`, "\n"),
+					},
+					{
+						Name:    "namespaces/test/pods/my-pod.suffix/my-container.current",
+						Content: "fake logs",
+					},
+				},
+			},
+		},
+		{
+			name: "nil TransformName behaves like zero-value options",
+			targetedObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "my-container"},
+					},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "my-container",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			existingObjects:  nil,
+			relatedResources: false,
+			keepGoing:        false,
+			collectOptions:   CollectObjectOptions{},
+			expectedError:    nil,
+			expectedDump: &testhelpers.GatherDump{
+				Files: []testhelpers.File{
+					{
+						Name: "namespaces/test/pods/my-pod.yaml",
+						Content: strings.TrimPrefix(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: test
+spec:
+  containers:
+  - name: my-container
+    resources: {}
+status:
+  containerStatuses:
+  - image: ""
+    imageID: ""
+    lastState: {}
+    name: my-container
+    ready: false
+    restartCount: 0
+    state:
+      running:
+        startedAt: null
+`, "\n"),
+					},
+					{
+						Name:    "namespaces/test/pods/my-pod/my-container.current",
 						Content: "fake logs",
 					},
 				},
@@ -1007,7 +1132,7 @@ status: {}
 				t.Fatal(err)
 			}
 
-			err = collector.CollectObject(ctx, u, NewResourceInfoFromMapping(mapping))
+			err = collector.CollectObjectWithOptions(ctx, u, NewResourceInfoFromMapping(mapping), tc.collectOptions)
 			if !reflect.DeepEqual(err, tc.expectedError) {
 				t.Fatal(err)
 			}

--- a/pkg/gather/collect/helpers.go
+++ b/pkg/gather/collect/helpers.go
@@ -10,7 +10,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func GetPodLogs(ctx context.Context, podClient corev1client.PodInterface, writer io.Writer, podName string, logOptions *corev1.PodLogOptions) error {
+// GetPodLogs streams logs into a writer.
+// streamOpenCallback is called after the stream is opened.
+func GetPodLogs(ctx context.Context, podClient corev1client.PodInterface, writer io.Writer, podName string, logOptions *corev1.PodLogOptions, streamOpenCallback func()) error {
 	logsReq := podClient.GetLogs(podName, logOptions)
 	readCloser, err := logsReq.Stream(ctx)
 	if err != nil {
@@ -22,6 +24,10 @@ func GetPodLogs(ctx context.Context, podClient corev1client.PodInterface, writer
 			klog.ErrorS(err, "can't close log stream", "Pod", podName, "Container", logOptions.Container)
 		}
 	}()
+
+	if streamOpenCallback != nil {
+		streamOpenCallback()
+	}
 
 	_, err = io.Copy(writer, readCloser)
 	if err != nil {

--- a/pkg/gather/collect/podcollector.go
+++ b/pkg/gather/collect/podcollector.go
@@ -26,7 +26,7 @@ import (
 
 type PodRuntimeCollector struct {
 	Filter  func(pod *corev1.Pod) bool
-	Collect func(context.Context, *corev1.Pod, *ResourceInfo) error
+	Collect func(context.Context, *corev1.Pod, *ResourceInfo, CollectObjectOptions) error
 }
 
 type PodCollector struct {
@@ -87,18 +87,22 @@ func NewPodCollector(restConfig *rest.Config, corev1Client corev1client.CoreV1In
 }
 
 func (c *PodCollector) Collect(ctx context.Context, u *unstructured.Unstructured, resourceInfo *ResourceInfo) error {
+	return c.CollectWithOptions(ctx, u, resourceInfo, CollectObjectOptions{})
+}
+
+func (c *PodCollector) CollectWithOptions(ctx context.Context, u *unstructured.Unstructured, resourceInfo *ResourceInfo, options CollectObjectOptions) error {
 	pod := &corev1.Pod{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, pod)
 	if err != nil {
 		return fmt.Errorf("can't convert secret from unstructured: %w", err)
 	}
 
-	err = c.resourceWriter.WriteResource(ctx, pod, resourceInfo)
+	err = c.resourceWriter.WriteResourceWithOptions(ctx, pod, resourceInfo, options)
 	if err != nil {
 		return fmt.Errorf("can't write resource %q: %w", resourceInfo, err)
 	}
 
-	err = c.collectPodRuntimeInformation(ctx, pod, resourceInfo)
+	err = c.collectPodRuntimeInformation(ctx, pod, resourceInfo, options)
 	if err != nil {
 		return fmt.Errorf("can't collect runtime information: %w", err)
 	}
@@ -193,14 +197,14 @@ func (c *PodCollector) collectContainerLogs(ctx context.Context, logsDir string,
 	return nil
 }
 
-func (c *PodCollector) collectPodRuntimeInformation(ctx context.Context, pod *corev1.Pod, resourceInfo *ResourceInfo) error {
+func (c *PodCollector) collectPodRuntimeInformation(ctx context.Context, pod *corev1.Pod, resourceInfo *ResourceInfo, options CollectObjectOptions) error {
 	var errs []error
 	for _, fc := range c.podRuntimeCollectors {
 		if fc.Filter != nil && !fc.Filter(pod) {
 			continue
 		}
 
-		err := fc.Collect(ctx, pod, resourceInfo)
+		err := fc.Collect(ctx, pod, resourceInfo, options)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("can't collect Pod %q runtime information: %w", naming.ObjRef(pod), err))
 		}
@@ -209,8 +213,8 @@ func (c *PodCollector) collectPodRuntimeInformation(ctx context.Context, pod *co
 	return nil
 }
 
-func (c *PodCollector) collectPodLogs(ctx context.Context, pod *corev1.Pod, resourceInfo *ResourceInfo) error {
-	podDir, err := c.createPodDirectory(pod, resourceInfo)
+func (c *PodCollector) collectPodLogs(ctx context.Context, pod *corev1.Pod, resourceInfo *ResourceInfo, options CollectObjectOptions) error {
+	podDir, err := c.createPodDirectory(pod, resourceInfo, options)
 	if err != nil {
 		return fmt.Errorf("can't create pod directory: %w", err)
 	}
@@ -239,12 +243,16 @@ func (c *PodCollector) collectPodLogs(ctx context.Context, pod *corev1.Pod, reso
 	return nil
 }
 
-func (c *PodCollector) createPodDirectory(pod *corev1.Pod, resourceInfo *ResourceInfo) (string, error) {
+func (c *PodCollector) createPodDirectory(pod *corev1.Pod, resourceInfo *ResourceInfo, options CollectObjectOptions) (string, error) {
 	resourceDir, err := c.resourceWriter.GetResourceDir(pod, resourceInfo)
 	if err != nil {
 		return "", fmt.Errorf("can't get resourceDir: %q", err)
 	}
-	podDir := filepath.Join(resourceDir, pod.GetName())
+	name := pod.GetName()
+	if options.TransformName != nil {
+		name = options.TransformName(name)
+	}
+	podDir := filepath.Join(resourceDir, name)
 
 	err = os.MkdirAll(podDir, 0770)
 	if err != nil {
@@ -288,11 +296,11 @@ func (c *PodCollector) executeRemoteCommand(ctx context.Context, pod *corev1.Pod
 	return stdout, stderr, nil
 }
 
-func (c *PodCollector) collectContainerCommandOutputFunc(containerName string, filename string, command []string) func(context.Context, *corev1.Pod, *ResourceInfo) error {
-	return func(ctx context.Context, pod *corev1.Pod, resourceInfo *ResourceInfo) error {
+func (c *PodCollector) collectContainerCommandOutputFunc(containerName string, filename string, command []string) func(context.Context, *corev1.Pod, *ResourceInfo, CollectObjectOptions) error {
+	return func(ctx context.Context, pod *corev1.Pod, resourceInfo *ResourceInfo, options CollectObjectOptions) error {
 		klog.V(4).InfoS("Collecting container command output", "Namespace", pod.Namespace, "Pod", pod.Name, "Container", containerName, "Command", command)
 
-		podDir, err := c.createPodDirectory(pod, resourceInfo)
+		podDir, err := c.createPodDirectory(pod, resourceInfo, options)
 		if err != nil {
 			return fmt.Errorf("can't create pod directory: %w", err)
 		}

--- a/pkg/gather/collect/podcollector.go
+++ b/pkg/gather/collect/podcollector.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -110,7 +111,36 @@ func (c *PodCollector) CollectWithOptions(ctx context.Context, u *unstructured.U
 	return nil
 }
 
-func writeContainerLogsToFile(ctx context.Context, podClient corev1client.PodInterface, destinationPath string, podName string, logOptions *corev1.PodLogOptions) error {
+// CollectAndFollowLogs writes the Pod manifest and collects all container logs.
+// For running containers, logs are streamed with Follow=true and the call blocks until the stream ends.
+// For previously-terminated and currently-terminated containers, logs are collected as one-shot dumps.
+// streamOpenCallback, if non-nil, is called once all running container log streams are successfully opened.
+func (c *PodCollector) CollectAndFollowLogs(ctx context.Context, u *unstructured.Unstructured, resourceInfo *ResourceInfo, options CollectObjectOptions, streamOpenCallback func()) error {
+	pod := &corev1.Pod{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, pod)
+	if err != nil {
+		return fmt.Errorf("can't convert pod from unstructured: %w", err)
+	}
+
+	err = c.resourceWriter.WriteResourceWithOptions(ctx, pod, resourceInfo, options)
+	if err != nil {
+		return fmt.Errorf("can't write resource %q: %w", resourceInfo, err)
+	}
+
+	podDir, err := c.createPodDirectory(pod, resourceInfo, options)
+	if err != nil {
+		return fmt.Errorf("can't create pod directory: %w", err)
+	}
+
+	err = c.followPodLogs(ctx, podDir, pod, streamOpenCallback)
+	if err != nil {
+		return fmt.Errorf("can't collect pod logs: %w", err)
+	}
+
+	return nil
+}
+
+func writeContainerLogsToFile(ctx context.Context, podClient corev1client.PodInterface, destinationPath string, podName string, logOptions *corev1.PodLogOptions, streamOpenCallback func()) error {
 	dest, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return fmt.Errorf("can't open file %q: %w", destinationPath, err)
@@ -122,24 +152,7 @@ func writeContainerLogsToFile(ctx context.Context, podClient corev1client.PodInt
 		}
 	}()
 
-	logsReq := podClient.GetLogs(podName, logOptions)
-	readCloser, err := logsReq.Stream(ctx)
-	if err != nil {
-		return fmt.Errorf("can't create a log stream: %w", err)
-	}
-	defer func() {
-		err := readCloser.Close()
-		if err != nil {
-			klog.ErrorS(err, "can't close log stream", "Path", destinationPath, "Pod", podName, "Container", logOptions.Container)
-		}
-	}()
-
-	_, err = io.Copy(dest, readCloser)
-	if err != nil {
-		return fmt.Errorf("can't read logs: %w", err)
-	}
-
-	return nil
+	return GetPodLogs(ctx, podClient, dest, podName, logOptions, streamOpenCallback)
 }
 
 func (c *PodCollector) collectContainerLogs(ctx context.Context, logsDir string, podMeta *metav1.ObjectMeta, podCSs []corev1.ContainerStatus, containerName string) error {
@@ -161,8 +174,8 @@ func (c *PodCollector) collectContainerLogs(ctx context.Context, logsDir string,
 	logOptions := &corev1.PodLogOptions{
 		Container:  containerName,
 		Timestamps: true,
-		Follow:     false,
 		LimitBytes: limitBytes,
+		Follow:     false,
 	}
 
 	// TODO: Tolerate errors in case state changes in the meantime (like when a pod is being restarted in backoff)
@@ -172,7 +185,7 @@ func (c *PodCollector) collectContainerLogs(ctx context.Context, logsDir string,
 	if cs.State.Running != nil {
 		// Retrieve current logs.
 		logOptions.Previous = false
-		err = writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".current"), podMeta.Name, logOptions)
+		err = writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".current"), podMeta.Name, logOptions, nil)
 		if err != nil {
 			return fmt.Errorf("can't retrieve pod logs for container %q in pod %q: %w", containerName, naming.ObjRef(podMeta), err)
 		}
@@ -180,7 +193,7 @@ func (c *PodCollector) collectContainerLogs(ctx context.Context, logsDir string,
 
 	if cs.LastTerminationState.Terminated != nil {
 		logOptions.Previous = true
-		err = writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".previous"), podMeta.Name, logOptions)
+		err = writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".previous"), podMeta.Name, logOptions, nil)
 		if err != nil {
 			return fmt.Errorf("can't retrieve previous pod logs for container %q in pod %q: %w", containerName, naming.ObjRef(podMeta), err)
 		}
@@ -188,10 +201,31 @@ func (c *PodCollector) collectContainerLogs(ctx context.Context, logsDir string,
 
 	if cs.State.Terminated != nil {
 		logOptions.Previous = false
-		err = writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".terminated"), podMeta.Name, logOptions)
+		err = writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".terminated"), podMeta.Name, logOptions, nil)
 		if err != nil {
 			return fmt.Errorf("can't retrieve pod logs for terminated container %q in pod %q: %w", containerName, naming.ObjRef(podMeta), err)
 		}
+	}
+
+	return nil
+}
+
+func (c *PodCollector) followContainerLogs(ctx context.Context, logsDir string, podMeta *metav1.ObjectMeta, containerName string, streamOpenCallback func()) error {
+	var limitBytes *int64
+	if c.logsLimitBytes > 0 {
+		limitBytes = pointer.Ptr(c.logsLimitBytes)
+	}
+
+	logOptions := &corev1.PodLogOptions{
+		Container:  containerName,
+		Timestamps: true,
+		LimitBytes: limitBytes,
+		Follow:     true,
+	}
+
+	err := writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".current"), podMeta.Name, logOptions, streamOpenCallback)
+	if err != nil {
+		return fmt.Errorf("can't retrieve pod logs for container %q in pod %q: %w", containerName, naming.ObjRef(podMeta), err)
 	}
 
 	return nil
@@ -243,11 +277,178 @@ func (c *PodCollector) collectPodLogs(ctx context.Context, pod *corev1.Pod, reso
 	return nil
 }
 
+func (c *PodCollector) followPodLogs(ctx context.Context, podDir string, pod *corev1.Pod, streamOpenCallback func()) error {
+	var errs []error
+	for _, container := range pod.Spec.InitContainers {
+		err := c.collectContainerOneShotLogs(ctx, podDir, &pod.ObjectMeta, pod.Status.InitContainerStatuses, container.Name)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't collect logs for init container %q in pod %q: %w", container.Name, naming.ObjRef(pod), err))
+		}
+	}
+
+	for _, container := range pod.Spec.Containers {
+		err := c.collectContainerOneShotLogs(ctx, podDir, &pod.ObjectMeta, pod.Status.ContainerStatuses, container.Name)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't collect logs for container %q in pod %q: %w", container.Name, naming.ObjRef(pod), err))
+		}
+	}
+
+	for _, container := range pod.Spec.EphemeralContainers {
+		err := c.collectContainerOneShotLogs(ctx, podDir, &pod.ObjectMeta, pod.Status.EphemeralContainerStatuses, container.Name)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't collect logs for ephemeral container %q in pod %q: %w", container.Name, naming.ObjRef(pod), err))
+		}
+	}
+
+	if len(errs) != 0 {
+		return apimachineryutilerrors.NewAggregate(errs)
+	}
+
+	return c.followCurrentContainerLogs(ctx, podDir, pod, streamOpenCallback)
+}
+
+func (c *PodCollector) collectContainerOneShotLogs(ctx context.Context, logsDir string, podMeta *metav1.ObjectMeta, podCSs []corev1.ContainerStatus, containerName string) error {
+	cs, _, found := oslices.Find(podCSs, func(s corev1.ContainerStatus) bool {
+		return s.Name == containerName
+	})
+	if !found {
+		klog.InfoS("Container doesn't yet have a status", "Pod", naming.ObjRef(podMeta), "Container", containerName)
+		return nil
+	}
+
+	var limitBytes *int64
+	if c.logsLimitBytes > 0 {
+		limitBytes = pointer.Ptr(c.logsLimitBytes)
+	}
+
+	logOptions := &corev1.PodLogOptions{
+		Container:  containerName,
+		Timestamps: true,
+		LimitBytes: limitBytes,
+		Follow:     false,
+	}
+
+	if cs.LastTerminationState.Terminated != nil {
+		logOptions.Previous = true
+		err := writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".previous"), podMeta.Name, logOptions, nil)
+		if err != nil {
+			return fmt.Errorf("can't retrieve previous pod logs for container %q in pod %q: %w", containerName, naming.ObjRef(podMeta), err)
+		}
+	}
+
+	if cs.State.Terminated != nil {
+		logOptions.Previous = false
+		err := writeContainerLogsToFile(ctx, c.corev1Client.Pods(podMeta.Namespace), filepath.Join(logsDir, containerName+".terminated"), podMeta.Name, logOptions, nil)
+		if err != nil {
+			return fmt.Errorf("can't retrieve pod logs for terminated container %q in pod %q: %w", containerName, naming.ObjRef(podMeta), err)
+		}
+	}
+
+	return nil
+}
+
+func (c *PodCollector) followCurrentContainerLogs(ctx context.Context, podDir string, pod *corev1.Pod, streamOpenCallback func()) error {
+	type containerLogs struct {
+		name string
+		kind string
+	}
+
+	var containers []containerLogs
+	for _, container := range pod.Spec.InitContainers {
+		if isContainerRunning(pod.Status.InitContainerStatuses, container.Name) {
+			containers = append(containers, containerLogs{name: container.Name, kind: "init container"})
+		}
+	}
+
+	for _, container := range pod.Spec.Containers {
+		if isContainerRunning(pod.Status.ContainerStatuses, container.Name) {
+			containers = append(containers, containerLogs{name: container.Name, kind: "container"})
+		}
+	}
+
+	for _, container := range pod.Spec.EphemeralContainers {
+		if isContainerRunning(pod.Status.EphemeralContainerStatuses, container.Name) {
+			containers = append(containers, containerLogs{name: container.Name, kind: "ephemeral container"})
+		}
+	}
+
+	followCtx, followCtxCancel := context.WithCancel(ctx)
+	defer followCtxCancel()
+
+	var wg sync.WaitGroup
+	openCh := make(chan struct{}, len(containers))
+	errCh := make(chan error, len(containers))
+
+	for _, container := range containers {
+		wg.Add(1)
+
+		go func(container containerLogs) {
+			defer wg.Done()
+
+			err := c.followContainerLogs(followCtx, podDir, &pod.ObjectMeta, container.name, func() {
+				openCh <- struct{}{}
+			})
+			if err != nil {
+				errCh <- fmt.Errorf("can't collect logs for %s %q in pod %q: %w", container.kind, container.name, naming.ObjRef(pod), err)
+			}
+		}(container)
+	}
+
+	for range containers {
+		select {
+		case <-openCh:
+
+		case err := <-errCh:
+			followCtxCancel()
+
+			wg.Wait()
+			close(errCh)
+
+			errs := []error{err}
+			for err := range errCh {
+				errs = append(errs, err)
+			}
+
+			return apimachineryutilerrors.NewAggregate(errs)
+
+		case <-ctx.Done():
+			followCtxCancel()
+			wg.Wait()
+
+			return ctx.Err()
+
+		}
+	}
+
+	if streamOpenCallback != nil {
+		streamOpenCallback()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+
+	return apimachineryutilerrors.NewAggregate(errs)
+}
+
+func isContainerRunning(statuses []corev1.ContainerStatus, containerName string) bool {
+	cs, _, found := oslices.Find(statuses, func(s corev1.ContainerStatus) bool {
+		return s.Name == containerName
+	})
+
+	return found && cs.State.Running != nil
+}
+
 func (c *PodCollector) createPodDirectory(pod *corev1.Pod, resourceInfo *ResourceInfo, options CollectObjectOptions) (string, error) {
 	resourceDir, err := c.resourceWriter.GetResourceDir(pod, resourceInfo)
 	if err != nil {
 		return "", fmt.Errorf("can't get resourceDir: %q", err)
 	}
+
 	name := pod.GetName()
 	if options.TransformName != nil {
 		name = options.TransformName(name)

--- a/pkg/gather/collect/podcollector_test.go
+++ b/pkg/gather/collect/podcollector_test.go
@@ -1,0 +1,293 @@
+// Copyright (C) 2026 ScyllaDB
+
+package collect
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfakeclient "k8s.io/client-go/dynamic/fake"
+	kubefakeclient "k8s.io/client-go/kubernetes/fake"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+type logRequestKey struct {
+	container string
+	previous  bool
+}
+
+func TestPodCollector_CollectAndFollowLogs_FollowOnlyCurrentLogs(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "my-pod",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "running-init-container"},
+				{Name: "prev-init-container"},
+				{Name: "terminated-init-container"},
+			},
+			Containers: []corev1.Container{
+				{Name: "running-container"},
+				{Name: "prev-container"},
+				{Name: "terminated-container"},
+			},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "running-ephemeral-container"}},
+				{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "prev-ephemeral-container"}},
+				{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "terminated-ephemeral-container"}},
+			},
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "running-init-container",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+				{
+					Name:  "prev-init-container",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
+				},
+				{
+					Name:  "terminated-init-container",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "running-container",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+				{
+					Name:  "prev-container",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
+				},
+				{
+					Name:  "terminated-container",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "running-ephemeral-container",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+				{
+					Name:  "prev-ephemeral-container",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
+				},
+				{
+					Name:  "terminated-ephemeral-container",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				},
+			},
+		},
+	}
+
+	fakeKubeClient := kubefakeclient.NewSimpleClientset(pod)
+
+	var mu sync.Mutex
+	capturedOpts := map[logRequestKey]*corev1.PodLogOptions{}
+	fakeKubeClient.PrependReactor("get", "pods", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		genericAction, ok := action.(kubetesting.GenericAction)
+		if !ok || genericAction.GetSubresource() != "log" {
+			return false, nil, nil
+		}
+
+		opts, ok := genericAction.GetValue().(*corev1.PodLogOptions)
+		if !ok {
+			return false, nil, nil
+		}
+
+		key := logRequestKey{container: opts.Container, previous: opts.Previous}
+		mu.Lock()
+		capturedOpts[key] = opts.DeepCopy()
+		mu.Unlock()
+
+		return false, nil, nil
+	})
+
+	tmpDir := t.TempDir()
+	printers := []ResourcePrinterInterface{
+		&OmitManagedFieldsPrinter{Delegate: &YAMLPrinter{}},
+	}
+
+	u := &unstructured.Unstructured{}
+	err := kubernetesscheme.Scheme.Convert(pod, u, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+	fakeDynamicClient := dynamicfakeclient.NewSimpleDynamicClient(kubernetesscheme.Scheme, u)
+	collector := NewCollector(tmpDir, printers, nil, nil, fakeKubeClient.CoreV1(), fakeDynamicClient, false, false, 0)
+
+	resourceInfo := &ResourceInfo{
+		Scope:    meta.RESTScopeNamespace,
+		Resource: corev1.SchemeGroupVersion.WithResource("pods"),
+	}
+
+	err = collector.CollectResourceObjectWithOptionsAndFollowLogs(t.Context(), resourceInfo, pod.Namespace, pod.Name, CollectObjectOptions{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedFollow := map[logRequestKey]bool{
+		{container: "running-init-container", previous: false}:         true,
+		{container: "prev-init-container", previous: false}:            true,
+		{container: "prev-init-container", previous: true}:             false,
+		{container: "terminated-init-container", previous: false}:      false,
+		{container: "running-container", previous: false}:              true,
+		{container: "prev-container", previous: false}:                 true,
+		{container: "prev-container", previous: true}:                  false,
+		{container: "terminated-container", previous: false}:           false,
+		{container: "running-ephemeral-container", previous: false}:    true,
+		{container: "prev-ephemeral-container", previous: false}:       true,
+		{container: "prev-ephemeral-container", previous: true}:        false,
+		{container: "terminated-ephemeral-container", previous: false}: false,
+	}
+
+	if len(capturedOpts) != len(expectedFollow) {
+		t.Errorf("expected %d log requests, got %d: %v", len(expectedFollow), len(capturedOpts), capturedOpts)
+	}
+
+	for key, wantFollow := range expectedFollow {
+		opts, ok := capturedOpts[key]
+		if !ok {
+			t.Errorf("no log request for container=%q previous=%v", key.container, key.previous)
+			continue
+		}
+
+		if opts.Follow != wantFollow {
+			t.Errorf("container=%q previous=%v: expected Follow=%v, got Follow=%v", key.container, key.previous, wantFollow, opts.Follow)
+		}
+	}
+}
+
+func TestPodCollector_CollectAndFollowLogs_CallsStreamOpenCallbackAfterAllCurrentStreamsOpen(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "my-pod",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "running-init-container"},
+			},
+			Containers: []corev1.Container{
+				{Name: "running-container-1"},
+				{Name: "running-container-2"},
+			},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "running-ephemeral-container"}},
+			},
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "running-init-container",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "running-container-1",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+				{
+					Name:  "running-container-2",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "running-ephemeral-container",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+		},
+	}
+
+	fakeKubeClient := kubefakeclient.NewSimpleClientset(pod)
+
+	var mu sync.Mutex
+	openContainerStreams := map[string]bool{}
+	fakeKubeClient.PrependReactor("get", "pods", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		genericAction, ok := action.(kubetesting.GenericAction)
+		if !ok || genericAction.GetSubresource() != "log" {
+			return false, nil, nil
+		}
+
+		opts, ok := genericAction.GetValue().(*corev1.PodLogOptions)
+		if !ok || !opts.Follow {
+			return false, nil, nil
+		}
+
+		mu.Lock()
+		openContainerStreams[opts.Container] = true
+		mu.Unlock()
+
+		return false, nil, nil
+	})
+
+	tmpDir := t.TempDir()
+	printers := []ResourcePrinterInterface{
+		&OmitManagedFieldsPrinter{Delegate: &YAMLPrinter{}},
+	}
+
+	u := &unstructured.Unstructured{}
+	err := kubernetesscheme.Scheme.Convert(pod, u, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+	fakeDynamicClient := dynamicfakeclient.NewSimpleDynamicClient(kubernetesscheme.Scheme, u)
+	collector := NewCollector(tmpDir, printers, nil, nil, fakeKubeClient.CoreV1(), fakeDynamicClient, false, false, 0)
+
+	resourceInfo := &ResourceInfo{
+		Scope:    meta.RESTScopeNamespace,
+		Resource: corev1.SchemeGroupVersion.WithResource("pods"),
+	}
+
+	expectedOpenedContainers := map[string]bool{
+		"running-init-container":      true,
+		"running-container-1":         true,
+		"running-container-2":         true,
+		"running-ephemeral-container": true,
+	}
+
+	err = collector.CollectResourceObjectWithOptionsAndFollowLogs(context.Background(), resourceInfo, pod.Namespace, pod.Name, CollectObjectOptions{}, func() {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if !reflect.DeepEqual(openContainerStreams, expectedOpenedContainers) {
+			t.Fatalf("expected opened containers %v, got %v", expectedOpenedContainers, openContainerStreams)
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/gather/collect/resourcewriter.go
+++ b/pkg/gather/collect/resourcewriter.go
@@ -48,10 +48,15 @@ func (c *ResourceWriter) GetResourceDir(obj kubeinterfaces.ObjectInterface, reso
 	}
 }
 
-func (c *ResourceWriter) WriteObject(ctx context.Context, dirPath string, obj kubeinterfaces.ObjectInterface, resourceInfo *ResourceInfo) error {
+func (c *ResourceWriter) WriteObjectWithOptions(ctx context.Context, dirPath string, obj kubeinterfaces.ObjectInterface, resourceInfo *ResourceInfo, options CollectObjectOptions) error {
+	name := obj.GetName()
+	if options.TransformName != nil {
+		name = options.TransformName(name)
+	}
+
 	var err error
 	for _, printer := range c.printers {
-		filePath := filepath.Join(dirPath, obj.GetName()+printer.GetSuffix())
+		filePath := filepath.Join(dirPath, name+printer.GetSuffix())
 		err = writeObject(printer, filePath, resourceInfo, obj)
 		if err != nil {
 			return fmt.Errorf("can't write object: %w", err)
@@ -62,6 +67,10 @@ func (c *ResourceWriter) WriteObject(ctx context.Context, dirPath string, obj ku
 }
 
 func (c *ResourceWriter) WriteResource(ctx context.Context, obj kubeinterfaces.ObjectInterface, resourceInfo *ResourceInfo) error {
+	return c.WriteResourceWithOptions(ctx, obj, resourceInfo, CollectObjectOptions{})
+}
+
+func (c *ResourceWriter) WriteResourceWithOptions(ctx context.Context, obj kubeinterfaces.ObjectInterface, resourceInfo *ResourceInfo, options CollectObjectOptions) error {
 	resourceDir, err := c.GetResourceDir(obj, resourceInfo)
 	if err != nil {
 		return fmt.Errorf("can't get resourceDir: %q", err)
@@ -72,7 +81,7 @@ func (c *ResourceWriter) WriteResource(ctx context.Context, obj kubeinterfaces.O
 		return fmt.Errorf("can't create resource dir %q: %w", resourceDir, err)
 	}
 
-	err = c.WriteObject(ctx, resourceDir, obj, resourceInfo)
+	err = c.WriteObjectWithOptions(ctx, resourceDir, obj, resourceInfo, options)
 	if err != nil {
 		return fmt.Errorf("can't write object: %w", err)
 	}

--- a/test/e2e/framework/dump.go
+++ b/test/e2e/framework/dump.go
@@ -2,7 +2,9 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/scylladb/scylla-operator/pkg/gather/collect"
 	"github.com/scylladb/scylla-operator/pkg/naming"
@@ -68,4 +70,88 @@ func DumpNamespace(ctx context.Context, restConfig *rest.Config, discoveryClient
 		corev1.NamespaceAll,
 		name,
 	)
+}
+
+// DumpPodAndFollowLogs starts dumping the pod manifest and following its current container logs.
+// The first returned function waits until all current log streams are open or collection fails,
+// and the second one cancels log following and waits for collection to finish.
+func DumpPodAndFollowLogs(ctx context.Context, restConfig *rest.Config, dynamicClient dynamic.Interface, corev1Client corev1client.CoreV1Interface, artifactsDir string, namespace string, name string, options collect.CollectObjectOptions) (func(context.Context) error, func(context.Context) error, error) {
+	collector := collect.NewCollector(
+		artifactsDir,
+		[]collect.ResourcePrinterInterface{
+			&collect.OmitManagedFieldsPrinter{
+				Delegate: &collect.YAMLPrinter{},
+			},
+		},
+		restConfig,
+		nil,
+		corev1Client,
+		dynamicClient,
+		false,
+		true,
+		0,
+	)
+
+	followCtx, followCtxCancel := context.WithCancel(ctx)
+	streamOpenCh := make(chan struct{})
+	doneCh := make(chan struct{})
+
+	streamOpenCallback := func() {
+		close(streamOpenCh)
+	}
+
+	podResourceInfo := &collect.ResourceInfo{
+		Scope:    meta.RESTScopeNamespace,
+		Resource: corev1.SchemeGroupVersion.WithResource("pods"),
+	}
+
+	var wg sync.WaitGroup
+	var collectErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		collectErr = collector.CollectResourceObjectWithOptionsAndFollowLogs(followCtx, podResourceInfo, namespace, name, options, streamOpenCallback)
+		close(doneCh)
+	}()
+
+	waitForStreamOpened := func(ctx context.Context) error {
+		select {
+		case <-streamOpenCh:
+			return nil
+
+		case <-doneCh:
+			if collectErr != nil {
+				return fmt.Errorf("failed to collect pod logs: %w", collectErr)
+			}
+
+			return nil
+
+		case <-ctx.Done():
+			return fmt.Errorf("failed to wait for pod logs to open: %w", ctx.Err())
+
+		}
+	}
+
+	stopAndWait := func(ctx context.Context) error {
+		followCtxCancel()
+		wg.Wait()
+
+		select {
+		case <-doneCh:
+			// Calling followCtxCancel() surfaces as context.Canceled. It's an expected stop path.
+			if collectErr != nil && !errors.Is(collectErr, context.Canceled) {
+				return fmt.Errorf("failed to collect pod logs: %w", collectErr)
+			}
+
+			return nil
+
+		case <-ctx.Done():
+			return fmt.Errorf("failed to stop collecting pod logs: %w", ctx.Err())
+
+		}
+	}
+
+	return waitForStreamOpened, stopAndWait, nil
 }

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -4,11 +4,13 @@ package scyllacluster
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/gather/collect"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
@@ -67,6 +69,37 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		var scyllaClusterProgressingWG sync.WaitGroup
 		// Ensure we wait for all background tasks on a test failure.
 		defer scyllaClusterProgressingWG.Wait()
+
+		// Start collecting logs from the pre-replacement Pod before the replacement is triggered,
+		// so we capture the full log history under a stable artifact name.
+		var stopPreReplacementPodLogCollection func(context.Context) error
+		if artifactsDir := f.GetDefaultArtifactsDir(); artifactsDir != "" {
+			var waitForStreamOpened func(context.Context) error
+			waitForStreamOpened, stopPreReplacementPodLogCollection, err = framework.DumpPodAndFollowLogs(
+				ctx,
+				nsClient.ClientConfig(),
+				nsClient.DynamicClient(),
+				nsClient.KubeClient().CoreV1(),
+				artifactsDir,
+				targetPod.Namespace,
+				targetPod.Name,
+				collect.CollectObjectOptions{
+					TransformName: func(name string) string {
+						return fmt.Sprintf("%s.pre-replacement", name)
+					},
+				},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to start following pod logs")
+			g.DeferCleanup(func(ctx context.Context) {
+				err := stopPreReplacementPodLogCollection(ctx)
+				o.Expect(err).NotTo(o.HaveOccurred(), "Failed to stop following pod logs")
+			})
+
+			// Wait until the log stream is open before triggering the replacement,
+			// to avoid a race where the Pod disappears before we start streaming.
+			err := waitForStreamOpened(ctx)
+			o.Expect(err).NotTo(o.HaveOccurred(), "Pre-replacement log stream failed before opening")
+		}
 
 		// Wait for the controllers to pick up the Pod replacement.
 		// Do this in the background to ensure we don't miss the progressing state if it happens too quickly.

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_replace.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_replace.go
@@ -4,6 +4,7 @@ package multidatacenter
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"slices"
 	"sync"
@@ -11,6 +12,7 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/gather/collect"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
@@ -82,6 +84,37 @@ var _ = g.Describe("ScyllaDBCluster", framework.SuiteMultiDatacenterParallel, fu
 		var scyllaDBClusterProgressingWG sync.WaitGroup
 		// Ensure we wait for all background tasks on a test failure.
 		defer scyllaDBClusterProgressingWG.Wait()
+
+		// Start collecting logs from the pre-replacement Pod before the replacement is triggered,
+		// so we capture the full log history under a stable artifact name.
+		var stopPreReplacementPodLogCollection func(context.Context) error
+		if artifactsDir := f.GetDefaultArtifactsDir(); artifactsDir != "" {
+			var waitForStreamOpened func(context.Context) error
+			waitForStreamOpened, stopPreReplacementPodLogCollection, err = framework.DumpPodAndFollowLogs(
+				ctx,
+				targetClusterClient.AdminClientConfig(),
+				targetClusterClient.DynamicAdminClient(),
+				targetClusterClient.KubeAdminClient().CoreV1(),
+				artifactsDir,
+				targetPod.Namespace,
+				targetPod.Name,
+				collect.CollectObjectOptions{
+					TransformName: func(name string) string {
+						return fmt.Sprintf("%s.pre-replacement", name)
+					},
+				},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to start following pod logs")
+			g.DeferCleanup(func(ctx context.Context) {
+				err := stopPreReplacementPodLogCollection(ctx)
+				o.Expect(err).NotTo(o.HaveOccurred(), "Failed to stop following pod logs")
+			})
+
+			// Wait until the log stream is open before triggering the replacement,
+			// to avoid a race where the pod disappears before we start streaming.
+			err := waitForStreamOpened(ctx)
+			o.Expect(err).NotTo(o.HaveOccurred(), "Pre-replacement log stream failed before opening")
+		}
 
 		// Wait for the controllers to pick up the Pod replacement.
 		// Do this in the background to ensure we don't miss the progressing state if it happens too quickly.

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -236,7 +236,7 @@ func RunEphemeralContainerAndCollectLogs(ctx context.Context, client corev1clien
 	}
 	logs := &bytes.Buffer{}
 
-	err = collect.GetPodLogs(ctx, client, logs, podName, logOptions)
+	err = collect.GetPodLogs(ctx, client, logs, podName, logOptions, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("can't collect Pod logs: %w", err)
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Node replacement E2E does not capture the logs of the replaced Pod. That leaves the replacement path hard to debug because the post-failure dump sees only the new Pod.

This PR extends the object collection machinery to allow for following the logs of currently running containers of a Pod.
It also extends the machinery to allow for transforming the artifact's filesystem path.

It extends the replacement E2Es to capture the pre-replacement Pod before replacement starts and make its artifacts distinct not to have it overwritten by the collection of the replacing Pod. It keeps the current container logs open while replacement runs, so the logs are collected until the Pod is deleted.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-204

/cc
