### PR TITLE
fix: allow operator to manager's scylladb connectivity

### DIFF
--- a/deploy/manager-dev.yaml
+++ b/deploy/manager-dev.yaml
@@ -23,7 +23,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   namespace: scylla-manager
-  name: scylla-manager-to-scylla-pod
+  name: scylla-manager-and-scylla-operator-to-scylla-pod
 spec:
   policyTypes:
   - Ingress
@@ -36,6 +36,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: scylla-manager
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: scylla-operator
 
 ---
 apiVersion: v1

--- a/deploy/manager-prod.yaml
+++ b/deploy/manager-prod.yaml
@@ -23,7 +23,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   namespace: scylla-manager
-  name: scylla-manager-to-scylla-pod
+  name: scylla-manager-and-scylla-operator-to-scylla-pod
 spec:
   policyTypes:
   - Ingress
@@ -36,6 +36,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: scylla-manager
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: scylla-operator
 
 ---
 apiVersion: v1

--- a/deploy/manager/dev/10_manager_networkpolicy.yaml
+++ b/deploy/manager/dev/10_manager_networkpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   namespace: scylla-manager
-  name: scylla-manager-to-scylla-pod
+  name: scylla-manager-and-scylla-operator-to-scylla-pod
 spec:
   policyTypes:
   - Ingress
@@ -15,3 +15,6 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: scylla-manager
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: scylla-operator

--- a/deploy/manager/prod/10_manager_networkpolicy.yaml
+++ b/deploy/manager/prod/10_manager_networkpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   namespace: scylla-manager
-  name: scylla-manager-to-scylla-pod
+  name: scylla-manager-and-scylla-operator-to-scylla-pod
 spec:
   policyTypes:
   - Ingress
@@ -15,3 +15,6 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: scylla-manager
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: scylla-operator

--- a/helm/scylla-manager/templates/manager_networkpolicy.yaml
+++ b/helm/scylla-manager/templates/manager_networkpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   namespace: scylla-manager
-  name: scylla-manager-to-scylla-pod
+  name: scylla-manager-and-scylla-operator-to-scylla-pod
 spec:
   policyTypes:
   - Ingress
@@ -15,3 +15,6 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: scylla-manager
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: scylla-operator


### PR DESCRIPTION
**Description of your changes:**
- prevent operator from stalling SM SC after operator upgrade (which incurs manager's own SC version upgrade)

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-283

See the [original failed test](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3546/pull-scylla-operator-master-e2e-kind-upgrade-operator/2084958525292810240) and [SM cluster failed rollout events](https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3546/pull-scylla-operator-master-e2e-kind-upgrade-operator/2084958525292810240/artifacts/upgrade-operator/must-gather/cluster/namespaces/scylla-manager/scylladbdatacenters.scylla.scylladb.com/scylla-manager-cluster.yaml)
and compare to the [deployment with fixes](https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3546/pull-scylla-operator-master-e2e-kind-upgrade-operator/2084990012025212928) and the [fixed SM cluster rollout](https://gcsweb.scylla-operator.scylladb.com/gcs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3546/pull-scylla-operator-master-e2e-kind-upgrade-operator/2084990012025212928/artifacts/upgrade-operator/must-gather/cluster/namespaces/scylla-manager/scylladbdatacenters.scylla.scylladb.com/scylla-manager-cluster.yaml) 