### PR TITLE
ci: add changelog entry check for PRs

### DIFF
--- a/.github/workflows/check-changelog.yaml
+++ b/.github/workflows/check-changelog.yaml
@@ -1,0 +1,17 @@
+name: "Check: Changelog entry"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  check-changelog:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    name: Verify changelog entry exists
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - run: ./hack/check-changelog-entry.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}"

--- a/hack/check-changelog-entry.sh
+++ b/hack/check-changelog-entry.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <ORG/REPO> <PR_NUMBER>" >&2
+    exit 1
+fi
+
+REPO="$1"
+PR_NUMBER="$2"
+
+if grep -q "\[#${PR_NUMBER}\](https://github.com/${REPO}/pull/${PR_NUMBER})" CHANGELOG.md; then
+    echo "Found changelog entry for PR #${PR_NUMBER}."
+    exit 0
+fi
+
+echo "ERROR: Missing changelog entry for PR #${PR_NUMBER}." >&2
+exit 1


### PR DESCRIPTION
Adds a CI check that verifies each PR has a corresponding entry in CHANGELOG.md, so that https://github.com/scylladb/scylla-operator/pull/3544 does not happen again.

- `hack/check-changelog-entry.sh` — takes `ORG/REPO` and `PR_NUMBER`, greps CHANGELOG.md for a matching PR link.
- `.github/workflows/check-changelog.yaml` — runs the script on PR events; skips if the PR has the `no-changelog` label.

Fixes: OPERATOR-273