### PR TITLE
chore(docs, examples): update infra and scylla pool instances

### DIFF
--- a/docs/source/deploy-scylladb/before-you-deploy/set-up-dedicated-node-pools.md
+++ b/docs/source/deploy-scylladb/before-you-deploy/set-up-dedicated-node-pools.md
@@ -33,8 +33,7 @@ See [GCE recommendations](https://docs.scylladb.com/manual/stable/getting-starte
 :::
 
 :::{tab} EKS
-Use storage-optimized instances from the `i` family (e.g., `i3en`, `i4i`, `i8g`).
-See [AWS recommendations](https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#amazon-web-services-aws).
+Use storage-optimized instances from the `i` family, as advised in the [AWS recommendations](https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#amazon-web-services-aws).
 :::
 
 :::{tab} OKE

--- a/docs/source/deploy-scylladb/reference-deployments/reference-deployment-eks.md
+++ b/docs/source/deploy-scylladb/reference-deployments/reference-deployment-eks.md
@@ -41,8 +41,7 @@ Follow [Configure nodes](../before-you-deploy/configure-nodes.md), selecting the
 :::
 
 Create a ScyllaDB cluster with one rack per availability zone.
-The resource requests are sized for `i4i.2xlarge` (8 vCPU, 64 GiB RAM), leaving headroom for the OS, kubelet, and `DaemonSets`.
-See the [ScyllaDB system requirements](https://docs.scylladb.com/manual/stable/getting-started/system-requirements.html) for general sizing guidance.
+The resource requests are sized for the OS, kubelet, and `DaemonSets` and follow the [ScyllaDB system requirements](https://docs.scylladb.com/manual/stable/getting-started/system-requirements.html) - see for general sizing guidance.
 Adjust if you use a different instance type.
 
 :::{code-block} console

--- a/docs/source/install-operator/provision-infrastructure/set-up-eks-cluster.md
+++ b/docs/source/install-operator/provision-infrastructure/set-up-eks-cluster.md
@@ -18,8 +18,7 @@ Set `AWS_REGION`, then run the script to provision everything in one go.
 - The [`eksctl` CLI](https://eksctl.io/installation/) installed.
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) installed.
 - AWS credentials configured (`aws configure` or environment variables).
-- Sufficient quota for `i4i.2xlarge` instances in your target region.
-  See [ScyllaDB cloud instance recommendations for AWS](https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#amazon-web-services-aws) for recommended instance types and [system requirements](https://docs.scylladb.com/manual/stable/getting-started/system-requirements.html) for minimum specifications.
+- Sufficient quota for `i` instances in your target region, as advised in the  [ScyllaDB cloud instance recommendations for AWS](https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#amazon-web-services-aws) and the [minimum system requirements](https://docs.scylladb.com/manual/stable/getting-started/system-requirements.html).
 
 ## Set environment variables
 
@@ -61,7 +60,7 @@ Generate the configuration file:
 :end-before: "# [END create_cluster_config]"
 :::
 
-The ScyllaDB node group uses `i4i.2xlarge` instances (8 vCPU, 64 GiB RAM, 1x1875 GB NVMe SSD) with:
+The ScyllaDB node group uses storage-optimized `i` instances, as advised in the [ScyllaDB cloud instance recommendations for AWS](https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#amazon-web-services-aws)
 
 - `cpuManagerPolicy: static` for CPU pinning.
 - ScyllaDB labels and taints so only ScyllaDB pods are scheduled on these nodes.

--- a/examples/eks/clusterconfig.eksctl.yaml
+++ b/examples/eks/clusterconfig.eksctl.yaml
@@ -9,7 +9,7 @@ availabilityZones:
 - eu-central-1c
 nodeGroups:
 - name: scylla-pool
-  instanceType: i4i.2xlarge
+  instanceType: i7i.2xlarge
   desiredCapacity: 3
   amiFamily: AmazonLinux2023
   labels:
@@ -23,7 +23,7 @@ nodeGroups:
   - eu-central-1b
   - eu-central-1c
 - name: infra-pool
-  instanceType: i3.large
+  instanceType: m7i.large
   desiredCapacity: 1
   amiFamily: AmazonLinux2023
   labels:

--- a/examples/eks/setup-eks-cluster.sh
+++ b/examples/eks/setup-eks-cluster.sh
@@ -34,13 +34,13 @@ export EKS_AZ_1="${EKS_AZ_1:-${AWS_REGION}a}"
 export EKS_AZ_2="${EKS_AZ_2:-${AWS_REGION}b}"
 export EKS_AZ_3="${EKS_AZ_3:-${AWS_REGION}c}"
 
-# Dedicated ScyllaDB node group. i4i.2xlarge provides 8 vCPU, 64 GiB RAM, and 1x1875 GB NVMe.
+# Dedicated ScyllaDB node group. i7i.2xlarge provides 8 vCPU, 64 GiB RAM, and 1x1875 GB NVMe.
 # See https://docs.scylladb.com/manual/stable/getting-started/cloud-instance-recommendations.html#amazon-web-services-aws
-export SCYLLA_INSTANCE_TYPE="${SCYLLA_INSTANCE_TYPE:-i4i.2xlarge}"
+export SCYLLA_INSTANCE_TYPE="${SCYLLA_INSTANCE_TYPE:-i7i.2xlarge}"
 export SCYLLA_NODE_COUNT="${SCYLLA_NODE_COUNT:-3}"
 
 # Infrastructure node group.
-export INFRA_INSTANCE_TYPE="${INFRA_INSTANCE_TYPE:-i3.large}"
+export INFRA_INSTANCE_TYPE="${INFRA_INSTANCE_TYPE:-m7i.large}"
 export INFRA_NODE_COUNT="${INFRA_NODE_COUNT:-1}"
 # [END env_defaults]
 


### PR DESCRIPTION
**Description of your changes:**
- lower infra instances to m7i.xl (we do not need huge storage-optimized `i3.large` for infra pool)
- bump scylla instances to i7i.2xl (current modern family of storage-optimized instance, as [advised](https://docs.scylladb.com/manual/master/getting-started/cloud-instance-recommendations.html#i7i-instances) in the ScyllaDB docs)

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-45

/kind documentation
/priority important-soon
