### PR TITLE
chore: generate local-csi-driver manifests based on upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,6 +554,8 @@ update-examples:
 	./hack/third-party/build-cert-manager-manifest.sh "./examples/third-party/cert-manager.yaml"
 
 	./hack/third-party/build-prometheus-operator-manifest.sh "./examples/third-party/prometheus-operator.yaml"
+
+	./hack/third-party/build-local-csi-driver-manifests.sh "./examples/common/local-volume-provisioner/local-csi-driver"
 .PHONY: update-examples
 
 verify-examples: tmp_dir :=$(shell mktemp -d)
@@ -568,8 +570,21 @@ verify-examples:
 
 	./hack/third-party/build-prometheus-operator-manifest.sh "$(tmp_dir)/third-party/prometheus-operator.yaml"
 
+	./hack/third-party/build-local-csi-driver-manifests.sh "$(tmp_dir)/common/local-volume-provisioner/local-csi-driver"
+
 	$(diff) -r '$(tmp_dir)'/ ./examples
 .PHONY: verify-examples
+
+update-local-csi-driver-ci-manifests:
+	./hack/third-party/build-local-csi-driver-manifests.sh "./hack/.ci/manifests/namespaces/local-csi-driver"
+.PHONY: update-local-csi-driver-ci-manifests
+
+verify-local-csi-driver-ci-manifests: tmp_dir :=$(shell mktemp -d)
+verify-local-csi-driver-ci-manifests:
+	./hack/third-party/build-local-csi-driver-manifests.sh "$(tmp_dir)/local-csi-driver"
+
+	$(diff) -r '$(tmp_dir)'/local-csi-driver ./hack/.ci/manifests/namespaces/local-csi-driver || (echo 'Local CSI Driver CI manifests are not up to date. Please run `make update-local-csi-driver-ci-manifests` to update them.' && false)
+.PHONY: verify-local-csi-driver-ci-manifests
 
 # $1 - dashboard dir
 # $2 - output configmap location
@@ -784,10 +799,10 @@ verify-e2e-suite-coverage:
 	./hack/verify-e2e-suite-coverage.sh
 .PHONY: verify-e2e-suite-coverage
 
-verify: verify-codegen verify-crds verify-helm-schemas verify-helm-charts verify-deploy verify-lint verify-helm-lint verify-links verify-examples verify-docs-api verify-monitoring verify-bundle verify-renovate-config verify-in-tree-prometheus-operator-exports verify-config verify-e2e-suite-coverage
+verify: verify-codegen verify-crds verify-helm-schemas verify-helm-charts verify-deploy verify-lint verify-helm-lint verify-links verify-examples verify-local-csi-driver-ci-manifests verify-docs-api verify-monitoring verify-bundle verify-renovate-config verify-in-tree-prometheus-operator-exports verify-config verify-e2e-suite-coverage
 .PHONY: verify
 
-update: update-codegen update-crds update-helm-schemas update-helm-charts update-deploy update-examples update-docs-api update-monitoring update-bundle update-go-mod-replace update-renovate-config update-in-tree-prometheus-operator-exports update-config
+update: update-codegen update-crds update-helm-schemas update-helm-charts update-deploy update-examples update-local-csi-driver-ci-manifests update-docs-api update-monitoring update-bundle update-go-mod-replace update-renovate-config update-in-tree-prometheus-operator-exports update-config
 .PHONY: update
 
 test-unit:

--- a/assets/config/config.go
+++ b/assets/config/config.go
@@ -49,9 +49,14 @@ type PrometheusOperatorConfig struct {
 	Namespace string `json:"namespace"`
 }
 
