### PR TITLE
fix: prevent ScyllaDBDatacenter rollout deadlock when rack is prepended during a progressing rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- Fixed `ScyllaDBDatacenter` rollouts getting stuck when a new rack was inserted before existing racks while an existing 
+  rack was still progressing. The controller now waits for all existing `StatefulSets` to roll out before a new
+  `StatefulSet` is created.
+  [#3513](https://github.com/scylladb/scylla-operator/pull/3513)
+
 ### Other changes
 
 - ScyllaDB Operator now runs `scylladb-node-exporter` as a dedicated sidecar container for ScyllaDB clusters running

--- a/pkg/controller/scylladbdatacenter/controller.go
+++ b/pkg/controller/scylladbdatacenter/controller.go
@@ -50,7 +50,9 @@ import (
 const (
 	ControllerName = "ScyllaDBDatacenterController"
 
-	artificialDelayForCachesToCatchUp = 10 * time.Second
+	// defaultStatefulSetCachePropagationDelay is the default value for the delay after applying StatefulSet changes
+	// to let informer caches observe the update.
+	defaultStatefulSetCachePropagationDelay = 10 * time.Second
 )
 
 var (
@@ -87,6 +89,18 @@ type Controller struct {
 	handlers *controllerhelpers.Handlers[*scyllav1alpha1.ScyllaDBDatacenter]
 
 	keyGetter crypto.KeyGenerator
+
+	statefulSetCachePropagationDelay time.Duration
+}
+
+type ControllerOption func(ctrl *Controller)
+
+// WithStatefulSetCachePropagationDelay overrides the delay after applying StatefulSet changes to let informer caches
+// observe the update.
+func WithStatefulSetCachePropagationDelay(delay time.Duration) ControllerOption {
+	return func(c *Controller) {
+		c.statefulSetCachePropagationDelay = delay
+	}
 }
 
 func NewController(
@@ -108,6 +122,7 @@ func NewController(
 	operatorImage string,
 	cqlsIngressPort int,
 	keyGetter crypto.KeyGenerator,
+	options ...ControllerOption,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -160,6 +175,12 @@ func NewController(
 		),
 
 		keyGetter: keyGetter,
+
+		statefulSetCachePropagationDelay: defaultStatefulSetCachePropagationDelay,
+	}
+
+	for _, option := range options {
+		option(sdcc)
 	}
 
 	var err error

--- a/pkg/controller/scylladbdatacenter/status.go
+++ b/pkg/controller/scylladbdatacenter/status.go
@@ -6,10 +6,10 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/naming"
-	"github.com/scylladb/scylla-operator/pkg/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -36,49 +36,51 @@ func (sdcc *Controller) updateStatus(ctx context.Context, currentSC *scyllav1alp
 	return nil
 }
 
-func (sdcc *Controller) getScyllaVersion(sts *appsv1.StatefulSet) (string, error) {
+// getScyllaVersion returns the Scylla version from the ordinal-0 pod owned by sts.
+func getScyllaVersion(podLister corev1listers.PodLister, sts *appsv1.StatefulSet) (string, error) {
 	firstMemberName := fmt.Sprintf("%s-0", sts.Name)
-	firstMember, err := sdcc.podLister.Pods(sts.Namespace).Get(firstMemberName)
+	firstMember, err := podLister.Pods(sts.Namespace).Get(firstMemberName)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("can't get pod %q: %w", naming.ManualRef(sts.Namespace, firstMemberName), err)
 	}
 
 	controllerRef := metav1.GetControllerOfNoCopy(firstMember)
 	if controllerRef == nil || controllerRef.UID != sts.UID {
-		return "", fmt.Errorf("foreign pod")
+		return "", fmt.Errorf("internal error: pod %q is not controlled by us", naming.ManualRef(sts.Namespace, firstMemberName))
 	}
 
 	version, err := naming.ScyllaVersion(firstMember.Spec.Containers)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("can't get scylla version for pod %q: %w", naming.ManualRef(sts.Namespace, firstMemberName), err)
 	}
 
 	return version, nil
 }
 
-// calculateRackStatus calculates a status for the rack.
-// sts and old status may be nil.
-func (sdcc *Controller) calculateRackStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, sts *appsv1.StatefulSet) *scyllav1alpha1.RackStatus {
+// calculateRackStatus builds rack status from its StatefulSet.
+// If sts is nil, it returns a stale zero status so the rack still appears in status.
+// Empty racks report the target image version; non-empty racks report the version from ordinal-0.
+func calculateRackStatus(podLister corev1listers.PodLister, sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, sts *appsv1.StatefulSet) *scyllav1alpha1.RackStatus {
 	status := &scyllav1alpha1.RackStatus{
 		Name:           rackName,
-		Nodes:          pointer.Ptr(int32(0)),
-		CurrentNodes:   pointer.Ptr(int32(0)),
-		UpdatedNodes:   pointer.Ptr(int32(0)),
-		ReadyNodes:     pointer.Ptr(int32(0)),
-		AvailableNodes: pointer.Ptr(int32(0)),
-		Stale:          pointer.Ptr(true),
+		Nodes:          new(int32(0)),
+		CurrentNodes:   new(int32(0)),
+		UpdatedNodes:   new(int32(0)),
+		ReadyNodes:     new(int32(0)),
+		AvailableNodes: new(int32(0)),
+		Stale:          new(true),
 	}
 
 	if sts == nil {
 		return status
 	}
 
-	status.Nodes = pointer.Ptr(*sts.Spec.Replicas)
-	status.ReadyNodes = pointer.Ptr(sts.Status.ReadyReplicas)
-	status.AvailableNodes = pointer.Ptr(sts.Status.AvailableReplicas)
-	status.UpdatedNodes = pointer.Ptr(sts.Status.UpdatedReplicas)
-	status.CurrentNodes = pointer.Ptr(sts.Status.CurrentReplicas)
-	status.Stale = pointer.Ptr(sts.Status.ObservedGeneration < sts.Generation)
+	status.Nodes = new(*sts.Spec.Replicas)
+	status.ReadyNodes = new(sts.Status.ReadyReplicas)
+	status.AvailableNodes = new(sts.Status.AvailableReplicas)
+	status.UpdatedNodes = new(sts.Status.UpdatedReplicas)
+	status.CurrentNodes = new(sts.Status.CurrentReplicas)
+	status.Stale = new(sts.Status.ObservedGeneration < sts.Generation)
 
 	scyllaDBImageVersion, err := naming.ImageToVersion(sdc.Spec.ScyllaDB.Image)
 	if err != nil {
@@ -91,7 +93,7 @@ func (sdcc *Controller) calculateRackStatus(sdc *scyllav1alpha1.ScyllaDBDatacent
 	if status.Nodes != nil && *status.Nodes == 0 {
 		status.CurrentVersion = scyllaDBImageVersion
 	} else {
-		version, err := sdcc.getScyllaVersion(sts)
+		version, err := getScyllaVersion(podLister, sts)
 		if err != nil {
 			klog.ErrorS(err, "can't get scylla version")
 		} else {
@@ -103,9 +105,9 @@ func (sdcc *Controller) calculateRackStatus(sdc *scyllav1alpha1.ScyllaDBDatacent
 }
 
 func updateAggregatedStatusFields(status *scyllav1alpha1.ScyllaDBDatacenterStatus) {
-	status.Nodes = pointer.Ptr(int32(0))
-	status.ReadyNodes = pointer.Ptr(int32(0))
-	status.AvailableNodes = pointer.Ptr(int32(0))
+	status.Nodes = new(int32(0))
+	status.ReadyNodes = new(int32(0))
+	status.AvailableNodes = new(int32(0))
 
 	for rackName := range status.Racks {
 		rackStatus := status.Racks[rackName]
@@ -121,7 +123,7 @@ func updateAggregatedStatusFields(status *scyllav1alpha1.ScyllaDBDatacenterStatu
 // If a particular object can be missing, it should be reflected in the value itself, like "Unknown" or "".
 func (sdcc *Controller) calculateStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, statefulSetMap map[string]*appsv1.StatefulSet) *scyllav1alpha1.ScyllaDBDatacenterStatus {
 	status := sdc.Status.DeepCopy()
-	status.ObservedGeneration = pointer.Ptr(sdc.Generation)
+	status.ObservedGeneration = new(sdc.Generation)
 
 	// Clear the previous rack status.
 	status.Racks = []scyllav1alpha1.RackStatus{}
@@ -129,7 +131,7 @@ func (sdcc *Controller) calculateStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, 
 	// Calculate the status for racks.
 	for _, rack := range sdc.Spec.Racks {
 		stsName := naming.StatefulSetNameForRack(rack, sdc)
-		status.Racks = append(status.Racks, *sdcc.calculateRackStatus(sdc, rack.Name, statefulSetMap[stsName]))
+		status.Racks = append(status.Racks, *calculateRackStatus(sdcc.podLister, sdc, rack.Name, statefulSetMap[stsName]))
 	}
 
 	updateAggregatedStatusFields(status)

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -561,7 +561,7 @@ func (sdcc *Controller) syncStatefulSets(
 	if len(createProgressingConditions) > 0 {
 		// Wait for the informers to catch up.
 		// TODO: Add expectations, not to reconcile sooner then we see this new StatefulSet in our caches. (#682)
-		time.Sleep(artificialDelayForCachesToCatchUp)
+		time.Sleep(sdcc.statefulSetCachePropagationDelay)
 		return progressingConditions, nil
 	}
 
@@ -818,7 +818,7 @@ func (sdcc *Controller) syncStatefulSets(
 			}
 			if anyStsChanged {
 				// TODO: Add expectations, not to reconcile sooner then we see this new StatefulSet in our caches. (#682)
-				time.Sleep(artificialDelayForCachesToCatchUp)
+				time.Sleep(sdcc.statefulSetCachePropagationDelay)
 			}
 			err = apimachineryutilerrors.NewAggregate(errs)
 			if err != nil {
@@ -996,7 +996,7 @@ func (sdcc *Controller) syncStatefulSets(
 	defer func() {
 		if anyStsChanged {
 			// TODO: Add expectations, not to reconcile sooner then we see this new StatefulSet in our caches. (#682)
-			time.Sleep(artificialDelayForCachesToCatchUp)
+			time.Sleep(sdcc.statefulSetCachePropagationDelay)
 		}
 	}()
 	for _, required := range requiredStatefulSets {

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	apimachineryutilsets "k8s.io/apimachinery/pkg/util/sets"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
@@ -392,66 +393,32 @@ func (sdcc *Controller) pruneStatefulSets(
 	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
 }
 
-// createMissingStatefulSets creates missing StatefulSets.
-// It return true if done and an error.
-func (sdcc *Controller) createMissingStatefulSets(
+// checkExistingStatefulSetsRolloutStatus returns progressing conditions for existing StatefulSets that haven't rolled out yet.
+func (sdcc *Controller) checkExistingStatefulSetsRolloutStatus(
 	ctx context.Context,
 	sdc *scyllav1alpha1.ScyllaDBDatacenter,
-	status *scyllav1alpha1.ScyllaDBDatacenterStatus,
 	requiredStatefulSets []*appsv1.StatefulSet,
 	statefulSets map[string]*appsv1.StatefulSet,
-	services map[string]*corev1.Service,
 ) ([]metav1.Condition, error) {
 	var errs []error
 	var progressingConditions []metav1.Condition
+
 	for _, req := range requiredStatefulSets {
-		klog.V(4).InfoS("Processing required StatefulSet", "StatefulSet", klog.KObj(req))
-		// Check the adopted set.
-		sts, found := statefulSets[req.Name]
-		if !found {
-			klog.V(2).InfoS("Creating missing StatefulSet", "StatefulSet", klog.KObj(req))
-			var changed bool
-			var err error
-			sts, changed, err = resourceapply.ApplyStatefulSet(ctx, sdcc.kubeClient.AppsV1(), sdcc.statefulSetLister, sdcc.eventRecorder, req, resourceapply.ApplyOptions{})
-			if err != nil {
-				errs = append(errs, fmt.Errorf("can't create missing statefulset: %w", err))
-				continue
-			}
-			if changed {
-				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, statefulSetControllerProgressingCondition, req, "apply", sdc.Generation)
-
-				rackName, ok := sts.Labels[naming.RackNameLabel]
-				if !ok {
-					errs = append(errs, fmt.Errorf(
-						"can't determine rack name: statefulset %s is missing label %q",
-						naming.ObjRef(sts),
-						naming.RackNameLabel),
-					)
-					continue
-				}
-
-				updatedRackStatus := *sdcc.calculateRackStatus(sdc, rackName, sts)
-				_, idx, ok := oslices.Find(status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
-					return rackStatus.Name == rackName
-				})
-				if ok {
-					status.Racks[idx] = updatedRackStatus
-				} else {
-					status.Racks = append(status.Racks, updatedRackStatus)
-				}
-			}
-		} else {
-			// When we decommission a member there is a pod left that's not ready until we scale.
-			if req.Spec.Replicas != nil && sts.Spec.Replicas != nil &&
-				*req.Spec.Replicas != *sts.Spec.Replicas {
-				continue
-			}
+		sts, ok := statefulSets[req.Name]
+		if !ok {
+			continue
 		}
 
-		// Wait for the StatefulSet to roll out. Racks can only bootstrap one by one.
+		// When we decommission a member there is a pod left that's not ready until we scale.
+		if req.Spec.Replicas != nil && sts.Spec.Replicas != nil &&
+			*req.Spec.Replicas != *sts.Spec.Replicas {
+			continue
+		}
+
 		rolledOut, err := controllerhelpers.IsStatefulSetRolledOut(sts)
 		if err != nil {
-			return progressingConditions, err
+			errs = append(errs, fmt.Errorf("can't verify statefulset %q rollout status: %w", naming.ObjRef(sts), err))
+			continue
 		}
 
 		if !rolledOut {
@@ -460,14 +427,84 @@ func (sdcc *Controller) createMissingStatefulSets(
 				Type:               statefulSetControllerProgressingCondition,
 				Status:             metav1.ConditionTrue,
 				Reason:             "WaitingForStatefulSetRollout",
-				Message:            fmt.Sprintf("Waiting for StatefulSet %q to roll out.", naming.ObjRef(req)),
+				Message:            fmt.Sprintf("Waiting for StatefulSet %q to roll out.", naming.ObjRef(sts)),
 				ObservedGeneration: sdc.Generation,
 			})
-			return progressingConditions, nil
 		}
 	}
 
 	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
+}
+
+// createMissingStatefulSets creates the missing StatefulSets from requiredStatefulSets.
+// Existing StatefulSets are skipped and at most one missing StatefulSet is created so racks bootstrap sequentially.
+// It returns the created StatefulSet and its progressing conditions, or an error if creation failed.
+func createMissingStatefulSets(
+	ctx context.Context,
+	applyStatefulSet func(context.Context, *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error),
+	sdc *scyllav1alpha1.ScyllaDBDatacenter,
+	requiredStatefulSets []*appsv1.StatefulSet,
+	statefulSets map[string]*appsv1.StatefulSet,
+) ([]*appsv1.StatefulSet, []metav1.Condition, error) {
+	for _, req := range requiredStatefulSets {
+		sts, found := statefulSets[req.Name]
+		if found {
+			continue
+		}
+
+		klog.V(2).InfoS("Creating missing StatefulSet", "StatefulSet", klog.KObj(req))
+		var changed bool
+		var err error
+		sts, changed, err = applyStatefulSet(ctx, req)
+		if err != nil {
+			return nil, nil, fmt.Errorf("can't create missing statefulset %q: %w", naming.ManualRef(sdc.Namespace, req.Name), err)
+		}
+		if !changed {
+			continue
+		}
+
+		var progressingConditions []metav1.Condition
+		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, statefulSetControllerProgressingCondition, req, "apply", sdc.Generation)
+
+		// StatefulSets must be created sequentially. Return early.
+		return []*appsv1.StatefulSet{sts}, progressingConditions, nil
+	}
+
+	return []*appsv1.StatefulSet{}, []metav1.Condition{}, nil
+}
+
+// ensureRackNamesInRackStatuses records statuses for newly created racks before informer caches catch up.
+func ensureRackNamesInRackStatuses(
+	podLister corev1listers.PodLister,
+	sdc *scyllav1alpha1.ScyllaDBDatacenter,
+	status *scyllav1alpha1.ScyllaDBDatacenterStatus,
+	statefulSets []*appsv1.StatefulSet,
+) error {
+	var errs []error
+
+	for _, sts := range statefulSets {
+		rackName, ok := sts.Labels[naming.RackNameLabel]
+		if !ok {
+			errs = append(errs, fmt.Errorf(
+				"can't determine rack name: statefulset %s is missing label %q",
+				naming.ObjRef(sts),
+				naming.RackNameLabel),
+			)
+			continue
+		}
+
+		updatedRackStatus := *calculateRackStatus(podLister, sdc, rackName, sts)
+		_, idx, ok := oslices.Find(status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
+			return rackStatus.Name == rackName
+		})
+		if ok {
+			status.Racks[idx] = updatedRackStatus
+		} else {
+			status.Racks = append(status.Racks, updatedRackStatus)
+		}
+	}
+
+	return apimachineryutilerrors.NewAggregate(errs)
 }
 
 func (sdcc *Controller) syncStatefulSets(
@@ -551,17 +588,45 @@ func (sdcc *Controller) syncStatefulSets(
 		return progressingConditions, nil
 	}
 
+	progressingConditions, err = sdcc.checkExistingStatefulSetsRolloutStatus(ctx, sdc, requiredStatefulSets, statefulSets)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't check existing statefulset(s) rollout status: %w", err)
+	}
+	// Wait for existing StatefulSets to roll out. Racks can only bootstrap one by one.
+	if len(progressingConditions) > 0 {
+		return progressingConditions, nil
+	}
+
 	// Before any update, make sure all StatefulSets are present.
 	// Create any that are missing.
-	createProgressingConditions, err := sdcc.createMissingStatefulSets(ctx, sdc, status, requiredStatefulSets, statefulSets, services)
+	createdStatefulSets, createProgressingConditions, err := createMissingStatefulSets(
+		ctx,
+		func(ctx context.Context, required *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
+			return resourceapply.ApplyStatefulSet(ctx, sdcc.kubeClient.AppsV1(), sdcc.statefulSetLister, sdcc.eventRecorder, required, resourceapply.ApplyOptions{})
+		},
+		sdc,
+		requiredStatefulSets,
+		statefulSets,
+	)
 	progressingConditions = append(progressingConditions, createProgressingConditions...)
+	defer func() {
+		if len(createProgressingConditions) > 0 {
+			// Wait for the informers to catch up.
+			// TODO: Add expectations, not to reconcile sooner then we see this new StatefulSet in our caches. (#682)
+			time.Sleep(sdcc.statefulSetCachePropagationDelay)
+		}
+	}()
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't create StatefulSet(s): %w", err)
 	}
-	if len(createProgressingConditions) > 0 {
-		// Wait for the informers to catch up.
-		// TODO: Add expectations, not to reconcile sooner then we see this new StatefulSet in our caches. (#682)
-		time.Sleep(sdcc.statefulSetCachePropagationDelay)
+
+	err = ensureRackNamesInRackStatuses(sdcc.podLister, sdc, status, createdStatefulSets)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't update status with rack statuses: %w", err)
+	}
+
+	// Return to wait for created StatefulSets to roll out before proceeding.
+	if len(progressingConditions) > 0 {
 		return progressingConditions, nil
 	}
 
@@ -813,7 +878,7 @@ func (sdcc *Controller) syncStatefulSets(
 						continue
 					}
 
-					status.Racks[idx] = *sdcc.calculateRackStatus(sdc, rackName, updatedSts)
+					status.Racks[idx] = *calculateRackStatus(sdcc.podLister, sdc, rackName, updatedSts)
 				}
 			}
 			if anyStsChanged {
@@ -1081,7 +1146,7 @@ func (sdcc *Controller) syncStatefulSets(
 				return progressingConditions, fmt.Errorf("can't find rack %q status in %q ScyllaDBDatacenter", rackName, naming.ObjRef(sdc))
 			}
 
-			status.Racks[idx] = *sdcc.calculateRackStatus(sdc, rackName, updatedSts)
+			status.Racks[idx] = *calculateRackStatus(sdcc.podLister, sdc, rackName, updatedSts)
 		}
 
 		// Wait for the StatefulSet to roll out.

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
@@ -1,0 +1,349 @@
+package scylladbdatacenter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	testNamespace     = "default"
+	testScyllaDBImage = "scylladb/scylla:latest"
+)
+
+func Test_createMissingStatefulSets(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name                string
+		scyllaDBDatacenter  *scyllav1alpha1.ScyllaDBDatacenter
+		required            []*appsv1.StatefulSet
+		existing            map[string]*appsv1.StatefulSet
+		applyStatefulSet    func(context.Context, *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error)
+		expectedCreated     []*appsv1.StatefulSet
+		expectedConditions  []metav1.Condition
+		expectedErrorString string
+	}{
+		{
+			name:               "skips existing StatefulSets",
+			scyllaDBDatacenter: newScyllaDBDatacenter(),
+			required: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+			},
+			existing: map[string]*appsv1.StatefulSet{
+				"foo": newStatefulSet("foo"),
+			},
+			applyStatefulSet: func(context.Context, *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
+				t.Fatal("applyStatefulSet called for an existing StatefulSet")
+				return nil, false, nil
+			},
+			expectedCreated:     []*appsv1.StatefulSet{},
+			expectedConditions:  []metav1.Condition{},
+			expectedErrorString: "",
+		},
+		{
+			name: "creates first missing StatefulSet only",
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newScyllaDBDatacenter()
+				sdc.Generation = 3
+				return sdc
+			}(),
+			required: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+				newStatefulSet("bar"),
+			},
+			existing: map[string]*appsv1.StatefulSet{},
+			applyStatefulSet: func(context.Context, *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
+				return newStatefulSet("foo"), true, nil
+			},
+			expectedCreated: []*appsv1.StatefulSet{newStatefulSet("foo")},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             internalapi.ProgressingReason,
+					Message:            `Progressing: Running "apply" on "apps/v1, Kind=StatefulSet"`,
+					ObservedGeneration: 3,
+				},
+			},
+			expectedErrorString: "",
+		},
+		{
+			name:               "does not add condition when apply is unchanged",
+			scyllaDBDatacenter: newScyllaDBDatacenter(),
+			required: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+			},
+			existing: map[string]*appsv1.StatefulSet{},
+			applyStatefulSet: func(context.Context, *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
+				return newStatefulSet("foo"), false, nil
+			},
+			expectedCreated:     []*appsv1.StatefulSet{},
+			expectedConditions:  []metav1.Condition{},
+			expectedErrorString: "",
+		},
+		{
+			name:               "returns apply error",
+			scyllaDBDatacenter: newScyllaDBDatacenter(),
+			required: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+			},
+			existing: map[string]*appsv1.StatefulSet{},
+			applyStatefulSet: func(context.Context, *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
+				return nil, false, errors.New("apply failed")
+			},
+			expectedCreated:     nil,
+			expectedConditions:  nil,
+			expectedErrorString: `can't create missing statefulset "default/foo": apply failed`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			created, conditions, err := createMissingStatefulSets(
+				context.Background(),
+				tc.applyStatefulSet,
+				tc.scyllaDBDatacenter,
+				tc.required,
+				tc.existing,
+			)
+
+			var errStr string
+			if err != nil {
+				errStr = err.Error()
+			}
+			if diff := cmp.Diff(tc.expectedErrorString, errStr); diff != "" {
+				t.Errorf("expected and actual error strings differ (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedCreated, created, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); diff != "" {
+				t.Errorf("created StatefulSets differ (-want +got):\n%s", diff)
+			}
+
+			for i := range conditions {
+				conditions[i].LastTransitionTime = metav1.Time{}
+			}
+			if diff := cmp.Diff(tc.expectedConditions, conditions); diff != "" {
+				t.Errorf("conditions differ (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_ensureRackNamesInRackStatuses(t *testing.T) {
+	t.Parallel()
+
+	newRackStatefulSet := func(rackName string) *appsv1.StatefulSet {
+		sts := newStatefulSet(rackName)
+		sts.Labels = map[string]string{
+			naming.RackNameLabel: rackName,
+		}
+
+		return sts
+	}
+
+	newPodLister := func(t *testing.T, statefulSets ...*appsv1.StatefulSet) corev1listers.PodLister {
+		t.Helper()
+
+		podCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		for _, sts := range statefulSets {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: sts.Namespace,
+					Name:      sts.Name + "-0",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "StatefulSet",
+							Name:       sts.Name,
+							UID:        sts.UID,
+							Controller: new(true),
+						},
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  naming.ScyllaContainerName,
+							Image: testScyllaDBImage,
+						},
+					},
+				},
+			}
+			if err := podCache.Add(pod); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		return corev1listers.NewPodLister(podCache)
+	}
+
+	freshRackStatus := func(name string) scyllav1alpha1.RackStatus {
+		return scyllav1alpha1.RackStatus{
+			Name:           name,
+			CurrentVersion: "latest",
+			UpdatedVersion: "latest",
+			Nodes:          new(int32(1)),
+			CurrentNodes:   new(int32(0)),
+			UpdatedNodes:   new(int32(0)),
+			ReadyNodes:     new(int32(0)),
+			AvailableNodes: new(int32(0)),
+			Stale:          new(false),
+		}
+	}
+
+	tt := []struct {
+		name                string
+		scyllaDBDatacenter  *scyllav1alpha1.ScyllaDBDatacenter
+		status              *scyllav1alpha1.ScyllaDBDatacenterStatus
+		statefulSets        []*appsv1.StatefulSet
+		expectedRacks       []scyllav1alpha1.RackStatus
+		expectedErrorString string
+	}{
+		{
+			name:               "adds status calculated from statefulset and pod",
+			scyllaDBDatacenter: newScyllaDBDatacenter(),
+			status:             &scyllav1alpha1.ScyllaDBDatacenterStatus{},
+			statefulSets: []*appsv1.StatefulSet{
+				newRackStatefulSet("foo"),
+			},
+			expectedRacks: []scyllav1alpha1.RackStatus{
+				freshRackStatus("foo"),
+			},
+		},
+		{
+			name:               "recalculates existing rack status",
+			scyllaDBDatacenter: newScyllaDBDatacenter(),
+			status: &scyllav1alpha1.ScyllaDBDatacenterStatus{
+				Racks: []scyllav1alpha1.RackStatus{
+					{
+						Name:           "foo",
+						CurrentVersion: "old",
+						UpdatedVersion: "old",
+						Nodes:          new(int32(2)),
+						CurrentNodes:   new(int32(2)),
+						UpdatedNodes:   new(int32(2)),
+						ReadyNodes:     new(int32(2)),
+						AvailableNodes: new(int32(2)),
+						Stale:          new(true),
+					},
+				},
+			},
+			statefulSets: []*appsv1.StatefulSet{
+				newRackStatefulSet("foo"),
+			},
+			expectedRacks: []scyllav1alpha1.RackStatus{
+				freshRackStatus("foo"),
+			},
+		},
+		{
+			name:               "keeps stale status for rack without statefulset",
+			scyllaDBDatacenter: newScyllaDBDatacenter(),
+			status: &scyllav1alpha1.ScyllaDBDatacenterStatus{
+				Racks: []scyllav1alpha1.RackStatus{
+					{
+						Name:           "bar",
+						CurrentVersion: "old",
+						UpdatedVersion: "old",
+						Stale:          new(true),
+					},
+				},
+			},
+			statefulSets: []*appsv1.StatefulSet{
+				newRackStatefulSet("foo"),
+			},
+			expectedRacks: []scyllav1alpha1.RackStatus{
+				{
+					Name:           "bar",
+					CurrentVersion: "old",
+					UpdatedVersion: "old",
+					Stale:          new(true),
+				},
+				freshRackStatus("foo"),
+			},
+		},
+		{
+			name:               "returns missing rack label error",
+			scyllaDBDatacenter: newScyllaDBDatacenter(),
+			status:             &scyllav1alpha1.ScyllaDBDatacenterStatus{},
+			statefulSets: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+			},
+			expectedErrorString: `can't determine rack name: statefulset default/foo is missing label "scylla/rack"`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakePodLister := newPodLister(t, tc.statefulSets...)
+
+			err := ensureRackNamesInRackStatuses(
+				fakePodLister,
+				tc.scyllaDBDatacenter,
+				tc.status,
+				tc.statefulSets,
+			)
+
+			var errStr string
+			if err != nil {
+				errStr = err.Error()
+			}
+			if diff := cmp.Diff(tc.expectedErrorString, errStr); diff != "" {
+				t.Errorf("expected and actual error strings differ (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedRacks, tc.status.Racks); diff != "" {
+				t.Errorf("rack statuses differ (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func newScyllaDBDatacenter() *scyllav1alpha1.ScyllaDBDatacenter {
+	return &scyllav1alpha1.ScyllaDBDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+		},
+		Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
+			ScyllaDB: scyllav1alpha1.ScyllaDB{
+				Image: testScyllaDBImage,
+			},
+		},
+	}
+}
+
+func newStatefulSet(name string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: scyllav1alpha1.GroupVersion.String(),
+					Kind:       "ScyllaDBDatacenter",
+					Name:       "basic",
+					UID:        "owner",
+					Controller: new(true),
+				},
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: new(int32(1)),
+		},
+	}
+}

