### PR TITLE
ci: run arm64 e2e ScyllaDB on local NVMe instead of a loopback image

### DIFF
--- a/hack/.ci/manifests/cluster/nodeconfig-gke-arm64.yaml
+++ b/hack/.ci/manifests/cluster/nodeconfig-gke-arm64.yaml
@@ -4,18 +4,27 @@ metadata:
   name: cluster
 spec:
   localDiskSetup:
-    loopDevices:
-    - name: persistent-volumes
-      imagePath: /var/lib/persistent-volumes.img
-      size: 80Gi
     filesystems:
-    - device: /dev/loops/persistent-volumes
+    - device: /dev/md/nvmes
       type: xfs
     mounts:
-    - device: /dev/loops/persistent-volumes
+    - device: /dev/md/nvmes
       mountPoint: /var/lib/persistent-volumes
       unsupportedOptions:
       - prjquota
+    raids:
+    - name: nvmes
+      type: RAID0
+      RAID0:
+        devices:
+          # On C4A instances every disk is attached over NVMe and each one gets
+          # its own controller, e.g. the boot Hyperdisk is /dev/nvme0n1 and the
+          # bundled Local SSDs are /dev/nvme1n1, /dev/nvme2n1, and so on.
+          # Ordering isn't guaranteed, so the devices are told apart by their
+          # model: the boot Hyperdisk reports "nvme_card-pd", while the Local
+          # SSDs report "nvme_card0", "nvme_card1", etc.
+          nameRegex: ^/dev/nvme\d+n\d+$
+          modelRegex: ^nvme_card\d+$
   sysctls:
   - name: fs.aio-max-nr
     value: "4294967295" # Allow for high parallelism in CI.

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -154,7 +154,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 						Status: *pvc.Status.DeepCopy(),
 					}
 					pvcClone.Spec.VolumeName = ""
-					pvcClone.Spec.StorageClassName = nil
+					pvcClone.Spec.StorageClassName = pointer.Ptr(framework.TestContext.ScyllaClusterOptions.StorageClassName)
 
 					framework.Infof("Creating clone PVC for %q", pvc.Name)
 					pvcClone, _, err := resourceapply.ApplyPersistentVolumeClaimWithControl(


### PR DESCRIPTION
arm64 e2e fails intermittently with `gocql: no response received from cassandra within timeout period` on `CREATE KEYSPACE` / `CREATE TABLE`. A DDL statement gets 11 s ([gocql default](https://github.com/scylladb/scylla-operator/blob/3d2511a055d400c8a2a2551a339f480cb9540195/vendor/github.com/gocql/gocql/cluster.go#L393), not overridden). 4 of the last 34 arm64 runs hit it, and all 4 failed the job: [2026-06-08](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/ci-scylla-operator-latest-e2e-gke-arm64-parallel/2063863619451359232), [07-20](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/ci-scylla-operator-latest-e2e-gke-arm64-parallel/2079083913241694208), [07-22](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/ci-scylla-operator-latest-e2e-gke-arm64-parallel/2079821817748393984), [07-23](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/ci-scylla-operator-latest-e2e-gke-arm64-parallel/2080266028218060800).

`t2a-standard-8` has no local SSD, so the arm64 NodeConfig put ScyllaDB data in an 80Gi sparse image on a loop device — sitting on the `pd-balanced` **boot disk**. Every commitlog fsync went over the network, and schema DDL is fsync- and agreement-heavy. Backing it with local NVMe in RAID0 moves `/var/lib/scylla` from `/dev/loop0` to `/dev/md127`, with DDL timings (from `DataInserter` log lines, x86 as an unchanged reference):

| | x86 ref (`n2d`, local NVMe) | BEFORE arm64 (`t2a`, loopback) | AFTER arm64 (`c4a`, NVMe RAID0) |
|---|---|---|---|
| runs / DDL sequences | 9 / 354 | 32 / 935 | 4 / 121 |
| median `CREATE KEYSPACE` | 0.012 s | 0.304 s | **0.016 s** |
| median `CREATE TABLE` | 0.038 s | 0.256 s | **0.031 s** |
| worst DDL | 2.831 s | 10.985 s | **2.415 s** |
| DDL ops > 5 s | 0 / 708 | 34 / 1870 (1.8 %) | **0 / 242** |
| gocql DDL timeouts | 0 | 7 specs | **0** |

arm64 was ~25× slower than x86 at the median; it now matches x86. The `c4a` runs — the first three predate commit 2 and failed on the `pd-balanced` orphaned-PV issue it fixes, with DDL timings unaffected:

- [2081704819474567168](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/ci-scylla-operator-latest-e2e-gke-arm64-parallel/2081704819474567168)
- [2081717634117668864](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/ci-scylla-operator-latest-e2e-gke-arm64-parallel/2081717634117668864)
- [2081748435240751104](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/logs/ci-scylla-operator-latest-e2e-gke-arm64-parallel/2081748435240751104)
- [2082061640928333824](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3522/pull-scylla-operator-master-e2e-gke-arm64-parallel-manual-czeslavo/2082061640928333824) — green, 68 passed / 0 failed

Had an attempt to switch the `serial` job to C4A machines for uniformity, but it would require more code changes in tests (serial tests assume they can use a default storageClass, which cannot be used in a cluster with C4A nodes as they do not support `pd-balanced`). Decided to ignore it for now as the serial tests aren't affected by the DDL timing issue.

Requires scylladb/scylla-operator-release#646, which moves the arm64 pool to `c4a-standard-8-lssd`.

Closes https://scylladb.atlassian.net/browse/OPERATOR-246