### PR TITLE
feat(api): add bootstrapPolicy API field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   which resulted in an unhandled error being logged.
   [#3538](https://github.com/scylladb/scylla-operator/pull/3538)
 
+### Features & Enhancements
+- Added an optional `bootstrapPolicy` field to `ScyllaCluster.spec` and `ScyllaDBDatacenter.spec`, accepting `Sequential`
+  or `Parallel`. `Parallel` requires ScyllaDB 2026.2 or later, declared with a semver-parseable image tag.
+  [#3568](https://github.com/scylladb/scylla-operator/pull/3568)
+
 ### Other changes
 
 - ScyllaDB Operator now runs `scylladb-node-exporter` as a dedicated sidecar container for ScyllaDB clusters running

--- a/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
@@ -237,6 +237,15 @@ spec:
                       type: array
                   type: object
                 type: array
+              bootstrapPolicy:
+                description: |-
+                  bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
+                  parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
+                  If not provided, it's treated as Sequential.
+                enum:
+                - Sequential
+                - Parallel
+                type: string
               cpuset:
                 description: |-
                   cpuset determines if the cluster will use cpu-pinning.

--- a/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -53,6 +53,15 @@ spec:
           spec:
             description: spec defines the desired state of this ScyllaDBDatacenter.
             properties:
+              bootstrapPolicy:
+                description: |-
+                  bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
+                  parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
+                  If not provided, it's treated as Sequential.
+                enum:
+                - Sequential
+                - Parallel
+                type: string
               clusterName:
                 description: |-
                   clusterName specifies the name of the ScyllaDB cluster.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2016,6 +2016,15 @@ spec:
                         type: array
                     type: object
                   type: array
+                bootstrapPolicy:
+                  description: |-
+                    bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
+                    parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
+                    If not provided, it's treated as Sequential.
+                  enum:
+                    - Sequential
+                    - Parallel
+                  type: string
                 cpuset:
                   description: |-
                     cpuset determines if the cluster will use cpu-pinning.
@@ -35606,6 +35615,15 @@ spec:
             spec:
               description: spec defines the desired state of this ScyllaDBDatacenter.
               properties:
+                bootstrapPolicy:
+                  description: |-
+                    bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
+                    parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
+                    If not provided, it's treated as Sequential.
+                  enum:
+                    - Sequential
+                    - Parallel
+                  type: string
                 clusterName:
                   description: |-
                     clusterName specifies the name of the ScyllaDB cluster.

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -90,6 +90,9 @@ object
    * - :ref:`backups<api-scylla.scylladb.com-scyllaclusters-v1-.spec.backups[]>`
      - array (object)
      - backups specifies backup tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
+   * - bootstrapPolicy
+     - string
+     - bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later. If not provided, it's treated as Sequential.
    * - cpuset
      - boolean
      - cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
@@ -75,6 +75,9 @@ object
    * - Property
      - Type
      - Description
+   * - bootstrapPolicy
+     - string
+     - bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later. If not provided, it's treated as Sequential.
    * - clusterName
      - string
      - clusterName specifies the name of the ScyllaDB cluster. When joining two DCs, their cluster name must match. This field is immutable.

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -230,6 +230,14 @@
           },
           "type": "array"
         },
+        "bootstrapPolicy": {
+          "description": "bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in\nparallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as Sequential.",
+          "enum": [
+            "Sequential",
+            "Parallel"
+          ],
+          "type": "string"
+        },
         "cpuset": {
           "description": "cpuset determines if the cluster will use cpu-pinning.\nDeprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.",
           "type": "boolean"

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -173,6 +173,14 @@
       },
       "type": "array"
     },
