### PR TITLE
[v1.20] docs: fix llms.txt generation in multiversion builds

### DIFF
--- a/docs/source/_ext/version_context_substitutions.py
+++ b/docs/source/_ext/version_context_substitutions.py
@@ -315,9 +315,12 @@ def setup_version_context_substitutions(app: Sphinx, config: Config) -> None:
     if not hasattr(config, 'myst_substitutions'):
         raise ExtensionError("myst_substitutions not found in config")
 
-    # Get the repository root directory from the original checkout (app.confdir).
-    # This is used for git operations that work across all versions (e.g., listing tags).
-    repo_root = os.path.abspath(os.path.join(app.confdir, '..', '..'))
+    # Repository root of the original checkout, used for git operations (e.g., listing tags).
+    # Recorded in the environment so child builds can inherit it: sphinx-llm's markdown
+    # sub-build runs from a temporary source export whose confdir is not a git checkout.
+    repo_root = os.environ.setdefault(
+        'SPHINX_VERSION_CONTEXT_REPO_ROOT',
+        os.path.abspath(os.path.join(app.confdir, '..', '..')))
     if not os.path.exists(os.path.join(repo_root, '.git')):
         raise ExtensionError(f"Not a git repository: {repo_root}")
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,9 +18,9 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.githubpages',
     'sphinx.ext.extlinks',
+    "sphinx_sitemap",
     'sphinx_scylladb_theme',
     'sphinx_multiversion',
-    "sphinx_sitemap",
     "myst_parser",
     "version_context_substitutions",
 ]


### PR DESCRIPTION
Backport of https://github.com/scylladb/scylla-operator/pull/3531 to v1.20

## Problem

Per-page `.md` files and `llms.txt` are missing from the versions built from this branch, while `master` serves them correctly:

- https://operator.docs.scylladb.com/stable/llms.txt → 404
- https://operator.docs.scylladb.com/v1.21/reference/api/groups/scylla.scylladb.com/nodeconfigs.md → 404
-  → 404
- https://operator.docs.scylladb.com/master/llms.txt → 200 (works)

## Solution

Cherry-pick `2c2401df8` from `master`.

## After merging

Trigger a docs rebuild/redeploy [publishing the docs manually](https://sphinx-theme.scylladb.com/stable/deployment/production.html#publishing-the-docs-manually)