### PR TITLE
fix(webhook): correct port logging logic

### DIFF
--- a/pkg/cmd/operator/webhooks.go
+++ b/pkg/cmd/operator/webhooks.go
@@ -105,7 +105,7 @@ var portFlagRe = regexp.MustCompile(`^(?:tcp://[^:]+:)?(\d+)$`)
 type portFlag int
 
 func (pf *portFlag) String() string {
-	return fmt.Sprintf("%d", pf)
+	return fmt.Sprintf("%d", *pf)
 }
 
 func (pf *portFlag) Set(v string) error {


### PR DESCRIPTION
**Description of your changes:**
- log real port number in webhook logs and not the pointer memory address

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-251

/priority important-longterm