### PR TITLE
test: introduce the upgrade operator test in ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ GO_LD_FLAGS ?=-ldflags '$(strip $(call version-ldflags,$(GO_PACKAGE)/pkg/build) 
 RENOVATE_CONFIG ?=./renovate.json
 
 KIND_CLUSTER_NAME=scylla-operator-e2e
+KIND_OPERATOR_UPGRADE_CLUSTER_NAME=kind-operator-upgrade
 
 # TODO: look into how to make these local to the targets
 export DOCKER_BUILDKIT :=1
@@ -877,3 +878,8 @@ kind-teardown:
 test-e2e-kind: kind-setup
 	CLUSTER_NAME=$(KIND_CLUSTER_NAME) ./hack/kind/run-e2e-tests.sh
 .PHONY: test-e2e-kind
+
+# This target runs a modified kind-setup on its own (no auto deployment)
+test-e2e-kind-operator-upgrade:
+	CLUSTER_NAME=$(KIND_OPERATOR_UPGRADE_CLUSTER_NAME) ./hack/kind/run-e2e-operator-upgrade.sh
+.PHONY: test-e2e-kind-operator-upgrade

--- a/assets/config/config.go
+++ b/assets/config/config.go
@@ -34,7 +34,13 @@ type ScyllaDBTestVersions struct {
 	UpgradeFrom string `json:"upgradeFrom"`
 }
 
