### PR TITLE
chore(renovate): manage local-csi-driver image references

### DIFF
--- a/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
+++ b/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
@@ -24,6 +24,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
+        # renovate: datasource=docker depName=local-csi-driver packageName=docker.io/scylladb/local-csi-driver versioning=semver
         image: docker.io/scylladb/local-csi-driver:0.5.0@sha256:46c1d2e9be8edf076d8dea7e82a3bb763d4bdda5adf43c794f617e9c94251079
         imagePullPolicy: IfNotPresent
         args:

--- a/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
@@ -24,6 +24,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
+        # renovate: datasource=docker depName=local-csi-driver packageName=docker.io/scylladb/local-csi-driver versioning=semver
         image: docker.io/scylladb/local-csi-driver:0.5.0@sha256:46c1d2e9be8edf076d8dea7e82a3bb763d4bdda5adf43c794f617e9c94251079
         imagePullPolicy: IfNotPresent
         args:

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "custom.regex",
     "gomod"
   ],
+  "ignorePaths": [],
   "schedule": [
     "before 5am on monday"
   ],
@@ -17,12 +18,9 @@
   ],
   "packageRules": [
     {
-      "description": "Image references in assets/config/config.yaml should be updated every weekday",
+      "description": "Container image references should be updated every weekday",
       "matchDatasources": [
         "docker"
-      ],
-      "matchFileNames": [
-        "assets/config/config.yaml"
       ],
       "schedule": [
         "before 5am every weekday"
@@ -127,18 +125,6 @@
       ]
     },
     {
-      "description": "Dockerfile base images should be updated every weekday",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchFileNames": [
-        "Dockerfile"
-      ],
-      "schedule": [
-        "before 5am every weekday"
-      ]
-    },
-    {
       "description": "ScyllaDB dependency bump in config.yaml requires manual action",
       "matchDepNames": [
         "scylladb"
@@ -220,6 +206,17 @@
       ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\nFROM\\s+\\S+:(?<currentValue>\\S+)"
+      ]
+    },
+    {
+      "description": "Custom manager for local-csi-driver image references in Kubernetes manifests with Renovate annotations matching the regex.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^examples/common/local-volume-provisioner/local-csi-driver/50_daemonset\\.yaml$/",
+        "/^hack/\\.ci/manifests/namespaces/local-csi-driver/50_daemonset\\.yaml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*image:\\s*[^\\s:]+:(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ]
     },
     {


### PR DESCRIPTION
Adds Renovate coverage for the `local-csi-driver` image pins in `examples/common/local-volume-provisioner/` and `hack/.ci/manifests/`, so that version bumps are proposed automatically, and consolidates the per-file weekday schedule rules for container images into a single datasource-matched rule. `ignorePaths` is overridden to be empty because `config:recommended` ignores `**/examples/**`, which hid the example manifest from Renovate.

Closes https://scylladb.atlassian.net/browse/OPERATOR-263