### PR TITLE
chore: use scylladb-node-exporter image for node-exporter sidecar

### DIFF
--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -2,8 +2,8 @@ operator:
   # renovate: datasource=docker depName=scylladb packageName=docker.io/scylladb/scylla versioning=semver
   scyllaDBVersion: "2026.2.2"
   scyllaDBUtilsImage: "docker.io/scylladb/scylla:2026.1.0@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a"
-  # FIXME: switch to scylladb-node-exporter image once https://scylladb.atlassian.net/browse/RELENG-711 is completed.
-  scyllaDBNodeExporterImage: "quay.io/prometheus/node-exporter:v1.11.1"
+  # renovate: datasource=docker depName=scylladb-node-exporter packageName=docker.io/scylladb/scylladb-node-exporter versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-(?<build>\d+)$
+  scyllaDBNodeExporterImage: "docker.io/scylladb/scylladb-node-exporter:1.12.1-1@sha256:7fc93b58d9711400a54b36fd06141bcb3972260b74738f299d7980eebee3a711"
   # renovate: datasource=docker depName=scylla-manager packageName=docker.io/scylladb/scylla-manager versioning=semver
   scyllaDBManagerVersion: "3.11.2@sha256:61ec1396d438945abf3db46db893d7e4d2324acb5523d143077f8fdfea05779d"
   # renovate: datasource=docker depName=scylla-manager-agent packageName=docker.io/scylladb/scylla-manager-agent versioning=semver

--- a/renovate.json
+++ b/renovate.json
@@ -195,7 +195,7 @@
         "/^assets/config/config\\.yaml$/"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*\\S+:\\s*\"?(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\"?"
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*\\S+:\\s*\"?(?:[^@\"\\s:]+(?:/[^@\"\\s:]+)+:)?(?<currentValue>[^@\"\\s:/]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\"?"
       ]
     },
     {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Switch the upstream node-exporter image reference to scylladb-node-exporter. Configure renovate to automate updates.

**Prerequisites**:
- [x] https://scylladb.atlassian.net/browse/RELENG-711

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-219

/cc
