### PR TITLE
docs: fix llms.txt generation in multiversion builds

### DIFF
--- a/docs/source/_ext/version_context_substitutions.py
+++ b/docs/source/_ext/version_context_substitutions.py
@@ -381,9 +381,12 @@ def setup_version_context_substitutions(app: Sphinx, config: Config) -> None:
     if not hasattr(config, 'myst_substitutions'):
         raise ExtensionError("myst_substitutions not found in config")
 
-    # Get the repository root directory from the original checkout (app.confdir).
-    # This is used for git operations that work across all versions (e.g., listing tags).
-    repo_root = os.path.abspath(os.path.join(app.confdir, '..', '..'))
+    # Repository root of the original checkout, used for git operations (e.g., listing tags).
+    # Recorded in the environment so child builds can inherit it: sphinx-llm's markdown
+    # sub-build runs from a temporary source export whose confdir is not a git checkout.
+    repo_root = os.environ.setdefault(
+        'SPHINX_VERSION_CONTEXT_REPO_ROOT',
+        os.path.abspath(os.path.join(app.confdir, '..', '..')))
     if not os.path.exists(os.path.join(repo_root, '.git')):
         raise ExtensionError(f"Not a git repository: {repo_root}")
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,9 +18,9 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.githubpages",
     "sphinx.ext.extlinks",
+    "sphinx_sitemap",
     "sphinx_scylladb_theme",
     "sphinx_multiversion",
-    "sphinx_sitemap",
     "myst_parser",
     "version_context_substitutions",
 ]


### PR DESCRIPTION
Resolves https://github.com/scylladb/scylladb-docs-homepage/issues/253

## Problem

https://operator.docs.scylladb.com/llms.txt and  https://operator.docs.scylladb.com/sitemap.xml returns 404.

The markdown sub-build that `sphinx-llm` uses to generate `llms.txt` runs from `sphinx-multiversion`'s temporary source export, which is not a Git repository.

As a result, `version_context_substitutions` raises `Not a git repository`, the sub-build exits silently for every version, and no `llms.txt`, `llms-full.txt`, or per-page `.md` files are generated.

The root `sitemap.xml` is also missing because the theme copies it to the site root before `sphinx_sitemap` has generated it.

## Solution

- `_ext/version_context_substitutions.py`: The primary build resolves the repository root from `confdir` and stores it in the `SPHINX_VERSION_CONTEXT_REPO_ROOT` environment variable. The markdown sub-build inherits this variable and uses it instead of trying to discover the repository from its temporary export.
- `conf.py`: Load `sphinx_sitemap` before `sphinx_scylladb_theme` so `sitemap.xml` exists before the theme copies it to the site root.

## How to test

Run `make multiversion` and verify that `_build/dirhtml/llms.txt` and `sitemap.xml`are generated.

## After merging

[Redeploy the docs manually](https://sphinx-theme.scylladb.com/stable/deployment/production.html#publishing-the-docs-manually).