### PR TITLE
feat: modify seed selection algorithm to allow for parallel bootstrap

### DIFF
--- a/pkg/sidecar/config/config.go
+++ b/pkg/sidecar/config/config.go
@@ -193,7 +193,7 @@ func (s *ScyllaConfig) setupEntrypoint(ctx context.Context) (*exec.Cmd, error) {
 	if err != nil {
 		return nil, fmt.Errorf("can't get seeds: %w", err)
 	}
-
+	klog.InfoS("Setting up ScyllaDB entrypoint with resolved seeds", "Seeds", seeds)
 	overprovisioned := "0"
 	if m.Overprovisioned {
 		overprovisioned = "1"

--- a/pkg/sidecar/identity/member.go
+++ b/pkg/sidecar/identity/member.go
@@ -1,10 +1,13 @@
 package identity
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"maps"
 	"slices"
-	"strconv"
+	"strings"
+	"time"
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
@@ -12,8 +15,21 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
 )
+
+// seedResolutionPollInterval is how often an unready fallback seed candidate's broadcast address is
+// re-checked while waiting for it to be assigned. It's a fixed, short interval because resolving a
+// broadcast address is quick and there's no benefit in waiting longer between attempts.
+const seedResolutionPollInterval = 500 * time.Millisecond
+
+// seedResolutionPollTimeout bounds how long we wait for an unready fallback seed candidate's broadcast address
+// to become resolvable. In practice the container's startup and liveness probes should fail and restart the
+// process long before this fires, so the timeout is only a defensive backstop against waiting forever.
+const seedResolutionPollTimeout = 15 * time.Minute
 
 // Member encapsulates the identity for a single member
 // of a Scylla Cluster.
@@ -23,7 +39,6 @@ type Member struct {
 	// Namespace of the Pod
 	Namespace     string
 	Rack          string
-	RackOrdinal   int
 	Datacenter    string
 	Cluster       string
 	ServiceLabels map[string]string
@@ -39,20 +54,12 @@ type Member struct {
 }
 
 func NewMember(service *corev1.Service, pod *corev1.Pod, nodesAddressType, clientAddressType scyllav1alpha1.BroadcastAddressType, ipFamily corev1.IPFamily, additionalScyllaDBArguments []string) (*Member, error) {
-	rackOrdinalString, ok := pod.Labels[naming.RackOrdinalLabel]
-	if !ok {
-		return nil, fmt.Errorf("pod %q is missing %q label", naming.ObjRef(pod), naming.RackOrdinalLabel)
-	}
-	rackOrdinal, err := strconv.Atoi(rackOrdinalString)
-	if err != nil {
-		return nil, fmt.Errorf("can't get rack ordinal from label %q: %w", rackOrdinalString, err)
-	}
+	var err error
 
 	m := &Member{
 		Namespace:                   service.Namespace,
 		Name:                        service.Name,
 		Rack:                        pod.Labels[naming.RackNameLabel],
-		RackOrdinal:                 rackOrdinal,
 		Datacenter:                  pod.Labels[naming.DatacenterNameLabel],
 		Cluster:                     pod.Labels[naming.ClusterNameLabel],
 		ServiceLabels:               service.Labels,
@@ -76,78 +83,239 @@ func NewMember(service *corev1.Service, pod *corev1.Pod, nodesAddressType, clien
 	return m, nil
 }
 
-func (m *Member) GetSeeds(ctx context.Context, coreClient v1.CoreV1Interface, externalSeeds []string) ([]string, error) {
+// seedCandidate is a node in this member's DC, which may end up being selected as its seed.
+type seedCandidate struct {
+	pod *corev1.Pod
+	svc *corev1.Service
+}
+
+// GetSeeds returns the seeds for this member. External seeds, if provided, are always included.
+// If no ready seed candidate exists, it blocks polling until the selected fallback candidate's
+// broadcast address becomes resolvable or ctx is canceled.
+func (m *Member) GetSeeds(ctx context.Context, coreClient corev1client.CoreV1Interface, externalSeeds []string) ([]string, error) {
+	candidates, err := m.getDCSeedCandidates(ctx, coreClient)
+	if err != nil {
+		return nil, fmt.Errorf("can't get seed candidates: %w", err)
+	}
+	klog.V(4).InfoS("Found DC seed candidates", "Candidates", seedCandidateNames(candidates))
+
+	// Self takes part in selection like any other node.
+	selected, fallback := m.selectDCSeedCandidates(candidates)
+	klog.V(4).InfoS("Selected DC seed candidates", "Candidates", seedCandidateNames(selected), "Fallback", fallback)
+
+	if fallback {
+		// No ready Pods exist - fall back to distinguished unready candidate.
+		klog.V(2).InfoS("Falling back to distinguished DC seed candidate", "Candidate", selected[0].pod.Name, "ExternalSeeds", externalSeeds)
+		return m.fallBackWithDistinguishedCandidate(ctx, coreClient, selected[0], externalSeeds)
+	}
+
+	klog.V(2).InfoS("Seeding off the selected DC seed candidates", "Candidates", seedCandidateNames(selected), "ExternalSeeds", externalSeeds)
+	seeds := make([]string, 0, len(externalSeeds)+len(selected))
+	seeds = append(seeds, externalSeeds...)
+
+	var errs []error
+	for _, s := range selected {
+		resolved, err := m.resolveSeedBroadcastAddress(s)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't resolve seed broadcast address: %w", err))
+			continue
+		}
+		seeds = append(seeds, resolved)
+	}
+
+	// Selected seed candidates must be ready so we assume their broadcast addresses should be resolvable and error otherwise.
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("can't resolve seed broadcast addresses: %w", apimachineryutilerrors.NewAggregate(errs))
+	}
+
+	return seeds, nil
+}
+
+// fallBackWithDistinguishedCandidate returns the seeds for the case where no candidate was ready and a single, possibly not ready,
+// candidate was distinguished. It blocks polling until the candidate's broadcast address becomes resolvable or ctx is canceled.
+func (m *Member) fallBackWithDistinguishedCandidate(ctx context.Context, coreClient corev1client.CoreV1Interface, fallbackCandidate seedCandidate, externalSeeds []string) ([]string, error) {
+	if fallbackCandidate.pod.Name == m.Name {
+		// Avoid seeding of itself when external seeds are provided not to form a separate cluster.
+		if len(externalSeeds) > 0 {
+			klog.V(2).InfoS("Self is the fallback DC seed candidate, seeding off the external seeds only to avoid forming a separate cluster", "ExternalSeeds", externalSeeds)
+			return externalSeeds, nil
+		}
+
+		// Self is the fallback node, and it isn't joining an existing cluster - seed of itself.
+		klog.V(2).InfoS("Self is the fallback DC seed candidate and there are no external seeds, seeding off itself", "BroadcastAddress", m.BroadcastAddress)
+		return []string{m.BroadcastAddress}, nil
+	}
+
+	seeds := make([]string, 0, len(externalSeeds)+1)
+	seeds = append(seeds, externalSeeds...)
+
+	// The fallback candidate isn't self and isn't ready, so its broadcast address may be unresolvable.
+	// Wait for it rather than fail.
+	klog.V(2).InfoS("Waiting for the DC fallback seed candidate's broadcast address to become resolvable", "Candidate", fallbackCandidate.pod.Name)
+	var resolved string
+	err := apimachineryutilwait.PollUntilContextTimeout(ctx, seedResolutionPollInterval, seedResolutionPollTimeout, true, func(ctx context.Context) (bool, error) {
+		pod, err := coreClient.Pods(m.Namespace).Get(ctx, fallbackCandidate.pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("can't get pod %q: %w", fallbackCandidate.pod.Name, err)
+		}
+		svc, err := coreClient.Services(m.Namespace).Get(ctx, fallbackCandidate.svc.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("can't get service %q: %w", fallbackCandidate.svc.Name, err)
+		}
+
+		resolved, err = m.resolveSeedBroadcastAddress(seedCandidate{pod: pod, svc: svc})
+		if err != nil {
+			klog.V(4).InfoS("Fallback seed broadcast address not resolvable yet, retrying", "Candidate", fallbackCandidate.pod.Name, "Error", err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't resolve fallback seed broadcast address of %q: %w", fallbackCandidate.pod.Name, err)
+	}
+
+	seeds = append(seeds, resolved)
+	return seeds, nil
+}
+
+// getDCSeedCandidates returns all seed candidates, including itself, from this member's DC, in no particular order.
+func (m *Member) getDCSeedCandidates(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]seedCandidate, error) {
 	clusterLabels := naming.ScyllaLabels()
 	clusterLabels[naming.ClusterNameLabel] = m.Cluster
 
+	// The Pod type narrows the selector to ScyllaDB nodes, excluding other Pods that could otherwise match cluster labels.
+	nodePodLabels := maps.Clone(clusterLabels)
+	nodePodLabels[naming.PodTypeLabel] = string(naming.PodTypeScyllaDBNode)
+
 	podList, err := coreClient.Pods(m.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(clusterLabels).String(),
+		LabelSelector: labels.SelectorFromSet(nodePodLabels).String(),
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can't list pods: %w", err)
 	}
 
 	if len(podList.Items) == 0 {
 		return nil, fmt.Errorf("internal error: can't find any pod for this cluster, including itself")
 	}
 
-	var otherPods []*corev1.Pod
+	// The Service type narrows the selector to ScyllaDB nodes, excluding other Services that could otherwise match cluster labels.
+	memberServiceLabels := maps.Clone(clusterLabels)
+	memberServiceLabels[naming.ScyllaServiceTypeLabel] = string(naming.ScyllaServiceTypeMember)
+
+	svcList, err := coreClient.Services(m.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(memberServiceLabels).String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't list services: %w", err)
+	}
+
+	svcs := make(map[string]*corev1.Service, len(svcList.Items))
+	for i := range svcList.Items {
+		svc := &svcList.Items[i]
+		svcs[svc.Name] = svc
+	}
+
+	var errs []error
+	candidates := make([]seedCandidate, 0, len(podList.Items))
 	for i := range podList.Items {
 		pod := &podList.Items[i]
-		if pod.Name != m.Name {
-			otherPods = append(otherPods, pod)
+
+		if len(pod.Labels[naming.RackNameLabel]) == 0 {
+			errs = append(errs, fmt.Errorf("pod %q is missing %q label", naming.ObjRef(pod), naming.RackNameLabel))
+			continue
 		}
+
+		// Members share their name with their Service.
+		svc, ok := svcs[pod.Name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("can't find service for pod %q", naming.ObjRef(pod)))
+			continue
+		}
+
+		candidates = append(candidates, seedCandidate{pod: pod, svc: svc})
 	}
 
-	if len(otherPods) == 0 {
-		// We are the only one, assuming first bootstrap.
-
-		podOrdinal, err := naming.IndexFromName(m.Name)
-		if err != nil {
-			return nil, fmt.Errorf("can't get pod index from name: %w", err)
-		}
-
-		if m.RackOrdinal != 0 || podOrdinal != 0 {
-			return nil, fmt.Errorf("pod is not first in the cluster, but there are no other pods")
-		}
-
-		if len(externalSeeds) > 0 {
-			return externalSeeds, nil
-		}
-
-		return []string{m.BroadcastAddress}, nil
-	}
-
-	slices.SortFunc(otherPods, func(a, b *corev1.Pod) int {
-		aReady := controllerhelpers.IsPodReady(a)
-		bReady := controllerhelpers.IsPodReady(b)
-		if aReady && !bReady {
-			return -1
-		}
-		if !aReady && bReady {
-			return 1
-		}
-
-		return a.ObjectMeta.CreationTimestamp.Time.Compare(b.ObjectMeta.CreationTimestamp.Time)
-	})
-
-	pod := otherPods[0]
-
-	svc, err := coreClient.Services(m.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
-	if err != nil {
+	if err := apimachineryutilerrors.NewAggregate(errs); err != nil {
 		return nil, err
 	}
 
-	res := make([]string, 0, len(externalSeeds)+1)
-	res = append(res, externalSeeds...)
+	return candidates, nil
+}
 
-	// Assume nodes share broadcast address type and IP family and they are immutable.
-	localSeed, err := controllerhelpers.GetScyllaBroadcastAddress(m.NodesBroadcastAddressType, svc, pod, &m.IPFamily)
-	if err != nil {
-		return nil, fmt.Errorf("can't get node broadcast address for service %q: %w", naming.ObjRef(svc), err)
+// seedCandidateNames returns the Pod/Service names of the given candidates.
+func seedCandidateNames(candidates []seedCandidate) []string {
+	return slices.Collect(func(yield func(string) bool) {
+		for _, c := range candidates {
+			if !yield(c.pod.Name) {
+				return
+			}
+		}
+	})
+}
+
+// selectDCSeedCandidates returns the candidates to seed off, given all candidates from a DC in no particular order,
+// and whether it had to fall back to a single, possibly not ready, candidate because none was ready.
+func (m *Member) selectDCSeedCandidates(candidates []seedCandidate) ([]seedCandidate, bool) {
+	// Rank the candidates by the creation timestamp of their Service, with the name as a tiebreak.
+	// Ranking deliberately depends on nothing but those two, because every node selects its own seeds
+	// independently, and they have to agree: two nodes each picking the other as its seed would never form a
+	// cluster. Service creation time serves as the ordering input that outlives the Pods.
+	rankedCandidates := slices.Clone(candidates)
+	slices.SortFunc(rankedCandidates, func(a, b seedCandidate) int {
+		return cmp.Or(
+			a.svc.CreationTimestamp.Time.Compare(b.svc.CreationTimestamp.Time),
+			// Members created within the same second tie. Fall back to the name to keep the order total.
+			strings.Compare(a.pod.Name, b.pod.Name),
+		)
+	})
+
+	// If any candidate is ready, the first ready one of each rack is selected, since a seed which is already
+	// serving lets the node join without waiting. The readiness probe only passes once ScyllaDB reports the
+	// node as UN with the native transport enabled, so it's a liveness signal, not just a Kubernetes one.
+	var selected []seedCandidate
+	seenRacks := map[string]bool{}
+	for _, c := range rankedCandidates {
+		// Self can't be ready as seed selection runs before ScyllaDB starts,
+		// but it can appear so after a restart before the condition is flipped.
+		// Self is still considered in a fallback path.
+		if c.pod.Name == m.Name {
+			continue
+		}
+
+		rack := c.pod.Labels[naming.RackNameLabel]
+		if !controllerhelpers.IsPodReady(c.pod) || seenRacks[rack] {
+			continue
+		}
+		seenRacks[rack] = true
+
+		selected = append(selected, c)
 	}
 
-	res = append(res, localSeed)
+	// Otherwise, the first-ranked candidate is selected on its own - it's the one all nodes agree on.
+	// Selecting a seed which isn't serving yet is safe: a restarting node ignores the seeds, contacting the
+	// peers persisted in system.peers instead, and a bootstrapping node keeps retrying group 0 discovery until a seed responds.
+	// Node replacement requires a live seed, but it replaces a node of an otherwise running cluster,
+	// so a ready candidate is expected to exist.
+	if len(selected) == 0 {
+		return rankedCandidates[:1], true
+	}
 
-	return res, nil
+	return selected, false
+}
+
+// resolveSeedBroadcastAddress returns the broadcast address of the given candidate.
+func (m *Member) resolveSeedBroadcastAddress(candidate seedCandidate) (string, error) {
+	if candidate.pod.Name == m.Name {
+		// This node's own address has already been resolved when the member was built.
+		return m.BroadcastAddress, nil
+	}
+
+	// Assume nodes share broadcast address type and IP family and they are immutable.
+	broadcastAddress, err := controllerhelpers.GetScyllaBroadcastAddress(m.NodesBroadcastAddressType, candidate.svc, candidate.pod, &m.IPFamily)
+	if err != nil {
+		return "", fmt.Errorf("can't get broadcast address of %q: %w", candidate.pod.Name, err)
+	}
+
+	return broadcastAddress, nil
 }

--- a/pkg/sidecar/identity/member_test.go
+++ b/pkg/sidecar/identity/member_test.go
@@ -4,8 +4,12 @@ package identity
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,43 +19,43 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	kubetesting "k8s.io/client-go/testing"
 )
 
 func TestMember_GetSeeds(t *testing.T) {
 	t.Parallel()
 
 	createPodAndSvc := func(name, ip string, creationTimestamp time.Time) (*corev1.Pod, *corev1.Service) {
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: "namespace",
-				Labels: map[string]string{
-					"scylla/cluster":               "my-cluster",
-					"app":                          "scylla",
-					"app.kubernetes.io/name":       "scylla",
-					"app.kubernetes.io/managed-by": "scylla-operator",
-					"scylla/rack-ordinal":          "0",
-				},
-				CreationTimestamp: metav1.NewTime(creationTimestamp),
-			},
-		}
-		svc := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: "namespace",
-			},
-			Spec: corev1.ServiceSpec{
-				ClusterIP:  ip,
-				ClusterIPs: []string{ip},
-			},
-		}
-		return pod, svc
+		return createPodAndSvcInRack(name, "rack", ip, creationTimestamp)
 	}
 
-	now := time.Now()
+	// unresolvableSvc makes a Service whose broadcast address of ClusterIP type can't be resolved.
+	// A headless Service is what a member looks like before an address is assigned to it.
+	unresolvableSvc := func(svc *corev1.Service) *corev1.Service {
+		svc = svc.DeepCopy()
+		svc.Spec.ClusterIP = corev1.ClusterIPNone
+		svc.Spec.ClusterIPs = []string{corev1.ClusterIPNone}
+		return svc
+	}
+
+	// Truncated to whole seconds because metav1.Time serializes as RFC3339 with second granularity, so a
+	// real API server never returns sub-second creation timestamps. The fake client skips serialization
+	// and would otherwise let fixtures rank on a precision production doesn't have.
+	now := time.Now().Truncate(time.Second)
 	firstPod, firstService := createPodAndSvc("pod-0", "1.1.1.1", now)
 	secondPod, secondService := createPodAndSvc("pod-1", "2.2.2.2", now.Add(time.Second))
 	thirdPod, thirdService := createPodAndSvc("pod-2", "3.3.3.3", now.Add(2*time.Second))
+
+	// Members spread across distinct racks, to exercise the per-rack seed selection. Ranked by the
+	// creation timestamp of their Service: rackAPod, then rackBPod, then rackCPod.
+	rackAPod, rackAService := createPodAndSvcInRack("rack-a-0", "rack-a", "10.1.0.1", now)
+	rackBPod, rackBService := createPodAndSvcInRack("rack-b-0", "rack-b", "10.2.0.1", now.Add(time.Second))
+	rackCPod, rackCService := createPodAndSvcInRack("rack-c-0", "rack-c", "10.3.0.1", now.Add(2*time.Second))
+
+	// Two members of the same rack whose Services were created within the same second, so only their
+	// names can break the tie.
+	sameSecondFirstPod, sameSecondFirstService := createPodAndSvcInRack("rack-d-0", "rack-d", "10.4.0.1", now)
+	sameSecondSecondPod, sameSecondSecondService := createPodAndSvcInRack("rack-d-1", "rack-d", "10.4.0.2", now)
 
 	ts := []struct {
 		name                       string
@@ -63,7 +67,7 @@ func TestMember_GetSeeds(t *testing.T) {
 		externalSeeds              []string
 		objects                    []runtime.Object
 		expectSeeds                []string
-		expectError                error
+		expectErrorString          string
 	}{
 		{
 			name:                       "error when no pods are found",
@@ -73,7 +77,7 @@ func TestMember_GetSeeds(t *testing.T) {
 			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
 			ipFamily:                   corev1.IPv4Protocol,
 			objects:                    []runtime.Object{},
-			expectError:                fmt.Errorf("internal error: can't find any pod for this cluster, including itself"),
+			expectErrorString:          `can't get seed candidates: internal error: can't find any pod for this cluster, including itself`,
 		},
 		{
 			name:                       "bootstrap with external seeds only when cluster is empty and external seeds are provided",
@@ -98,7 +102,7 @@ func TestMember_GetSeeds(t *testing.T) {
 			expectSeeds:                []string{"10.0.1.1", "10.0.1.2", secondService.Spec.ClusterIP},
 		},
 		{
-			name:                       "bootstrap with external seeds and first created Pod when all Pods from DC are down and external seeds are provided",
+			name:                       "bootstrap with external seeds only when all Pods from DC are down and the first created Pod is itself",
 			memberPod:                  firstPod,
 			memberService:              firstService,
 			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
@@ -106,17 +110,18 @@ func TestMember_GetSeeds(t *testing.T) {
 			ipFamily:                   corev1.IPv4Protocol,
 			objects:                    []runtime.Object{firstPod, firstService, secondPod, secondService, thirdPod, thirdService},
 			externalSeeds:              []string{"10.0.1.1", "10.0.1.2"},
-			expectSeeds:                []string{"10.0.1.1", "10.0.1.2", secondService.Spec.ClusterIP},
+			expectSeeds:                []string{"10.0.1.1", "10.0.1.2"},
 		},
 		{
-			name:                       "bootstraps with itself using node-to-node identifier of ClusterIP type when cluster is empty",
-			memberPod:                  firstPod,
-			memberService:              firstService,
+			name:                       "bootstrap with external seeds and first created Pod when all Pods from DC are down and external seeds are provided",
+			memberPod:                  thirdPod,
+			memberService:              thirdService,
 			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
 			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
 			ipFamily:                   corev1.IPv4Protocol,
-			objects:                    []runtime.Object{firstPod, firstService},
-			expectSeeds:                []string{firstService.Spec.ClusterIP},
+			objects:                    []runtime.Object{firstPod, firstService, secondPod, secondService, thirdPod, thirdService},
+			externalSeeds:              []string{"10.0.1.1", "10.0.1.2"},
+			expectSeeds:                []string{"10.0.1.1", "10.0.1.2", firstService.Spec.ClusterIP},
 		},
 		{
 			name:                       "bootstraps with itself using node-to-node identifier of ClusterIP type when cluster is empty",
@@ -205,14 +210,24 @@ func TestMember_GetSeeds(t *testing.T) {
 			expectSeeds:                []string{thirdService.Spec.ClusterIP},
 		},
 		{
-			name:                       "bootstrap with first created Pod when all are down",
+			name:                       "bootstrap with first created Pod when all are down, which is itself",
 			memberPod:                  firstPod,
 			memberService:              firstService,
 			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
 			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
 			ipFamily:                   corev1.IPv4Protocol,
 			objects:                    []runtime.Object{firstPod, firstService, secondPod, secondService, thirdPod, thirdService},
-			expectSeeds:                []string{secondService.Spec.ClusterIP},
+			expectSeeds:                []string{firstService.Spec.ClusterIP},
+		},
+		{
+			name:                       "bootstrap with first created Pod when all are down, which is another node",
+			memberPod:                  thirdPod,
+			memberService:              thirdService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects:                    []runtime.Object{firstPod, firstService, secondPod, secondService, thirdPod, thirdService},
+			expectSeeds:                []string{firstService.Spec.ClusterIP},
 		},
 		{
 			name: "use PodIP from status when node broadcast address type is PodIP",
@@ -251,6 +266,150 @@ func TestMember_GetSeeds(t *testing.T) {
 		},
 		{
 			name:                       "use ClusterIP from Service when node broadcast address type is ClusterIP",
+			memberPod:                  thirdPod,
+			memberService:              thirdService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				func() runtime.Object {
+					svc := firstService.DeepCopy()
+					svc.Spec.ClusterIP = "1.2.3.4"
+					svc.Spec.ClusterIPs = []string{"1.2.3.4"}
+					return svc
+				}(),
+				firstPod,
+				secondPod,
+				secondService,
+				thirdPod,
+				thirdService,
+			},
+			expectSeeds: []string{"1.2.3.4"},
+		},
+		{
+			name:      "use preferred IP address from first Service ingress status when node broadcast address type is LoadBalancer Ingress",
+			memberPod: thirdPod,
+			memberService: func() *corev1.Service {
+				svc := thirdService.DeepCopy()
+				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+				svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{
+							Hostname: "third.service.scylladb.com",
+						},
+					},
+				}
+				return svc
+			}(),
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceLoadBalancerIngress,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				firstPod,
+				func() runtime.Object {
+					svc := firstService.DeepCopy()
+					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP:       "1.2.3.4",
+								Hostname: "first.service.scylladb.com",
+							},
+						},
+					}
+					return svc
+				}(),
+				secondPod,
+				secondService,
+				thirdPod,
+				func() runtime.Object {
+					svc := thirdService.DeepCopy()
+					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								Hostname: "third.service.scylladb.com",
+							},
+						},
+					}
+					return svc
+				}(),
+			},
+			expectSeeds: []string{"1.2.3.4"},
+		},
+		{
+			name:      "use hostname from first Service ingress status when node broadcast address type is LoadBalancer Ingress and IP is not available",
+			memberPod: thirdPod,
+			memberService: func() *corev1.Service {
+				svc := thirdService.DeepCopy()
+				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+				svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{
+							Hostname: "third.service.scylladb.com",
+						},
+					},
+				}
+				return svc
+			}(),
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceLoadBalancerIngress,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				firstPod,
+				func() runtime.Object {
+					svc := firstService.DeepCopy()
+					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								Hostname: "first.service.scylladb.com",
+							},
+						},
+					}
+					return svc
+				}(),
+				secondPod,
+				secondService,
+				thirdPod,
+				func() runtime.Object {
+					svc := thirdService.DeepCopy()
+					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								Hostname: "third.service.scylladb.com",
+							},
+						},
+					}
+					return svc
+				}(),
+			},
+			expectSeeds: []string{"first.service.scylladb.com"},
+		},
+		{
+			name:                       "bootstraps with itself when it's the only node, regardless of its ordinal within the rack",
+			memberPod:                  secondPod,
+			memberService:              secondService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects:                    []runtime.Object{secondPod, secondService},
+			expectSeeds:                []string{secondService.Spec.ClusterIP},
+		},
+		{
+			name:                       "bootstrap with the first-ranked pod when it isn't self and there are other pods",
+			memberPod:                  secondPod,
+			memberService:              secondService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects:                    []runtime.Object{firstPod, firstService, secondPod, secondService},
+			expectSeeds:                []string{firstService.Spec.ClusterIP},
+		},
+		{
+			// Cleanup Job pods inherit the cluster's labels, but they have neither a rack nor a member Service.
+			name:                       "ignores pods of the cluster which aren't ScyllaDB nodes",
 			memberPod:                  firstPod,
 			memberService:              firstService,
 			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
@@ -259,158 +418,21 @@ func TestMember_GetSeeds(t *testing.T) {
 			objects: []runtime.Object{
 				firstPod,
 				firstService,
-				secondPod,
-				func() runtime.Object {
-					svc := secondService.DeepCopy()
-					svc.Spec.ClusterIP = "1.2.3.4"
-					svc.Spec.ClusterIPs = []string{"1.2.3.4"}
-					return svc
-				}(),
-				thirdPod,
-				thirdService,
-			},
-			expectSeeds: []string{"1.2.3.4"},
-		},
-		{
-			name:      "use preferred IP address from first Service ingress status when node broadcast address type is LoadBalancer Ingress",
-			memberPod: firstPod,
-			memberService: func() *corev1.Service {
-				svc := firstService.DeepCopy()
-				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-				svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-					Ingress: []corev1.LoadBalancerIngress{
-						{
-							Hostname: "first.service.scylladb.com",
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cleanup-first-pod-abcde",
+						Namespace: "namespace",
+						Labels: map[string]string{
+							"scylla/cluster":                        "my-cluster",
+							"app":                                   "scylla",
+							"app.kubernetes.io/name":                "scylla",
+							"app.kubernetes.io/managed-by":          "scylla-operator",
+							"scylla-operator.scylladb.com/pod-type": "cleanup-job",
 						},
 					},
-				}
-				return svc
-			}(),
-			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
-			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceLoadBalancerIngress,
-			ipFamily:                   corev1.IPv4Protocol,
-			objects: []runtime.Object{
-				firstPod,
-				func() runtime.Object {
-					svc := firstService.DeepCopy()
-					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-						Ingress: []corev1.LoadBalancerIngress{
-							{
-								Hostname: "first.service.scylladb.com",
-							},
-						},
-					}
-					return svc
-				}(),
-				secondPod,
-				func() runtime.Object {
-					svc := secondService.DeepCopy()
-					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-						Ingress: []corev1.LoadBalancerIngress{
-							{
-								IP:       "1.2.3.4",
-								Hostname: "second.service.scylladb.com",
-							},
-						},
-					}
-					return svc
-				}(),
-				thirdPod,
-				thirdService,
+				},
 			},
