### PR TITLE
[Backport v1.21] docs(openshift): fix outdated anchor in RH docs

### DIFF
--- a/docs/source/deploy-scylladb/reference-deployments/reference-deployment-openshift.md
+++ b/docs/source/deploy-scylladb/reference-deployments/reference-deployment-openshift.md
@@ -9,7 +9,7 @@ This guide walks you through deploying ScyllaDB on Red Hat OpenShift.
 - Dedicated nodes labeled and tainted per [Set up dedicated node pools](../before-you-deploy/set-up-dedicated-node-pools.md).
 - ScyllaDB Operator installed.
   Follow [Install on OpenShift](../../install-operator/install-on-openshift.md) if you have not done so yet.
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) or OpenShift CLI ([`oc`](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/cli_tools/openshift-cli-oc#installing-openshift-cli)) installed.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) or OpenShift CLI ([`oc`](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/cli_tools/openshift-cli-oc)) installed.
 
 ## Set up nodes
 

--- a/docs/source/install-operator/install-on-openshift.md
+++ b/docs/source/install-operator/install-on-openshift.md
@@ -12,7 +12,7 @@ ScyllaDB Operator is a Red Hat OpenShift Certified Operator. It is available in 
 
 - An OpenShift Container Platform cluster meeting the [infrastructure requirements](provision-infrastructure/index.md).
 - An account with `cluster-admin` permissions.
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) or [OpenShift CLI (`oc`)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/cli_tools/openshift-cli-oc#installing-openshift-cli) configured to communicate with the cluster.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) or [OpenShift CLI (`oc`)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/cli_tools/openshift-cli-oc) configured to communicate with the cluster.
 
 :::{tip}
 All `kubectl` commands in this guide can be executed using the OpenShift CLI (`oc`) instead.


### PR DESCRIPTION
**Description of your changes:**
- fix outdated anchor link (backport of (cherry picked from commit 269be19598ee17533fe0d308d737f4b442698268)

**Which issue is resolved by this Pull Request:**
Part of https://scylladb.atlassian.net/browse/OPERATOR-236

/kind documentation
/priority important-soon