### PR TITLE
fix(SC API): change SM Agent configmap to a secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   Previously every node expected to exist in the Kubernetes state was required to be reported and UP, including nodes
   that hadn't joined yet and couldn't report their status.
   [#3530](https://github.com/scylladb/scylla-operator/pull/3530)
+- Corrected the API reference for `ScyllaCluster.spec.datacenter.racks[].scyllaAgentConfig`. Its description
+  previously referred to a ConfigMap, but the operator has always resolved this field to a Secret, since the
+  Scylla Manager Agent config may contain a sensitive auth token. Only the field description and generated
+  reference were updated — the expected resource type and runtime behavior are unchanged.
+  [#3534](https://github.com/scylladb/scylla-operator/pull/3534)
 
 ## [1.21.0](https://github.com/scylladb/scylla-operator/releases/tag/v1.21.0)
 

--- a/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
@@ -1441,8 +1441,9 @@ spec:
                               type: object
                           type: object
                         scyllaAgentConfig:
-                          description: Scylla config map name to customize scylla
-                            manager agent
+                          description: ScyllaAgentConfig specifies a reference to
+                            custom ScyllaDB Manager Agent configuration stored as
+                            Secret.
                           type: string
                         scyllaConfig:
                           description: Scylla config map name to customize scylla.yaml

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3158,7 +3158,7 @@ spec:
                                 type: object
                             type: object
                           scyllaAgentConfig:
-                            description: Scylla config map name to customize scylla manager agent
+                            description: ScyllaAgentConfig specifies a reference to custom ScyllaDB Manager Agent configuration stored as Secret.
                             type: string
                           scyllaConfig:
                             description: Scylla config map name to customize scylla.yaml

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -405,7 +405,7 @@ object
      - resources the Scylla container will use.
    * - scyllaAgentConfig
      - string
-     - Scylla config map name to customize scylla manager agent
+     - ScyllaAgentConfig specifies a reference to custom ScyllaDB Manager Agent configuration stored as Secret.
    * - scyllaConfig
      - string
      - Scylla config map name to customize scylla.yaml

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -1607,7 +1607,7 @@
                 "type": "object"
               },
               "scyllaAgentConfig": {
-                "description": "Scylla config map name to customize scylla manager agent",
+                "description": "ScyllaAgentConfig specifies a reference to custom ScyllaDB Manager Agent configuration stored as Secret.",
                 "type": "string"
               },
               "scyllaConfig": {

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -1550,7 +1550,7 @@
             "type": "object"
           },
           "scyllaAgentConfig": {
-            "description": "Scylla config map name to customize scylla manager agent",
+            "description": "ScyllaAgentConfig specifies a reference to custom ScyllaDB Manager Agent configuration stored as Secret.",
             "type": "string"
           },
           "scyllaConfig": {

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -1364,7 +1364,7 @@ spec:
                                 type: object
                             type: object
                           scyllaAgentConfig:
-                            description: Scylla config map name to customize scylla manager agent
+                            description: ScyllaAgentConfig specifies a reference to custom ScyllaDB Manager Agent configuration stored as Secret.
                             type: string
                           scyllaConfig:
                             description: Scylla config map name to customize scylla.yaml

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -544,7 +544,7 @@ type RackSpec struct {
 	// Scylla config map name to customize scylla.yaml
 	ScyllaConfig string `json:"scyllaConfig"`
 
-	// Scylla config map name to customize scylla manager agent
+	// ScyllaAgentConfig specifies a reference to custom ScyllaDB Manager Agent configuration stored as Secret.
 	ScyllaAgentConfig string `json:"scyllaAgentConfig"`
 
 	// exposeOptions specifies rack-specific parameters related to exposing ScyllaDBDatacenter backends.


### PR DESCRIPTION
**Description of your changes:**
- as seen by pkg/controller/scyllacluster/migrate.go:235, SC API spec was not meant to be a configmap (it can contain auth token); this PR amends the API, the documentation and generated files

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-248