-			expectSeeds: []string{"1.2.3.4"},
-		},
-		{
-			name:      "use hostname from first Service ingress status when node broadcast address type is LoadBalancer Ingress and IP is not available",
-			memberPod: firstPod,
-			memberService: func() *corev1.Service {
-				svc := firstService.DeepCopy()
-				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-				svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-					Ingress: []corev1.LoadBalancerIngress{
-						{
-							Hostname: "first.service.scylladb.com",
-						},
-					},
-				}
-				return svc
-			}(),
-			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
-			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceLoadBalancerIngress,
-			ipFamily:                   corev1.IPv4Protocol,
-			objects: []runtime.Object{
-				firstPod,
-				func() runtime.Object {
-					svc := firstService.DeepCopy()
-					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-						Ingress: []corev1.LoadBalancerIngress{
-							{
-								Hostname: "first.service.scylladb.com",
-							},
-						},
-					}
-					return svc
-				}(),
-				secondPod,
-				func() runtime.Object {
-					svc := secondService.DeepCopy()
-					svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-					svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-						Ingress: []corev1.LoadBalancerIngress{
-							{
-								Hostname: "second.service.scylladb.com",
-							},
-						},
-					}
-					return svc
-				}(),
-				thirdPod,
-				thirdService,
-			},
-			expectSeeds: []string{"second.service.scylladb.com"},
-		},
-		{
-			name:                       "error when node is not first in rack, but there are no other pods",
-			memberPod:                  secondPod,
-			memberService:              secondService,
-			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
-			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
-			ipFamily:                   corev1.IPv4Protocol,
-			objects:                    []runtime.Object{secondPod, secondService},
-			expectSeeds:                nil,
-			expectError:                fmt.Errorf("pod is not first in the cluster, but there are no other pods"),
-		},
-		{
-			name: "error when node is first in rack of ordinal > 0, but there are no other pods",
-			memberPod: func() *corev1.Pod {
-				pod := firstPod.DeepCopy()
-				pod.Labels["scylla/rack-ordinal"] = "1"
-				return pod
-			}(),
-			memberService:              firstService,
-			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
-			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
-			ipFamily:                   corev1.IPv4Protocol,
-			objects:                    []runtime.Object{firstPod, firstService},
-			expectSeeds:                nil,
-			expectError:                fmt.Errorf("pod is not first in the cluster, but there are no other pods"),
-		},
-		{
-			name: "bootstrap with other pod when node is first in rack of ordinal > 0 and there are other pods",
-			memberPod: func() *corev1.Pod {
-				pod := secondPod.DeepCopy()
-				pod.Labels["scylla/rack-ordinal"] = "1"
-				return pod
-			}(),
-			memberService:              secondService,
-			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
-			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
-			ipFamily:                   corev1.IPv4Protocol,
-			objects:                    []runtime.Object{firstPod, firstService, secondPod, secondService},
-			expectSeeds:                []string{firstService.Spec.ClusterIP},
+			expectSeeds: []string{firstService.Spec.ClusterIP},
 		},
 		{
 			name: "IPv6-only service uses IPv6 broadcast addresses",
@@ -533,30 +555,479 @@ func TestMember_GetSeeds(t *testing.T) {
 			},
 			expectSeeds: []string{"2001:db8::1"}, // Should use IPv6 from PodIPs[0]
 		},