+type OperatorTestVersions struct {
+	UpgradeFrom string `json:"upgradeFrom"`
+	UpgradeTo   string `json:"upgradeTo"`
+}
+
 type OperatorTestsConfig struct {
+	OperatorVersions         OperatorTestVersions `json:"operatorVersions"`
 	ScyllaDBVersions         ScyllaDBTestVersions `json:"scyllaDBVersions"`
 	NodeSetupImage           string               `json:"nodeSetupImage"`
 	EnvTestKubernetesVersion string               `json:"envTestKubernetesVersion"`

--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -13,6 +13,10 @@ operator:
   grafanaDefaultPlatformDashboard: "scylladb-2026.2/scylla-overview.2026.2.json"
   prometheusVersion: "v3.12.0" # Generated from scylla-monitoring/versions.sh PROMETHEUS_VERSION.
 operatorTests:
+  operatorVersions:
+    # renovate: datasource=github-releases depName=scylla-operator packageName=scylladb/scylla-operator versioning=semver
+    upgradeFrom: "1.21.0" # latest released minor.patch, the version operator-upgrade tests upgrade from
+    upgradeTo: "latest" # the version operator-upgrade tests upgrade to
   scyllaDBVersions:
     updateFrom: "2026.2.1" # One patch lower than .operator.scyllaDBVersion (if no patches yet for this minor, use a release candidate)
     upgradeFrom: "2026.1.9" # One minor lower than .operator.scyllaDBVersion

--- a/assets/config/config_test.go
+++ b/assets/config/config_test.go
@@ -178,6 +178,20 @@ func TestProjectConfig(t *testing.T) {
 			),
 		},
 		{
+			name:        "operatorVersions.upgradeFrom",
+			configField: Project.OperatorTests.OperatorVersions.UpgradeFrom,
+			testFn: composeValidators(
+				validateRequired,
+				validateSemanticVersion,
+				validateMultiPlatformVersionWithRepo(ctx, OperatorImageRepository),
+			),
+		},
+		{
+			name:        "operatorVersions.upgradeTo",
+			configField: Project.OperatorTests.OperatorVersions.UpgradeTo,
+			testFn:      validateRequired,
+		},
+		{
 			name:        "scyllaDBVersions.UpdateFrom",
 			configField: Project.OperatorTests.ScyllaDBVersions.UpdateFrom,
 			testFn: composeValidators(

--- a/assets/config/images.go
+++ b/assets/config/images.go
@@ -1,6 +1,7 @@
 package configassests
 
 const (
+	OperatorImageRepository             = "docker.io/scylladb/scylla-operator"
 	ScyllaDBImageRepository             = "docker.io/scylladb/scylla"
 	ScyllaDBManagerImageRepository      = "docker.io/scylladb/scylla-manager"
 	ScyllaDBManagerAgentImageRepository = "docker.io/scylladb/scylla-manager-agent"

--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -84,12 +84,15 @@ function run-deploy-script-in-all-clusters {
 # $1- target directory
 function gather-artifacts {
   if [ -z "${1+x}" ]; then
-    echo -e "Missing target directory.\nUsage: ${FUNCNAME[0]} target_directory" > /dev/stderr
+    echo -e "Missing target directory.\nUsage: ${FUNCNAME[0]} target_directory [must_gather_image]" > /dev/stderr
     exit 2
   fi
 
-  if [ -z "${SO_IMAGE+x}" ]; then
-    echo "SO_IMAGE can't be empty" > /dev/stderr
+  # The must-gather image defaults to SO_IMAGE, but callers may override it (e.g. the operator-upgrade
+  # test builds its own image and never sets SO_IMAGE).
+  local must_gather_image="${2:-${SO_IMAGE:-}}"
+  if [ -z "${must_gather_image}" ]; then
+    echo "must-gather image can't be empty (pass it as the second argument or set SO_IMAGE)" > /dev/stderr
     exit 2
   fi
 
@@ -114,7 +117,7 @@ spec:
     command:
     - /usr/bin/sleep
     - infinity
-    image: "${SO_IMAGE}"
+    image: "${must_gather_image}"
     imagePullPolicy: Always
     volumeMounts:
     - name: artifacts
@@ -125,7 +128,7 @@ spec:
     - --all-resources
     - --loglevel=2
     - --dest-dir=/tmp/artifacts
-    image: "${SO_IMAGE}"
+    image: "${must_gather_image}"
     imagePullPolicy: Always
     volumeMounts:
     - name: artifacts
@@ -155,7 +158,10 @@ EOF
 function gather-artifacts-on-exit {
   ec=$?
 
-  gather-artifacts "${ARTIFACTS}/must-gather/cluster" &
+  # Optional must-gather image override forwarded to gather-artifacts; defaults to SO_IMAGE there.
+  local must_gather_image="${1:-}"
+
+  gather-artifacts "${ARTIFACTS}/must-gather/cluster" "${must_gather_image}" &
   gather_artifacts_bg_pids=( $! )
 
   for name in "${!WORKER_KUBECONFIGS[@]}"; do
@@ -165,7 +171,7 @@ function gather-artifacts-on-exit {
       continue
     fi
 
-    KUBECONFIG="${WORKER_KUBECONFIGS[$name]}" gather-artifacts "${ARTIFACTS}/must-gather/workers/${name}" &
+    KUBECONFIG="${WORKER_KUBECONFIGS[$name]}" gather-artifacts "${ARTIFACTS}/must-gather/workers/${name}" "${must_gather_image}" &
     gather_artifacts_bg_pids+=( $! )
   done
 
@@ -268,6 +274,8 @@ function run-e2e {
   SCYLLADB_MANAGER_AGENT_VERSION="${SCYLLADB_MANAGER_AGENT_VERSION:-$(yq '.operator.scyllaDBManagerAgentVersion' "$config_file")}"
   SCYLLADB_UPDATE_FROM_VERSION="${SCYLLADB_UPDATE_FROM_VERSION:-$(yq '.operatorTests.scyllaDBVersions.updateFrom' "$config_file")}"
   SCYLLADB_UPGRADE_FROM_VERSION="${SCYLLADB_UPGRADE_FROM_VERSION:-$(yq '.operatorTests.scyllaDBVersions.upgradeFrom' "$config_file")}"
+  OPERATOR_UPGRADE_FROM_VERSION="${OPERATOR_UPGRADE_FROM_VERSION:-$(yq '.operatorTests.operatorVersions.upgradeFrom' "$config_file")}"
+  OPERATOR_UPGRADE_TO_VERSION="${OPERATOR_UPGRADE_TO_VERSION:-$(yq '.operatorTests.operatorVersions.upgradeTo' "$config_file")}"
 
   kubectl create namespace e2e --dry-run=client -o=yaml | kubectl_create -f=-
   kubectl create clusterrolebinding e2e --clusterrole=cluster-admin --serviceaccount=e2e:default --dry-run=client -o=yaml | kubectl_create -f=-
@@ -379,6 +387,8 @@ function run-e2e {
     "--scylladb-manager-agent-version=${SCYLLADB_MANAGER_AGENT_VERSION}"
     "--scylladb-update-from-version=${SCYLLADB_UPDATE_FROM_VERSION}"
     "--scylladb-upgrade-from-version=${SCYLLADB_UPGRADE_FROM_VERSION}"
+    "--operator-upgrade-from-version=${OPERATOR_UPGRADE_FROM_VERSION}"
+    "--operator-upgrade-to-version=${OPERATOR_UPGRADE_TO_VERSION}"
   )
 
   if [[ -n "${worker_kubeconfigs_in_container_paths}" ]]; then

--- a/hack/kind/cluster-setup.sh
+++ b/hack/kind/cluster-setup.sh
@@ -11,6 +11,8 @@ shopt -s inherit_errexit
 
 readonly repo_root="$( dirname "${BASH_SOURCE[0]}" )/../.."
 
+source "${repo_root}/hack/kind/lib.sh"
+
 # Ensure all kind calls use podman.
 export KIND_EXPERIMENTAL_PROVIDER=podman
 
@@ -31,8 +33,7 @@ if ! podman network inspect kind >/dev/null 2>&1; then
   podman network create kind
 fi
 
-# Source shared constants and generate containerd registry configuration.
-source "${repo_root}/hack/kind/lib.sh"
+# Generate containerd registry configuration (mounted into KinD nodes via cluster-config.yaml).
 internal_reg_port=5000
 containerd_reg_dir="${repo_root}/hack/kind/containerd-registries/localhost:${KIND_REGISTRY_PORT}"
 mkdir -p "${containerd_reg_dir}"
@@ -84,7 +85,7 @@ metadata:
   namespace: kube-public
 data:
   localRegistryHosting.v1: |
-    host: "localhost:${KIND_REGISTRY_PORT}"
+    host: "${KIND_REGISTRY_HOST}:${KIND_REGISTRY_PORT}"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
 rm "${temp_kubeconfig}"
@@ -105,12 +106,17 @@ export SO_SCYLLACLUSTER_STORAGECLASS_NAME
 
 source "${repo_root}/hack/.ci/run-e2e-shared.env.sh"
 
-# Build and push operator image to the local registry (skips if SO_IMAGE is already set).
-build-and-push-operator-image "${repo_root}"
+# Deploy the operator stack unless the caller opts out (e.g. operator-upgrade tests deploy it themselves).
+if [ "${SO_SKIP_DEPLOYMENT:-false}" == "true" ]; then
+  echo "Skipping operator stack deployment (SO_SKIP_DEPLOYMENT=true)."
+else
+  # Build and push operator image to the local registry (skips if SO_IMAGE is already set).
+  build-and-push-operator-image "${repo_root}" SO_IMAGE
 
-# Set up ARTIFACTS directory to store manifests that are used to deploy the operator stack for inspection.
-ARTIFACTS="${ARTIFACTS:-$( mktemp -d )}"
-export ARTIFACTS
+  # Set up ARTIFACTS directory to store manifests that are used to deploy the operator stack for inspection.
+  ARTIFACTS="${ARTIFACTS:-$( mktemp -d )}"
+  export ARTIFACTS
 
-# Deploy the full operator stack (cert-manager, prometheus, haproxy-ingress, operator, scylla-manager).
-"${repo_root}/hack/ci-deploy.sh" "${SO_IMAGE}"
+  # Deploy the full operator stack (cert-manager, prometheus, haproxy-ingress, operator, scylla-manager).
+  "${repo_root}/hack/ci-deploy.sh" "${SO_IMAGE}"
+fi

--- a/hack/kind/lib.sh
+++ b/hack/kind/lib.sh
@@ -6,31 +6,38 @@
 
 shopt -s inherit_errexit
 
+# Local registry backing KIND clusters. Set up by hack/kind/cluster-setup.sh and shared with the build helpers below.
+KIND_REGISTRY_NAME="kind-registry"
 KIND_REGISTRY_PORT="${KIND_REGISTRY_PORT:-5001}"
-KIND_REGISTRY_NAME='kind-registry'
+KIND_REGISTRY_HOST="localhost"
 
-# build-and-push-operator-image builds the operator image and pushes it to the local registry if SO_IMAGE is not set.
-# It sets and exports SO_IMAGE with the built image reference.
+# build-and-push-operator-image builds the operator image and pushes it to the local registry, storing (and exporting)
+# the reference in the variable named by $2. No-op if that variable is already set.
+# Usage: build-and-push-operator-image <root_dir> <image_var_name>
 function build-and-push-operator-image {
-  if [ -z "${1:-}" ]; then
-    echo "Missing parent directory argument.\nUsage: ${FUNCNAME[0]} <root_dir>" > /dev/stderr
-    exit 2
+  local root_dir="${1:?Missing root dir}"
+  local -n image_ref="${2:?Missing image variable name}"
+
+  if [ -n "${image_ref:-}" ]; then
+    echo "Using existing operator image: ${image_ref}"
+    return
   fi
 
-  local root_dir="${1}"
+  local tag_ref="${KIND_REGISTRY_HOST}:${KIND_REGISTRY_PORT}/scylladb/scylla-operator:latest"
 
-  # If SO_IMAGE is not set, build the image.
-  if [ -z "${SO_IMAGE:-}" ]; then
-    SO_IMAGE="localhost:${KIND_REGISTRY_PORT}/scylladb/scylla-operator:e2e-$( date +%Y%m%d%H%M%S )"
-    export SO_IMAGE
+  echo "Building operator image: ${tag_ref}"
+  podman build --format docker -t "${tag_ref}" -f "${root_dir}/Dockerfile" "${root_dir}"
 
-    echo "Building operator image: ${SO_IMAGE}"
-    podman build --format docker -t "${SO_IMAGE}" -f "${root_dir}/Dockerfile" "${root_dir}"
+  # Push the image to the local registry. Use --tls-verify=false as we're running local registry without TLS.
+  echo "Pushing operator image to local registry: ${tag_ref}"
+  local digestfile
+  digestfile="$( mktemp )"
+  podman push --tls-verify=false --digestfile="${digestfile}" "${tag_ref}"
 
-    # Push the image to the local registry. Use --tls-verify=false as we're running local registry without TLS.
-    echo "Pushing operator image to local registry: ${SO_IMAGE}"
-    podman push --tls-verify=false "${SO_IMAGE}"
-  else
-    echo "Using existing operator image: ${SO_IMAGE}"
-  fi
+  # Deploy by digest: the ref changes with image content, so the kubelet's IfNotPresent cache never serves
+  # a stale image on a reused cluster, while unchanged images stay cached (no pull-policy changes needed).
+  image_ref="${KIND_REGISTRY_HOST}:${KIND_REGISTRY_PORT}/scylladb/scylla-operator@$( cat "${digestfile}" )"
+  rm -f "${digestfile}"
+  export "${2}"
+  echo "Operator image reference: ${image_ref}"
 }

--- a/hack/kind/run-e2e-operator-upgrade.sh
+++ b/hack/kind/run-e2e-operator-upgrade.sh
@@ -5,7 +5,8 @@
 set -euExo pipefail
 shopt -s inherit_errexit
 
-readonly repo_root="$( dirname "${BASH_SOURCE[0]}" )/../.."
+# Absolute, so it stays valid when the test is run from the build root below.
+readonly repo_root="$( realpath "$( dirname "${BASH_SOURCE[0]}" )/../.." )"
 
 # Ensure all kind calls use podman.
 export KIND_EXPERIMENTAL_PROVIDER=podman
@@ -17,6 +18,9 @@ fi
 
 REENTRANT="${REENTRANT:-true}"
 export REENTRANT
+
+# Release branch worktrees created by resolve-operator-version below; removed by cleanup.
+worktrees=()
 
 # cleanup collects artifacts (best-effort, before teardown as it needs the cluster) and always tears the cluster
 # down, preserving the original exit code. Unlike other kind e2e tests, this one dirties the environment (deploys
@@ -30,6 +34,9 @@ function cleanup {
     must_gather_image="docker.io/scylladb/scylla-operator:${must_gather_image}"
   fi
   ( gather-artifacts-on-exit "${must_gather_image}" ) || true
+  for worktree in "${worktrees[@]}"; do
+    git -C "${repo_root}" worktree remove --force "${worktree}" || true
+  done
   "${repo_root}/hack/kind/cluster-teardown.sh" || true
   rm -f "${KUBECONFIG:-}" || true
   exit "${exit_code}"
@@ -70,16 +77,44 @@ ARTIFACTS="${ARTIFACTS:-$( mktemp -d )}/upgrade-operator"
 mkdir -p "${ARTIFACTS}"
 export ARTIFACTS
 
-# Optional upgrade target override (e.g. parsed from the triggering CI comment). A value other than "latest"
-# (a released version or a full image ref) is used directly as the upgrade target; unset or "latest" builds the
-# current tree and pushes it to the local registry. Env name matches run-e2e in hack/.ci/lib/e2e.sh.
-if [ "${OPERATOR_UPGRADE_TO_VERSION:-latest}" == "latest" ]; then
-  OPERATOR_UPGRADE_TO_VERSION=""
-fi
-build-and-push-operator-image "${repo_root}" OPERATOR_UPGRADE_TO_VERSION
-
-# Version to upgrade from; env-overridable, defaulting from the config assets like run-e2e in hack/.ci/lib/e2e.sh.
+# Versions to upgrade between; env-overridable (e.g. parsed from the triggering CI comment), defaulting from the
+# config assets like run-e2e in hack/.ci/lib/e2e.sh. Each accepts a released version, a full image ref, "latest"
+# (build the current tree) or "<major.minor>-latest" (e.g. "1.21-latest": build the tip of the corresponding
+# release branch, v1.21); the "-latest" forms are kind-runner-only, as they require building an image.
 OPERATOR_UPGRADE_FROM_VERSION="${OPERATOR_UPGRADE_FROM_VERSION:-$( yq '.operatorTests.operatorVersions.upgradeFrom' "${repo_root}/assets/config/config.yaml" )}"
+OPERATOR_UPGRADE_TO_VERSION="${OPERATOR_UPGRADE_TO_VERSION:-latest}"
+
+# resolve-operator-version resolves the "latest"/"<major.minor>-latest" forms in the version variable named by $1:
+# it builds the image from the corresponding tree (the current one, or a temporary release branch worktree) and
+# replaces the value with the SHA-pinned image ref. The tree is stored in the variable named by $2 — the test runs
+# that version's deploy script from it, so the deployed manifests match the tree the image was built from.
+# Released versions and full image refs are left as-is; a released version deploys via hack/ci-deploy-release.sh,
+# which resolves the manifests from the image's OCI source/revision labels — the release's exact git SHA.
+function resolve-operator-version {
+  local -n version="${1:?Missing version variable name}"
+  local -n deploy_dir="${2:?Missing deploy dir variable name}"
+
+  deploy_dir="${repo_root}"
+  if [[ "${version}" =~ ^([0-9]+\.[0-9]+)-latest$ ]]; then
+    local release_branch="v${BASH_REMATCH[1]}"
+    deploy_dir="$( mktemp -d )"
+    worktrees+=( "${deploy_dir}" )
+    # Fetch by URL: CI checkouts (Prow clonerefs) have no "origin" remote, and a local clone's
+    # "origin" may be a fork without the release branches.
+    git -C "${repo_root}" fetch https://github.com/scylladb/scylla-operator.git "${release_branch}"
+    git -C "${repo_root}" worktree add --detach "${deploy_dir}" FETCH_HEAD
+    version=""
+  elif [ "${version}" == "latest" ]; then
+    version=""
+  else
+    # A released version or a full image ref needs no build.
+    return 0
+  fi
+  build-and-push-operator-image "${deploy_dir}" "${1}"
+}
+
+resolve-operator-version OPERATOR_UPGRADE_FROM_VERSION operator_upgrade_from_deploy_dir
+resolve-operator-version OPERATOR_UPGRADE_TO_VERSION operator_upgrade_to_deploy_dir
 
 apply-e2e-workarounds
 
@@ -96,4 +131,6 @@ go run "${repo_root}/cmd/scylla-operator-tests" run kind-operator-upgrade \
   --scyllacluster-storageclass-name=standard \
   --scyllacluster-reactor-backend=io_uring \
   --operator-upgrade-from-version="${OPERATOR_UPGRADE_FROM_VERSION}" \
-  --operator-upgrade-to-version="${OPERATOR_UPGRADE_TO_VERSION}"
+  --operator-upgrade-from-deploy-dir="${operator_upgrade_from_deploy_dir}" \
+  --operator-upgrade-to-version="${OPERATOR_UPGRADE_TO_VERSION}" \
+  --operator-upgrade-to-deploy-dir="${operator_upgrade_to_deploy_dir}"

--- a/hack/kind/run-e2e-operator-upgrade.sh
+++ b/hack/kind/run-e2e-operator-upgrade.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026 ScyllaDB
+
+set -euExo pipefail
+shopt -s inherit_errexit
+
+readonly repo_root="$( dirname "${BASH_SOURCE[0]}" )/../.."
+
+# Ensure all kind calls use podman.
+export KIND_EXPERIMENTAL_PROVIDER=podman
+
+if [ -z "${CLUSTER_NAME}" ]; then
+  echo "CLUSTER_NAME must be set" > /dev/stderr
+  exit 1
+fi
+
+REENTRANT="${REENTRANT:-true}"
+export REENTRANT
+
+# cleanup collects artifacts (best-effort, before teardown as it needs the cluster) and always tears the cluster
+# down, preserving the original exit code. Unlike other kind e2e tests, this one dirties the environment (deploys
+# and upgrades the operator stack), so it must not leave the cluster around for reuse.
+function cleanup {
+  local exit_code=$?
+  # The must-gather image has to be a full ref; resolve a bare released version against the released repository
+  # (mirroring getOperatorImageRef in the test).
+  local must_gather_image="${OPERATOR_UPGRADE_TO_VERSION:-}"
+  if [ -n "${must_gather_image}" ] && [[ "${must_gather_image}" != */* ]]; then
+    must_gather_image="docker.io/scylladb/scylla-operator:${must_gather_image}"
+  fi
+  ( gather-artifacts-on-exit "${must_gather_image}" ) || true
+  "${repo_root}/hack/kind/cluster-teardown.sh" || true
+  rm -f "${KUBECONFIG:-}" || true
+  exit "${exit_code}"
+}
+
+# The test deploys the operator stack itself (released version, then the upgrade target), so cluster-setup.sh only
+# prepares the cluster and registry. Force a fresh cluster (RECREATE) in case a previous run was killed before its
+# teardown trap fired and left a dirty cluster behind.
+export SO_SKIP_DEPLOYMENT=true
+export RECREATE=true
+"${repo_root}/hack/kind/cluster-setup.sh"
+trap cleanup EXIT
+
+# Set KUBECONFIG to point to the kind cluster.
+KUBECONFIG="$(mktemp --suffix ".kubeconfig")"
+kind get kubeconfig --name="${CLUSTER_NAME}" > "${KUBECONFIG}"
+export KUBECONFIG
+
+source "${repo_root}/hack/kind/lib.sh"
+source "${repo_root}/hack/lib/kube.sh"
+source "${repo_root}/hack/.ci/lib/e2e.sh"
+
+# Use 'standard' storage class that comes with KinD by default, matching cluster-setup.sh's initial deploy.
+# The upgrade re-applies the scylla-manager ScyllaCluster, and changing its storage class is forbidden by the webhook.
+# This must be set before sourcing run-e2e-shared.env.sh, which would otherwise default to 'scylladb-local-xfs'.
+SO_SCYLLACLUSTER_STORAGECLASS_NAME="${SO_SCYLLACLUSTER_STORAGECLASS_NAME:-standard}"
+export SO_SCYLLACLUSTER_STORAGECLASS_NAME
+
+# Force-skip the local-csi-driver: KinD uses the 'standard' storage class and has no XFS local disks, so the driver's
+# daemonset would never roll out.
+export SO_CSI_DRIVER_PATH=""
+
+source "${repo_root}/hack/.ci/run-e2e-shared.env.sh"
+
+# Keep this test's artifacts (test output and must-gather) under a dedicated sub-dir so they are easy to find,
+# in particular locally where ARTIFACTS otherwise defaults to a throwaway temp dir.
+ARTIFACTS="${ARTIFACTS:-$( mktemp -d )}/upgrade-operator"
+mkdir -p "${ARTIFACTS}"
+export ARTIFACTS
+
+# Optional upgrade target override (e.g. parsed from the triggering CI comment). A value other than "latest"
+# (a released version or a full image ref) is used directly as the upgrade target; unset or "latest" builds the
+# current tree and pushes it to the local registry. Env name matches run-e2e in hack/.ci/lib/e2e.sh.
+if [ "${OPERATOR_UPGRADE_TO_VERSION:-latest}" == "latest" ]; then
+  OPERATOR_UPGRADE_TO_VERSION=""
+fi
+build-and-push-operator-image "${repo_root}" OPERATOR_UPGRADE_TO_VERSION
+
+# Version to upgrade from; env-overridable, defaulting from the config assets like run-e2e in hack/.ci/lib/e2e.sh.
+OPERATOR_UPGRADE_FROM_VERSION="${OPERATOR_UPGRADE_FROM_VERSION:-$( yq '.operatorTests.operatorVersions.upgradeFrom' "${repo_root}/assets/config/config.yaml" )}"
+
+apply-e2e-workarounds
+
+# Run the test directly on the host (not in a pod) because it needs access to the repo
+# to call hack/ci-deploy.sh for the operator upgrade.
+go run "${repo_root}/cmd/scylla-operator-tests" run kind-operator-upgrade \
+  --kubeconfig="${KUBECONFIG}" \
+  --loglevel=2 \
+  --color=false \
+  --artifacts-dir="${ARTIFACTS}" \
+  --scyllacluster-node-service-type=Headless \
+  --scyllacluster-nodes-broadcast-address-type=PodIP \
+  --scyllacluster-clients-broadcast-address-type=PodIP \
+  --scyllacluster-storageclass-name=standard \
+  --scyllacluster-reactor-backend=io_uring \
+  --operator-upgrade-from-version="${OPERATOR_UPGRADE_FROM_VERSION}" \
+  --operator-upgrade-to-version="${OPERATOR_UPGRADE_TO_VERSION}"

--- a/hack/kind/run-e2e-tests.sh
+++ b/hack/kind/run-e2e-tests.sh
@@ -40,7 +40,7 @@ source "${repo_root}/hack/.ci/run-e2e-shared.env.sh"
 trap 'gather-artifacts-on-exit; rm -f "${KUBECONFIG}" "${IN_CLUSTER_KUBECONFIG}"' EXIT
 trap gracefully-shutdown-e2es INT
 
-build-and-push-operator-image "${repo_root}"
+build-and-push-operator-image "${repo_root}" SO_IMAGE
 
 # Use 'standard' storage class that comes with KinD by default.
 SO_SCYLLACLUSTER_STORAGECLASS_NAME="standard"

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/containers/image/v5/docker/reference"
 	configassets "github.com/scylladb/scylla-operator/assets/config"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
@@ -60,19 +61,23 @@ type TestFrameworkOptions struct {
 	genericclioptions.MultiDatacenterClientConfig
 	ObjectStorageOptions
 
-	ArtifactsDir                string
-	CleanupPolicyUntyped        string
-	CleanupPolicy               framework.CleanupPolicyType
-	IngressController           *IngressControllerOptions
-	ScyllaClusterOptionsUntyped *ScyllaClusterOptions
-	scyllaClusterOptions        *framework.ScyllaClusterOptions
-	ScyllaDBVersion             string
-	ScyllaDBImageRef            string
-	ScyllaDBManagerVersion      string
-	ScyllaDBManagerAgentVersion string
-	ScyllaDBUpdateFrom          string
-	ScyllaDBUpgradeFrom         string
-	DryRun                      bool
+	ArtifactsDir                 string
+	CleanupPolicyUntyped         string
+	CleanupPolicy                framework.CleanupPolicyType
+	IngressController            *IngressControllerOptions
+	ScyllaClusterOptionsUntyped  *ScyllaClusterOptions
+	scyllaClusterOptions         *framework.ScyllaClusterOptions
+	ScyllaDBVersion              string
+	ScyllaDBImageRef             string
+	ScyllaDBManagerVersion       string
+	ScyllaDBManagerAgentVersion  string
+	ScyllaDBUpdateFrom           string
+	ScyllaDBUpgradeFrom          string
+	OperatorUpgradeFrom          string
+	OperatorUpgradeTo            string
+	OperatorUpgradeFromDeployDir string
+	OperatorUpgradeToDeployDir   string
+	DryRun                       bool
 }
 
 func NewTestFrameworkOptions(streams genericclioptions.IOStreams, userAgent string) *TestFrameworkOptions {
@@ -94,6 +99,8 @@ func NewTestFrameworkOptions(streams genericclioptions.IOStreams, userAgent stri
 		ScyllaDBManagerAgentVersion: configassets.Project.Operator.ScyllaDBManagerAgentVersion,
 		ScyllaDBUpdateFrom:          configassets.Project.OperatorTests.ScyllaDBVersions.UpdateFrom,
 		ScyllaDBUpgradeFrom:         configassets.Project.OperatorTests.ScyllaDBVersions.UpgradeFrom,
+		OperatorUpgradeFrom:         configassets.Project.OperatorTests.OperatorVersions.UpgradeFrom,
+		OperatorUpgradeTo:           configassets.Project.OperatorTests.OperatorVersions.UpgradeTo,
 	}
 }
 
@@ -142,6 +149,10 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&o.ScyllaDBManagerAgentVersion, "scylladb-manager-agent-version", "", o.ScyllaDBManagerAgentVersion, "Version of Scylla Manager Agent to use.")
 	cmd.PersistentFlags().StringVarP(&o.ScyllaDBUpdateFrom, "scylladb-update-from-version", "", o.ScyllaDBUpdateFrom, "Version of ScyllaDB to update from.")
 	cmd.PersistentFlags().StringVarP(&o.ScyllaDBUpgradeFrom, "scylladb-upgrade-from-version", "", o.ScyllaDBUpgradeFrom, "Version of ScyllaDB to upgrade from.")
+	cmd.PersistentFlags().StringVarP(&o.OperatorUpgradeFrom, "operator-upgrade-from-version", "", o.OperatorUpgradeFrom, "Version of the operator to upgrade from during operator upgrade tests. Either a released version or a full image reference.")
+	cmd.PersistentFlags().StringVarP(&o.OperatorUpgradeTo, "operator-upgrade-to-version", "", o.OperatorUpgradeTo, "Version of the operator to upgrade to during operator upgrade tests. Either a released version or a full image reference, e.g. of a locally built image.")
+	cmd.PersistentFlags().StringVarP(&o.OperatorUpgradeFromDeployDir, "operator-upgrade-from-deploy-dir", "", o.OperatorUpgradeFromDeployDir, "Repository tree to run the deploy script from when deploying the version being upgraded from during operator upgrade tests. Defaults to the current directory.")
+	cmd.PersistentFlags().StringVarP(&o.OperatorUpgradeToDeployDir, "operator-upgrade-to-deploy-dir", "", o.OperatorUpgradeToDeployDir, "Repository tree to run the deploy script from when deploying the version being upgraded to during operator upgrade tests. Defaults to the current directory.")
 }
 
 func (o *TestFrameworkOptions) Validate(args []string) error {
@@ -207,6 +218,23 @@ func (o *TestFrameworkOptions) Validate(args []string) error {
 		))
 	}
 
+	// The operator upgrade versions are either a bare version (a tag) or a full image reference (with a repository).
+	for flagName, value := range map[string]string{
+		"operator-upgrade-from-version": o.OperatorUpgradeFrom,
+		"operator-upgrade-to-version":   o.OperatorUpgradeTo,
+	} {
+		if strings.Contains(value, "/") {
+			if _, err := reference.ParseAnyReference(value); err != nil {
+				errors = append(errors, fmt.Errorf("invalid %s image reference %q: %w", flagName, value, err))
+			}
+		} else if !tagWithOptionalDigestRegexp.MatchString(value) {
+			errors = append(errors, fmt.Errorf(
+				"invalid %s format: %q. Expected format: <tag>[@<digest>] or a full image reference",
+				flagName, value,
+			))
+		}
+	}
+
 	if !tagWithOptionalDigestRegexp.MatchString(o.ScyllaDBManagerVersion) {
 		errors = append(errors, fmt.Errorf(
 			"invalid scylladb-manager-version format: %q. Expected format: <tag>[@<digest>]",
@@ -219,6 +247,17 @@ func (o *TestFrameworkOptions) Validate(args []string) error {
 			"invalid scylladb-manager-agent-version format: %q. Expected format: <tag>[@<digest>]",
 			o.ScyllaDBManagerAgentVersion,
 		))
+	}
+
+	for flagName, dir := range map[string]string{
+		"operator-upgrade-from-deploy-dir": o.OperatorUpgradeFromDeployDir,
+		"operator-upgrade-to-deploy-dir":   o.OperatorUpgradeToDeployDir,
+	} {
+		if len(dir) > 0 {
+			if _, err := os.Stat(dir); err != nil {
+				errors = append(errors, fmt.Errorf("can't stat %s %q: %w", flagName, dir, err))
+			}
+		}
 	}
 
 	if len(o.ArtifactsDir) > 0 {
@@ -286,6 +325,10 @@ func (o *TestFrameworkOptions) Complete(args []string) error {
 		ScyllaDBManagerAgentVersion:        o.ScyllaDBManagerAgentVersion,
 		ScyllaDBUpdateFrom:                 o.ScyllaDBUpdateFrom,
 		ScyllaDBUpgradeFrom:                o.ScyllaDBUpgradeFrom,
+		OperatorUpgradeFrom:                o.OperatorUpgradeFrom,
+		OperatorUpgradeTo:                  o.OperatorUpgradeTo,
+		OperatorUpgradeFromDeployDir:       o.OperatorUpgradeFromDeployDir,
+		OperatorUpgradeToDeployDir:         o.OperatorUpgradeToDeployDir,
 		ClusterObjectStorageSettings:       o.ClusterObjectStorageSettings,
 		WorkerClusterObjectStorageSettings: o.WorkerClusterObjectStorageSettings,
 	}

--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -88,6 +88,16 @@ var Suites = ginkgotest.TestSuites{
 		LabelFilter:        framework.SuiteKindScyllaDBMonitoringLabelName,
 		DefaultParallelism: defaultParallelParallelism,
 	},
+	{
+		Name: "kind-operator-upgrade",
+		Description: templates.LongDesc(`
+		Tests that verify operator upgrade from a released version to the current one. Runs in CI outside of k8s
+		(requires kubectl, kubeconfig - scylla-operator docker image does not have kubectl).
+		Must be run from the repository root, as it invokes hack/ci-deploy.sh via a relative path.
+		`),
+		LabelFilter:        framework.SuiteOperatorUpgradeLabelName,
+		DefaultParallelism: 1,
+	},
 }
 
 func NewTestsCommand(streams genericclioptions.IOStreams) *cobra.Command {

--- a/test/e2e/framework/meta.go
+++ b/test/e2e/framework/meta.go
@@ -16,6 +16,7 @@ const (
 	SuiteParallelIPv6LabelName            = "SuiteParallelIPv6"
 	SuiteKindFastLabelName                = "SuiteKindFast"
 	SuiteKindScyllaDBMonitoringLabelName  = "SuiteKindScyllaDBMonitoring"
+	SuiteOperatorUpgradeLabelName         = "SuiteOperatorUpgrade"
 )
 
 var (
@@ -25,6 +26,7 @@ var (
 	SuiteParallelIPv6            = g.Label(SuiteParallelIPv6LabelName)
 	SuiteKindFast                = g.Label(SuiteKindFastLabelName)
 	SuiteKindScyllaDBMonitoring  = g.Label(SuiteKindScyllaDBMonitoringLabelName)
+	SuiteOperatorUpgrade         = g.Label(SuiteOperatorUpgradeLabelName)
 
 	// SuiteSerial bundles the Ginkgo serial-execution decorator with the
 	// suite label, so a single value is enough to mark a spec as part of the

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -69,6 +69,10 @@ type TestContextType struct {
 	ScyllaDBManagerAgentVersion        string
 	ScyllaDBUpdateFrom                 string
 	ScyllaDBUpgradeFrom                string
+	OperatorUpgradeFrom                string
+	OperatorUpgradeTo                  string
+	OperatorUpgradeFromDeployDir       string
+	OperatorUpgradeToDeployDir         string
 	WorkerClusterObjectStorageSettings map[string]ClusterObjectStorageSettings
 	ClusterObjectStorageSettings       *ClusterObjectStorageSettings
 }

--- a/test/e2e/include.go
+++ b/test/e2e/include.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	_ "github.com/scylladb/scylla-operator/test/e2e/set/nodeconfig"
+	_ "github.com/scylladb/scylla-operator/test/e2e/set/operatorupgrade"
 	_ "github.com/scylladb/scylla-operator/test/e2e/set/remotekubernetescluster"
 	_ "github.com/scylladb/scylla-operator/test/e2e/set/scyllacluster"
 	_ "github.com/scylladb/scylla-operator/test/e2e/set/scyllacluster/multidatacenter"

--- a/test/e2e/set/operatorupgrade/config.go
+++ b/test/e2e/set/operatorupgrade/config.go
@@ -1,0 +1,9 @@
+// Copyright (C) 2026 ScyllaDB
+
+package operatorupgrade
+
+import "time"
+
+const (
+	testTimeout = 30 * time.Minute
+)

--- a/test/e2e/set/operatorupgrade/operator_upgrade.go
+++ b/test/e2e/set/operatorupgrade/operator_upgrade.go
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 ScyllaDB
+
+package operatorupgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/image/v5/docker/reference"
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	configassets "github.com/scylladb/scylla-operator/assets/config"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	operatorName = "scylla-operator"
+
+	// releaseDeployScript deploys the released manifests/CRDs; masterDeployScript deploys the current checkout's bundle.
+	releaseDeployScript = "hack/ci-deploy-release.sh"
+	masterDeployScript  = "hack/ci-deploy.sh"
+)
+
+var _ = g.Describe("Operator Upgrade", framework.SuiteOperatorUpgrade, func() {
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "operator-upgrade")
+	})
+
+	g.It("should upgrade the operator between the configured versions", g.SpecTimeout(testTimeout), func(ctx g.SpecContext) {
+		// The upgrade endpoints are independent: each is either a released version (resolved against the released
+		// operator repository) or a full image ref (e.g. a locally built image pushed to the kind registry), so the
+		// test covers released -> current checkout as well as released -> released upgrades.
+		upgradeFromImageRef := getOperatorImageRef(framework.TestContext.OperatorUpgradeFrom)
+		upgradeToImageRef := getOperatorImageRef(framework.TestContext.OperatorUpgradeTo)
+
+		// The deploy scripts write the rendered manifests under the given dir; use a per-phase sub-dir of the
+		// suite's artifacts dir (--artifacts-dir) so both the initial and upgraded manifests are preserved.
+		// Absolute, so the bundles land there regardless of the per-deploy working directory.
+		artifactsDir, err := filepath.Abs(framework.TestContext.ArtifactsDir)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Verifying the operator is not deployed yet")
+		_, err = f.KubeAdminClient().AppsV1().Deployments(operatorName).Get(ctx, operatorName, metav1.GetOptions{})
+		o.Expect(apierrors.IsNotFound(err)).To(o.BeTrue(), "expected no operator deployment before the test deploys it, got err=%v", err)
+
+		framework.By("Deploying the released operator stack (%s)", upgradeFromImageRef)
+		ciDeploy(ctx, upgradeFromImageRef, framework.TestContext.OperatorUpgradeFromDeployDir, filepath.Join(artifactsDir, "initial-manifest-bundle"))
+		o.Expect(getOperatorImage(ctx, f)).To(o.Equal(upgradeFromImageRef))
+
+		framework.By("Creating a ScyllaCluster")
+		sc := f.GetDefaultScyllaCluster()
+		sc, err = f.ScyllaAdminClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
+		initialRolloutCtx, initialRolloutCtxCancel := utils.ContextForRollout(ctx, sc)
+		defer initialRolloutCtxCancel()
+		sc, err = controllerhelpers.WaitForScyllaClusterState(initialRolloutCtx, f.ScyllaAdminClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Upgrading the operator stack to image %s", upgradeToImageRef)
+		ciDeploy(ctx, upgradeToImageRef, framework.TestContext.OperatorUpgradeToDeployDir, filepath.Join(artifactsDir, "upgraded-manifest-bundle"))
+		o.Expect(getOperatorImage(ctx, f)).To(o.Equal(upgradeToImageRef))
+
+		// Trigger a reconciliation by the upgraded operator and make sure it rolls the ScyllaCluster back to a stable state.
+		framework.By("Triggering reconciliation by the upgraded operator")
+		sc, err = utils.PatchScyllaClusterForceRedeploymentReason(ctx, f.ScyllaAdminClient().ScyllaV1().ScyllaClusters(f.Namespace()), sc.Name, "operator-upgrade")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		framework.By("Waiting for the ScyllaCluster to stabilize after the upgrade (RV=%s)", sc.ResourceVersion)
+		postUpgradeRolloutCtx, postUpgradeRolloutCtxCancel := utils.ContextForRollout(ctx, sc)
+		defer postUpgradeRolloutCtxCancel()
+		sc, err = controllerhelpers.WaitForScyllaClusterState(postUpgradeRolloutCtx, f.ScyllaAdminClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify CQL connectivity via `kubectl exec`-style access through the API server (cqlsh to localhost inside the
+		// pod), rather than dialing the node's broadcast (Pod IP) address, which is not routable from the host this test runs on.
+		framework.By("Verifying CQL connectivity")
+		pod, err := f.KubeAdminClient().CoreV1().Pods(f.Namespace()).Get(ctx, utils.GetNodeName(sc, 0), metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		stdout, stderr, err := utils.ExecuteInPod(ctx, f.AdminClientConfig(), f.KubeAdminClient().CoreV1(), pod, naming.ScyllaContainerName, "cqlsh", "localhost", "-e", "SELECT key, cluster_name, data_center FROM system.local")
+		o.Expect(err).NotTo(o.HaveOccurred(), "cqlsh failed: stdout=%q stderr=%q", stdout, stderr)
+	})
+})
+
+// ciDeploy deploys the operator stack with the given operator image via the deploy script matching the ref. The
+// script path is relative, so it resolves within deployDir — the repository tree whose scripts and manifests are
+// deployed (empty means the current directory, i.e. the repository root). The script sets the operator image from
+// the ref and blocks on `kubectl rollout status`, so on return the operator is running the target image and available.
+func ciDeploy(ctx context.Context, operatorImageRef, deployDir, artifactsDir string) {
+	deployScript := getDeployScriptForImageRef(operatorImageRef)
+
+	cmd := exec.CommandContext(ctx, deployScript, operatorImageRef)
+	cmd.Dir = deployDir
+	cmd.Env = append(os.Environ(), "REENTRANT=true", fmt.Sprintf("ARTIFACTS=%s", artifactsDir))
+	output, err := cmd.CombinedOutput()
+	o.Expect(err).NotTo(o.HaveOccurred(), "%s failed: %s", deployScript, string(output))
+}
+
+// getDeployScriptForImageRef picks the deploy script for the given operator image. A released image (explicit tag
+// other than "latest") deploys via releaseDeployScript, which resolves the manifests from the image's
+// org.opencontainers.image.{source,revision} labels, so the deployed manifests belong to that exact version.
+// Anything else — a "latest" tag or an untagged/digest-only ref, like a locally built image pushed to the kind
+// registry — deploys the current checkout's manifests via masterDeployScript.
+func getDeployScriptForImageRef(operatorImageRef string) string {
+	ref, err := reference.ParseAnyReference(operatorImageRef)
+	o.Expect(err).NotTo(o.HaveOccurred(), "invalid operator image reference %q", operatorImageRef)
+
+	if tagged, ok := ref.(reference.Tagged); ok && tagged.Tag() != "latest" {
+		return releaseDeployScript
+	}
+	return masterDeployScript
+}
+
+// getOperatorImageRef resolves an operator upgrade version flag value into a fully qualified image ref: a full image
+// ref (contains a repository path) is used verbatim; a bare version resolves against the released operator repository.
+func getOperatorImageRef(versionOrRef string) string {
+	if strings.Contains(versionOrRef, "/") {
+		return versionOrRef
+	}
+	return fmt.Sprintf("%s:%s", configassets.OperatorImageRepository, versionOrRef)
+}
+
+// getOperatorImage returns the image of the deployed operator container, failing the spec if the deployment or the
+// container is missing.
+func getOperatorImage(ctx context.Context, f *framework.Framework) string {
+	deployment, err := f.KubeAdminClient().AppsV1().Deployments(operatorName).Get(ctx, operatorName, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		if c.Name == operatorName {
+			return c.Image
+		}
+	}
+	g.Fail(fmt.Sprintf("container %q not found in deployment %q", operatorName, naming.ManualRef(deployment.Namespace, deployment.Name)))
+	return ""
+}

--- a/test/e2e/set/operatorupgrade/operator_upgrade_test.go
+++ b/test/e2e/set/operatorupgrade/operator_upgrade_test.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 ScyllaDB
+
+package operatorupgrade
+
+import (
+	"testing"
+
+	o "github.com/onsi/gomega"
+	configassets "github.com/scylladb/scylla-operator/assets/config"
+)
+
+func TestGetOperatorImageRef(t *testing.T) {
+	o.RegisterTestingT(t)
+
+	o.Expect(getOperatorImageRef("1.21.0")).To(o.Equal(configassets.OperatorImageRepository + ":1.21.0"))
+	o.Expect(getOperatorImageRef("latest")).To(o.Equal(configassets.OperatorImageRepository + ":latest"))
+	o.Expect(getOperatorImageRef("localhost:5001/scylladb/scylla-operator@sha256:1111111111111111111111111111111111111111111111111111111111111111")).To(o.Equal("localhost:5001/scylladb/scylla-operator@sha256:1111111111111111111111111111111111111111111111111111111111111111"))
+}
+
+func TestGetDeployScriptForImageRef(t *testing.T) {
+	tt := []struct {
+		name                 string
+		operatorImageRef     string
+		expectedDeployScript string
+	}{
+		{
+			name:                 "released version",
+			operatorImageRef:     configassets.OperatorImageRepository + ":1.21.0",
+			expectedDeployScript: releaseDeployScript,
+		},
+		{
+			name:                 "release candidate version",
+			operatorImageRef:     configassets.OperatorImageRepository + ":1.21.1-rc.0",
+			expectedDeployScript: releaseDeployScript,
+		},
+		{
+			name:                 "latest tag",
+			operatorImageRef:     configassets.OperatorImageRepository + ":latest",
+			expectedDeployScript: masterDeployScript,
+		},
+		{
+			name:                 "digest-only kind local registry ref",
+			operatorImageRef:     "localhost:5001/scylladb/scylla-operator@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+			expectedDeployScript: masterDeployScript,
+		},
+		{
+			name:                 "bare ref without a tag means implicit latest",
+			operatorImageRef:     configassets.OperatorImageRepository,
+			expectedDeployScript: masterDeployScript,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			// getDeployScriptForImageRef asserts internally via the global gomega, which requires a registered handler.
+			o.RegisterTestingT(t)
+
+			o.Expect(getDeployScriptForImageRef(tc.operatorImageRef)).To(o.Equal(tc.expectedDeployScript))
+		})
+	}
+}

--- a/test/e2e/set/scyllacluster/scyllacluster_auth.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_auth.go
@@ -108,13 +108,7 @@ var _ = g.Describe("ScyllaCluster authentication", framework.SuiteParallel, fram
 		// TODO: restart should be triggered by the Operator
 		framework.By("Initiating a rolling restart")
 
-		_, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-			ctx,
-			sc.Name,
-			types.MergePatchType,
-			[]byte(fmt.Sprintf(`{"spec": {"forceRedeploymentReason": "%s"}}`, "scyllaAgenConfig was updated to contain a token")),
-			metav1.PatchOptions{},
-		)
+		_, err = utils.PatchScyllaClusterForceRedeploymentReason(ctx, f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()), sc.Name, "scyllaAgenConfig was updated to contain a token")
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for the ScyllaCluster to pick up token change")
@@ -151,13 +145,7 @@ var _ = g.Describe("ScyllaCluster authentication", framework.SuiteParallel, fram
 
 		framework.By("Initiating a rolling restart")
 
-		_, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-			ctx,
-			sc.Name,
-			types.MergePatchType,
-			[]byte(fmt.Sprintf(`{"spec": {"forceRedeploymentReason": "%s"}}`, "scyllaAgenConfig token was changed")),
-			metav1.PatchOptions{},
-		)
+		_, err = utils.PatchScyllaClusterForceRedeploymentReason(ctx, f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()), sc.Name, "scyllaAgenConfig token was changed")
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for the ScyllaCluster to pick up token change")

--- a/test/e2e/set/scyllacluster/scyllacluster_updates.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_updates.go
@@ -66,13 +66,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		initialPodUID := pod.UID
 		framework.Infof("Initial pod %q UID is %q", pod.Name, initialPodUID)
 
-		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-			ctx,
-			sc.Name,
-			types.JSONPatchType,
-			[]byte(`[{"op": "replace", "path": "/spec/forceRedeploymentReason", "value": "foo"}]`),
-			metav1.PatchOptions{},
-		)
+		sc, err = utils.PatchScyllaClusterForceRedeploymentReason(ctx, f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()), sc.Name, "foo")
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for the ScyllaCluster to redeploy")

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	scyllav1client "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned/typed/scylla/v1"
 	scyllav1alpha1client "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned/typed/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	ocrypto "github.com/scylladb/scylla-operator/pkg/crypto"
@@ -96,6 +97,17 @@ func GetMemberCount(sc *scyllav1.ScyllaCluster) int32 {
 	}
 
 	return members
+}
+
+// PatchScyllaClusterForceRedeploymentReason sets spec.forceRedeploymentReason to trigger a rolling restart.
+func PatchScyllaClusterForceRedeploymentReason(ctx context.Context, client scyllav1client.ScyllaClusterInterface, name, reason string) (*scyllav1.ScyllaCluster, error) {
+	return client.Patch(
+		ctx,
+		name,
+		types.MergePatchType,
+		[]byte(fmt.Sprintf(`{"spec":{"forceRedeploymentReason":%q}}`, reason)),
+		metav1.PatchOptions{},
+	)
 }
 
 func ContextForRollout(parent context.Context, sc *scyllav1.ScyllaCluster) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
**Description of your changes:**
- introduces a kind of upgrade operator test, but in Ginkgo (compare: [GHA version](https://github.com/scylladb/scylla-operator/pull/3527) - note that the test, being run outside k8s, has to `kubectl exec` to connect to internal containers. I found no good way of routing traffic otherwise.
- introduce a separate suite and machinery to run the test
- introduce optional runner arguments, config values and wired machinery for `OPERATOR_UPGRADE_FROM_VERSION` (defaults to the latest minor.patch released version, renovate-managed) and `OPERATOR_UPGRADE_TO_VERSION` (defaults to latest unreleased version). Either can be unreleased versions (i.e. `1.20-latest`, `1.21-latest`), in which case relevant images will be built off tip of the branch and the branch's manifests will be used for deployment.
- small refactor (extract common helper)

NB: the -release action (using the machinery) follows in a [separate PR](https://github.com/scylladb/scylla-operator-release/pull/655). This PR is blocking the release PR and should be merged first.

**Which issue is resolved by this Pull Request:**
Part of https://scylladb.atlassian.net/browse/OPERATOR-274