+    "bootstrapPolicy": {
+      "description": "bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in\nparallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as Sequential.",
+      "enum": [
+        "Sequential",
+        "Parallel"
+      ],
+      "type": "string"
+    },
     "cpuset": {
       "description": "cpuset determines if the cluster will use cpu-pinning.\nDeprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.",
       "type": "boolean"

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -222,6 +222,15 @@ spec:
                         type: array
                     type: object
                   type: array
+                bootstrapPolicy:
+                  description: |-
+                    bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
+                    parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
+                    If not provided, it's treated as Sequential.
+                  enum:
+                    - Sequential
+                    - Parallel
+                  type: string
                 cpuset:
                   description: |-
                     cpuset determines if the cluster will use cpu-pinning.

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -151,7 +151,26 @@ type ScyllaClusterSpec struct {
 	// about readiness gates.
 	// +optional
 	ReadinessGates []corev1.PodReadinessGate `json:"readinessGates,omitempty"`
+
+	// bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
+	// parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
+	// If not provided, it's treated as Sequential.
+	// TODO(https://scylladb.atlassian.net/browse/OPERATOR-290): Update the description above when this field starts being defaulted on creation.
+	// +kubebuilder:validation:Enum=Sequential;Parallel
+	// +optional
+	BootstrapPolicy *BootstrapPolicy `json:"bootstrapPolicy,omitempty"`
 }
+
+// BootstrapPolicy describes the ordering of ScyllaDB nodes bootstrap.
+type BootstrapPolicy string
+
+const (
+	// BootstrapPolicySequential specifies that ScyllaDB nodes are bootstrapped one at a time.
+	BootstrapPolicySequential BootstrapPolicy = "Sequential"
+
+	// BootstrapPolicyParallel specifies that ScyllaDB nodes are started in parallel.
+	BootstrapPolicyParallel BootstrapPolicy = "Parallel"
+)
 
 type PodIPSourceType string
 

--- a/pkg/api/scylla/v1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1/zz_generated.deepcopy.go
@@ -951,6 +951,11 @@ func (in *ScyllaClusterSpec) DeepCopyInto(out *ScyllaClusterSpec) {
 		*out = make([]corev1.PodReadinessGate, len(*in))
 		copy(*out, *in)
 	}
+	if in.BootstrapPolicy != nil {
+		in, out := &in.BootstrapPolicy, &out.BootstrapPolicy
+		*out = new(BootstrapPolicy)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -52,6 +52,15 @@ spec:
             spec:
               description: spec defines the desired state of this ScyllaDBDatacenter.
               properties:
+                bootstrapPolicy:
+                  description: |-
+                    bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
+                    parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
+                    If not provided, it's treated as Sequential.
+                  enum:
+                    - Sequential
+                    - Parallel
+                  type: string
                 clusterName:
                   description: |-
                     clusterName specifies the name of the ScyllaDB cluster.

--- a/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
+++ b/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
@@ -101,7 +101,26 @@ type ScyllaDBDatacenterSpec struct {
 	// about readiness gates.
 	// +optional
 	ReadinessGates []corev1.PodReadinessGate `json:"readinessGates,omitempty"`
+
+	// bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
+	// parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
+	// If not provided, it's treated as Sequential.
+	// TODO(https://scylladb.atlassian.net/browse/OPERATOR-290): Update the description above when this field starts being defaulted on creation.
+	// +kubebuilder:validation:Enum=Sequential;Parallel
+	// +optional
+	BootstrapPolicy *BootstrapPolicy `json:"bootstrapPolicy,omitempty"`
 }
+
+// BootstrapPolicy describes the ordering of ScyllaDB nodes bootstrap.
+type BootstrapPolicy string
+
+const (
+	// BootstrapPolicySequential specifies that ScyllaDB nodes are bootstrapped one at a time.
+	BootstrapPolicySequential BootstrapPolicy = "Sequential"
+
+	// BootstrapPolicyParallel specifies that ScyllaDB nodes are started in parallel.
+	BootstrapPolicyParallel BootstrapPolicy = "Parallel"
+)
 
 type ObjectTemplateMetadata struct {
 	// labels specify a custom key value map that gets merged with managed object labels.

--- a/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
@@ -2169,6 +2169,11 @@ func (in *ScyllaDBDatacenterSpec) DeepCopyInto(out *ScyllaDBDatacenterSpec) {
 		*out = make([]v1.PodReadinessGate, len(*in))
 		copy(*out, *in)
 	}
+	if in.BootstrapPolicy != nil {
+		in, out := &in.BootstrapPolicy, &out.BootstrapPolicy
+		*out = new(BootstrapPolicy)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -37,6 +37,11 @@ var (
 		scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress,
 	}
 
+	SupportedScyllaV1BootstrapPolicies = []scyllav1.BootstrapPolicy{
+		scyllav1.BootstrapPolicySequential,
+		scyllav1.BootstrapPolicyParallel,
+	}
+
 	schedulerTaskSpecCronParseOptions = cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor
 )
 
@@ -217,6 +222,15 @@ func ValidateScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *field.
 
 	if spec.MinReadySeconds != nil && *spec.MinReadySeconds < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("minReadySeconds"), *spec.MinReadySeconds, "must be non-negative integer"))
+	}
+
+	if spec.BootstrapPolicy != nil {
+		allErrs = append(allErrs, validateEnum(*spec.BootstrapPolicy, SupportedScyllaV1BootstrapPolicies, fldPath.Child("bootstrapPolicy"))...)
+
+		if *spec.BootstrapPolicy == scyllav1.BootstrapPolicyParallel {
+			// spec.version is used verbatim as the tag of the ScyllaDB image, so there's no image reference to strip the version from.
+			allErrs = append(allErrs, validateParallelBootstrapPolicyScyllaDBVersion(*spec.BootstrapPolicy, spec.Version, fldPath.Child("bootstrapPolicy"))...)
+		}
 	}
 
 	return allErrs

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -1078,6 +1078,124 @@ func TestValidateScyllaCluster(t *testing.T) {
 			},
 			expectedErrorString: `spec.alternator.servingCertificate.operatorManagedOptions.additionalIPAddresses: Invalid value: "0.not-an-ip.0.0": must be a valid IP address, (e.g. 10.9.8.7 or 2001:db8::ffff)`,
 		},
