### PR TITLE
feat: relax bootstrap barrier to allow for parallel bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
   version 2026.3 or later, since these versions no longer bundle node-exporter. The node-exporter container image is configurable via
   `ScyllaOperatorConfig.spec.scyllaDBNodeExporterImage`.
   [#3482](https://github.com/scylladb/scylla-operator/pull/3482)
+- The bootstrap barrier now only takes into account nodes that have already joined the ScyllaDB cluster and own tokens
+  in it. `ScyllaDBDatacenterNodesStatusReport` reflects the same: a node appears in it only once it's a member of the
+  ScyllaDB cluster, so the absence of an entry no longer implies the corresponding node is missing or unhealthy.
+  Previously every node expected to exist in the Kubernetes state was required to be reported and UP, including nodes
+  that hadn't joined yet and couldn't report their status.
+  [#3530](https://github.com/scylladb/scylla-operator/pull/3530)
 
 ## [1.21.0](https://github.com/scylladb/scylla-operator/releases/tag/v1.21.0)
 

--- a/bundle/manifests/scylla.scylladb.com_scylladbdatacenternodesstatusreports.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scylladbdatacenternodesstatusreports.yaml
@@ -21,6 +21,7 @@ spec:
         description: |-
           ScyllaDBDatacenterNodesStatusReport serves as an internal interface for propagating and aggregating node statuses observed by nodes in a ScyllaDB datacenter.
           It is used by ScyllaDB Operator for coordinating operations such as topology changes and is not intended for direct user interaction.
+          The report only covers nodes that have joined the ScyllaDB cluster, which is distinct from the set of Kubernetes objects that represent them.
         properties:
           apiVersion:
             description: |-
@@ -50,8 +51,11 @@ spec:
                   description: Name is the name of the rack.
                   type: string
                 nodes:
-                  description: Nodes holds the list of node status reports collected
-                    from nodes from this rack.
+                  description: |-
+                    Nodes holds the list of node status reports collected from nodes from this rack.
+                    Entries correspond to ScyllaDB nodes, not to the Kubernetes objects representing them: a node is reported only
+                    once its ScyllaDB instance has joined the cluster and owns tokens in it.
+                    The absence of an entry doesn't imply the node is missing or unhealthy.
                   items:
                     properties:
                       hostID:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -35488,6 +35488,7 @@ spec:
           description: |-
             ScyllaDBDatacenterNodesStatusReport serves as an internal interface for propagating and aggregating node statuses observed by nodes in a ScyllaDB datacenter.
             It is used by ScyllaDB Operator for coordinating operations such as topology changes and is not intended for direct user interaction.
+            The report only covers nodes that have joined the ScyllaDB cluster, which is distinct from the set of Kubernetes objects that represent them.
           properties:
             apiVersion:
               description: |-
@@ -35517,7 +35518,11 @@ spec:
                     description: Name is the name of the rack.
                     type: string
                   nodes:
-                    description: Nodes holds the list of node status reports collected from nodes from this rack.
+                    description: |-
+                      Nodes holds the list of node status reports collected from nodes from this rack.
+                      Entries correspond to ScyllaDB nodes, not to the Kubernetes objects representing them: a node is reported only
+                      once its ScyllaDB instance has joined the cluster and owns tokens in it.
+                      The absence of an entry doesn't imply the node is missing or unhealthy.
                     items:
                       properties:
                         hostID:

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenternodesstatusreports.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenternodesstatusreports.rst
@@ -14,6 +14,7 @@ Description
 -----------
 ScyllaDBDatacenterNodesStatusReport serves as an internal interface for propagating and aggregating node statuses observed by nodes in a ScyllaDB datacenter.
 It is used by ScyllaDB Operator for coordinating operations such as topology changes and is not intended for direct user interaction.
+The report only covers nodes that have joined the ScyllaDB cluster, which is distinct from the set of Kubernetes objects that represent them.
 
 Specification
 -------------
@@ -81,7 +82,7 @@ object
      - Name is the name of the rack.
    * - :ref:`nodes<api-scylla.scylladb.com-scylladbdatacenternodesstatusreports-v1alpha1-.racks[].nodes[]>`
      - array (object)
-     - Nodes holds the list of node status reports collected from nodes from this rack.
+     - Nodes holds the list of node status reports collected from nodes from this rack. Entries correspond to ScyllaDB nodes, not to the Kubernetes objects representing them: a node is reported only once its ScyllaDB instance has joined the cluster and owns tokens in it. The absence of an entry doesn't imply the node is missing or unhealthy.
 
 .. _api-scylla.scylladb.com-scylladbdatacenternodesstatusreports-v1alpha1-.racks[].nodes[]:
 

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenternodesstatusreports.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenternodesstatusreports.yaml
@@ -21,6 +21,7 @@ spec:
           description: |-
             ScyllaDBDatacenterNodesStatusReport serves as an internal interface for propagating and aggregating node statuses observed by nodes in a ScyllaDB datacenter.
             It is used by ScyllaDB Operator for coordinating operations such as topology changes and is not intended for direct user interaction.
+            The report only covers nodes that have joined the ScyllaDB cluster, which is distinct from the set of Kubernetes objects that represent them.
           properties:
             apiVersion:
               description: |-
@@ -50,7 +51,11 @@ spec:
                     description: Name is the name of the rack.
                     type: string
                   nodes:
-                    description: Nodes holds the list of node status reports collected from nodes from this rack.
+                    description: |-
+                      Nodes holds the list of node status reports collected from nodes from this rack.
+                      Entries correspond to ScyllaDB nodes, not to the Kubernetes objects representing them: a node is reported only
+                      once its ScyllaDB instance has joined the cluster and owns tokens in it.
+                      The absence of an entry doesn't imply the node is missing or unhealthy.
                     items:
                       properties:
                         hostID:

--- a/pkg/api/scylla/v1alpha1/types_scylladbdatacenternodesstatusreport.go
+++ b/pkg/api/scylla/v1alpha1/types_scylladbdatacenternodesstatusreport.go
@@ -37,11 +37,15 @@ type RackNodesStatusReport struct {
 	Name string `json:"name"`
 
 	// Nodes holds the list of node status reports collected from nodes from this rack.
+	// Entries correspond to ScyllaDB nodes, not to the Kubernetes objects representing them: a node is reported only
+	// once its ScyllaDB instance has joined the cluster and owns tokens in it.
+	// The absence of an entry doesn't imply the node is missing or unhealthy.
 	Nodes []NodeStatusReport `json:"nodes"`
 }
 
 // ScyllaDBDatacenterNodesStatusReport serves as an internal interface for propagating and aggregating node statuses observed by nodes in a ScyllaDB datacenter.
 // It is used by ScyllaDB Operator for coordinating operations such as topology changes and is not intended for direct user interaction.
+// The report only covers nodes that have joined the ScyllaDB cluster, which is distinct from the set of Kubernetes objects that represent them.
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +genclient

--- a/pkg/cmd/operator/sidecar/sidecar.go
+++ b/pkg/cmd/operator/sidecar/sidecar.go
@@ -13,8 +13,10 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
 	"github.com/scylladb/scylla-operator/pkg/cmdutil"
 	sidecarcontroller "github.com/scylladb/scylla-operator/pkg/controller/sidecar"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
 	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 	"github.com/scylladb/scylla-operator/pkg/sidecar/config"
 	"github.com/scylladb/scylla-operator/pkg/sidecar/identity"
 	"github.com/scylladb/scylla-operator/pkg/signals"
@@ -211,12 +213,17 @@ func (o *Options) Run(streams genericclioptions.IOStreams, cmd *cobra.Command, a
 
 	singleServiceInformer := identityKubeInformers.Core().V1().Services()
 
+	newScyllaClient := func() (*scyllaclient.Client, error) {
+		return controllerhelpers.NewScyllaClientForLocalhost(o.ipFamily)
+	}
+
 	sc, err := sidecarcontroller.NewController(
 		o.Namespace,
 		o.ServiceName,
 		o.scyllaLocalhostAddress,
 		o.kubeClient,
 		singleServiceInformer,
+		newScyllaClient,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create sidecar controller: %w", err)
@@ -226,9 +233,9 @@ func (o *Options) Run(streams genericclioptions.IOStreams, cmd *cobra.Command, a
 		o.Namespace,
 		o.ServiceName,
 		o.statusReportInterval,
-		o.ipFamily,
 		o.kubeClient,
 		identityKubeInformers.Core().V1().Pods(),
+		newScyllaClient,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create status reporter: %w", err)

--- a/pkg/cmd/operator/sidecar/statusreporter.go
+++ b/pkg/cmd/operator/sidecar/statusreporter.go
@@ -9,10 +9,8 @@ import (
 	"time"
 
 	"github.com/scylladb/scylla-operator/pkg/controller/statusreport"
-	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -54,16 +52,12 @@ func NewStatusReporter(
 	namespace string,
 	podName string,
 	interval time.Duration,
-	ipFamily corev1.IPFamily,
 	kubeClient kubernetes.Interface,
 	podInformer corev1informers.PodInformer,
+	newScyllaClient func() (*scyllaclient.Client, error),
 ) (*StatusReporter, error) {
 	sr := &StatusReporter{
 		interval: interval,
-	}
-
-	newScyllaClient := func() (*scyllaclient.Client, error) {
-		return controllerhelpers.NewScyllaClientForLocalhost(ipFamily)
 	}
 
 	c, err := statusreport.NewController(

--- a/pkg/controller/bootstrapbarrier/controller.go
+++ b/pkg/controller/bootstrapbarrier/controller.go
@@ -169,6 +169,11 @@ func isBootstrapPreconditionSatisfied(scyllaDBDatacenterNodesStatusReports []*sc
 	// reportingHostIDToObservedNodeStatusesMap maps a reporting node's host ID to a map of observed nodes' host IDs to their statuses as observed by the reporting node.
 	reportingHostIDToObservedNodeStatusesMap := map[string]map[string]scyllav1alpha1.NodeStatus{}
 
+	// The reports only contain nodes that have already joined the ScyllaDB cluster, so nodes that are still bootstrapping
+	// are absent from rack.Nodes by construction. They can still enter allHostIDs through other nodes' ObservedNodes.
+	// A host ID that appears there without a corresponding report entry fails the precondition below,
+	// so a node joining concurrently may hold up other nodes' bootstrap.
+	// That's the conservative direction: nodes that joined but haven't had their own entries included yet don't drop out of the required set.
 	for _, report := range scyllaDBDatacenterNodesStatusReports {
 		for _, rack := range report.Racks {
 			for _, node := range rack.Nodes {

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -2439,18 +2439,9 @@ func makeRackNodesStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec 
 		return nil, fmt.Errorf("can't get rack %q node count of ScyllaDBDatacenter %q: %w", rackSpec.Name, naming.ObjRef(sdc), err)
 	}
 
-	actualRackNodeCount := int32(0)
-	rackStatus, _, found := oslices.Find(sdc.Status.Racks, func(status scyllav1alpha1.RackStatus) bool {
-		return status.Name == rackSpec.Name
-	})
-	if found && rackStatus.CurrentNodes != nil {
-		actualRackNodeCount = *rackStatus.CurrentNodes
-	}
-
 	var nodeStatusReports []scyllav1alpha1.NodeStatusReport
 	for ord := int32(0); ord < *desiredRackNodeCount; ord++ {
-		isNodeExpectedInK8sState := ord < actualRackNodeCount
-		nodeStatusReport, ok, err := makeNodeStatusReport(sdc, rackSpec, int(ord), services, podLister, isNodeExpectedInK8sState)
+		nodeStatusReport, ok, err := makeNodeStatusReport(sdc, rackSpec, int(ord), services, podLister)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("can't make node status report for node %d of rack %q of ScyllaDBDatacenter %q: %w", ord, rackSpec.Name, naming.ObjRef(sdc), err))
 			continue
@@ -2475,17 +2466,18 @@ func makeRackNodesStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec 
 
 // makeNodeStatusReport creates a NodeStatusReport for a specific node in a rack.
 // It returns an optional NodeStatusReport, a boolean indicating whether the NodeStatusReport is non-nil, and an error.
-func makeNodeStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec *scyllav1alpha1.RackSpec, ordinal int, services map[string]*corev1.Service, podLister corev1listers.PodLister, isNodeExpectedInK8sState bool) (*scyllav1alpha1.NodeStatusReport, bool, error) {
-	var hostID string
+// A node is included in the report only while its Service is annotated with naming.NodeJoinedScyllaDBClusterAnnotation
+// set to true, signaling it is a member of the ScyllaDB cluster.
+func makeNodeStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec *scyllav1alpha1.RackSpec, ordinal int, services map[string]*corev1.Service, podLister corev1listers.PodLister) (*scyllav1alpha1.NodeStatusReport, bool, error) {
 	svcName := naming.MemberServiceName(*rackSpec, sdc, ordinal)
-	svc, svcExists := services[svcName]
-	if svcExists {
-		hostID = svc.Annotations[naming.HostIDAnnotation]
+	svc, ok := services[svcName]
+	if !ok {
+		klog.V(4).InfoS("Member Service is missing, skipping", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KRef(sdc.Namespace, svcName))
+		return nil, false, nil
 	}
 
-	if !isNodeExpectedInK8sState && len(hostID) == 0 {
-		// The node is not expected to be a part of the cluster in K8s state, and it has no known identity in ScyllaDB. Skip it.
-		klog.V(5).InfoS("Node is not expected to be part of the cluster in Kubernetes state and has no known identity in ScyllaDB, skipping", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KRef(sdc.Namespace, svcName))
+	if svc.Annotations[naming.NodeJoinedScyllaDBClusterAnnotation] != naming.LabelValueTrue {
+		klog.V(5).InfoS("Node has not yet been annotated as a member of the ScyllaDB cluster, skipping", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "AnnotationKey", naming.NodeJoinedScyllaDBClusterAnnotation)
 		return nil, false, nil
 	}
 
@@ -2493,14 +2485,15 @@ func makeNodeStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec *scyl
 		Ordinal: ordinal,
 	}
 
+	hostID := svc.Annotations[naming.HostIDAnnotation]
 	if len(hostID) == 0 {
-		// Host ID hasn't been propagated yet, report an empty status without a hostID.
-		klog.V(4).InfoS("HostID of an expected node has nod been propagated yet, reporting an empty status", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KRef(sdc.Namespace, svcName))
+		// HostID hasn't been propagated yet, report an empty status.
+		// It should never happen unless the annotation has been manually removed.
+		klog.Warningf("Required node %q of ScyllaDBDatacenter %q has no HostID annotation, reporting an empty status", klog.KObj(svc), klog.KObj(sdc))
 		return nodeStatusReport, true, nil
 	}
 	nodeStatusReport.HostID = &hostID
 
-	// HostID is non-empty, we can now safely use the svc object.
 	podName := naming.PodNameFromService(svc)
 	pod, err := podLister.Pods(sdc.Namespace).Get(podName)
 	if err != nil {
@@ -2509,26 +2502,26 @@ func makeNodeStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec *scyl
 		}
 
 		// Pod is missing, report an empty status.
-		klog.V(4).InfoS("Pod of an expected node is missing, reporting an empty status", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "Pod", klog.KRef(sdc.Namespace, podName))
+		klog.V(4).InfoS("Pod of a required node is missing, reporting an empty status", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "Pod", klog.KRef(sdc.Namespace, podName))
 		return nodeStatusReport, true, nil
 	}
 
 	nodeStatusReportAnnotationValue, ok := pod.Annotations[naming.NodeStatusReportAnnotation]
 	if !ok {
 		// The node might not have reported its status yet, report an empty status.
-		klog.V(4).InfoS("Node status report annotation is missing on Pod of an expected node, reporting an empty status", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "Pod", klog.KObj(pod), "AnnotationKey", naming.NodeStatusReportAnnotation)
+		klog.V(4).InfoS("Node status report annotation is missing on Pod of a required node, reporting an empty status", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "Pod", klog.KObj(pod), "AnnotationKey", naming.NodeStatusReportAnnotation)
 		return nodeStatusReport, true, nil
 	}
 
 	var internalNodeStatusReport internalapi.NodeStatusReport
 	err = internalNodeStatusReport.Decode(strings.NewReader(nodeStatusReportAnnotationValue))
 	if err != nil {
-		return nil, false, fmt.Errorf("can't decode annotation %q of pod %q for ScyllaDBDatacenter %q: %w", naming.NodeStatusReportAnnotation, naming.ManualRef(sdc.Namespace, podName), naming.ObjRef(sdc), err)
+		return nil, false, fmt.Errorf("can't decode annotation %q of Pod %q for ScyllaDBDatacenter %q: %w", naming.NodeStatusReportAnnotation, naming.ManualRef(sdc.Namespace, podName), naming.ObjRef(sdc), err)
 	}
 
 	if internalNodeStatusReport.Error != nil {
 		// The node reported an error, report an empty status.
-		klog.V(4).InfoS("Node reported an error in its status report, reporting an empty status", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "Pod", klog.KObj(pod), "Error", internalNodeStatusReport.Error)
+		klog.V(4).InfoS("Required node reported an error in its status report, reporting an empty status", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "Pod", klog.KObj(pod), "Error", internalNodeStatusReport.Error)
 		return nodeStatusReport, true, nil
 	}
 
@@ -2539,6 +2532,6 @@ func makeNodeStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec *scyl
 
 	nodeStatusReport.ObservedNodes = internalNodeStatusReport.ObservedNodes
 
-	klog.V(5).InfoS("Successfully built a node status report for an expected node", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "Pod", klog.KObj(pod))
+	klog.V(5).InfoS("Successfully built a node status report", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "Pod", klog.KObj(pod))
 	return nodeStatusReport, true, nil
 }

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -5510,8 +5510,9 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				Name:      name,
 				Namespace: "default",
 				Annotations: map[string]string{
-					"default-sc-annotation":                         "bar",
-					"internal.scylla-operator.scylladb.com/host-id": hostID,
+					"default-sc-annotation":                                              "bar",
+					"internal.scylla-operator.scylladb.com/host-id":                      hostID,
+					"internal.scylla-operator.scylladb.com/node-joined-scylladb-cluster": "true",
 				},
 				Labels: map[string]string{
 					"default-sc-label": "foo",
@@ -5721,12 +5722,8 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				DatacenterName: "dc",
 				Racks: []scyllav1alpha1.RackNodesStatusReport{
 					{
-						Name: "a",
-						Nodes: []scyllav1alpha1.NodeStatusReport{
-							{
-								Ordinal: 0,
-							},
-						},
+						Name:  "a",
+						Nodes: []scyllav1alpha1.NodeStatusReport{},
 					},
 				},
 			},
@@ -5784,12 +5781,8 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				DatacenterName: "dc",
 				Racks: []scyllav1alpha1.RackNodesStatusReport{
 					{
-						Name: "a",
-						Nodes: []scyllav1alpha1.NodeStatusReport{
-							{
-								Ordinal: 0,
-							},
-						},
+						Name:  "a",
+						Nodes: []scyllav1alpha1.NodeStatusReport{},
 					},
 				},
 			},
@@ -6122,7 +6115,7 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "status with one current node, service without host ID and pod with status report",
+			name: "status with one current node, service included in status report but without host ID",
 			sdc: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := basicScyllaDBDatacenter()
 
@@ -6143,6 +6136,7 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 						Namespace: "default",
 						Annotations: map[string]string{
 							"default-sc-annotation": "bar",
+							"internal.scylla-operator.scylladb.com/node-joined-scylladb-cluster": "true",
 						},
 						Labels: map[string]string{
 							"default-sc-label": "foo",
@@ -6269,9 +6263,6 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 										Status: scyllav1alpha1.NodeStatusUp,
 									},
 								},
-							},
-							{
-								Ordinal: 1,
 							},
 						},
 					},

--- a/pkg/controller/sidecar/controller.go
+++ b/pkg/controller/sidecar/controller.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/scylladb/scylla-operator/pkg/scheme"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
-	"github.com/scylladb/scylla-operator/pkg/util/hash"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -306,18 +305,4 @@ func (c *Controller) getHostID(ctx context.Context, scyllaClient *scyllaclient.C
 	c.hostID.v = v
 
 	return v, nil
-}
-
-func (c *Controller) getTokenRingHash(ctx context.Context, scyllaClient *scyllaclient.Client, localhostAddr string) (string, error) {
-	tokenRing, err := scyllaClient.GetTokenRing(ctx, localhostAddr)
-	if err != nil {
-		return "", fmt.Errorf("can't get token ring: %w", err)
-	}
-
-	h, err := hash.HashObjects(tokenRing)
-	if err != nil {
-		return "", fmt.Errorf("can't hash token ring: %w", err)
-	}
-
-	return h, nil
 }

--- a/pkg/controller/sidecar/controller.go
+++ b/pkg/controller/sidecar/controller.go
@@ -51,6 +51,8 @@ type Controller struct {
 	kubeClient          kubernetes.Interface
 	singleServiceLister corev1listers.ServiceLister
 
+	newScyllaClient func() (*scyllaclient.Client, error)
+
 	cachesToSync []cache.InformerSynced
 
 	eventRecorder record.EventRecorder
@@ -67,6 +69,7 @@ func NewController(
 	localhostAddress string,
 	kubeClient kubernetes.Interface,
 	singleServiceInformer corev1informers.ServiceInformer,
+	newScyllaClient func() (*scyllaclient.Client, error),
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -100,6 +103,8 @@ func NewController(
 
 		kubeClient:          kubeClient,
 		singleServiceLister: singleServiceInformer.Lister(),
+
+		newScyllaClient: newScyllaClient,
 
 		cachesToSync: []cache.InformerSynced{
 			singleServiceInformer.Informer().HasSynced,

--- a/pkg/controller/sidecar/sync.go
+++ b/pkg/controller/sidecar/sync.go
@@ -6,8 +6,6 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 	corev1 "k8s.io/api/core/v1"
@@ -23,15 +21,9 @@ const (
 )
 
 func (c *Controller) decommissionNode(ctx context.Context, svc *corev1.Service) error {
-	parsedIP, err := helpers.ParseIP(c.localhostAddress)
+	scyllaClient, err := c.newScyllaClient()
 	if err != nil {
-		return fmt.Errorf("can't parse localhost address %q: %w", c.localhostAddress, err)
-	}
-	ipFamily := helpers.GetIPFamily(parsedIP)
-
-	scyllaClient, err := controllerhelpers.NewScyllaClientForLocalhost(ipFamily)
-	if err != nil {
-		return err
+		return fmt.Errorf("can't create a new ScyllaClient: %w", err)
 	}
 	defer scyllaClient.Close()
 
@@ -120,15 +112,9 @@ func (c *Controller) syncAnnotations(ctx context.Context, svc *corev1.Service) e
 		klog.V(4).InfoS("Finished syncing Service annotation", "Service", klog.KObj(svc), "duration", time.Since(startTime))
 	}()
 
-	parsedIP, err := helpers.ParseIP(c.localhostAddress)
+	scyllaClient, err := c.newScyllaClient()
 	if err != nil {
-		return fmt.Errorf("can't parse localhost address %q: %w", c.localhostAddress, err)
-	}
-	ipFamily := helpers.GetIPFamily(parsedIP)
-
-	scyllaClient, err := controllerhelpers.NewScyllaClientForLocalhost(ipFamily)
-	if err != nil {
-		return fmt.Errorf("can't create a new ScyllaClient for localhost: %w", err)
+		return fmt.Errorf("can't create a new ScyllaClient: %w", err)
 	}
 	defer scyllaClient.Close()
 

--- a/pkg/controller/sidecar/sync.go
+++ b/pkg/controller/sidecar/sync.go
@@ -3,11 +3,13 @@ package sidecar
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os/exec"
 	"time"
 
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
+	"github.com/scylladb/scylla-operator/pkg/util/hash"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +19,9 @@ import (
 )
 
 const (
+	// requeueWaitDuration is the delay used when the sidecar polls ScyllaDB's local state and has to wait for it to
+	// advance. The happy path with tablets takes single-digit seconds. The value should keep the poll
+	// count low while staying well below the slow paths (30s ring delay, 60s CDC generation propagation).
 	requeueWaitDuration = 5 * time.Second
 )
 
@@ -118,15 +123,78 @@ func (c *Controller) syncAnnotations(ctx context.Context, svc *corev1.Service) e
 	}
 	defer scyllaClient.Close()
 
-	hostID, err := c.getHostID(ctx, scyllaClient, c.localhostAddress)
+	var errs []error
+	annotations, requeue, err := c.getRequiredServiceAnnotations(ctx, scyllaClient)
 	if err != nil {
-		return fmt.Errorf("can't get HostID: %w", err)
+		errs = append(errs, fmt.Errorf("can't get required service annotations: %w", err))
 	}
 
-	ipToHostIDMap, err := scyllaClient.GetIPToHostIDMap(ctx, c.localhostAddress)
-	if err != nil {
-		return fmt.Errorf("can't get host id to ip mapping: %w", err)
+	if requeue {
+		klog.V(4).InfoS("Requeuing to sync Service annotations later", "Service", klog.KObj(svc), "After", requeueWaitDuration.String())
+		c.queue.AddAfter(c.key, requeueWaitDuration)
 	}
+
+	err = c.updateServiceAnnotations(ctx, svc, annotations)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("can't update service annotations: %w", err))
+	}
+
+	return apimachineryutilerrors.NewAggregate(errs)
+}
+
+// getRequiredServiceAnnotations reads the ScyllaDB API and returns the annotations required on the member Service,
+// a boolean stating if it should be requeued, and an error. Explicit requeue is not requested on an error.
+// Annotations are produced on a best-effort basis: only those backed by a successful observation are returned, so
+// a non-nil error comes with whatever was produced before it and the caller should leave the rest untouched (keep existing).
+func (c *Controller) getRequiredServiceAnnotations(ctx context.Context, scyllaClient *scyllaclient.Client) (map[string]string, bool, error) {
+	annotations := map[string]string{}
+
+	hostID, err := c.getHostID(ctx, scyllaClient, c.localhostAddress)
+	if err != nil {
+		return nil, false, fmt.Errorf("can't get HostID: %w", err)
+	}
+
+	annotations[naming.HostIDAnnotation] = hostID
+
+	isMember, isKnown, err := nodeIsScyllaDBClusterMember(ctx, scyllaClient, c.localhostAddress, hostID)
+	if err != nil {
+		return annotations, false, fmt.Errorf("can't determine ScyllaDB cluster membership: %w", err)
+	}
+
+	if !isKnown {
+		klog.V(4).InfoS("Node hasn't joined the ScyllaDB cluster yet", "HostID", hostID)
+		return annotations, true, nil
+	}
+
+	if !isMember {
+		klog.V(4).InfoS("Node doesn't own any tokens yet", "HostID", hostID)
+		annotations[naming.NodeJoinedScyllaDBClusterAnnotation] = naming.LabelValueFalse
+		return annotations, true, nil
+	}
+
+	annotations[naming.NodeJoinedScyllaDBClusterAnnotation] = naming.LabelValueTrue
+
+	currentTokenRingHash, err := getTokenRingHash(ctx, scyllaClient, c.localhostAddress)
+	if err != nil {
+		return annotations, false, fmt.Errorf("can't get current token ring hash: %w", err)
+	}
+	annotations[naming.CurrentTokenRingHashAnnotation] = currentTokenRingHash
+
+	return annotations, false, nil
+}
+
+// nodeIsScyllaDBClusterMember reports whether the node is a member of the ScyllaDB cluster, i.e. whether it owns normal
+// tokens in the cluster's token metadata. Unlike the node's operation mode, this survives a restart: a bootstrapped node
+// has its token metadata restored from disk before gossip starts, so it never stops owning normal tokens while it boots.
+// A node that is bootstrapping holds only pending tokens and is not a member until the operation completes.
+// The second return value reports whether membership could be determined at all. When it is false, the caller must not act
+// on the first one.
+func nodeIsScyllaDBClusterMember(ctx context.Context, scyllaClient *scyllaclient.Client, localhostAddr string, hostID string) (bool, bool, error) {
+	ipToHostIDMap, err := scyllaClient.GetIPToHostIDMap(ctx, localhostAddr)
+	if err != nil {
+		return false, false, fmt.Errorf("can't get host id to ip mapping: %w", err)
+	}
+	klog.V(4).InfoS("Got IP to HostID mapping", "IPToHostIDMap", ipToHostIDMap)
 
 	var localIP string
 	for ip, id := range ipToHostIDMap {
@@ -137,42 +205,51 @@ func (c *Controller) syncAnnotations(ctx context.Context, svc *corev1.Service) e
 	}
 
 	if len(localIP) == 0 {
-		// It most likely means that the Scylla node the sidecar is running on has not joined the cluster yet. We need
-		// to requeue and try again later.
-		klog.V(2).InfoS("The node with the expected HostID has not joined the cluster yet, will retry in a bit", "HostID", hostID, "IPToHostIDMap", ipToHostIDMap)
-		c.queue.AddRateLimited(c.key)
+		// The node is not present in the cluster's token metadata, so its membership can't be determined.
+		return false, false, nil
+	}
+
+	// Only normal tokens are reported for the endpoint, pending tokens of a bootstrapping or replacing node are not.
+	nodeTokens, err := scyllaClient.GetNodeTokens(ctx, localhostAddr, localIP)
+	if err != nil {
+		return false, false, fmt.Errorf("can't get node tokens: %w", err)
+	}
+
+	return len(nodeTokens) != 0, true, nil
+}
+
+func getTokenRingHash(ctx context.Context, scyllaClient *scyllaclient.Client, localhostAddr string) (string, error) {
+	tokenRing, err := scyllaClient.GetTokenRing(ctx, localhostAddr)
+	if err != nil {
+		return "", fmt.Errorf("can't get token ring: %w", err)
+	}
+
+	h, err := hash.HashObjects(tokenRing)
+	if err != nil {
+		return "", fmt.Errorf("can't hash token ring: %w", err)
+	}
+
+	return h, nil
+}
+
+func (c *Controller) updateServiceAnnotations(ctx context.Context, svc *corev1.Service, annotations map[string]string) error {
+	svcCopy := svc.DeepCopy()
+	if svcCopy.Annotations == nil {
+		svcCopy.Annotations = make(map[string]string)
+	}
+
+	maps.Insert(svcCopy.Annotations, maps.All(annotations))
+
+	if equality.Semantic.DeepEqual(svc, svcCopy) {
 		return nil
 	}
 
-	nodeTokens, err := scyllaClient.GetNodeTokens(ctx, c.localhostAddress, localIP)
+	_, err := c.kubeClient.CoreV1().Services(svcCopy.Namespace).Update(ctx, svcCopy, metav1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("can't get node tokens: %w", err)
+		return fmt.Errorf("can't update Service %q: %w", naming.ObjRef(svc), err)
 	}
 
-	svcCopy := svc.DeepCopy()
-	svcCopy.Annotations[naming.HostIDAnnotation] = hostID
-
-	var currentTokenRingHash string
-	if len(nodeTokens) == 0 {
-		klog.V(4).InfoS("Node doesn't have any tokens assigned, looks like it's still bootstrapping, requeueing")
-		c.queue.AddAfter(c.key, requeueWaitDuration)
-	} else {
-		currentTokenRingHash, err = c.getTokenRingHash(ctx, scyllaClient, c.localhostAddress)
-		if err != nil {
-			return fmt.Errorf("can't get token hash: %w", err)
-		}
-
-		svcCopy.Annotations[naming.CurrentTokenRingHashAnnotation] = currentTokenRingHash
-	}
-
-	if !equality.Semantic.DeepEqual(svc, svcCopy) {
-		_, err = c.kubeClient.CoreV1().Services(svcCopy.Namespace).Update(ctx, svcCopy, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("can't update service %q: %w", naming.ObjRef(svc), err)
-		}
-
-		klog.V(2).InfoS("Successfully updated service annotations", "Service", klog.KObj(svc))
-	}
+	klog.V(2).InfoS("Successfully updated Service annotations", "Service", klog.KObj(svc))
 
 	return nil
 }

--- a/pkg/controller/sidecar/sync_test.go
+++ b/pkg/controller/sidecar/sync_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 ScyllaDB.
+
+package sidecar
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
+)
+
+func TestNodeIsScyllaDBClusterMember(t *testing.T) {
+	t.Parallel()
+
+	const hostID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+	tt := []struct {
+		name           string
+		handler        http.HandlerFunc
+		expectedMember bool
+		expectedKnown  bool
+		expectedErr    bool
+	}{
+		{
+			name: "node owning normal tokens is a member",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/storage_service/host_id":
+					w.Write([]byte(`[{"key":"10.0.0.1","value":"` + hostID + `"}]`))
+				case "/storage_service/tokens/10.0.0.1":
+					w.Write([]byte(`["-1","0","1"]`))
+				default:
+					t.Errorf("unexpected request to %q", r.URL.Path)
+				}
+			},
+			expectedMember: true,
+			expectedKnown:  true,
+			expectedErr:    false,
+		},
+		{
+			name: "node without normal tokens is known but not a member",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/storage_service/host_id":
+					w.Write([]byte(`[{"key":"10.0.0.1","value":"` + hostID + `"}]`))
+				case "/storage_service/tokens/10.0.0.1":
+					w.Write([]byte(`[]`))
+				default:
+					t.Errorf("unexpected request to %q", r.URL.Path)
+				}
+			},
+			expectedMember: false,
+			expectedKnown:  true,
+			expectedErr:    false,
+		},
+		{
+			name: "node absent from the host ID map is undeterminable",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/storage_service/host_id":
+					w.Write([]byte(`[{"key":"10.0.0.2","value":"ffffffff-ffff-ffff-ffff-ffffffffffff"}]`))
+				default:
+					// The node tokens endpoint must not be reached, it reports an empty token list for an
+					// address the cluster doesn't know, which is indistinguishable from a bootstrapping node.
+					t.Errorf("unexpected request to %q", r.URL.Path)
+				}
+			},
+			expectedMember: false,
+			expectedKnown:  false,
+			expectedErr:    false,
+		},
+		{
+			name: "host ID map error is propagated",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			expectedMember: false,
+			expectedKnown:  false,
+			expectedErr:    true,
+		},
+		{
+			name: "node tokens error is propagated",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/storage_service/host_id":
+					w.Write([]byte(`[{"key":"10.0.0.1","value":"` + hostID + `"}]`))
+				default:
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			},
+			expectedMember: false,
+			expectedKnown:  false,
+			expectedErr:    true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(tc.handler)
+			t.Cleanup(server.Close)
+
+			u, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			config := scyllaclient.DefaultConfig("", u.Hostname())
+			config.Scheme = "http"
+			config.Port = u.Port()
+
+			client, err := scyllaclient.NewClient(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			isMember, isKnown, err := nodeIsScyllaDBClusterMember(context.Background(), client, u.Hostname(), hostID)
+			if (err != nil) != tc.expectedErr {
+				t.Fatalf("expected error %v, got %v", tc.expectedErr, err)
+			}
+			if isMember != tc.expectedMember {
+				t.Errorf("expected isMember %v, got %v", tc.expectedMember, isMember)
+			}
+			if isKnown != tc.expectedKnown {
+				t.Errorf("expected isKnown %v, got %v", tc.expectedKnown, isKnown)
+			}
+		})
+	}
+}

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -49,6 +49,18 @@ const (
 
 	// NodeStatusReportAnnotation reflects the current status report from the ScyllaDB node.
 	NodeStatusReportAnnotation = "internal.scylla.scylladb.com/scylladb-node-status-report"
+
+	// NodeJoinedScyllaDBClusterAnnotation reflects whether the node is a member of the ScyllaDB cluster
+	// (the actual ScyllaDB cluster, not the Kubernetes abstraction). Membership is determined by whether the node
+	// owns normal tokens in the cluster's token metadata, so it is unaffected by the node restarting - a bootstrapped
+	// node has its token metadata restored from disk before gossip starts and never stops owning normal tokens while
+	// it boots. It is set to "false" when the node owns no normal tokens, which covers a node that is bootstrapping
+	// for the first time, a node that has lost its state, and a node undergoing a replacement procedure.
+	// The value is only ever written from a successful observation and is left untouched when membership can't be
+	// determined. Since the ScyllaDB API is unreachable for as long as the node is down, the annotation retains the
+	// last observed value throughout - a node that has lost its state keeps "true" from before the loss until its
+	// sidecar can query the API again.
+	NodeJoinedScyllaDBClusterAnnotation = "internal.scylla-operator.scylladb.com/node-joined-scylladb-cluster"
 )
 
 // Annotations used for feature backward compatibility between v1.ScyllaCluster and v1alpha1.ScyllaDBDatacenter

