### PR TITLE
fix(renovate): scope git add for scylla-monitoring bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -180,7 +180,7 @@
         "   git add submodules/github.com/scylladb/scylla-monitoring",
         "   git commit --amend",
         "   make update",
-        "   git add .",
+        "   git add assets/config/config.yaml assets/monitoring/",
         "   git commit -m \"chore(deps): update generated files\" && git push --force",
         "   ```",
         "3. Remove the `do-not-merge/hold` label."


### PR DESCRIPTION
The scylla-monitoring submodule bump rule's manual instructions told the person handling the bump to run a bare `git add .` after `make update`, which risks staging unrelated untracked files in a working tree.

Checked what `make update` actually touches for this rule against the prior 4.15.1 bump (`9f27c58d3`, child of submodule-bump commit `c281718a2`): only `assets/config/config.yaml` (via `hack/sync-config-with-monitoring-versions.sh`) and `assets/monitoring/**` (via the `update-monitoring` make target). Scoping the `git add` to those two paths.