### PR TITLE
fix(sidecar): check node state before fetching HostID map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   wrapper incorrectly compared against `OperationalModeDecommissioned` instead of `OperationalModeDecommissioning`,
   which resulted in an unhandled error being logged.
   [#3538](https://github.com/scylladb/scylla-operator/pull/3538)
+- Fixed sidecar annotation sync to check the local ScyllaDB node operation mode before fetching the IP-to-HostID map.
+  Nodes that are not yet in `NORMAL` mode are requeued, while a missing HostID for a `NORMAL` node is surfaced as an error.
+  [#3535](https://github.com/scylladb/scylla-operator/pull/3535)
 - Fixed nodes being skipped by cleanup after the token ring changed. The operator seeded a node's last cleaned up token
   ring hash with whatever ring state its sidecar sampled first, which exempted that node from cleanup of the ring it
   first observed. Which nodes ended up exempt depended on the race between node joins and the time for sidecar to propagate the token ring hash.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   wrapper incorrectly compared against `OperationalModeDecommissioned` instead of `OperationalModeDecommissioning`,
   which resulted in an unhandled error being logged.
   [#3538](https://github.com/scylladb/scylla-operator/pull/3538)
-- Fixed sidecar annotation sync to check the local ScyllaDB node operation mode before fetching the IP-to-HostID map.
+- Fixed sidecar annotation sync to check the local ScyllaDB node operation mode when the node's HostID is missing from the IP-to-HostID map.
   Nodes that are not yet in `NORMAL` mode are requeued, while a missing HostID for a `NORMAL` node is surfaced as an error.
   [#3535](https://github.com/scylladb/scylla-operator/pull/3535)
 - Fixed nodes being skipped by cleanup after the token ring changed. The operator seeded a node's last cleaned up token

--- a/pkg/controller/sidecar/sync.go
+++ b/pkg/controller/sidecar/sync.go
@@ -190,6 +190,15 @@ func (c *Controller) getRequiredServiceAnnotations(ctx context.Context, scyllaCl
 // The second return value reports whether membership could be determined at all. When it is false, the caller must not act
 // on the first one.
 func nodeIsScyllaDBClusterMember(ctx context.Context, scyllaClient *scyllaclient.Client, localhostAddr string, hostID string) (bool, bool, error) {
+	opMode, err := scyllaClient.OperationMode(ctx, localhostAddr)
+	if err != nil {
+		return false, false, fmt.Errorf("can't get node operation mode: %w", err)
+	}
+
+	if opMode != scyllaclient.OperationalModeNormal {
+		return false, false, nil
+	}
+
 	ipToHostIDMap, err := scyllaClient.GetIPToHostIDMap(ctx, localhostAddr)
 	if err != nil {
 		return false, false, fmt.Errorf("can't get host id to ip mapping: %w", err)
@@ -205,8 +214,7 @@ func nodeIsScyllaDBClusterMember(ctx context.Context, scyllaClient *scyllaclient
 	}
 
 	if len(localIP) == 0 {
-		// The node is not present in the cluster's token metadata, so its membership can't be determined.
-		return false, false, nil
+		return false, false, fmt.Errorf("node is in %s operation mode, but HostID %q is missing from the IP-to-HostID map: %v", opMode, hostID, ipToHostIDMap)
 	}
 
 	// Only normal tokens are reported for the endpoint, pending tokens of a bootstrapping or replacing node are not.

--- a/pkg/controller/sidecar/sync.go
+++ b/pkg/controller/sidecar/sync.go
@@ -190,15 +190,6 @@ func (c *Controller) getRequiredServiceAnnotations(ctx context.Context, scyllaCl
 // The second return value reports whether membership could be determined at all. When it is false, the caller must not act
 // on the first one.
 func nodeIsScyllaDBClusterMember(ctx context.Context, scyllaClient *scyllaclient.Client, localhostAddr string, hostID string) (bool, bool, error) {
-	opMode, err := scyllaClient.OperationMode(ctx, localhostAddr)
-	if err != nil {
-		return false, false, fmt.Errorf("can't get node operation mode: %w", err)
-	}
-
-	if opMode != scyllaclient.OperationalModeNormal {
-		return false, false, nil
-	}
-
 	ipToHostIDMap, err := scyllaClient.GetIPToHostIDMap(ctx, localhostAddr)
 	if err != nil {
 		return false, false, fmt.Errorf("can't get host id to ip mapping: %w", err)
@@ -214,6 +205,15 @@ func nodeIsScyllaDBClusterMember(ctx context.Context, scyllaClient *scyllaclient
 	}
 
 	if len(localIP) == 0 {
+		opMode, err := scyllaClient.OperationMode(ctx, localhostAddr)
+		if err != nil {
+			return false, false, fmt.Errorf("can't get node operation mode: %w", err)
+		}
+
+		if opMode != scyllaclient.OperationalModeNormal {
+			return false, false, nil
+		}
+
 		return false, false, fmt.Errorf("node is in %s operation mode, but HostID %q is missing from the IP-to-HostID map: %v", opMode, hostID, ipToHostIDMap)
 	}
 

--- a/pkg/controller/sidecar/sync_test.go
+++ b/pkg/controller/sidecar/sync_test.go
@@ -61,13 +61,14 @@ func TestNodeIsScyllaDBClusterMember(t *testing.T) {
 			expectedErr:    false,
 		},
 		{
-			name: "node not in normal operation mode is undeterminable",
+			name: "node absent from the host ID map is undeterminable when node is not in normal operation mode",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
+				case "/storage_service/host_id":
+					w.Write([]byte(`[{"key":"10.0.0.2","value":"different-host-id"}]`))
 				case "/storage_service/operation_mode":
 					w.Write([]byte(`"JOINING"`))
 				default:
-					// The IP-to-HostID map must not be fetched until the node is in NORMAL operation mode.
 					t.Errorf("unexpected request to %q", r.URL.Path)
 				}
 			},

--- a/pkg/controller/sidecar/sync_test.go
+++ b/pkg/controller/sidecar/sync_test.go
@@ -28,6 +28,8 @@ func TestNodeIsScyllaDBClusterMember(t *testing.T) {
 			name: "node owning normal tokens is a member",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
+				case "/storage_service/operation_mode":
+					w.Write([]byte(`"NORMAL"`))
 				case "/storage_service/host_id":
 					w.Write([]byte(`[{"key":"10.0.0.1","value":"` + hostID + `"}]`))
 				case "/storage_service/tokens/10.0.0.1":
@@ -44,6 +46,8 @@ func TestNodeIsScyllaDBClusterMember(t *testing.T) {
 			name: "node without normal tokens is known but not a member",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
+				case "/storage_service/operation_mode":
+					w.Write([]byte(`"NORMAL"`))
 				case "/storage_service/host_id":
 					w.Write([]byte(`[{"key":"10.0.0.1","value":"` + hostID + `"}]`))
 				case "/storage_service/tokens/10.0.0.1":
@@ -57,14 +61,13 @@ func TestNodeIsScyllaDBClusterMember(t *testing.T) {
 			expectedErr:    false,
 		},
 		{
-			name: "node absent from the host ID map is undeterminable",
+			name: "node not in normal operation mode is undeterminable",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
-				case "/storage_service/host_id":
-					w.Write([]byte(`[{"key":"10.0.0.2","value":"ffffffff-ffff-ffff-ffff-ffffffffffff"}]`))
+				case "/storage_service/operation_mode":
+					w.Write([]byte(`"JOINING"`))
 				default:
-					// The node tokens endpoint must not be reached, it reports an empty token list for an
-					// address the cluster doesn't know, which is indistinguishable from a bootstrapping node.
+					// The IP-to-HostID map must not be fetched until the node is in NORMAL operation mode.
 					t.Errorf("unexpected request to %q", r.URL.Path)
 				}
 			},
@@ -73,9 +76,40 @@ func TestNodeIsScyllaDBClusterMember(t *testing.T) {
 			expectedErr:    false,
 		},
 		{
-			name: "host ID map error is propagated",
+			name: "node absent from the host ID map while normal is an error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/storage_service/operation_mode":
+					w.Write([]byte(`"NORMAL"`))
+				case "/storage_service/host_id":
+					w.Write([]byte(`[{"key":"10.0.0.2","value":"ffffffff-ffff-ffff-ffff-ffffffffffff"}]`))
+				default:
+					// The node tokens endpoint must not be reached when the expected HostID is absent.
+					t.Errorf("unexpected request to %q", r.URL.Path)
+				}
+			},
+			expectedMember: false,
+			expectedKnown:  false,
+			expectedErr:    true,
+		},
+		{
+			name: "operation mode error is propagated",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
+			},
+			expectedMember: false,
+			expectedKnown:  false,
+			expectedErr:    true,
+		},
+		{
+			name: "host ID map error is propagated",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/storage_service/operation_mode":
+					w.Write([]byte(`"NORMAL"`))
+				default:
+					w.WriteHeader(http.StatusInternalServerError)
+				}
 			},
 			expectedMember: false,
 			expectedKnown:  false,
@@ -85,6 +119,8 @@ func TestNodeIsScyllaDBClusterMember(t *testing.T) {
 			name: "node tokens error is propagated",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
+				case "/storage_service/operation_mode":
+					w.Write([]byte(`"NORMAL"`))
 				case "/storage_service/host_id":
 					w.Write([]byte(`[{"key":"10.0.0.1","value":"` + hostID + `"}]`))
 				default:

--- a/test/envtest/controllers/sidecar_controller_test.go
+++ b/test/envtest/controllers/sidecar_controller_test.go
@@ -486,6 +486,9 @@ func newFakeScyllaDBTokenMetadataHandler(fake fakeScyllaDBTokenMetadata) http.Ha
 			}
 			encodeJSON(w, r, fake.localHostID)
 
+		case r.URL.Path == "/storage_service/operation_mode":
+			encodeJSON(w, r, scyllaclient.OperationalModeNormal)
+
 		case r.URL.Path == "/storage_service/host_id":
 			if fake.failIPToHostIDMap {
 				failWith("host id mapping is unavailable")


### PR DESCRIPTION
**Description of your changes:**

This PR updates the sidecar annotation sync flow to check the local ScyllaDB node operation mode when the node's HostID is missing from the IP-to-HostID map.

Previously, if the local HostID was missing from the IP-to-HostID map, the sidecar assumed the node had not joined the cluster yet and requeued. This change makes that check explicit: the sidecar now waits while the node is not in `NORMAL` operation mode, and returns an error if the node is already `NORMAL` but the expected HostID is still missing from the mapping.

Changes:
- Fetch the IP-to-HostID map before checking the local node operation mode.
- Check the local node operation mode only when the local HostID is missing from the IP-to-HostID map.
- Requeue while the node is not in `NORMAL` operation mode.
- Return an error if the node is already in `NORMAL` mode but its HostID is still missing from the IP-to-HostID map.

Testing:
- `go test ./pkg/controller/sidecar -run TestNodeIsScyllaDBClusterMember -count=1`
- `go test -tags=envtest ./test/envtest/controllers/... -count=1 -timeout=30m -ginkgo.focus='SidecarController'`

**Which issue is resolved by this Pull Request:**

Resolves #3020