--- a/test/envtest/controllers/fakescyllaclient_test.go
+++ b/test/envtest/controllers/fakescyllaclient_test.go
@@ -1,0 +1,99 @@
+//go:build envtest
+
+// Copyright (c) 2026 ScyllaDB.
+
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
+)
+
+// newFakeScyllaDBClientFactory returns a ScyllaDB client factory backed by a single httptest.Server serving the given
+// handler. The server is torn down on spec cleanup.
+func newFakeScyllaDBClientFactory(handler http.Handler) func() (*scyllaclient.Client, error) {
+	g.GinkgoHelper()
+
+	server := httptest.NewServer(handler)
+	g.DeferCleanup(server.Close)
+
+	return func() (*scyllaclient.Client, error) {
+		parsedURL, err := url.Parse(server.URL)
+		if err != nil {
+			return nil, fmt.Errorf("can't parse server URL: %w", err)
+		}
+
+		return scyllaclient.NewClient(&scyllaclient.Config{
+			Hosts:   []string{parsedURL.Hostname()},
+			Port:    parsedURL.Port(),
+			Scheme:  "http",
+			Timeout: 5 * time.Second,
+		})
+	}
+}
+
+// newSwitchableFakeScyllaDBClientFactory returns a switcher and a ScyllaDB client factory, both backed by a single
+// httptest.Server. The server serves firstHandler until SwitchToPhaseTwo is called on the switcher, and secondHandler
+// afterwards. The server is torn down on spec cleanup.
+func newSwitchableFakeScyllaDBClientFactory(firstHandler, secondHandler http.Handler) (*switchableHandler, func() (*scyllaclient.Client, error)) {
+	g.GinkgoHelper()
+
+	handler := &switchableHandler{
+		first:            firstHandler,
+		second:           secondHandler,
+		phaseTwoServedCh: make(chan struct{}),
+	}
+
+	return handler, newFakeScyllaDBClientFactory(handler)
+}
+
+// switchableHandler serves the first handler until SwitchToPhaseTwo is called, and the second one afterwards. It backs
+// a fake ScyllaDB API whose responses have to change mid-spec.
+type switchableHandler struct {
+	first  http.Handler
+	second http.Handler
+
+	inPhaseTwo       atomic.Bool
+	phaseTwoOnce     sync.Once
+	phaseTwoServedCh chan struct{}
+}
+
+func (h *switchableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.inPhaseTwo.Load() {
+		h.first.ServeHTTP(w, r)
+		return
+	}
+
+	h.phaseTwoOnce.Do(func() {
+		close(h.phaseTwoServedCh)
+	})
+
+	h.second.ServeHTTP(w, r)
+}
+
+// SwitchToPhaseTwo makes the handler start serving the second handler.
+func (h *switchableHandler) SwitchToPhaseTwo() {
+	h.inPhaseTwo.Store(true)
+}
+
+// PhaseTwoServedCh returns a channel closed when the handler first serves a request in phase two. Waiting on it before
+// asserting keeps a phase two assertion from passing against a phase one observation.
+func (h *switchableHandler) PhaseTwoServedCh() <-chan struct{} {
+	return h.phaseTwoServedCh
+}
+
+// encodeJSON writes v as the JSON response body, logging an encoding failure to the Ginkgo output.
+func encodeJSON(w http.ResponseWriter, r *http.Request, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		g.GinkgoWriter.Printf("failed to encode response for %q: %v\n", r.URL.Path, err)
+	}
+}