+		{
+			// Ready path. Self reads ready and ranks first, but is skipped, so rack-a contributes no seed.
+			name:                       "selects the first ready member of each rack, excluding itself",
+			memberPod:                  rackAPod,
+			memberService:              rackAService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				markPodReady(rackAPod), rackAService,
+				markPodReady(rackBPod), rackBService,
+				markPodReady(rackCPod), rackCService,
+			},
+			expectSeeds: []string{rackBService.Spec.ClusterIP, rackCService.Spec.ClusterIP},
+		},
+		{
+			name:                       "selects a non-self ready member of its own rack",
+			memberPod:                  sameSecondFirstPod,
+			memberService:              sameSecondFirstService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				markPodReady(sameSecondFirstPod), sameSecondFirstService,
+				markPodReady(sameSecondSecondPod), sameSecondSecondService,
+			},
+			expectSeeds: []string{sameSecondSecondService.Spec.ClusterIP},
+		},
+		{
+			// Fallback path. Self reads ready, which can only mean its Pod condition hasn't flipped to
+			// False yet after a scylla container restart - seed selection runs before ScyllaDB starts, so
+			// self can't truly be ready. Self is skipped regardless, leaving nothing ready, so all members
+			// fall back to the candidate they agree on: the first-ranked one, which here is self.
+			name:                       "falls back to external seeds when the first-ranked member is itself",
+			memberPod:                  rackAPod,
+			memberService:              rackAService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				markPodReady(rackAPod), rackAService,
+				rackBPod, rackBService,
+			},
+			externalSeeds: []string{"10.0.1.1"},
+			expectSeeds:   []string{"10.0.1.1"},
+		},
+		{
+			// Fallback path. The agreed candidate is self, and with no external seeds there are
+			// no other addresses to name, so self is the only seed.
+			name:                       "falls back to the first-ranked member, which is itself",
+			memberPod:                  rackAPod,
+			memberService:              rackAService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				markPodReady(rackAPod), rackAService,
+				rackBPod, rackBService,
+			},
+			expectSeeds: []string{rackAService.Spec.ClusterIP},
+		},
+		{
+			name:                       "skips racks whose members are all unready",
+			memberPod:                  rackAPod,
+			memberService:              rackAService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				markPodReady(rackAPod), rackAService,
+				rackBPod, rackBService,
+				markPodReady(rackCPod), rackCService,
+			},
+			expectSeeds: []string{rackCService.Spec.ClusterIP},
+		},
+		{
+			name:                       "selects only the first-ranked member when none is ready, across racks",
+			memberPod:                  rackCPod,
+			memberService:              rackCService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				rackAPod, rackAService,
+				rackBPod, rackBService,
+				rackCPod, rackCService,
+			},
+			expectSeeds: []string{rackAService.Spec.ClusterIP},
+		},
+		{
+			name:                       "seeds with itself when none is ready and it's the first-ranked member, across racks",
+			memberPod:                  rackAPod,
+			memberService:              rackAService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				rackAPod, rackAService,
+				rackBPod, rackBService,
+				rackCPod, rackCService,
+			},
+			expectSeeds: []string{rackAService.Spec.ClusterIP},
+		},
+		{
+			name:                       "seeds with external seeds only, and never itself, when none is ready and it's the first-ranked member",
+			memberPod:                  rackAPod,
+			memberService:              rackAService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				rackAPod, rackAService,
+				rackBPod, rackBService,
+			},
+			externalSeeds: []string{"10.0.1.1"},
+			expectSeeds:   []string{"10.0.1.1"},
+		},
+		{
+			name:                       "ranks members whose Services were created within the same second by name",
+			memberPod:                  sameSecondSecondPod,
+			memberService:              sameSecondSecondService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				sameSecondFirstPod, sameSecondFirstService,
+				sameSecondSecondPod, sameSecondSecondService,
+			},
+			expectSeeds: []string{sameSecondFirstService.Spec.ClusterIP},
+		},
+		{
+			// This shouldn't happen in practice: a ready member's own sidecar must already have resolved
+			// its own address before it could become ready. Kept as defense-in-depth in case that
+			// invariant is ever violated.
+			name:                       "errors when a selected ready member's broadcast address can't be resolved",
+			memberPod:                  rackAPod,
+			memberService:              rackAService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				markPodReady(rackAPod), rackAService,
+				markPodReady(rackBPod), unresolvableSvc(rackBService),
+				markPodReady(rackCPod), rackCService,
+			},
+			expectErrorString: `can't resolve seed broadcast addresses: can't resolve seed broadcast address: can't get broadcast address of "rack-b-0": service "namespace/rack-b-0" does not have a ClusterIP address`,
+		},
+		{
+			name:                       "returns an error when no selected member's broadcast address can be resolved",
+			memberPod:                  rackBPod,
+			memberService:              rackBService,
+			memberClientsBroadcastType: scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			memberNodesBroadcastType:   scyllav1alpha1.BroadcastAddressTypeServiceClusterIP,
+			ipFamily:                   corev1.IPv4Protocol,
+			objects: []runtime.Object{
+				markPodReady(rackAPod), unresolvableSvc(rackAService),
+			},
+			expectErrorString: `can't resolve seed broadcast addresses: can't resolve seed broadcast address: can't get broadcast address of "rack-a-0": service "namespace/rack-a-0" does not have a ClusterIP address`,
+		},
 	}
 
 	for _, test := range ts {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			member, err := NewMember(test.memberService, test.memberPod, test.memberNodesBroadcastType, test.memberClientsBroadcastType, test.ipFamily, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			fakeClient := fake.NewSimpleClientset(test.objects...)
-			seeds, err := member.GetSeeds(ctx, fakeClient.CoreV1(), test.externalSeeds)
-			if !reflect.DeepEqual(err, test.expectError) {
-				t.Errorf("expected error %v, got %v", test.expectError, err)
+			verifyErrorString := func(t *testing.T, err error) {
+				var gotErrorString string
+				if err != nil {
+					gotErrorString = err.Error()
+				}
+				if gotErrorString != test.expectErrorString {
+					t.Errorf("expected error %q, got %q", test.expectErrorString, gotErrorString)
+				}
 			}
+
+			fakeClient := fake.NewSimpleClientset(test.objects...)
+			seeds, err := member.GetSeeds(t.Context(), fakeClient.CoreV1(), test.externalSeeds)
+			verifyErrorString(t, err)
 			if !reflect.DeepEqual(seeds, test.expectSeeds) {
 				t.Errorf("expected seeds %v, got %v", test.expectSeeds, seeds)
 			}
+
+			// Every node selects seeds from its own view of the cluster, and the order the API server
+			// happens to return the members in is not guaranteed, so the result must not depend on it.
+			reversedObjects := slices.Clone(test.objects)
+			slices.Reverse(reversedObjects)
+			reversedFakeClient := fake.NewSimpleClientset(reversedObjects...)
+
+			reversedSeeds, err := member.GetSeeds(t.Context(), reversedFakeClient.CoreV1(), test.externalSeeds)
+			verifyErrorString(t, err)
+
+			if !reflect.DeepEqual(reversedSeeds, test.expectSeeds) {
+				t.Errorf("expected seeds %v, got %v", test.expectSeeds, reversedSeeds)
+			}
 		})
 	}