+		{
+			name: "unset bootstrapPolicy",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.BootstrapPolicy = nil
+				return cluster
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "unsupported bootstrapPolicy",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicy("foo"))
+				return cluster
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeNotSupported, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicy("foo"), Detail: `supported values: "Sequential", "Parallel"`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Unsupported value: "foo": supported values: "Sequential", "Parallel"`,
+		},
+		{
+			name: "Sequential bootstrapPolicy with a version not supporting parallel bootstrap",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.Version = "2025.1.0"
+				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				return cluster
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "Sequential bootstrapPolicy with an unparseable version",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.Version = "latest"
+				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				return cluster
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "Parallel bootstrapPolicy with the minimal supported version",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.Version = "2026.2.0"
+				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return cluster
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "Parallel bootstrapPolicy with a pre-release of the minimal supported version",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.Version = "2026.2.0-rc0"
+				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return cluster
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
+		{
+			name: "Parallel bootstrapPolicy with a version newer than the minimal supported one",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.Version = "2026.3.0"
+				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return cluster
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "Parallel bootstrapPolicy with an older major version",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.Version = "2025.1.0"
+				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return cluster
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
+		{
+			name: "Parallel bootstrapPolicy with an older minor version",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.Version = "2026.1.0"
+				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return cluster
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
+		{
+			name: "Parallel bootstrapPolicy with an unparseable version",
+			cluster: func() *scyllav1.ScyllaCluster {
+				cluster := validCluster.DeepCopy()
+				cluster.Spec.Version = "latest"
+				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return cluster
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
 	}
 
 	for _, test := range tests {
@@ -1352,6 +1470,78 @@ func TestValidateScyllaClusterUpdate(t *testing.T) {
 				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.exposeOptions.broadcastOptions.nodes.type", BadValue: pointer.Ptr(scyllav1.BroadcastAddressTypePodIP), Detail: `field is immutable`},
 			},
 			expectedErrorString: `spec.exposeOptions.broadcastOptions.nodes.type: Invalid value: "PodIP": field is immutable`,
+		},
+		{
+			name: "bootstrapPolicy can be changed to Parallel with a supported version",
+			old: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.Version = "2026.2.0"
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				return sc
+			}(),
+			new: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.Version = "2026.2.0"
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return sc
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "bootstrapPolicy can be changed to Sequential with an unsupported version",
+			old: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.Version = "2026.1.0"
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return sc
+			}(),
+			new: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.Version = "2026.1.0"
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				return sc
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "bootstrapPolicy cannot be changed to Parallel with an unsupported version",
+			old: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.Version = "2026.1.0"
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				return sc
+			}(),
+			new: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.Version = "2026.1.0"
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return sc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
+		{
+			name: "version cannot be downgraded below the one required by Parallel bootstrapPolicy",
+			old: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.Version = "2026.2.0"
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return sc
+			}(),
+			new: func() *scyllav1.ScyllaCluster {
+				sc := unit.NewSingleRackCluster(3)
+				sc.Spec.Version = "2026.1.0"
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return sc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 	}
 

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation.go
@@ -12,7 +12,9 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
+	"github.com/scylladb/scylla-operator/pkg/semver"
 	corevalidation "github.com/scylladb/scylla-operator/pkg/thirdparty/k8s.io/kubernetes/pkg/apis/core/validation"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -49,6 +51,11 @@ var (
 		scyllav1alpha1.NodeServiceTypeHeadless,
 		scyllav1alpha1.NodeServiceTypeClusterIP,
 		scyllav1alpha1.NodeServiceTypeLoadBalancer,
+	}
+
+	SupportedScyllaV1Alpha1BootstrapPolicies = []scyllav1alpha1.BootstrapPolicy{
+		scyllav1alpha1.BootstrapPolicySequential,
+		scyllav1alpha1.BootstrapPolicyParallel,
 	}
 )
 
@@ -98,6 +105,17 @@ func ValidateScyllaDBDatacenterSpec(spec scyllav1alpha1.ScyllaDBDatacenterSpec, 
 
 	if spec.MinReadySeconds != nil && *spec.MinReadySeconds < 0 {
 		allErrs = append(allErrs, apimachineryvalidation.ValidateNonnegativeField(int64(*spec.MinReadySeconds), fldPath.Child("minReadySeconds"))...)
+	}
+
+	if spec.BootstrapPolicy != nil {
+		allErrs = append(allErrs, validateEnum(*spec.BootstrapPolicy, SupportedScyllaV1Alpha1BootstrapPolicies, fldPath.Child("bootstrapPolicy"))...)
+
+		if *spec.BootstrapPolicy == scyllav1alpha1.BootstrapPolicyParallel {
+			// An image whose version can't be determined, e.g. one pinned by a digest, is deliberately treated as not
+			// supporting parallel bootstrap.
+			scyllaDBVersion, _ := naming.ImageToVersion(spec.ScyllaDB.Image)
+			allErrs = append(allErrs, validateParallelBootstrapPolicyScyllaDBVersion(*spec.BootstrapPolicy, scyllaDBVersion, fldPath.Child("bootstrapPolicy"))...)
+		}
 	}
 
 	return allErrs
@@ -578,6 +596,23 @@ func validateEnum[E ~string](value E, supported []E, fldPath *field.Path) field.
 
 	if !oslices.ContainsItem(supported, value) {
 		allErrs = append(allErrs, field.NotSupported(fldPath, value, oslices.ConvertSlice(supported, oslices.ToString[E])))
+	}
+
+	return allErrs
+}
+
+// validateParallelBootstrapPolicyScyllaDBVersion validates that the given ScyllaDB version supports bootstrapping nodes
+// in parallel. A version which can't be parsed is deliberately treated as not supporting it, so that parallel bootstrap
+// can only be enabled for versions known to support it.
+func validateParallelBootstrapPolicyScyllaDBVersion[P ~string](bootstrapPolicy P, scyllaDBVersion string, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if !semver.NewScyllaVersion(scyllaDBVersion).SupportFeatureSafe(semver.ScyllaDBVersionRequiredForParallelBootstrap) {
+		allErrs = append(allErrs, field.Invalid(fldPath, bootstrapPolicy, fmt.Sprintf(
+			"requires a semver-parseable ScyllaDB version >= %d.%d",
+			semver.ScyllaDBVersionRequiredForParallelBootstrap.Major,
+			semver.ScyllaDBVersionRequiredForParallelBootstrap.Minor,
+		)))
 	}
 
 	return allErrs

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
@@ -667,6 +667,137 @@ func TestValidateScyllaDBDatacenter(t *testing.T) {
 			},
 			expectedErrorString: `spec.rackTemplate.scyllaDBManagerAgent.customConfigSecretRef: Invalid value: "-hello": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
 		},
