### PR TITLE
fix(e2e): apply io_uring reactor to manager's scylla instance

### DIFF
--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -174,6 +174,21 @@ EOF
 EOF
   fi
 
+  if [[ -n "${SO_SCYLLACLUSTER_REACTOR_BACKEND:-}" ]]; then
+    cat << EOF | \
+    yq eval-all --inplace 'select(fileIndex == 0) as $f | select(fileIndex == 1) as $p | with( $f.patches; . += $p | ... style="") | $f' "${ARTIFACTS_DEPLOY_DIR}/manager/kustomization.yaml" -
+- patch: |-
+    - op: add
+      path: /spec/scyllaArgs
+      value: "--reactor-backend=${SO_SCYLLACLUSTER_REACTOR_BACKEND}"
+  target:
+    group: scylla.scylladb.com
+    version: v1
+    kind: ScyllaCluster
+    name: scylla-manager-cluster
+EOF
+  fi
+
   kubectl kustomize "${ARTIFACTS_DEPLOY_DIR}/manager" | kubectl_create -n=scylla-manager -f=-
 
   kubectl -n=scylla-manager wait --timeout=5m --for='condition=Progressing=False' scyllaclusters.scylla.scylladb.com/scylla-manager-cluster

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -110,6 +110,10 @@ else
     yq e --inplace '.spec.agentVersion = env(SCYLLA_MANAGER_AGENT_VERSION)' "${ARTIFACTS_DEPLOY_DIR}/manager/50_scyllacluster.yaml"
   fi
 
+  if [[ -n "${SO_SCYLLACLUSTER_REACTOR_BACKEND:-}" ]]; then
+    yq e --inplace '.spec.scyllaArgs = "--reactor-backend=" + strenv(SO_SCYLLACLUSTER_REACTOR_BACKEND)' "${ARTIFACTS_DEPLOY_DIR}/manager/50_scyllacluster.yaml"
+  fi
+
   kubectl_create -f "${ARTIFACTS_DEPLOY_DIR}"/manager
 
   kubectl -n=scylla-manager wait --timeout=10m --for='condition=Progressing=False' scyllaclusters.scylla.scylladb.com/scylla-manager-cluster


### PR DESCRIPTION
**Description of your changes:**
- make manager's scylla instance use the same `io_uring` reactor as used for other deployed scylla instances, when defined

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-284