### PR TITLE
docs: improve wording of the introductory header in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Language](https://img.shields.io/badge/Language-Go-blue.svg)](https://golang.org/)
 [![LICENSE](https://img.shields.io/github/license/scylladb/scylla-operator.svg)](https://github.com/scylladb/scylla-operator/blob/master/LICENSE)
 
-[Scylla Operator](https://github.com/scylladb/scylla-operator) is a Kubernetes Operator for managing and automating tasks related to managing ScyllaDB clusters.
+[Scylla Operator](https://github.com/scylladb/scylla-operator) is a Kubernetes Operator for managing and automating ScyllaDB clusters.
 
 [ScyllaDB](https://www.scylladb.com) is a close-to-the-hardware rewrite of Cassandra in C++. It features a shared nothing architecture that enables true linear scaling and major hardware optimizations that achieve ultra-low latencies and extreme throughput. It is a drop-in replacement for Cassandra and uses the same interfaces.
 


### PR DESCRIPTION
## Summary

- Remove redundant "tasks related to managing" from the README header, making it more concise.

Fixes: OPERATOR-234

/cc @rzetelskik