+		{
+			name: "unset bootstrapPolicy",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.BootstrapPolicy = nil
+				return sdc
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "unsupported bootstrapPolicy",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicy("foo"))
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeNotSupported, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicy("foo"), Detail: `supported values: "Sequential", "Parallel"`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Unsupported value: "foo": supported values: "Sequential", "Parallel"`,
+		},
+		{
+			name: "Sequential bootstrapPolicy with an image tag not supporting parallel bootstrap",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2025.1.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				return sdc
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "Sequential bootstrapPolicy with an unparseable image tag",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:latest"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				return sdc
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "Parallel bootstrapPolicy with an image tag of the minimal supported version",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "Parallel bootstrapPolicy with an image tag of a pre-release of the minimal supported version",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0-rc0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
+		{
+			name: "Parallel bootstrapPolicy with an image tag of a version newer than the minimal supported one",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.3.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "Parallel bootstrapPolicy with an image tag of an older major version",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2025.1.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
+		{
+			name: "Parallel bootstrapPolicy with an image tag of an older minor version",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
+		{
+			name: "Parallel bootstrapPolicy with an unparseable image tag",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:latest"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
+		{
+			name: "Parallel bootstrapPolicy with a digest pinned image",
+			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
 	}
 
 	for _, test := range tests {
@@ -1213,6 +1344,78 @@ func TestValidateScyllaDBDatacenterUpdate(t *testing.T) {
 				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.exposeOptions.broadcastOptions.nodes.type", BadValue: pointer.Ptr(scyllav1alpha1.BroadcastAddressTypePodIP), Detail: `field is immutable`},
 			},
 			expectedErrorString: `spec.exposeOptions.broadcastOptions.nodes.type: Invalid value: "PodIP": field is immutable`,
+		},
+		{
+			name: "bootstrapPolicy can be changed to Parallel with a supported image tag",
+			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				return sdc
+			}(),
+			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "bootstrapPolicy can be changed to Sequential with an unsupported image tag",
+			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				return sdc
+			}(),
+			expectedErrorList:   nil,
+			expectedErrorString: "",
+		},
+		{
+			name: "bootstrapPolicy cannot be changed to Parallel with an unsupported image tag",
+			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				return sdc
+			}(),
+			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+		},
+		{
+			name: "image cannot be downgraded below the version required by Parallel bootstrapPolicy",
+			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
+				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+			},
+			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 	}
 

--- a/pkg/controller/scyllacluster/migrate.go
+++ b/pkg/controller/scyllacluster/migrate.go
@@ -275,6 +275,18 @@ func MigrateV1ScyllaClusterSpecToV1Alpha1ScyllaDBDatacenterSpec(scName string, s
 		MinTerminationGracePeriodSeconds:        scSpec.MinTerminationGracePeriodSeconds,
 		MinReadySeconds:                         scSpec.MinReadySeconds,
 		ReadinessGates:                          scSpec.ReadinessGates,
+		BootstrapPolicy: func() *scyllav1alpha1.BootstrapPolicy {
+			// A managed ScyllaDBDatacenter always carries an explicit bootstrapPolicy.
+			// An unset bootstrapPolicy in the parent ScyllaCluster means it was created before the field was defaulted on
+			// creation, hence it must keep bootstrapping its nodes sequentially. This resolution is permanently frozen and
+			// must not be changed when the create-time default becomes Parallel, as that would silently parallelize
+			// bootstrap of pre-existing clusters.
+			if scSpec.BootstrapPolicy == nil {
+				return pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+			}
+
+			return pointer.Ptr(scyllav1alpha1.BootstrapPolicy(*scSpec.BootstrapPolicy))
+		}(),
 	}, apimachineryutilerrors.NewAggregate(migrateErrs)
 }
 

--- a/pkg/controller/scyllacluster/migrate_test.go
+++ b/pkg/controller/scyllacluster/migrate_test.go
@@ -309,6 +309,45 @@ func TestMigrateV1ScyllaClusterToV1Alpha1ScyllaDBDatacenter(t *testing.T) {
 			},
 		},
 		{
+			name: "unset bootstrapPolicy is migrated into Sequential",
+			scyllaCluster: func() *scyllav1.ScyllaCluster {
+				sc := newBasicScyllaCluster()
+				sc.Spec.BootstrapPolicy = nil
+				return sc
+			}(),
+			expectedScyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sd := newBasicScyllaDBDatacenterWithNoStatus()
+				sd.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				return sd
+			}(),
+		},
+		{
+			name: "explicit Sequential bootstrapPolicy is migrated verbatim",
+			scyllaCluster: func() *scyllav1.ScyllaCluster {
+				sc := newBasicScyllaCluster()
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				return sc
+			}(),
+			expectedScyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sd := newBasicScyllaDBDatacenterWithNoStatus()
+				sd.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				return sd
+			}(),
+		},
+		{
+			name: "explicit Parallel bootstrapPolicy is migrated verbatim",
+			scyllaCluster: func() *scyllav1.ScyllaCluster {
+				sc := newBasicScyllaCluster()
+				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				return sc
+			}(),
+			expectedScyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sd := newBasicScyllaDBDatacenterWithNoStatus()
+				sd.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				return sd
+			}(),
+		},
+		{
 			name: "global manager integration disabled with the annotation",
 			scyllaCluster: func() *scyllav1.ScyllaCluster {
 				sc := newBasicScyllaCluster()
@@ -705,6 +744,7 @@ func newBasicScyllaDBDatacenterWithStatus() *scyllav1alpha1.ScyllaDBDatacenter {
 					Name:         "a",
 				},
 			},
+			BootstrapPolicy: pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential),
 		},
 		Status: scyllav1alpha1.ScyllaDBDatacenterStatus{
 			ObservedGeneration: pointer.Ptr[int64](123),

--- a/pkg/controller/scylladbcluster/resource.go
+++ b/pkg/controller/scylladbcluster/resource.go
@@ -294,6 +294,10 @@ func MakeRemoteScyllaDBDatacenters(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyll
 			MinTerminationGracePeriodSeconds:        sc.Spec.MinTerminationGracePeriodSeconds,
 			MinReadySeconds:                         sc.Spec.MinReadySeconds,
 			ReadinessGates:                          sc.Spec.ReadinessGates,
+			// A managed ScyllaDBDatacenter always carries an explicit bootstrapPolicy.
+			// ScyllaDBCluster has no equivalent field, as bootstrapping nodes in parallel is not supported in automated
+			// multi-datacenter deployments, hence it's always resolved to Sequential.
+			BootstrapPolicy: pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential),
 			// TODO: not supported yet
 			// Ref: https://github.com/scylladb/scylla-operator/issues/2262
 			ImagePullSecrets: nil,

--- a/pkg/controller/scylladbcluster/resource_test.go
+++ b/pkg/controller/scylladbcluster/resource_test.go
@@ -565,6 +565,7 @@ func TestMakeScyllaDBDatacenters(t *testing.T) {
 						Name: "c",
 					},
 				},
+				BootstrapPolicy: pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential),
 			},
 		}
 	}

--- a/pkg/semver/version.go
+++ b/pkg/semver/version.go
@@ -26,7 +26,8 @@ var (
 	// ScyllaDBVersionWithoutNodeExporter is "2026.3.0-0", not "2026.3.0": per semver precedence a pre-release
 	// version is always lower than the same version without one, so a plain "2026.3.0" threshold would reject
 	// pre-GA nightly builds that already ship without node-exporter.
-	ScyllaDBVersionWithoutNodeExporter = semver.MustParse("2026.3.0-0")
+	ScyllaDBVersionWithoutNodeExporter          = semver.MustParse("2026.3.0-0")
+	ScyllaDBVersionRequiredForParallelBootstrap = semver.MustParse("2026.2.0")
 )
 
 // ScyllaVersion contains the version of a cluster with unkown version support


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Extends `ScyllaDBDatacenter` and `ScyllaCluster` CRDs with an optional `bootstrapPolicy` enum field. Setting it to `Parallel` requires Scylla version >= 2026.2.

Managed `ScyllaDBDatanceter`: if its parent doesn't set `bootstrapPolicy` explicitly, we always set `bootstrapPolicy` to `Sequential` to ensure preexisting clusters do not use `Parallel` without opting in when we implement https://scylladb.atlassian.net/browse/OPERATOR-290.

For `ScyllaDBCluster`, we hardcode the value to `Sequential` in child `ScyllaDBDatacenter`s as we won't support parallel bootstrap in automated multi-DC.

**Which issue is resolved by this Pull Request:**
Closes https://scylladb.atlassian.net/browse/OPERATOR-148