--- a/test/envtest/controllers/controllers_suite_test.go
+++ b/test/envtest/controllers/controllers_suite_test.go
@@ -7,7 +7,12 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
 )
+
+func init() {
+	klog.InitFlags(nil)
+}
 
 func TestEnvtest(t *testing.T) {
 	o.RegisterFailHandler(g.Fail)

--- a/test/envtest/controllers/scylladbdatacenter_controller_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_test.go
@@ -1,0 +1,307 @@
+//go:build envtest
+
+package controllers
+
+import (
+	"context"
+	stdcrypto "crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	scyllainformers "github.com/scylladb/scylla-operator/pkg/client/scylla/informers/externalversions"
+	"github.com/scylladb/scylla-operator/pkg/controller/scylladbdatacenter"
+	"github.com/scylladb/scylla-operator/pkg/crypto"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/scylla"
+	"github.com/scylladb/scylla-operator/test/envtest"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	// scyllaDBDatacenterControllerDisabledStatefulSetCachePropagationDelay disables the production cache-propagation
+	// wait in envtests. Envtest runs the controller and API server in-process, so the default delay only slows tests down.
+	// Tests that need to exercise cache lag should override this.
+	scyllaDBDatacenterControllerDisabledStatefulSetCachePropagationDelay = 0 * time.Second
+
+	scyllaDBDatacenterControllerResyncPeriod = 12 * time.Hour
+
+	// scyllaDBDatacenterControllerDefaultEventuallyTimeout is the default timeout for async envtest assertions.
+	// Pad accordingly when a test uses a non-zero cache-propagation delay, otherwise Eventually may time out before
+	// the controller resumes reconciliation.
+	scyllaDBDatacenterControllerDefaultEventuallyTimeout = 15 * time.Second
+
+	// scyllaDBDatacenterControllerDefaultConsistentlyTimeout is the default window for stability assertions.
+	// Pad accordingly when a test uses a non-zero cache-propagation delay, otherwise Consistently may pass while the
+	// controller is delayed instead of observing real steady state.
+	scyllaDBDatacenterControllerDefaultConsistentlyTimeout = 5 * time.Second
+)
+
+var _ = g.Describe("ScyllaDBDatacenter controller", func() {
+	var env *envtest.Environment
+	g.BeforeEach(func(ctx g.SpecContext) {
+		env = envtest.Setup(ctx)
+	})
+
+	g.It("should create rack StatefulSets sequentially", func(ctx g.SpecContext) {
+		g.By("Running ScyllaDBDatacenter controller")
+		runScyllaDBDatacenterController(ctx, env)
+
+		g.By("Creating ScyllaOperatorConfig singleton")
+		createScyllaOperatorConfig(ctx, env)
+
+		g.By("Creating a ScyllaDBDatacenter with two racks")
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a", "rack-b"})
+		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for the first rack StatefulSet to be created")
+		firstRackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+		waitForStatefulSet(ctx, env, firstRackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+
+		g.By("Verifying the second rack StatefulSet is not created before the first rack rolls out")
+		secondRackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[1], sdc)
+		o.Consistently(func(co o.Gomega, ctx context.Context) {
+			_, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, secondRackStatefulSetName, metav1.GetOptions{})
+			co.Expect(apierrors.IsNotFound(err)).To(o.BeTrue())
+		}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+		g.By("Marking the first rack StatefulSet as rolled out")
+		markStatefulSetAsRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), firstRackStatefulSetName)
+
+		g.By("Waiting for the second rack StatefulSet to be created")
+		waitForStatefulSet(ctx, env, secondRackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+	})
+
+	g.DescribeTable("should not create a StatefulSet for a new rack while an existing rack is not rolled out",
+		func(ctx g.SpecContext, initialRacks, updatedRacks []string, existingRack, newRack string) {
+			g.By("Running ScyllaDBDatacenter controller")
+			runScyllaDBDatacenterController(ctx, env)
+
+			g.By("Creating ScyllaOperatorConfig singleton")
+			createScyllaOperatorConfig(ctx, env)
+
+			g.By("Creating a ScyllaDBDatacenter")
+			sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), initialRacks)
+			sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Waiting for the first StatefulSet to be created")
+			existingRackStatefulSetName := naming.StatefulSetNameForRack(makeRackSpec(existingRack), sdc)
+			waitForStatefulSet(ctx, env, existingRackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+
+			g.By("Marking the first rack StatefulSet as not rolled out")
+			markStatefulSetAsNotRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), existingRackStatefulSetName)
+
+			g.By("Adding a new rack")
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				sdc, err = env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("can't get ScyllaDBDatacenter %q: %w", naming.ManualRef(env.Namespace(), sdc.Name), err)
+				}
+
+				sdc.Spec.Racks = makeRackSpecs(updatedRacks...)
+				_, err = env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Update(ctx, sdc, metav1.UpdateOptions{})
+				if err != nil {
+					return fmt.Errorf("can't update ScyllaDBDatacenter %q: %w", naming.ObjRef(sdc), err)
+				}
+
+				return nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Verifying the new rack StatefulSet is not created")
+			newRackStatefulSetName := naming.StatefulSetNameForRack(makeRackSpec(newRack), sdc)
+			o.Consistently(func(co o.Gomega, ctx context.Context) {
+				_, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, newRackStatefulSetName, metav1.GetOptions{})
+				co.Expect(apierrors.IsNotFound(err)).To(o.BeTrue())
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+		},
+		g.Entry("when new rack is prepended", []string{"rack-b"}, []string{"rack-a", "rack-b"}, "rack-b", "rack-a"),
+		g.Entry("when new rack is appended", []string{"rack-a"}, []string{"rack-a", "rack-b"}, "rack-a", "rack-b"),
+	)
+})
+
+func waitForStatefulSet(ctx context.Context, e *envtest.Environment, name string, timeout time.Duration) *appsv1.StatefulSet {
+	g.GinkgoHelper()
+
+	var statefulSet *appsv1.StatefulSet
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		var err error
+		statefulSet, err = e.TypedKubeClient().AppsV1().StatefulSets(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+	}).WithContext(ctx).WithTimeout(timeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+	return statefulSet
+}
+
+func makeEnvtestScyllaDBDatacenter(namespace string, racks []string) *scyllav1alpha1.ScyllaDBDatacenter {
+	sdc := &scyllav1alpha1.ScyllaDBDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "envtest-sdc",
+			Namespace: namespace,
+		},
+		Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
+			ClusterName: "envtest-cluster",
+			DNSDomains:  []string{"envtest.local"},
+			ScyllaDB: scyllav1alpha1.ScyllaDB{
+				Image:               "scylladb/scylla:envtest",
+				EnableDeveloperMode: new(true),
+			},
+			RackTemplate: &scyllav1alpha1.RackTemplate{
+				Nodes: new(int32(1)),
+				ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+					Storage: &scyllav1alpha1.StorageOptions{
+						Capacity: "1Gi",
+					},
+				},
+			},
+		},
+	}
+
+	sdc.Spec.Racks = makeRackSpecs(racks...)
+
+	return sdc
+}
+
+func makeRackSpecs(names ...string) []scyllav1alpha1.RackSpec {
+	racks := make([]scyllav1alpha1.RackSpec, 0, len(names))
+	for _, name := range names {
+		racks = append(racks, makeRackSpec(name))
+	}
+	return racks
+}
+
+func makeRackSpec(name string) scyllav1alpha1.RackSpec {
+	return scyllav1alpha1.RackSpec{Name: name}
+}
+
+func markStatefulSetAsNotRolledOut(ctx context.Context, statefulSets appsv1client.StatefulSetInterface, name string) {
+	g.GinkgoHelper()
+
+	statefulSet, err := statefulSets.Get(ctx, name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	statefulSet.Status.ObservedGeneration = statefulSet.Generation - 1
+	statefulSet.Status.Replicas = 1
+	statefulSet.Status.ReadyReplicas = 0
+	statefulSet.Status.UpdatedReplicas = 0
+	_, err = statefulSets.UpdateStatus(ctx, statefulSet, metav1.UpdateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func markStatefulSetAsRolledOut(ctx context.Context, statefulSets appsv1client.StatefulSetInterface, name string) {
+	g.GinkgoHelper()
+
+	statefulSet, err := statefulSets.Get(ctx, name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	replicas := *statefulSet.Spec.Replicas
+	statefulSet.Status.ObservedGeneration = statefulSet.Generation
+	statefulSet.Status.Replicas = replicas
+	statefulSet.Status.ReadyReplicas = replicas
+	statefulSet.Status.AvailableReplicas = replicas
+	statefulSet.Status.UpdatedReplicas = replicas
+	statefulSet.Status.CurrentRevision = "envtest-revision"
+	statefulSet.Status.UpdateRevision = statefulSet.Status.CurrentRevision
+	_, err = statefulSets.UpdateStatus(ctx, statefulSet, metav1.UpdateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+type staticKeyGenerator struct {
+	key stdcrypto.Signer
+}
+
+func newStaticKeyGenerator() *staticKeyGenerator {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return &staticKeyGenerator{key: key}
+}
+
+func (g *staticKeyGenerator) GetNewKey(ctx context.Context) (stdcrypto.Signer, error) {
+	return g.key, nil
+}
+
+func (g *staticKeyGenerator) GetKeyType() crypto.KeyType {
+	return crypto.ECDSAKeyType
+}
+
+func runScyllaDBDatacenterController(ctx context.Context, e *envtest.Environment) {
+	g.GinkgoHelper()
+
+	kubeClient := e.TypedKubeClient()
+	scyllaClient := e.ScyllaClient()
+	kubeInformers := informers.NewSharedInformerFactoryWithOptions(
+		kubeClient,
+		scyllaDBDatacenterControllerResyncPeriod,
+		informers.WithNamespace(e.Namespace()),
+	)
+	scyllaInformers := scyllainformers.NewSharedInformerFactoryWithOptions(
+		scyllaClient,
+		scyllaDBDatacenterControllerResyncPeriod,
+		scyllainformers.WithNamespace(e.Namespace()),
+	)
+	scyllaGlobalInformers := scyllainformers.NewSharedInformerFactoryWithOptions(
+		scyllaClient,
+		scyllaDBDatacenterControllerResyncPeriod,
+		scyllainformers.WithNamespace(corev1.NamespaceAll),
+	)
+	keyGenerator := newStaticKeyGenerator()
+
+	options := []scylladbdatacenter.ControllerOption{
+		// The default delay only slows tests down; tests that need to exercise cache lag should override this.
+		scylladbdatacenter.WithStatefulSetCachePropagationDelay(scyllaDBDatacenterControllerDisabledStatefulSetCachePropagationDelay),
+	}
+
+	sdcc, err := scylladbdatacenter.NewController(
+		kubeClient,
+		scyllaClient.ScyllaV1alpha1(),
+		kubeInformers.Core().V1().Pods(),
+		kubeInformers.Core().V1().Services(),
+		kubeInformers.Core().V1().Secrets(),
+		kubeInformers.Core().V1().ConfigMaps(),
+		kubeInformers.Core().V1().ServiceAccounts(),
+		kubeInformers.Rbac().V1().RoleBindings(),
+		kubeInformers.Apps().V1().StatefulSets(),
+		kubeInformers.Policy().V1().PodDisruptionBudgets(),
+		kubeInformers.Networking().V1().Ingresses(),
+		kubeInformers.Batch().V1().Jobs(),
+		scyllaInformers.Scylla().V1alpha1().ScyllaDBDatacenters(),
+		scyllaInformers.Scylla().V1alpha1().ScyllaDBDatacenterNodesStatusReports(),
+		scyllaGlobalInformers.Scylla().V1alpha1().ScyllaOperatorConfigs(),
+		"scylla/operator:envtest",
+		scylla.DefaultNativeTransportPort,
+		keyGenerator,
+		options...,
+	)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	kubeInformers.Start(ctx.Done())
+	scyllaInformers.Start(ctx.Done())
+	scyllaGlobalInformers.Start(ctx.Done())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sdcc.Run(ctx, 1)
+	}()
+
+	g.DeferCleanup(func() {
+		kubeInformers.Shutdown()
+		scyllaInformers.Shutdown()
+		scyllaGlobalInformers.Shutdown()
+		wg.Wait()
+	})
+}

--- a/test/envtest/controllers/scylladbmonitoring_controller_test.go
+++ b/test/envtest/controllers/scylladbmonitoring_controller_test.go
@@ -273,7 +273,7 @@ var _ = g.Describe("ScyllaDBMonitoringController", func() {
 })
 
 // createScyllaOperatorConfig creates a ScyllaOperatorConfig singleton (name="cluster") with
-// the minimal status fields required by the ScyllaDBMonitoring controller.
+// the minimal status fields required by envtest controllers.
 func createScyllaOperatorConfig(ctx context.Context, e *envtest.Environment) *scyllav1alpha1.ScyllaOperatorConfig {
 	g.GinkgoHelper()
 
@@ -294,6 +294,7 @@ func createScyllaOperatorConfig(ctx context.Context, e *envtest.Environment) *sc
 	socCopy.Status.GrafanaImage = pointer.Ptr("docker.io/grafana/grafana:10.0.0")
 	socCopy.Status.BashToolsImage = pointer.Ptr("docker.io/scylladb/scylla-operator-bash-tools:latest")
 	socCopy.Status.PrometheusVersion = pointer.Ptr("2.48.0")
+	socCopy.Status.ScyllaDBNodeExporterImage = pointer.Ptr("docker.io/scylladb/scylla-operator-node-exporter:latest")
 	soc, err = e.ScyllaClient().ScyllaV1alpha1().ScyllaOperatorConfigs().UpdateStatus(ctx, socCopy, metav1.UpdateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to update ScyllaOperatorConfig status")
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Currently, ScyllaDBDatacenter rollout can deadlock when a a rack is prepended during a progressing rollout with bootstrap sync enabled.

This is due to an [incorrect implementation of ScyllaDBDatacenter controller](https://github.com/scylladb/scylla-operator/blob/412f2606a6ea7ccbbd5b2c655ea3681afb71a75f/pkg/controller/scylladbdatacenter/sync_statefulsets.go#L397-L471) .
`createMissingStatefulSets` convoluted logic mixes waiting for the rollout of existing StatefulSets with creation of new StatefulSets, assuming it should only wait for the rollout of StatefulSets earlier in the spec’s slice. Prepending a rack during an active rollout breaks it.

This PR fixes it by separating these actions: the controller now waits for all existing StatefulSets to roll out before a new StatefulSet is created. It also splits the logic into separate functions.

To test this, the PR introduces ScyllaDBDatacenter controller envtests ensuring sequential creation of StatefulSets in different scenarios.

Envtest failure before the fix: https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3513/pull-scylla-operator-master-envtest/2080348833983762432.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-247

/cc