### PR TITLE
fix(sidecar): invalid operational mode check in decommission

### DIFF
--- a/pkg/scyllaclient/model.go
+++ b/pkg/scyllaclient/model.go
@@ -87,7 +87,7 @@ func (o OperationalMode) IsDecommissioned() bool {
 }
 
 func (o OperationalMode) IsDecommissioning() bool {
-	return o == OperationalModeDecommissioned
+	return o == OperationalModeDecommissioning
 }
 
 func (o OperationalMode) IsLeaving() bool {


### PR DESCRIPTION
Fixes: OPERATOR-270

Six years old(!) bug in the ScyllaDB API wrapper - checking for `OperationalModeDecommissioned` where it should be `OperationalModeDecommissioning`:

https://github.com/scylladb/scylla-operator/blob/adfc7607f2be507c3a87b77949f32c7b2ff97624/pkg/scyllaclient/model.go#L89-L91

The impact was the following:
- when the decommission label appears on the node service (e.g. because the user has scaled the rack down)
- sidecar triggers `Decommission()` https://github.com/scylladb/scylla-operator/blob/adfc7607f2be507c3a87b77949f32c7b2ff97624/pkg/controller/sidecar/sync.go#L78
- the call times out as expected by the comment https://github.com/scylladb/scylla-operator/blob/adfc7607f2be507c3a87b77949f32c7b2ff97624/pkg/controller/sidecar/sync.go#L80-L81
- at the point of the call to `OperationMode()`, the node status is very likely DECOMMISSIONING (but it's a race condition so it might not yet be, or the failure may be for another reason than "happy timeout")
- assuming the above: the check https://github.com/scylladb/scylla-operator/blob/adfc7607f2be507c3a87b77949f32c7b2ff97624/pkg/controller/sidecar/sync.go#L83 should evaluate to `true` but it evaluates to `false` because `IsDecommissioning` has a bug
- as a result, error gets returned while it should be suppressed by the conditional in the point above https://github.com/scylladb/scylla-operator/blob/adfc7607f2be507c3a87b77949f32c7b2ff97624/pkg/controller/sidecar/sync.go#L89

This PR fixes the faulty conditional (and does not have any other visible impact on the sidecar/operator logic) and therefore suppresses returning the error (that gets logged as unhandled).

I have tested this manually (that it does not regress decommission). I'd like to have an integration test for the decommission state machine but it might be made possible only with control loop testability improvements that I'd hope to see with the introduction of parallel decommission that's on the short-term horizon.