--- a/test/envtest/controllers/sidecar_controller_test.go
+++ b/test/envtest/controllers/sidecar_controller_test.go
@@ -1,0 +1,561 @@
+//go:build envtest
+
+// Copyright (c) 2026 ScyllaDB.
+
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	sidecarcontroller "github.com/scylladb/scylla-operator/pkg/controller/sidecar"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
+	"github.com/scylladb/scylla-operator/pkg/util/hash"
+	"github.com/scylladb/scylla-operator/test/envtest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	kubeinformers "k8s.io/client-go/informers"
+)
+
+var _ = g.Describe("SidecarController", func() {
+	const (
+		nodeServiceName  = "dc1-rack1-0"
+		localhostAddress = "127.0.0.1"
+		localIP          = "10.0.0.1"
+		hostID           = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	)
+
+	var env *envtest.Environment
+	g.BeforeEach(func(ctx g.SpecContext) {
+		env = envtest.Setup(ctx)
+	})
+
+	// waitForServiceAnnotations polls the Service until it satisfies the given assertion and returns it at that point.
+	waitForServiceAnnotations := func(ctx context.Context, svcName string, assert func(o.Gomega, *corev1.Service)) *corev1.Service {
+		g.GinkgoHelper()
+
+		var svc *corev1.Service
+		o.Eventually(func(eo o.Gomega, ctx context.Context) {
+			var err error
+			svc, err = env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, svcName, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			assert(eo, svc)
+		}).WithTimeout(30 * time.Second).WithPolling(250 * time.Millisecond).WithContext(ctx).Should(o.Succeed())
+
+		return svc
+	}
+
+	// consistentlyAssertServiceAnnotations asserts the Service keeps satisfying the given assertion over time.
+	consistentlyAssertServiceAnnotations := func(ctx context.Context, svcName string, assert func(o.Gomega, *corev1.Service)) {
+		g.GinkgoHelper()
+
+		o.Consistently(func(eo o.Gomega, ctx context.Context) {
+			svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, svcName, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			assert(eo, svc)
+		}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).WithContext(ctx).Should(o.Succeed())
+	}
+
+	// expectedTokenRingHash returns the token ring hash the controller is expected to annotate for the given ring.
+	expectedTokenRingHash := func(ringTokens []string) string {
+		g.GinkgoHelper()
+
+		h, err := hash.HashObjects(ringTokens)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		return h
+	}
+
+	// annotationTestCase covers a sidecar sync against a ScyllaDB API whose responses don't change during the spec.
+	type annotationTestCase struct {
+		// existingAnnotations is what the Service carries before the controller starts.
+		existingAnnotations map[string]string
+		// fake is the ScyllaDB API the sidecar runs against.
+		fake fakeScyllaDBTokenMetadata
+		// expectedAnnotations must all eventually be present with the given values.
+		expectedAnnotations map[string]string
+		// expectedTokenRingHashOf, when set, additionally expects the token ring hash annotation to hold the hash of
+		// these tokens. It's kept separate from expectedAnnotations because the hash has to be computed at run time.
+		expectedTokenRingHashOf []string
+		// absentAnnotations must never be set.
+		absentAnnotations []string
+	}
+
+	syncsAnnotations := func(ctx g.SpecContext, tc annotationTestCase) {
+		g.By("Creating a member Service")
+		createNodeService(ctx, env, nodeServiceName, tc.existingAnnotations)
+
+		g.By("Running the SidecarController")
+		newScyllaClient := newFakeScyllaDBClientFactory(newFakeScyllaDBTokenMetadataHandler(tc.fake))
+		runSidecarController(ctx, env, nodeServiceName, localhostAddress, newScyllaClient)
+
+		if len(tc.expectedAnnotations) != 0 || len(tc.expectedTokenRingHashOf) != 0 {
+			g.By("Waiting for the expected annotations to be set")
+			waitForServiceAnnotations(ctx, nodeServiceName, func(eo o.Gomega, svc *corev1.Service) {
+				for k, v := range tc.expectedAnnotations {
+					eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(k, v))
+				}
+				if len(tc.expectedTokenRingHashOf) != 0 {
+					eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(naming.CurrentTokenRingHashAnnotation, expectedTokenRingHash(tc.expectedTokenRingHashOf)))
+				}
+			})
+		}
+
+		if len(tc.absentAnnotations) != 0 {
+			g.By("Ensuring the annotations which must not be set are never set")
+			consistentlyAssertServiceAnnotations(ctx, nodeServiceName, func(eo o.Gomega, svc *corev1.Service) {
+				for _, k := range tc.absentAnnotations {
+					eo.Expect(svc.Annotations).NotTo(o.HaveKey(k))
+				}
+			})
+		}
+	}
+
+	g.DescribeTable("annotates the node's membership in the ScyllaDB cluster", syncsAnnotations,
+		g.Entry("when the node owns normal tokens", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:   hostID,
+				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
+				ringTokens:    []string{"-1", "0", "1"},
+			},
+			expectedAnnotations: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+				naming.HostIDAnnotation:                    hostID,
+			},
+			expectedTokenRingHashOf: []string{"-1", "0", "1"},
+		}),
+		g.Entry("when the node owns no normal tokens", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:   hostID,
+				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				// A bootstrapping node holds only pending tokens, which the endpoint doesn't report.
+				nodeTokens: map[string][]string{localIP: {}},
+				ringTokens: []string{},
+			},
+			expectedAnnotations: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueFalse,
+				naming.HostIDAnnotation:                    hostID,
+			},
+			// The token ring hash is not written for a non-member.
+			absentAnnotations: []string{naming.CurrentTokenRingHashAnnotation},
+		}),
+		g.Entry("when the token ring hash can't be fetched", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:    hostID,
+				ipToHostIDMap:  []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:     map[string][]string{localIP: {"-1", "0", "1"}},
+				failRingTokens: true,
+			},
+			expectedAnnotations: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+			},
+			absentAnnotations: []string{naming.CurrentTokenRingHashAnnotation},
+		}),
+	)
+
+	g.DescribeTable("annotates the HostID", syncsAnnotations,
+		g.Entry("when the host ID mapping can't be fetched", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:       hostID,
+				failIPToHostIDMap: true,
+				ringTokens:        []string{"-1", "0", "1"},
+			},
+			expectedAnnotations: map[string]string{
+				naming.HostIDAnnotation: hostID,
+			},
+			absentAnnotations: []string{naming.NodeJoinedScyllaDBClusterAnnotation, naming.CurrentTokenRingHashAnnotation},
+		}),
+		g.Entry("when the node's tokens can't be fetched", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID: hostID,
+				// The node is present in the cluster's token metadata, but its tokens can't be read.
+				ipToHostIDMap:  []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				failNodeTokens: true,
+				ringTokens:     []string{"-1", "0", "1"},
+			},
+			expectedAnnotations: map[string]string{
+				naming.HostIDAnnotation: hostID,
+			},
+			absentAnnotations: []string{naming.NodeJoinedScyllaDBClusterAnnotation, naming.CurrentTokenRingHashAnnotation},
+		}),
+	)
+
+	g.DescribeTable("leaves the annotations untouched", syncsAnnotations,
+		g.Entry("when the node is absent from the cluster's token metadata", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID: hostID,
+				// The node's own host ID is absent from the mapping, so its membership can't be determined.
+				ipToHostIDMap: []scyllaNodeResponse{{Key: "10.0.0.2", Value: "ffffffff-ffff-ffff-ffff-ffffffffffff"}},
+				ringTokens:    []string{"-1", "0", "1"},
+			},
+			expectedAnnotations: map[string]string{
+				naming.HostIDAnnotation: hostID,
+			},
+			absentAnnotations: []string{naming.NodeJoinedScyllaDBClusterAnnotation},
+		}),
+		g.Entry("when the ScyllaDB API is failing and a membership was already observed", annotationTestCase{
+			existingAnnotations: map[string]string{
+				naming.HostIDAnnotation:                    hostID,
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
+			},
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:       hostID,
+				failIPToHostIDMap: true,
+				ringTokens:        []string{"-1", "0", "1"},
+			},
+			expectedAnnotations: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
+			},
+		}),
+		g.Entry("when the local HostID can't be fetched", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				failLocalHostID: true,
+				ipToHostIDMap:   []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:      map[string][]string{localIP: {"-1", "0", "1"}},
+				ringTokens:      []string{"-1", "0", "1"},
+			},
+			absentAnnotations: []string{naming.HostIDAnnotation, naming.NodeJoinedScyllaDBClusterAnnotation, naming.CurrentTokenRingHashAnnotation},
+		}),
+	)
+
+	g.DescribeTable("annotates the token ring hash", syncsAnnotations,
+		g.Entry("when the cluster has a token ring", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:   hostID,
+				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
+				ringTokens:    []string{"-1", "0", "1"},
+			},
+			expectedTokenRingHashOf: []string{"-1", "0", "1"},
+		}),
+		// The token ring is hashed as returned by the ScyllaDB API, without sorting, so the hash is order-sensitive.
+		// Expecting the hash of the reordered ring asserts exactly that: the in-order hash would not match.
+		g.Entry("when the same tokens are returned in a different order", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:   hostID,
+				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
+				ringTokens:    []string{"1", "-1", "0"},
+			},
+			expectedTokenRingHashOf: []string{"1", "-1", "0"},
+		}),
+	)
+
+	g.It("doesn't update the Service on subsequent syncs when nothing changed", func(ctx g.SpecContext) {
+		g.By("Creating a member Service")
+		createNodeService(ctx, env, nodeServiceName, nil)
+
+		ringTokens := []string{"-1", "0", "1"}
+
+		g.By("Running the SidecarController against a ScyllaDB owning normal tokens")
+		newScyllaClient := newFakeScyllaDBClientFactory(newFakeScyllaDBTokenMetadataHandler(fakeScyllaDBTokenMetadata{
+			localHostID:   hostID,
+			ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+			nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
+			ringTokens:    ringTokens,
+		}))
+		runSidecarController(ctx, env, nodeServiceName, localhostAddress, newScyllaClient)
+
+		g.By("Waiting for the annotations to settle")
+		svc := waitForServiceAnnotations(ctx, nodeServiceName, func(eo o.Gomega, svc *corev1.Service) {
+			eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(naming.NodeJoinedScyllaDBClusterAnnotation, naming.LabelValueTrue))
+			eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(naming.CurrentTokenRingHashAnnotation, expectedTokenRingHash(ringTokens)))
+		})
+		settledResourceVersion := svc.ResourceVersion
+
+		// A ResourceVersion bump would mean the controller issued an Update despite computing identical annotations.
+		g.By("Ensuring the Service is not updated again")
+		consistentlyAssertServiceAnnotations(ctx, nodeServiceName, func(eo o.Gomega, svc *corev1.Service) {
+			eo.Expect(svc.ResourceVersion).To(o.Equal(settledResourceVersion))
+		})
+	})
+
+	// transitionTestCase covers a sidecar sync against a ScyllaDB whose state changes mid-spec, where the change is
+	// expected to be picked up and reflected in the annotations.
+	type transitionTestCase struct {
+		// firstFake is the ScyllaDB API served before the state change.
+		firstFake fakeScyllaDBTokenMetadata
+		// secondFake is the ScyllaDB API served after it.
+		secondFake fakeScyllaDBTokenMetadata
+		// expectedAnnotationsBefore must be set before the state change.
+		expectedAnnotationsBefore map[string]string
+		// absentAnnotationsBefore must not be set before the state change.
+		absentAnnotationsBefore []string
+		// expectedAnnotationsAfter must be set once the state change has been observed.
+		expectedAnnotationsAfter map[string]string
+		// expectedTokenRingHashOfAfter is the token ring whose hash is expected once the state change is observed.
+		expectedTokenRingHashOfAfter []string
+	}
+
+	g.DescribeTable("annotates the node as a member", func(ctx g.SpecContext, tc transitionTestCase) {
+		g.By("Creating a member Service")
+		createNodeService(ctx, env, nodeServiceName, nil)
+
+		g.By("Running the SidecarController")
+		switcher, newScyllaClient := newSwitchableFakeScyllaDBClientFactory(
+			newFakeScyllaDBTokenMetadataHandler(tc.firstFake),
+			newFakeScyllaDBTokenMetadataHandler(tc.secondFake),
+		)
+		runSidecarController(ctx, env, nodeServiceName, localhostAddress, newScyllaClient)
+
+		g.By("Waiting for the annotations expected before the state change")
+		waitForServiceAnnotations(ctx, nodeServiceName, func(eo o.Gomega, svc *corev1.Service) {
+			for k, v := range tc.expectedAnnotationsBefore {
+				eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(k, v))
+			}
+			for _, k := range tc.absentAnnotationsBefore {
+				eo.Expect(svc.Annotations).NotTo(o.HaveKey(k))
+			}
+		})
+
+		g.By("Changing the state of the ScyllaDB the sidecar runs against")
+		switcher.SwitchToPhaseTwo()
+		o.Eventually(switcher.PhaseTwoServedCh()).WithTimeout(30 * time.Second).Should(o.BeClosed())
+
+		g.By("Waiting for the annotations to reflect the new state")
+		waitForServiceAnnotations(ctx, nodeServiceName, func(eo o.Gomega, svc *corev1.Service) {
+			for k, v := range tc.expectedAnnotationsAfter {
+				eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(k, v))
+			}
+			eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(naming.CurrentTokenRingHashAnnotation, expectedTokenRingHash(tc.expectedTokenRingHashOfAfter)))
+		})
+	},
+		g.Entry("when the node finishes bootstrapping", transitionTestCase{
+			firstFake: fakeScyllaDBTokenMetadata{
+				localHostID:   hostID,
+				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				// A bootstrapping node holds only pending tokens, which the endpoint doesn't report.
+				nodeTokens: map[string][]string{localIP: {}},
+				ringTokens: []string{},
+			},
+			secondFake: fakeScyllaDBTokenMetadata{
+				localHostID:   hostID,
+				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
+				ringTokens:    []string{"-1", "0", "1"},
+			},
+			expectedAnnotationsBefore: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueFalse,
+			},
+			expectedAnnotationsAfter: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+			},
+			expectedTokenRingHashOfAfter: []string{"-1", "0", "1"},
+		}),
+		g.Entry("when the node shows up in the cluster's token metadata", transitionTestCase{
+			firstFake: fakeScyllaDBTokenMetadata{
+				localHostID: hostID,
+				// The node's own host ID is absent from the mapping, so its membership can't be determined.
+				ipToHostIDMap: []scyllaNodeResponse{{Key: "10.0.0.2", Value: "ffffffff-ffff-ffff-ffff-ffffffffffff"}},
+				ringTokens:    []string{"-1", "0", "1"},
+			},
+			secondFake: fakeScyllaDBTokenMetadata{
+				localHostID:   hostID,
+				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
+				ringTokens:    []string{"-1", "0", "1"},
+			},
+			expectedAnnotationsBefore: map[string]string{
+				naming.HostIDAnnotation: hostID,
+			},
+			absentAnnotationsBefore: []string{naming.NodeJoinedScyllaDBClusterAnnotation},
+			expectedAnnotationsAfter: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+			},
+			expectedTokenRingHashOfAfter: []string{"-1", "0", "1"},
+		}),
+	)
+
+	g.It("retains the observed membership and token ring hash when the ScyllaDB API starts failing", func(ctx g.SpecContext) {
+		g.By("Creating a member Service")
+		createNodeService(ctx, env, nodeServiceName, nil)
+
+		ringTokens := []string{"-1", "0", "1"}
+
+		g.By("Running the SidecarController against a ScyllaDB owning normal tokens")
+		switcher, newScyllaClient := newSwitchableFakeScyllaDBClientFactory(
+			newFakeScyllaDBTokenMetadataHandler(fakeScyllaDBTokenMetadata{
+				localHostID:   hostID,
+				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
+				ringTokens:    ringTokens,
+			}),
+			newFakeScyllaDBTokenMetadataHandler(fakeScyllaDBTokenMetadata{
+				localHostID:       hostID,
+				failIPToHostIDMap: true,
+				ringTokens:        ringTokens,
+			}),
+		)
+		runSidecarController(ctx, env, nodeServiceName, localhostAddress, newScyllaClient)
+
+		g.By("Waiting for the node to be annotated as a member")
+		waitForServiceAnnotations(ctx, nodeServiceName, func(eo o.Gomega, svc *corev1.Service) {
+			eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(naming.NodeJoinedScyllaDBClusterAnnotation, naming.LabelValueTrue))
+			eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(naming.CurrentTokenRingHashAnnotation, expectedTokenRingHash(ringTokens)))
+		})
+
+		g.By("Making the ScyllaDB API fail the host ID mapping request")
+		switcher.SwitchToPhaseTwo()
+		o.Eventually(switcher.PhaseTwoServedCh()).WithTimeout(30 * time.Second).Should(o.BeClosed())
+
+		g.By("Ensuring the membership and the token ring hash retain their last observed values")
+		consistentlyAssertServiceAnnotations(ctx, nodeServiceName, func(eo o.Gomega, svc *corev1.Service) {
+			eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(naming.NodeJoinedScyllaDBClusterAnnotation, naming.LabelValueTrue))
+			eo.Expect(svc.Annotations).To(o.HaveKeyWithValue(naming.CurrentTokenRingHashAnnotation, expectedTokenRingHash(ringTokens)))
+		})
+	})
+})
+
+// createNodeService creates a member Service with the given annotations in the test namespace.
+func createNodeService(ctx context.Context, env *envtest.Environment, name string, annotations map[string]string) *corev1.Service {
+	g.GinkgoHelper()
+
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   env.Namespace(),
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
+			Ports: []corev1.ServicePort{
+				{
+					Name: "cql",
+					Port: 9042,
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create Service %q", naming.ManualRef(env.Namespace(), name))
+
+	return svc
+}
+
+// fakeScyllaDBTokenMetadata describes the fake ScyllaDB API responses for the token metadata surface the sidecar
+// controller reads.
+type fakeScyllaDBTokenMetadata struct {
+	// localHostID is returned for the local host ID request.
+	localHostID string
+	// ipToHostIDMap is the cluster's IP to host ID mapping.
+	ipToHostIDMap []scyllaNodeResponse
+	// nodeTokens maps an endpoint to the normal tokens it owns.
+	nodeTokens map[string][]string
+	// ringTokens is the cluster's token ring.
+	ringTokens []string
+	// failLocalHostID makes the local host ID request fail.
+	failLocalHostID bool
+	// failIPToHostIDMap makes the host ID mapping request fail.
+	failIPToHostIDMap bool
+	// failNodeTokens makes the per-endpoint tokens request fail.
+	failNodeTokens bool
+	// failRingTokens makes the token ring request fail.
+	failRingTokens bool
+}
+
+// newFakeScyllaDBTokenMetadataHandler returns a handler serving the given fake ScyllaDB API responses.
+func newFakeScyllaDBTokenMetadataHandler(fake fakeScyllaDBTokenMetadata) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// failWith serves a ScyllaDB-shaped JSON error so the client fails on the status code rather than on
+		// decoding a plain-text body.
+		failWith := func(message string) {
+			w.WriteHeader(http.StatusInternalServerError)
+			encodeJSON(w, r, map[string]any{"message": message, "code": http.StatusInternalServerError})
+		}
+
+		switch {
+		case r.URL.Path == "/storage_service/hostid/local":
+			if fake.failLocalHostID {
+				failWith("local host id is unavailable")
+				return
+			}
+			encodeJSON(w, r, fake.localHostID)
+
+		case r.URL.Path == "/storage_service/host_id":
+			if fake.failIPToHostIDMap {
+				failWith("host id mapping is unavailable")
+				return
+			}
+			encodeJSON(w, r, fake.ipToHostIDMap)
+
+		// The token ring and the per-endpoint tokens share a path prefix, so match the exact path first.
+		case r.URL.Path == "/storage_service/tokens":
+			if fake.failRingTokens {
+				failWith("token ring is unavailable")
+				return
+			}
+			encodeJSON(w, r, fake.ringTokens)
+
+		case strings.HasPrefix(r.URL.Path, "/storage_service/tokens/"):
+			if fake.failNodeTokens {
+				failWith("node tokens are unavailable")
+				return
+			}
+
+			endpoint := strings.TrimPrefix(r.URL.Path, "/storage_service/tokens/")
+			tokens, ok := fake.nodeTokens[endpoint]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			encodeJSON(w, r, tokens)
+
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+func runSidecarController(ctx context.Context, env *envtest.Environment, serviceName, localhostAddress string, newScyllaClient func() (*scyllaclient.Client, error)) *sidecarcontroller.Controller {
+	g.GinkgoHelper()
+
+	kubeInformers := kubeinformers.NewSharedInformerFactoryWithOptions(
+		env.TypedKubeClient(),
+		0,
+		kubeinformers.WithNamespace(env.Namespace()),
+		kubeinformers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", serviceName).String()
+		}),
+	)
+
+	c, err := sidecarcontroller.NewController(
+		env.Namespace(),
+		serviceName,
+		localhostAddress,
+		env.TypedKubeClient(),
+		kubeInformers.Core().V1().Services(),
+		newScyllaClient,
+	)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create sidecar controller")
+
+	kubeInformers.Start(ctx.Done())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.Run(ctx)
+	}()
+
+	g.DeferCleanup(func() {
+		kubeInformers.Shutdown()
+		wg.Wait()
+	})
+
+	return c
+}