+type LocalCSIDriverConfig struct {
+	Version string `json:"version"`
+}
+
 type ThirdPartyConfig struct {
 	CertManager              CertManagerConfig        `json:"certManager"`
 	PrometheusOperatorConfig PrometheusOperatorConfig `json:"prometheusOperator"`
+	LocalCSIDriver           LocalCSIDriverConfig     `json:"localCSIDriver"`
 }
 
 type ProjectConfig struct {

--- a/assets/config/config.yaml
+++ b/assets/config/config.yaml
@@ -27,3 +27,6 @@ thirdParty:
     # renovate: datasource=github-releases depName=prometheus-operator packageName=prometheus-operator/prometheus-operator versioning=semver
     version: "0.93.0" # Latest compatible with .operator.prometheusVersion (https://prometheus-operator.dev/docs/getting-started/compatibility/)
     namespace: "prometheus-operator"
+  localCSIDriver:
+    # renovate: datasource=docker depName=local-csi-driver packageName=docker.io/scylladb/local-csi-driver versioning=semver
+    version: "1.0.0@sha256:a80212705a6cfbc2e7115b276d0ace1bfe88bcdc56b1e20732a64a4e6c1af4ff"

--- a/assets/config/config_test.go
+++ b/assets/config/config_test.go
@@ -222,6 +222,14 @@ func TestProjectConfig(t *testing.T) {
 			configField: Project.ThirdParty.PrometheusOperatorConfig.Namespace,
 			testFn:      validateRequired,
 		},
+		{
+			name:        "thirdParty.localCSIDriver.version",
+			configField: Project.ThirdParty.LocalCSIDriver.Version,
+			testFn: composeValidators(
+				validateRequired,
+				validateMultiPlatformVersionWithRepo(ctx, LocalCSIDriverImageRepository),
+			),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/assets/config/images.go
+++ b/assets/config/images.go
@@ -4,4 +4,5 @@ const (
 	ScyllaDBImageRepository             = "docker.io/scylladb/scylla"
 	ScyllaDBManagerImageRepository      = "docker.io/scylladb/scylla-manager"
 	ScyllaDBManagerAgentImageRepository = "docker.io/scylladb/scylla-manager-agent"
+	LocalCSIDriverImageRepository       = "docker.io/scylladb/local-csi-driver"
 )

--- a/examples/common/local-volume-provisioner/local-csi-driver/00_clusterrole_def.yaml
+++ b/examples/common/local-volume-provisioner/local-csi-driver/00_clusterrole_def.yaml
@@ -5,98 +5,99 @@ metadata:
   labels:
     rbac.operator.scylladb.com/aggregate-to-csi-external-provisioner: "true"
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - "persistentvolumes"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-  - "create"
-  - "delete"
-- apiGroups:
-  - ""
-  resources:
-  - "persistentvolumeclaims"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-  - "update"
-- apiGroups:
-  - "storage.k8s.io"
-  resources:
-  - "storageclasses"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
-  resources:
-  - "events"
-  verbs:
-  - "list"
-  - "watch"
-  - "create"
-  - "update"
-  - "patch"
-- apiGroups:
-  - "snapshot.storage.k8s.io"
-  resources:
-  - "volumesnapshots"
-  verbs:
-  - "get"
-  - "list"
-- apiGroups:
-  - "snapshot.storage.k8s.io"
-  resources:
-  - "volumesnapshotcontents"
-  verbs:
-  - "get"
-  - "list"
-- apiGroups:
-  - "storage.k8s.io"
-  resources:
-  - "csinodes"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
-  resources:
-  - "nodes"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "storage.k8s.io"
-  resources:
-  - "csistoragecapacities"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-  - "create"
-  - "update"
-  - "patch"
-  - "delete"
-# The GET permissions below are needed for walking up the ownership chain
-# for CSIStorageCapacity. They are sufficient for deployment via
-# StatefulSet (only needs to get Pod) and Deployment (needs to get
-# Pod and then ReplicaSet to find the Deployment).
-- apiGroups:
-  - ""
-  resources:
-  - "pods"
-  verbs:
-  - "get"
-- apiGroups:
-  - "apps"
-  resources:
-  - "replicasets"
-  verbs:
-  - "get"
+  - apiGroups:
+      - ""
+    resources:
+      - "persistentvolumes"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "delete"
+      - "patch"
+  - apiGroups:
+      - ""
+    resources:
+      - "persistentvolumeclaims"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "update"
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - "storageclasses"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs:
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+  - apiGroups:
+      - "snapshot.storage.k8s.io"
+    resources:
+      - "volumesnapshots"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - "snapshot.storage.k8s.io"
+    resources:
+      - "volumesnapshotcontents"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - "csinodes"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - "csistoragecapacities"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
+  # The GET permissions below are needed for walking up the ownership chain
+  # for CSIStorageCapacity. They are sufficient for deployment via
+  # StatefulSet (only needs to get Pod) and Deployment (needs to get
+  # Pod and then ReplicaSet to find the Deployment).
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "replicasets"
+    verbs:
+      - "get"

--- a/examples/common/local-volume-provisioner/local-csi-driver/10_serviceaccount.yaml
+++ b/examples/common/local-volume-provisioner/local-csi-driver/10_serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: local-csi-driver
   name: local-csi-driver
+  namespace: local-csi-driver

--- a/examples/common/local-volume-provisioner/local-csi-driver/20_clusterrolebinding.yaml
+++ b/examples/common/local-volume-provisioner/local-csi-driver/20_clusterrolebinding.yaml
@@ -3,9 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: scylladb:csi-external-provisioner
 subjects:
-- kind: ServiceAccount
-  name: local-csi-driver
-  namespace: local-csi-driver
+  - kind: ServiceAccount
+    name: local-csi-driver
+    namespace: local-csi-driver
 roleRef:
   kind: ClusterRole
   name: scylladb:csi-external-provisioner

--- a/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
+++ b/examples/common/local-volume-provisioner/local-csi-driver/50_daemonset.yaml
@@ -1,8 +1,8 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  namespace: local-csi-driver
   name: local-csi-driver
+  namespace: local-csi-driver
   labels:
     app.kubernetes.io/name: local-csi-driver
 spec:
@@ -19,108 +19,106 @@ spec:
         scylla.scylladb.com/node-type: scylla
       serviceAccountName: local-csi-driver
       tolerations:
-      - operator: Exists
+        - operator: Exists
       containers:
-      - name: local-csi-driver
-        securityContext:
-          privileged: true
-        # renovate: datasource=docker depName=local-csi-driver packageName=docker.io/scylladb/local-csi-driver versioning=semver
-        image: docker.io/scylladb/local-csi-driver:1.0.0@sha256:a80212705a6cfbc2e7115b276d0ace1bfe88bcdc56b1e20732a64a4e6c1af4ff
-        imagePullPolicy: IfNotPresent
-        args:
-        - --listen=/csi/csi.sock
-        - --node-name=$(NODE_NAME)
-        - --volumes-dir=/var/lib/persistent-volumes
-        - --v=2
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        volumeMounts:
-        - name: kubelet-dir
-          mountPath: /var/lib/kubelet
-          mountPropagation: "Bidirectional"
-        - name: plugin-dir
-          mountPath: /csi
-        - name: volumes-dir
-          mountPath: /var/lib/persistent-volumes
-        ports:
-        - name: healthz
-          containerPort: 9809
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-          initialDelaySeconds: 10
-          timeoutSeconds: 3
-          periodSeconds: 2
-          failureThreshold: 5
-      - name: csi-driver-registrar
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:fdff3ee285341bc58033b6b2458a5d45fd90ec6922a8ba6ebdd49b0c41e2cd34
-        imagePullPolicy: Always
-        args:
-        - --csi-address=/csi/csi.sock
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/local.csi.scylladb.com/csi.sock
-        volumeMounts:
-        - name: plugin-dir
-          mountPath: /csi
-        - name: registration-dir
-          mountPath: /registration
-      - name: liveness-probe
-        image: registry.k8s.io/sig-storage/livenessprobe@sha256:cacee2b5c36dd59d4c7e8469c05c9e4ef53ecb2df9025fa8c10cdaf61bce62f0
-        imagePullPolicy: Always
-        args:
-        - --csi-address=/csi/csi.sock
-        - --health-port=9809
-        - --v=2
-        volumeMounts:
-        - name: plugin-dir
-          mountPath: /csi
-      - name: csi-provisioner
-        image: registry.k8s.io/sig-storage/csi-provisioner@sha256:ee3b525d5b89db99da3b8eb521d9cd90cb6e9ef0fbb651e98bb37be78d36b5b8
-        imagePullPolicy: Always
-        args:
-        - --csi-address=/csi/csi.sock
-        - --v=2
-        - --node-deployment
-        - --feature-gates=Topology=true
-        - --immediate-topology=false
-        - --enable-capacity
-        - --capacity-ownerref-level=0
-        - --capacity-poll-interval=30s
-        - --default-fstype=xfs
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        volumeMounts:
-        - name: plugin-dir
-          mountPath: /csi
+        - name: local-csi-driver
+          securityContext:
+            privileged: true
+          image: docker.io/scylladb/local-csi-driver:1.0.0@sha256:a80212705a6cfbc2e7115b276d0ace1bfe88bcdc56b1e20732a64a4e6c1af4ff
+          imagePullPolicy: IfNotPresent
+          args:
+            - --listen=/csi/csi.sock
+            - --node-name=$(NODE_NAME)
+            - --volumes-dir=/var/lib/persistent-volumes
+            - --v=2
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: volumes-dir
+              mountPath: /var/lib/persistent-volumes
+          ports:
+            - name: healthz
+              containerPort: 9809
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+        - name: csi-driver-registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0@sha256:f9de845b170155199f2a2a3f9531cf13d78e31235e9db6b6582a8b0db0a50dad
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/local.csi.scylladb.com/csi.sock
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0@sha256:06da0d5b8908072f2e4522692aee8dc119fba7247a9658497e1153992cd777e9
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9809
+            - --v=2
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0@sha256:bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --v=2
+            - --node-deployment
+            - --immediate-topology=false
+            - --enable-capacity
+            - --capacity-ownerref-level=0
+            - --capacity-poll-interval=30s
+            - --default-fstype=xfs
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
       volumes:
-      - name: kubelet-dir
-        hostPath:
-          path: /var/lib/kubelet
-          type: Directory
-      - name: plugin-dir
-        hostPath:
-          path: /var/lib/kubelet/plugins/local.csi.scylladb.com/
-          type: DirectoryOrCreate
-      - name: registration-dir
-        hostPath:
-          path: /var/lib/kubelet/plugins_registry/
-          type: Directory
-      - name: volumes-dir
-        hostPath:
-          path: /var/lib/persistent-volumes
-          type: Directory
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/local.csi.scylladb.com/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: volumes-dir
+          hostPath:
+            path: /var/lib/persistent-volumes
+            type: Directory

--- a/hack/.ci/manifests/namespaces/local-csi-driver/00_clusterrole_def.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/00_clusterrole_def.yaml
@@ -5,98 +5,99 @@ metadata:
   labels:
     rbac.operator.scylladb.com/aggregate-to-csi-external-provisioner: "true"
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - "persistentvolumes"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-  - "create"
-  - "delete"
-- apiGroups:
-  - ""
-  resources:
-  - "persistentvolumeclaims"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-  - "update"
-- apiGroups:
-  - "storage.k8s.io"
-  resources:
-  - "storageclasses"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
-  resources:
-  - "events"
-  verbs:
-  - "list"
-  - "watch"
-  - "create"
-  - "update"
-  - "patch"
-- apiGroups:
-  - "snapshot.storage.k8s.io"
-  resources:
-  - "volumesnapshots"
-  verbs:
-  - "get"
-  - "list"
-- apiGroups:
-  - "snapshot.storage.k8s.io"
-  resources:
-  - "volumesnapshotcontents"
-  verbs:
-  - "get"
-  - "list"
-- apiGroups:
-  - "storage.k8s.io"
-  resources:
-  - "csinodes"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
-  resources:
-  - "nodes"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-- apiGroups:
-  - "storage.k8s.io"
-  resources:
-  - "csistoragecapacities"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-  - "create"
-  - "update"
-  - "patch"
-  - "delete"
-# The GET permissions below are needed for walking up the ownership chain
-# for CSIStorageCapacity. They are sufficient for deployment via
-# StatefulSet (only needs to get Pod) and Deployment (needs to get
-# Pod and then ReplicaSet to find the Deployment).
-- apiGroups:
-  - ""
-  resources:
-  - "pods"
-  verbs:
-  - "get"
-- apiGroups:
-  - "apps"
-  resources:
-  - "replicasets"
-  verbs:
-  - "get"
+  - apiGroups:
+      - ""
+    resources:
+      - "persistentvolumes"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "delete"
+      - "patch"
+  - apiGroups:
+      - ""
+    resources:
+      - "persistentvolumeclaims"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "update"
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - "storageclasses"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs:
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+  - apiGroups:
+      - "snapshot.storage.k8s.io"
+    resources:
+      - "volumesnapshots"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - "snapshot.storage.k8s.io"
+    resources:
+      - "volumesnapshotcontents"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - "csinodes"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - "csistoragecapacities"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
+  # The GET permissions below are needed for walking up the ownership chain
+  # for CSIStorageCapacity. They are sufficient for deployment via
+  # StatefulSet (only needs to get Pod) and Deployment (needs to get
+  # Pod and then ReplicaSet to find the Deployment).
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "replicasets"
+    verbs:
+      - "get"

--- a/hack/.ci/manifests/namespaces/local-csi-driver/10_serviceaccount.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/10_serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: local-csi-driver
   name: local-csi-driver
+  namespace: local-csi-driver

--- a/hack/.ci/manifests/namespaces/local-csi-driver/20_clusterrolebinding.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/20_clusterrolebinding.yaml
@@ -3,9 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: scylladb:csi-external-provisioner
 subjects:
-- kind: ServiceAccount
-  name: local-csi-driver
-  namespace: local-csi-driver
+  - kind: ServiceAccount
+    name: local-csi-driver
+    namespace: local-csi-driver
 roleRef:
   kind: ClusterRole
   name: scylladb:csi-external-provisioner

--- a/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
+++ b/hack/.ci/manifests/namespaces/local-csi-driver/50_daemonset.yaml
@@ -1,8 +1,8 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  namespace: local-csi-driver
   name: local-csi-driver
+  namespace: local-csi-driver
   labels:
     app.kubernetes.io/name: local-csi-driver
 spec:
@@ -19,108 +19,106 @@ spec:
         scylla.scylladb.com/node-type: scylla
       serviceAccountName: local-csi-driver
       tolerations:
-      - operator: Exists
+        - operator: Exists
       containers:
-      - name: local-csi-driver
-        securityContext:
-          privileged: true
-        # renovate: datasource=docker depName=local-csi-driver packageName=docker.io/scylladb/local-csi-driver versioning=semver
-        image: docker.io/scylladb/local-csi-driver:1.0.0@sha256:a80212705a6cfbc2e7115b276d0ace1bfe88bcdc56b1e20732a64a4e6c1af4ff
-        imagePullPolicy: IfNotPresent
-        args:
-        - --listen=/csi/csi.sock
-        - --node-name=$(NODE_NAME)
-        - --volumes-dir=/var/lib/persistent-volumes
-        - --v=2
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        volumeMounts:
-        - name: kubelet-dir
-          mountPath: /var/lib/kubelet
-          mountPropagation: "Bidirectional"
-        - name: plugin-dir
-          mountPath: /csi
-        - name: volumes-dir
-          mountPath: /var/lib/persistent-volumes
-        ports:
-        - name: healthz
-          containerPort: 9809
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-          initialDelaySeconds: 10
-          timeoutSeconds: 3
-          periodSeconds: 2
-          failureThreshold: 5
-      - name: csi-driver-registrar
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:fdff3ee285341bc58033b6b2458a5d45fd90ec6922a8ba6ebdd49b0c41e2cd34
-        imagePullPolicy: Always
-        args:
-        - --csi-address=/csi/csi.sock
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/local.csi.scylladb.com/csi.sock
-        volumeMounts:
-        - name: plugin-dir
-          mountPath: /csi
-        - name: registration-dir
-          mountPath: /registration
-      - name: liveness-probe
-        image: registry.k8s.io/sig-storage/livenessprobe@sha256:cacee2b5c36dd59d4c7e8469c05c9e4ef53ecb2df9025fa8c10cdaf61bce62f0
-        imagePullPolicy: Always
-        args:
-        - --csi-address=/csi/csi.sock
-        - --health-port=9809
-        - --v=2
-        volumeMounts:
-        - name: plugin-dir
-          mountPath: /csi
-      - name: csi-provisioner
-        image: registry.k8s.io/sig-storage/csi-provisioner@sha256:ee3b525d5b89db99da3b8eb521d9cd90cb6e9ef0fbb651e98bb37be78d36b5b8
-        imagePullPolicy: Always
-        args:
-        - --csi-address=/csi/csi.sock
-        - --v=2
-        - --node-deployment
-        - --feature-gates=Topology=true
-        - --immediate-topology=false
-        - --enable-capacity
-        - --capacity-ownerref-level=0
-        - --capacity-poll-interval=30s
-        - --default-fstype=xfs
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        volumeMounts:
-        - name: plugin-dir
-          mountPath: /csi
+        - name: local-csi-driver
+          securityContext:
+            privileged: true
+          image: docker.io/scylladb/local-csi-driver:1.0.0@sha256:a80212705a6cfbc2e7115b276d0ace1bfe88bcdc56b1e20732a64a4e6c1af4ff
+          imagePullPolicy: IfNotPresent
+          args:
+            - --listen=/csi/csi.sock
+            - --node-name=$(NODE_NAME)
+            - --volumes-dir=/var/lib/persistent-volumes
+            - --v=2
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: volumes-dir
+              mountPath: /var/lib/persistent-volumes
+          ports:
+            - name: healthz
+              containerPort: 9809
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+        - name: csi-driver-registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0@sha256:f9de845b170155199f2a2a3f9531cf13d78e31235e9db6b6582a8b0db0a50dad
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/local.csi.scylladb.com/csi.sock
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0@sha256:06da0d5b8908072f2e4522692aee8dc119fba7247a9658497e1153992cd777e9
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9809
+            - --v=2
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0@sha256:bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --v=2
+            - --node-deployment
+            - --immediate-topology=false
+            - --enable-capacity
+            - --capacity-ownerref-level=0
+            - --capacity-poll-interval=30s
+            - --default-fstype=xfs
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
       volumes:
-      - name: kubelet-dir
-        hostPath:
-          path: /var/lib/kubelet
-          type: Directory
-      - name: plugin-dir
-        hostPath:
-          path: /var/lib/kubelet/plugins/local.csi.scylladb.com/
-          type: DirectoryOrCreate
-      - name: registration-dir
-        hostPath:
-          path: /var/lib/kubelet/plugins_registry/
-          type: Directory
-      - name: volumes-dir
-        hostPath:
-          path: /var/lib/persistent-volumes
-          type: Directory
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/local.csi.scylladb.com/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: volumes-dir
+          hostPath:
+            path: /var/lib/persistent-volumes
+            type: Directory

--- a/hack/third-party/build-local-csi-driver-manifests.sh
+++ b/hack/third-party/build-local-csi-driver-manifests.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 ScyllaDB
+#
+# This script builds the ScyllaDB Local CSI Driver manifests with a specified version from the manifests
+# shipped upstream in https://github.com/scylladb/local-csi-driver/tree/master/deploy/kubernetes/local-csi-driver
+# and applies the deliberate divergences this repository maintains on top of them.
+
+set -euxEo pipefail
+shopt -s inherit_errexit
+
+source "$( dirname "${BASH_SOURCE[0]}" )/../lib/assets.sh"
+
+if [[ -n "${1+x}" ]]; then
+    target_dir="${1}"
+else
+    printf 'Missing target directory.\nUsage: %s <target-dir>\n' "$0" >&2
+    exit 1
+fi
+
+# The volumes directory this repository uses. It has to match the mountPoint of the filesystem that NodeConfig
+# provisions, which differs from the upstream default.
+readonly volumes_dir="/var/lib/persistent-volumes"
+readonly upstream_volumes_dir="/mnt/persistent-volumes"
+
+# The driver only runs on nodes tuned by NodeConfig.
+readonly node_type_label="scylla.scylladb.com/node-type"
+readonly node_type="scylla"
+
+# This repository splits the upstream provisioner ClusterRole into an aggregated one, so that platform specific
+# permissions can be attached to it without patching the definition.
+readonly aggregated_clusterrole_name="scylladb:csi-external-provisioner"
+readonly aggregate_label="rbac.operator.scylladb.com/aggregate-to-csi-external-provisioner"
+
+function get-url() {
+    local ref="${1}"
+    local file="${2}"
+    echo "https://raw.githubusercontent.com/scylladb/local-csi-driver/refs/tags/${ref}/${file}"
+}
+
+# version holds a tag optionally suffixed with a digest, e.g. "1.0.0-rc.3@sha256:a802...". The upstream Git tag
+# that ships the matching manifests is the tag part prefixed with "v".
+version=$( get-config ".thirdParty.localCSIDriver.version" )
+tag="${version%%@*}"
+ref="v${tag}"
+
+tmp_dir=$( mktemp -d )
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+for file in '00_namespace.yaml' '10_csidriver.yaml' '10_driver_serviceaccount.yaml' '10_provisioner_clusterrole.yaml' '20_provisioner_clusterrolebinding.yaml' '50_daemonset.yaml'; do
+    curl --fail --retry 5 --retry-all-errors -L "$( get-url "${ref}" "deploy/kubernetes/local-csi-driver/${file}" )" -o "${tmp_dir}/${file}"
+done
+
+curl --fail --retry 5 --retry-all-errors -L "$( get-url "${ref}" 'example/storageclass_xfs.yaml' )" -o "${tmp_dir}/storageclass_xfs.yaml"
+
+mkdir -p "${target_dir}"
+
+# Taken over verbatim.
+yq '.' "${tmp_dir}/00_namespace.yaml" > "${target_dir}/00_namespace.yaml"
+yq '.' "${tmp_dir}/10_csidriver.yaml" > "${target_dir}/10_csidriver.yaml"
+yq '.' "${tmp_dir}/10_driver_serviceaccount.yaml" > "${target_dir}/10_serviceaccount.yaml"
+yq '.' "${tmp_dir}/20_provisioner_clusterrolebinding.yaml" > "${target_dir}/20_clusterrolebinding.yaml"
+yq '.' "${tmp_dir}/storageclass_xfs.yaml" > "${target_dir}/00_scylladb-local-xfs.storageclass.yaml"
+
+# The upstream provisioner ClusterRole becomes the aggregated definition holding the platform independent rules.
+yq " \
+    .metadata.name = \"scylladb:aggregate-to-csi-external-provisioner\" | \
+    .metadata.labels.\"${aggregate_label}\" = \"true\" \
+    " "${tmp_dir}/10_provisioner_clusterrole.yaml" > "${target_dir}/00_clusterrole_def.yaml"
+
+# The aggregating ClusterRole the ServiceAccount is actually bound to. It has no upstream counterpart.
+cat > "${target_dir}/00_clusterrole.yaml" << EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ${aggregated_clusterrole_name}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      ${aggregate_label}: "true"
+EOF
+
+# Permissions required on OpenShift only. They have no upstream counterpart.
+cat > "${target_dir}/00_clusterrole_def_openshift.yaml" << EOF
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scylladb:aggregate-to-csi-external-provisioner-openshift
+  labels:
+    ${aggregate_label}: "true"
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+EOF
+
+# The DaemonSet pins the driver image, is restricted to NodeConfig tuned nodes and uses this repository's
+# volumes directory in the driver flag, the mount and the host path backing it.
+yq " \
+    ( .spec.template.spec.containers[] | select(.name == \"local-csi-driver\") | .image ) = \"docker.io/scylladb/local-csi-driver:${version}\" | \
+    .spec.template.spec.nodeSelector.\"${node_type_label}\" = \"${node_type}\" | \
+    ( .. | select(tag == \"!!str\") ) |= sub(\"${upstream_volumes_dir}\"; \"${volumes_dir}\") \
+    " "${tmp_dir}/50_daemonset.yaml" |
+    # Upstream annotates the sidecar images for its own Renovate. Here the only managed version is the one in
+    # config.yaml and no manager reads this file, so keeping the annotations would claim an automation that
+    # does not exist.
+    grep -v -E '^[[:space:]]*# renovate:' > "${target_dir}/50_daemonset.yaml"
+
+# Every transform above is a no-op if upstream renames what it matches on, which would silently ship
+# upstream's defaults. Assert the results instead of trusting them.
+function assert-equal() {
+    local what="${1}"
+    local expected="${2}"
+    local actual="${3}"
+
+    if [[ "${expected}" != "${actual}" ]]; then
+        printf 'Manifest transform failed: %s is %q, expected %q. Did the upstream manifests change?\n' "${what}" "${actual}" "${expected}" >&2
+        exit 1
+    fi
+}
+
+assert-equal 'the driver image' \
+    "docker.io/scylladb/local-csi-driver:${version}" \
+    "$( yq '.spec.template.spec.containers[] | select(.name == "local-csi-driver") | .image' "${target_dir}/50_daemonset.yaml" )"
+
+assert-equal 'the node type node selector' \
+    "${node_type}" \
+    "$( yq ".spec.template.spec.nodeSelector.\"${node_type_label}\"" "${target_dir}/50_daemonset.yaml" )"
+
+assert-equal 'the number of remaining upstream volumes dir references' \
+    '0' \
+    "$( grep -c -F "${upstream_volumes_dir}" "${target_dir}/50_daemonset.yaml" || true )"
+
+assert-equal 'the number of volumes dir references' \
+    '3' \
+    "$( grep -c -F "${volumes_dir}" "${target_dir}/50_daemonset.yaml" )"
+
+assert-equal 'the number of remaining Renovate annotations' \
+    '0' \
+    "$( grep -c -E '^[[:space:]]*# renovate:' "${target_dir}/50_daemonset.yaml" || true )"
+
+# The upstream ClusterRoleBinding is taken over verbatim, so the ClusterRole this repository aggregates
+# into has to keep the name that binding refers to.
+assert-equal 'the aggregated ClusterRole name the ClusterRoleBinding refers to' \
+    "${aggregated_clusterrole_name}" \
+    "$( yq '.roleRef.name' "${target_dir}/20_clusterrolebinding.yaml" )"

--- a/renovate.json
+++ b/renovate.json
@@ -185,6 +185,33 @@
         "   ```",
         "3. Remove the `do-not-merge/hold` label."
       ]