+}
+
+// TestMember_GetSeeds_converges verifies that nodes selecting seeds independently agree on one of them.
+// Two nodes each picking the other would leave them in separate clusters, and asserting the selection
+// from a single node's perspective can't catch that.
+// Agreement only matters when the cluster hasn't formed yet, which is the case covered here.
+func TestMember_GetSeeds_converges(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Second)
+
+	type testMember struct {
+		name      string
+		rack      string
+		ip        string
+		createdAt time.Time
+	}
+
+	ts := []struct {
+		name        string
+		members     []testMember
+		expectSeeds []string
+	}{
+		{
+			name: "ranked by the creation timestamp of their Service, across racks",
+			members: []testMember{
+				{name: "rack-c-0", rack: "rack-c", ip: "10.3.0.1", createdAt: now.Add(2 * time.Second)},
+				{name: "rack-a-0", rack: "rack-a", ip: "10.1.0.1", createdAt: now},
+				{name: "rack-b-0", rack: "rack-b", ip: "10.2.0.1", createdAt: now.Add(time.Second)},
+			},
+			expectSeeds: []string{"10.1.0.1"},
+		},
+		{
+			// A real API server stores creation timestamps at second granularity, so members created
+			// moments apart tie and only the name orders them. That makes the tiebreak, not the timestamp,
+			// what every node agrees on here.
+			name: "ranked by name when the creation timestamps of their Services tie",
+			members: []testMember{
+				{name: "rack-a-2", rack: "rack-a", ip: "10.1.0.3", createdAt: now},
+				{name: "rack-a-0", rack: "rack-a", ip: "10.1.0.1", createdAt: now},
+				{name: "rack-a-1", rack: "rack-a", ip: "10.1.0.2", createdAt: now},
+			},
+			expectSeeds: []string{"10.1.0.1"},
+		},
+	}
+
+	for _, test := range ts {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			type member struct {
+				pod *corev1.Pod
+				svc *corev1.Service
+			}
+			var members []member
+			for _, m := range test.members {
+				pod, svc := createPodAndSvcInRack(m.name, m.rack, m.ip, m.createdAt)
+				members = append(members, member{pod: pod, svc: svc})
+			}
+
+			var objects []runtime.Object
+			for _, m := range members {
+				objects = append(objects, m.pod, m.svc)
+			}
+			fakeClient := fake.NewSimpleClientset(objects...)
+
+			seedsBySelf := map[string][]string{}
+			for _, self := range members {
+				m, err := NewMember(self.svc, self.pod, scyllav1alpha1.BroadcastAddressTypeServiceClusterIP, scyllav1alpha1.BroadcastAddressTypeServiceClusterIP, corev1.IPv4Protocol, nil)
+				if err != nil {
+					t.Fatal(fmt.Errorf("error creating member: %w", err))
+				}
+
+				seeds, err := m.GetSeeds(t.Context(), fakeClient.CoreV1(), nil)
+				if err != nil {
+					t.Fatal(fmt.Errorf("error getting seeds: %w", err))
+				}
+
+				seedsBySelf[self.pod.Name] = seeds
+			}
+
+			// Nothing is ready, so every node has to name the same single member: the first-ranked one.
+			for name, seeds := range seedsBySelf {
+				if !reflect.DeepEqual(seeds, test.expectSeeds) {
+					t.Errorf("expected node %q to select %v, got %v", name, test.expectSeeds, seeds)
+				}
+			}
+		})
+	}
+}
+
+// TestMember_GetSeeds_fallbackWaitsForResolution verifies that when no candidate is ready and the
+// resulting fallback candidate isn't self, GetSeeds waits for its broadcast address to become
+// resolvable instead of failing immediately.
+func TestMember_GetSeeds_fallbackWaitsForResolution(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Second)
+	rackAPod, rackAService := createPodAndSvcInRack("rack-a-0", "rack-a", "10.1.0.1", now)
+	rackBPod, rackBService := createPodAndSvcInRack("rack-b-0", "rack-b", "10.2.0.1", now.Add(time.Second))
+
+	unresolvableSvc := func(svc *corev1.Service) *corev1.Service {
+		svc = svc.DeepCopy()
+		svc.Spec.ClusterIP = corev1.ClusterIPNone
+		svc.Spec.ClusterIPs = []string{corev1.ClusterIPNone}
+		return svc
+	}
+
+	t.Run("gives up once the context is done", func(t *testing.T) {
+		t.Parallel()
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+
+		ctx, ctxCancel := context.WithCancel(t.Context())
+		defer ctxCancel()
+
+		member, err := NewMember(rackBService, rackBPod, scyllav1alpha1.BroadcastAddressTypeServiceClusterIP, scyllav1alpha1.BroadcastAddressTypeServiceClusterIP, corev1.IPv4Protocol, nil)
+		if err != nil {
+			t.Fatal(fmt.Errorf("error creating member: %w", err))
+		}
+
+		fakeClient := fake.NewSimpleClientset(rackAPod, unresolvableSvc(rackAService), rackBPod, rackBService)
+		polled := observeServiceGet(fakeClient, rackAService.Name)
+
+		wg.Go(func() {
+			defer ctxCancel()
+
+			// Cancel only once GetSeeds has observed the unresolvable Service, so the error can only come
+			// from the poll giving up rather than from it never having polled at all.
+			select {
+			case <-polled:
+			case <-ctx.Done():
+			}
+		})
+
+		_, err = member.GetSeeds(ctx, fakeClient.CoreV1(), nil)
+
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected error to be %v, got %v", context.Canceled, err)
+		}
+	})
+
+	t.Run("succeeds once the address becomes resolvable", func(t *testing.T) {
+		t.Parallel()
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+
+		ctx, ctxCancel := context.WithCancel(t.Context())
+		defer ctxCancel()
+
+		member, err := NewMember(rackBService, rackBPod, scyllav1alpha1.BroadcastAddressTypeServiceClusterIP, scyllav1alpha1.BroadcastAddressTypeServiceClusterIP, corev1.IPv4Protocol, nil)
+		if err != nil {
+			t.Fatal(fmt.Errorf("error creating member: %w", err))
+		}
+
+		fakeClient := fake.NewSimpleClientset(rackAPod, unresolvableSvc(rackAService), rackBPod, rackBService)
+		polled := observeServiceGet(fakeClient, rackAService.Name)
+
+		doneCh := make(chan struct{}, 1)
+		errCh := make(chan error, 1)
+		wg.Go(func() {
+			defer close(doneCh)
+
+			// Make the address resolvable only once GetSeeds has observed it unresolvable, so it has to
+			// wait for the update rather than resolving on its first attempt.
+			select {
+			case <-polled:
+			case <-ctx.Done():
+				return
+			}
+
+			// The update itself deliberately doesn't use ctx: it's canceled as this subtest returns, and a
+			// cancellation racing the update would surface as a fixture error rather than the real failure.
+			svc, err := fakeClient.CoreV1().Services(rackAService.Namespace).Get(context.Background(), rackAService.Name, metav1.GetOptions{})
+			if err != nil {
+				errCh <- fmt.Errorf("error getting service: %w", err)
+				return
+			}
+
+			svc.Spec.ClusterIP = rackAService.Spec.ClusterIP
+			svc.Spec.ClusterIPs = rackAService.Spec.ClusterIPs
+			_, err = fakeClient.CoreV1().Services(rackAService.Namespace).Update(context.Background(), svc, metav1.UpdateOptions{})
+			if err != nil {
+				errCh <- fmt.Errorf("error updating service: %w", err)
+			}
+		})
+
+		seeds, err := member.GetSeeds(ctx, fakeClient.CoreV1(), nil)
+		if err != nil {
+			t.Fatal(fmt.Errorf("error getting seeds: %w", err))
+		}
+
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		case <-doneCh:
+			break
+		}
+
+		expected := []string{rackAService.Spec.ClusterIP}
+		if !reflect.DeepEqual(seeds, expected) {
+			t.Errorf("expected seeds %v, got %v", expected, seeds)
+		}
+	})
+}
+
+// observeServiceGet returns a channel which is closed the first time the named Service is fetched.
+func observeServiceGet(fakeClient *fake.Clientset, svcName string) <-chan struct{} {
+	observed := make(chan struct{})
+
+	// The poll fetches the Service on every tick, and closing a closed channel panics.
+	var once sync.Once
+
+	fakeClient.PrependReactor("get", "services", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		getAction, ok := action.(kubetesting.GetAction)
+		if !ok || getAction.GetName() != svcName {
+			return false, nil, nil
+		}
+
+		once.Do(func() {
+			close(observed)
+		})
+
+		return false, nil, nil
+	})
+
+	return observed
+}
+
+// createPodAndSvcInRack makes a member of "my-cluster" in the given rack, with its Pod and Service sharing
+// a name and a creation timestamp, as the operator creates them.
+func createPodAndSvcInRack(name, rack, ip string, creationTimestamp time.Time) (*corev1.Pod, *corev1.Service) {
+	// Member Services are selected by the cluster's labels, same as their Pods.
+	clusterLabels := map[string]string{
+		"scylla/cluster":               "my-cluster",
+		"app":                          "scylla",
+		"app.kubernetes.io/name":       "scylla",
+		"app.kubernetes.io/managed-by": "scylla-operator",
+		"scylla/rack":                  rack,
+	}
+
+	podLabels := maps.Clone(clusterLabels)
+	podLabels["scylla/rack-ordinal"] = "0"
+	podLabels["scylla-operator.scylladb.com/pod-type"] = "scylladb-node"
+
+	svcLabels := maps.Clone(clusterLabels)
+	svcLabels["scylla-operator.scylladb.com/scylla-service-type"] = "member"
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "namespace",
+			Labels:            podLabels,
+			CreationTimestamp: metav1.NewTime(creationTimestamp),
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "namespace",
+			Labels:            svcLabels,
+			CreationTimestamp: metav1.NewTime(creationTimestamp),
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP:  ip,
+			ClusterIPs: []string{ip},
+		},
+	}
+
+	return pod, svc
 }
 
 func markPodReady(pod *corev1.Pod) *corev1.Pod {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR modifies the seed selection algorithm to:
- Align with siren's implementation as decided by @mflendrich in parallel bootstrap discovery. The algorithm is not 1-1 as coordinating a single node bootstrap before the other Pods are created would complicate things much more and it's not really necessary - ScyllaDB can wait until a selected, initially non-serving seed responds. Node's operational mode as input is also replaced by Pod's readiness for simplicity.
- Allow for parallel bootstrap.

Here're the pointers to siren's implementation for reference:
- https://github.com/scylladb/siren/blob/ad5411c44a8591d3474f78d8db88912775768925/cluster/init.go#L86-L158
- https://github.com/scylladb/siren/blob/ad5411c44a8591d3474f78d8db88912775768925/cluster/cluster.go#L1678-L1732

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-150

/cc