--- a/test/envtest/controllers/statusreport_test.go
+++ b/test/envtest/controllers/statusreport_test.go
@@ -4,13 +4,8 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -93,11 +88,16 @@ var _ = g.Describe("StatusReportController", func() {
 
 	g.DescribeTable("keeps the Pod annotation stable with respect to the ordering of status reports", func(ctx g.SpecContext, tc statusStabilityTestCase) {
 		// Liveness is intentionally kept the same across both phases to focus on reordering changes across subsequent API calls.
-		scyllaClientFactory := NewSwitchableScyllaClientFactory(
-			tc.firstCallHostIDs, tc.liveEndpoints,
-			tc.subsequentCallHostIDs, tc.liveEndpoints,
+		switcher, newScyllaClient := newSwitchableFakeScyllaDBClientFactory(
+			newFakeScyllaDBNodeStatusHandler(fakeScyllaDBNodeStatus{
+				ipToHostIDMap: tc.firstCallHostIDs,
+				liveEndpoints: tc.liveEndpoints,
+			}),
+			newFakeScyllaDBNodeStatusHandler(fakeScyllaDBNodeStatus{
+				ipToHostIDMap: tc.subsequentCallHostIDs,
+				liveEndpoints: tc.liveEndpoints,
+			}),
 		)
-		g.DeferCleanup(scyllaClientFactory.Close)
 
 		g.By("Creating the Pod")
 		pod := newBasicPod(env.Namespace())
@@ -105,7 +105,7 @@ var _ = g.Describe("StatusReportController", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Starting status report controller")
-		ctrl := runStatusReportController(ctx, env, pod.Name, scyllaClientFactory.NewClient)
+		ctrl := runStatusReportController(ctx, env, pod.Name, newScyllaClient)
 
 		g.By("Waiting for the Pod to get the expected node status report annotation")
 		pod = waitForPodToHaveNodeStatusReportAnnotation(ctx, pod.Namespace, pod.Name, tc.expectedAnnotation)
@@ -114,10 +114,10 @@ var _ = g.Describe("StatusReportController", func() {
 		// Switch to phase two and explicitly enqueue a sync so the controller re-runs with the reordered API response.
 		// phaseTwoCalled is then used to confirm the sync actually executed before asserting stability.
 		g.By("Switching to phase two and triggering a sync")
-		scyllaClientFactory.SwitchToPhaseTwo()
+		switcher.SwitchToPhaseTwo()
 		ctrl.Enqueue()
 
-		o.Eventually(scyllaClientFactory.PhaseTwoCalledCh()).WithTimeout(30 * time.Second).Should(o.BeClosed())
+		o.Eventually(switcher.PhaseTwoServedCh()).WithTimeout(30 * time.Second).Should(o.BeClosed())
 
 		// If the controller produces a different JSON encoding on the second call (e.g., due to non-deterministic node ordering),
 		// the annotation value will change and the Pod will be re-patched, bumping ResourceVersion.
@@ -215,11 +215,16 @@ var _ = g.Describe("StatusReportController", func() {
 	}
 
 	g.DescribeTable("updates the Pod annotation", func(ctx g.SpecContext, tc statusChangeTestCase) {
-		scyllaClientFactory := NewSwitchableScyllaClientFactory(
-			tc.firstCallHostIDs, tc.firstCallLiveEndpoints,
-			tc.subsequentCallHostIDs, tc.subsequentCallLiveEndpoints,
+		switcher, newScyllaClient := newSwitchableFakeScyllaDBClientFactory(
+			newFakeScyllaDBNodeStatusHandler(fakeScyllaDBNodeStatus{
+				ipToHostIDMap: tc.firstCallHostIDs,
+				liveEndpoints: tc.firstCallLiveEndpoints,
+			}),
+			newFakeScyllaDBNodeStatusHandler(fakeScyllaDBNodeStatus{
+				ipToHostIDMap: tc.subsequentCallHostIDs,
+				liveEndpoints: tc.subsequentCallLiveEndpoints,
+			}),
 		)
-		g.DeferCleanup(scyllaClientFactory.Close)
 
 		g.By("Creating the Pod")
 		pod := newBasicPod(env.Namespace())
@@ -228,14 +233,14 @@ var _ = g.Describe("StatusReportController", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Starting status report controller")
-		controller := runStatusReportController(ctx, env, pod.Name, scyllaClientFactory.NewClient)
+		controller := runStatusReportController(ctx, env, pod.Name, newScyllaClient)
 
 		g.By("Waiting for the Pod to get the initial node status report annotation")
 		waitForPodToHaveNodeStatusReportAnnotation(ctx, pod.Namespace, pod.Name, tc.expectedAnnotationAfterFirstCall)
 
 		// Switch to phase two and explicitly enqueue a sync so the controller picks up the status change.
 		g.By("Switching to phase two and triggering a sync")
-		scyllaClientFactory.SwitchToPhaseTwo()
+		switcher.SwitchToPhaseTwo()
 		controller.Enqueue()
 
 		g.By("Waiting for the Pod annotation to reflect the status change")
@@ -272,128 +277,31 @@ var _ = g.Describe("StatusReportController", func() {
 	)
 })
 
-// SwitchableScyllaClientFactory is a two-phase Scylla client factory with the below semantics:
-//   - Can be in Phase 1 or Phase 2; on initialization is in Phase 1.
-//   - In Phase 1, NewClient serves firstHostIDs and firstLiveEndpoints.
-//   - In Phase 2, NewClient serves subsequentHostIDs and subsequentLiveEndpoints.
-//   - Upon call to SwitchToPhaseTwo, moves from Phase 1 to 2.
-//   - On the first NewClient call in Phase 2, closes the channel returned by PhaseTwoCalledCh.
-type SwitchableScyllaClientFactory struct {
-	firstHostIDs            []scyllaNodeResponse
-	firstLiveEndpoints      []string
-	subsequentHostIDs       []scyllaNodeResponse
-	subsequentLiveEndpoints []string
-
-	inPhaseTwo       atomic.Bool
-	phaseTwoCalledCh chan struct{}
-	phaseTwoOnce     sync.Once
-
-	mu        sync.Mutex
-	teardowns []func()
+// fakeScyllaDBNodeStatus describes the fake ScyllaDB API responses for the node status surface the status report
+// controller reads.
+type fakeScyllaDBNodeStatus struct {
+	// ipToHostIDMap is the cluster's IP to host ID mapping.
+	ipToHostIDMap []scyllaNodeResponse
+	// liveEndpoints is the list of endpoints gossip reports as live.
+	liveEndpoints []string
 }
 
-func NewSwitchableScyllaClientFactory(
-	firstHostIDs []scyllaNodeResponse, firstLiveEndpoints []string,
-	subsequentHostIDs []scyllaNodeResponse, subsequentLiveEndpoints []string,
-) *SwitchableScyllaClientFactory {
-	return &SwitchableScyllaClientFactory{
-		firstHostIDs:            firstHostIDs,
-		firstLiveEndpoints:      firstLiveEndpoints,
-		subsequentHostIDs:       subsequentHostIDs,
-		subsequentLiveEndpoints: subsequentLiveEndpoints,
-		phaseTwoCalledCh:        make(chan struct{}),
-	}
-}
-
-// NewClient creates a new ScyllaDB client backed by a fake HTTP server.
-// The response data depends on the current phase.
-func (f *SwitchableScyllaClientFactory) NewClient() (*scyllaclient.Client, error) {
-	var client *scyllaclient.Client
-	var teardown func()
-	var err error
-
-	if f.inPhaseTwo.Load() {
-		f.phaseTwoOnce.Do(func() {
-			close(f.phaseTwoCalledCh)
-		})
-
-		client, teardown, err = newStaticScyllaClient(f.subsequentHostIDs, f.subsequentLiveEndpoints)
-	} else {
-		client, teardown, err = newStaticScyllaClient(f.firstHostIDs, f.firstLiveEndpoints)
-	}
-
-	if teardown != nil {
-		f.mu.Lock()
-		f.teardowns = append(f.teardowns, teardown)
-		f.mu.Unlock()
-	}
-
-	return client, err
-}
-
-// SwitchToPhaseTwo transitions the factory from Phase 1 to Phase 2.
-func (f *SwitchableScyllaClientFactory) SwitchToPhaseTwo() {
-	f.inPhaseTwo.Store(true)
-}
-
-// PhaseTwoCalledCh returns a channel that is closed on the first NewClient call in Phase 2.
-func (f *SwitchableScyllaClientFactory) PhaseTwoCalledCh() <-chan struct{} {
-	return f.phaseTwoCalledCh
-}
-
-// Close tears down all HTTP servers created by NewClient calls.
-func (f *SwitchableScyllaClientFactory) Close() {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	for _, td := range f.teardowns {
-		td()
-	}
-}
-
-// newStaticScyllaClient creates a ScyllaDB client backed by httptest.Server that serves the given host IDs and live endpoints.
-// It returns the client, a teardown function that closes the server, and any error.
-// The caller is responsible for invoking the teardown function at an appropriate point.
-func newStaticScyllaClient(hostIDNodes []scyllaNodeResponse, liveEndpoints []string) (*scyllaclient.Client, func(), error) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// newFakeScyllaDBNodeStatusHandler returns a handler serving the given fake ScyllaDB API responses.
+func newFakeScyllaDBNodeStatusHandler(fake fakeScyllaDBNodeStatus) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+
 		switch r.URL.Path {
 		case "/storage_service/host_id":
-			if err := json.NewEncoder(w).Encode(hostIDNodes); err != nil {
-				g.GinkgoWriter.Printf("failed to encode host_id response: %v\n", err)
-				http.Error(w, "internal error", http.StatusInternalServerError)
-			}
+			encodeJSON(w, r, fake.ipToHostIDMap)
+
 		case "/gossiper/endpoint/live/":
-			if err := json.NewEncoder(w).Encode(liveEndpoints); err != nil {
-				g.GinkgoWriter.Printf("failed to encode live nodes response: %v\n", err)
-				http.Error(w, "internal error", http.StatusInternalServerError)
-			}
+			encodeJSON(w, r, fake.liveEndpoints)
+
 		default:
 			http.NotFound(w, r)
 		}
 	})
-
-	server := httptest.NewServer(handler)
-
-	parsedURL, err := url.Parse(server.URL)
-	if err != nil {
-		server.Close()
-		return nil, nil, fmt.Errorf("can't parse server URL: %w", err)
-	}
-
-	cfg := &scyllaclient.Config{
-		Hosts:   []string{parsedURL.Hostname()},
-		Port:    parsedURL.Port(),
-		Scheme:  "http",
-		Timeout: 5 * time.Second,
-	}
-
-	client, err := scyllaclient.NewClient(cfg)
-	if err != nil {
-		server.Close()
-		return nil, nil, err
-	}
-
-	return client, server.Close, nil
 }
 
 func runStatusReportController(ctx context.Context, env *envtest.Environment, podName string, newScyllaClient func() (*scyllaclient.Client, error)) *statusreport.Controller {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
The bootstrap barrier requires every node in `ScyllaDBDatacenterNodesStatusReport` to be present and UP before a node proceeds with bootstrap, and membership in that required set was derived from Kubernetes state (`rackStatus.CurrentNodes`). A node that already exists as a Kubernetes object but hasn't joined the ScyllaDB cluster is therefore required, while being structurally unable to satisfy the precondition - it has no host ID and no status to propagate. This moves the criterion to actual ScyllaDB cluster membership: the sidecar checks whether the node owns normal tokens and records it on the member `Service` as `internal.scylla-operator.scylladb.com/node-joined-scylladb-cluster`, and report inclusion is gated on that. Normal tokens are used as signal rather than operation mode because token metadata is restored from disk before gossip starts, so a bootstrapped node never stops owning them across a restart. As a consequence, absence of an entry in the report no longer implies the node is missing or unhealthy.

This doesn't deliver parallel bootstrap on its own - `Pod` and `StatefulSet` creation are still sequential. There's no separate barrier path for sequential and parallel bootstrap, so this is E2E-tested as is.

**WARNING! Important notes**:
The barrier can still theoretically sequentialize joining nodes. A node that is joining is absent from the report's own entries by construction, but it can still reach `ObservedNodes` through its peers' gossip view, and the status report doesn't distinguish a joining node from a member - so a host ID appearing there without a corresponding report entry fails the precondition and holds up other nodes. I'm keeping that conservative: erring the other way lets nodes that have joined but aren't yet reported drop out of the required set. The practical implication is negligible, since raft sequentializes the joins anyway.

The other risk is that membership is now observed asynchronously, so it's inherently racy: a node can join and go down before its sidecar records the annotation, leaving it absent from the report and letting the barrier clear other nodes against a cluster that isn't actually healthy. The same unfiltered `ObservedNodes` channel keeps this narrow - a node that joined is still reported `DOWN` by its peers and re-enters the required set through their reports - so the window only really opens if no peer's `ObservedNodes` were propagated in time. I'm accepting that: the annotation is only ever written from a successful observation and never cleared, so once a node has been observed as a member it stays required permanently, and closing the window means either treating unobservable nodes as required, which is the deadlock this PR fixes, or clearing the annotation when the ScyllaDB API is unreachable, which would drop healthy nodes out of the required set on every restart.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-159

/cc