+    },
+    {
+      "description": "local-csi-driver dependency bump in config.yaml requires manual action",
+      "matchDepNames": [
+        "local-csi-driver"
+      ],
+      "matchFileNames": [
+        "assets/config/config.yaml"
+      ],
+      "addLabels": [
+        "do-not-merge/hold"
+      ],
+      "prBodyNotes": [
+        "### ⚠️ Manual Action Required",
+        "Renovate has bumped the local-csi-driver dependency, but cannot automatically regenerate the manifests.",
+        "",
+        "**Please complete the following steps before merging:**",
+        "1. Check out this branch locally.",
+        "2. Propagate changes by running:",
+        "   ```bash",
+        "   make update",
+        "   git add examples/common/local-volume-provisioner/local-csi-driver hack/.ci/manifests/namespaces/local-csi-driver",
+        "   git commit -m \"chore(deps): update generated files\" && git push --force",
+        "   ```",
+        "3. Review the regenerated manifests. A driver release may change the sidecar images, the provisioner flags or the RBAC rules, and those changes land in this PR.",
+        "4. Remove the `do-not-merge/hold` label."
+      ]
     }
   ],
   "customManagers": [
@@ -206,17 +233,6 @@
       ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\nFROM\\s+\\S+:(?<currentValue>\\S+)"
-      ]
-    },
-    {
-      "description": "Custom manager for local-csi-driver image references in Kubernetes manifests with Renovate annotations matching the regex.",
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^examples/common/local-volume-provisioner/local-csi-driver/50_daemonset\\.yaml$/",
-        "/^hack/\\.ci/manifests/namespaces/local-csi-driver/50_daemonset\\.yaml$/"
-      ],
-      "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*image:\\s*[^\\s:]+:(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ]
     },
     {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Adds `update-local-csi-driver-ci-manifests` Makefile target that renders all local-csi-driver manifests based on a single image reference defined in `assets/config/config.yaml` `thirdParty.localCSIDriver.version` key (Renovate-tracked).

Regenerates manifests for v1.0.0 (changed: updated sidecars versions, `persistentvolumes` patch permission; the rest is formatting/ordering inherited from the upstream). 

**Which issue is resolved by this Pull Request:**
Closes https://scylladb.atlassian.net/browse/OPERATOR-278.