### PR TITLE
[v1.21] fix(sidecar): invalid operational mode check in decommission

### DIFF
--- a/pkg/scyllaclient/model.go
+++ b/pkg/scyllaclient/model.go
@@ -87,7 +87,7 @@ func (o OperationalMode) IsDecommissioned() bool {
 }
 
 func (o OperationalMode) IsDecommissioning() bool {
-	return o == OperationalModeDecommissioned
+	return o == OperationalModeDecommissioning
 }
 
 func (o OperationalMode) IsLeaving() bool {


### PR DESCRIPTION
Backport of #3538 to v1.21.

Cherry-picked commit: 5c48e83

Linked issue: OPERATOR-276