### PR TITLE
feat: seed last cleaned up token ring hash with a never-cleaned-up value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
   wrapper incorrectly compared against `OperationalModeDecommissioned` instead of `OperationalModeDecommissioning`,
   which resulted in an unhandled error being logged.
   [#3538](https://github.com/scylladb/scylla-operator/pull/3538)
+- Fixed nodes being skipped by cleanup after the token ring changed. The operator seeded a node's last cleaned up token
+  ring hash with whatever ring state its sidecar sampled first, which exempted that node from cleanup of the ring it
+  first observed. Which nodes ended up exempt depended on the race between node joins and the time for sidecar to propagate the token ring hash.
+  Every node is now cleaned up once the ring changes. Note that this increases the number of cleanup jobs created at once,
+  from N-1 to N for an N node cluster.
+  [#3574](https://github.com/scylladb/scylla-operator/pull/3574)
 
 ### Other changes
 

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -156,16 +156,19 @@ func MemberService(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName, name string
 		maps.Copy(annotations, sdcAnnotations)
 	}
 
+	// Seed the annotation with a value meaning the node has never been cleaned up. Seeding it with the currently
+	// observed token ring hash would exempt the node from a cleanup of the ring state it happens to observe first,
+	// which depends on when its sidecar samples the ring.
+	// Only a completed cleanup Job may set it to a real hash.
+	lastCleanedUpTokenRingHash := naming.LastCleanedUpTokenRingHashAnnotationValueNeverCleanedUp
 	if oldService != nil {
-		_, hasLastCleanedUpRingHash := oldService.Annotations[naming.LastCleanedUpTokenRingHashAnnotation]
-		currentTokenRingHash, hasCurrentRingHash := oldService.Annotations[naming.CurrentTokenRingHashAnnotation]
-		if !hasLastCleanedUpRingHash && hasCurrentRingHash {
-			annotations[naming.LastCleanedUpTokenRingHashAnnotation] = currentTokenRingHash
+		if v, ok := oldService.Annotations[naming.LastCleanedUpTokenRingHashAnnotation]; ok {
+			lastCleanedUpTokenRingHash = v
 		}
 	}
+	annotations[naming.LastCleanedUpTokenRingHashAnnotation] = lastCleanedUpTokenRingHash
 
-	cleanupJob, ok := jobs[naming.CleanupJobForService(name)]
-	if ok {
+	if cleanupJob, ok := jobs[naming.CleanupJobForService(name)]; ok {
 		if len(cleanupJob.Annotations[naming.CleanupJobTokenRingHashAnnotation]) != 0 && cleanupJob.Status.CompletionTime != nil {
 			annotations[naming.LastCleanedUpTokenRingHashAnnotation] = cleanupJob.Annotations[naming.CleanupJobTokenRingHashAnnotation]
 		}
@@ -1830,18 +1833,6 @@ func MakeJobs(sdc *scyllav1alpha1.ScyllaDBDatacenter, services map[string]*corev
 					Message:            fmt.Sprintf("Service %q is missing last cleaned up token ring hash annotation", naming.ObjRef(svc)),
 					ObservedGeneration: sdc.Generation,
 				})
-				continue
-			}
-
-			if len(lastCleanedUpTokenRingHash) == 0 {
-				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               jobControllerProgressingCondition,
-					Status:             metav1.ConditionTrue,
-					Reason:             "UnexpectedServiceState",
-					Message:            fmt.Sprintf("Service %q has unexpected empty last cleaned up token ring hash annotation, can't create cleanup Job", naming.ObjRef(svc)),
-					ObservedGeneration: sdc.Generation,
-				})
-				klog.Warningf("Can't create cleanup Job for Service %s because it has unexpected empty last cleaned up token ring hash annotation", klog.KObj(svc))
 				continue
 			}
 

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -89,6 +89,7 @@ func TestMemberService(t *testing.T) {
 	basicSVCAnnotations := func() map[string]string {
 		return map[string]string{
 			"default-sc-annotation": "bar",
+			"internal.scylla-operator.scylladb.com/last-cleaned-up-token-ring-hash": "NeverCleanedUp",
 		}
 	}
 	basicPorts := []corev1.ServicePort{
@@ -228,7 +229,7 @@ func TestMemberService(t *testing.T) {
 			},
 		},
 		{
-			name:               "last cleaned up annotation is rewritten from current one when it's missing in existing service",
+			name:               "last cleaned up annotation is seeded as never cleaned up when it's missing in existing service",
 			scyllaDBDatacenter: basicSC,
 			rackName:           basicRackName,
 			svcName:            basicSVCName,
@@ -241,11 +242,64 @@ func TestMemberService(t *testing.T) {
 			}, jobs: nil,
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:            basicSVCName,
+					Labels:          basicSVCLabels(),
+					Annotations:     basicSVCAnnotations(),
+					OwnerReferences: basicSCOwnerRefs,
+				},
+				Spec: corev1.ServiceSpec{
+					Type:                     corev1.ServiceTypeClusterIP,
+					Selector:                 basicSVCSelector,
+					PublishNotReadyAddresses: true,
+					Ports:                    basicPorts,
+				},
+			},
+		},
+		{
+			name:               "last cleaned up annotation is seeded as never cleaned up when existing service has no token ring hash annotations",
+			scyllaDBDatacenter: basicSC,
+			rackName:           basicRackName,
+			svcName:            basicSVCName,
+			oldService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			}, jobs: nil,
+			expectedService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            basicSVCName,
+					Labels:          basicSVCLabels(),
+					Annotations:     basicSVCAnnotations(),
+					OwnerReferences: basicSCOwnerRefs,
+				},
+				Spec: corev1.ServiceSpec{
+					Type:                     corev1.ServiceTypeClusterIP,
+					Selector:                 basicSVCSelector,
+					PublishNotReadyAddresses: true,
+					Ports:                    basicPorts,
+				},
+			},
+		},
+		{
+			name:               "existing last cleaned up annotation is not overwritten by the seed",
+			scyllaDBDatacenter: basicSC,
+			rackName:           basicRackName,
+			svcName:            basicSVCName,
+			oldService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"internal.scylla-operator.scylladb.com/current-token-ring-hash":         "abc",
+						"internal.scylla-operator.scylladb.com/last-cleaned-up-token-ring-hash": "def",
+					},
+				},
+			}, jobs: nil,
+			expectedService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:   basicSVCName,
 					Labels: basicSVCLabels(),
 					Annotations: func() map[string]string {
 						res := basicSVCAnnotations()
-						res["internal.scylla-operator.scylladb.com/last-cleaned-up-token-ring-hash"] = "abc"
+						res["internal.scylla-operator.scylladb.com/last-cleaned-up-token-ring-hash"] = "def"
 						return res
 					}(),
 					OwnerReferences: basicSCOwnerRefs,
@@ -338,6 +392,7 @@ func TestMemberService(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"foo": "bar",
+						"internal.scylla-operator.scylladb.com/last-cleaned-up-token-ring-hash": "NeverCleanedUp",
 					},
 					OwnerReferences: basicSCOwnerRefs,
 				},
@@ -3070,23 +3125,98 @@ func TestMakeJobs(t *testing.T) {
 			},
 		},
 		{
-			name:               "progressing condition when member service last cleaned up token ring hash annotation is empty",
+			name:               "cleanup job when member service has never been cleaned up",
 			scyllaDBDatacenter: basicScyllaDBDatacenter(),
 			services: map[string]*corev1.Service{
 				"basic-dc-rack-0": newMemberService("basic-dc-rack-0", map[string]string{
 					"internal.scylla-operator.scylladb.com/current-token-ring-hash":         "abc",
-					"internal.scylla-operator.scylladb.com/last-cleaned-up-token-ring-hash": "",
+					"internal.scylla-operator.scylladb.com/last-cleaned-up-token-ring-hash": "NeverCleanedUp",
 				}, "1.1.1.1"),
 			},
-			expectedJobs: nil,
-			expectedConditions: []metav1.Condition{
+			pods: []*corev1.Pod{
+				newPod("basic-dc-rack-0", "2.2.2.2"),
+			},
+			expectedJobs: []*batchv1.Job{
 				{
-					Type:    "JobControllerProgressing",
-					Status:  "True",
-					Reason:  "UnexpectedServiceState",
-					Message: `Service "basic-dc-rack-0" has unexpected empty last cleaned up token ring hash annotation, can't create cleanup Job`,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cleanup-basic-dc-rack-0",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"default-sc-annotation": "bar",
+							"internal.scylla-operator.scylladb.com/cleanup-token-ring-hash": "abc",
+						},
+						Labels: map[string]string{
+							"default-sc-label":                           "foo",
+							"scylla/cluster":                             "basic",
+							"scylla-operator.scylladb.com/node-job":      "basic-dc-rack-0",
+							"scylla-operator.scylladb.com/node-job-type": "Cleanup",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "scylla.scylladb.com/v1alpha1",
+								Kind:               "ScyllaDBDatacenter",
+								Name:               "basic",
+								UID:                "the-uid",
+								Controller:         pointer.Ptr(true),
+								BlockOwnerDeletion: pointer.Ptr(true),
+							},
+						},
+					},
+					Spec: batchv1.JobSpec{
+						Selector:       nil,
+						ManualSelector: pointer.Ptr(false),
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"default-sc-annotation": "bar",
+									"internal.scylla-operator.scylladb.com/cleanup-token-ring-hash": "abc",
+								},
+								Labels: map[string]string{
+									"default-sc-label":                           "foo",
+									"scylla/cluster":                             "basic",
+									"scylla-operator.scylladb.com/node-job":      "basic-dc-rack-0",
+									"scylla-operator.scylladb.com/node-job-type": "Cleanup",
+									"scylla-operator.scylladb.com/pod-type":      "cleanup-job",
+								},
+							},
+							Spec: corev1.PodSpec{
+								RestartPolicy: corev1.RestartPolicyOnFailure,
+								Containers: []corev1.Container{
+									{
+										Name:            naming.CleanupContainerName,
+										Image:           unit.ScyllaDBOperatorImage,
+										ImagePullPolicy: corev1.PullIfNotPresent,
+										Args: []string{
+											"cleanup-job",
+											"--manager-auth-config-path=/etc/scylla-cleanup-job/auth-token.yaml",
+											"--node-address=1.1.1.1",
+										},
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name:      "scylla-manager-agent-token",
+												ReadOnly:  true,
+												MountPath: "/etc/scylla-cleanup-job/auth-token.yaml",
+												SubPath:   "auth-token.yaml",
+											},
+										},
+									},
+								},
+								Volumes: []corev1.Volume{
+									{
+										Name: "scylla-manager-agent-token",
+										VolumeSource: corev1.VolumeSource{
+											Secret: &corev1.SecretVolumeSource{
+												SecretName: "basic-auth-token",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
+			expectedConditions: nil,
 		},
 		{
 			name:               "no cleanup jobs when member service token ring hash annotations are equal",

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -667,32 +667,6 @@ func (sdcc *Controller) syncStatefulSets(
 
 				return progressingConditions, nil
 			}
-
-			requiredAnnotationsBeforeScaling := []string{
-				// We need to ensure token ring annotation is noticed by the cleanup logic before we scale the rack.
-				// Otherwise, new node could start joining, changing the ring hash and causing cleanup to be missed.
-				naming.LastCleanedUpTokenRingHashAnnotation,
-			}
-
-			for _, requiredAnnotation := range requiredAnnotationsBeforeScaling {
-				ord, err := naming.IndexFromName(svc.Name)
-				if err != nil {
-					return nil, fmt.Errorf("can't determine ordinal from Service name %q: %w", svc.Name, err)
-				}
-
-				if ord < *sts.Spec.Replicas {
-					_, ok := svc.Annotations[requiredAnnotation]
-					if !ok {
-						progressingConditions = append(progressingConditions, metav1.Condition{
-							Type:               statefulSetControllerProgressingCondition,
-							Status:             metav1.ConditionTrue,
-							Reason:             "WaitingForServiceState",
-							Message:            fmt.Sprintf("Statusfulset %q is waiting for Service %q to have required annotation %q before scaling", naming.ObjRef(req), naming.ObjRef(svc), requiredAnnotation),
-							ObservedGeneration: sdc.Generation,
-						})
-					}
-				}
-			}
 		}
 
 		if scale.Spec.Replicas == *sts.Spec.Replicas {

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -42,7 +42,14 @@ const (
 	CurrentTokenRingHashAnnotation = "internal.scylla-operator.scylladb.com/current-token-ring-hash"
 
 	// LastCleanedUpTokenRingHashAnnotation reflects the last cleaned up hash of token ring of the scylla node.
+	// A value of LastCleanedUpTokenRingHashAnnotationValueNeverCleanedUp means the node has never been cleaned up and
+	// is distinct from the annotation being absent, which means the operator hasn't seeded it yet and the node's
+	// cleanup state is not yet known.
 	LastCleanedUpTokenRingHashAnnotation = "internal.scylla-operator.scylladb.com/last-cleaned-up-token-ring-hash"
+
+	// LastCleanedUpTokenRingHashAnnotationValueNeverCleanedUp is the value of LastCleanedUpTokenRingHashAnnotation
+	// seeded for a node that has never been cleaned up.
+	LastCleanedUpTokenRingHashAnnotationValueNeverCleanedUp = "NeverCleanedUp"
 
 	// CleanupJobTokenRingHashAnnotation reflects which version of token ring cleanup Job is cleaning.
 	CleanupJobTokenRingHashAnnotation = "internal.scylla-operator.scylladb.com/cleanup-token-ring-hash"

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -12,7 +12,6 @@ import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
-	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
@@ -32,10 +31,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		f = framework.NewFramework(ctx, "scyllacluster")
 	})
 
-	g.It("nodes are cleaned up after horizontal scaling", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-		defer cancel()
-
+	g.It("nodes are cleaned up after horizontal scaling", func(ctx g.SpecContext) {
 		jobListWatcher := createJobListWatcher(ctx, f)
 		jobObserver := utils.ObserveObjects[*batchv1.Job](jobListWatcher)
 		err := jobObserver.Start(ctx)
@@ -44,10 +40,10 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		sc, err := createClusterAndWaitForRollout(ctx, f, 1)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		framework.By("Validating no cleanup jobs were created")
-		jobEvents, err := jobObserver.Stop()
+		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
+
+		_, err = jobObserver.Stop()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(jobEvents).To(o.BeEmpty())
 
 		jobObserver = utils.ObserveObjects[*batchv1.Job](jobListWatcher)
 		err = jobObserver.Start(ctx)
@@ -56,7 +52,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		sc, err = scaleClusterAndWaitForRollout(ctx, f, sc, 3)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver, []int32{0, 1})
+		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
 
 		_, err = jobObserver.Stop()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -68,16 +64,13 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		sc, err = scaleClusterAndWaitForRollout(ctx, f, sc, 2)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver, []int32{0, 1})
+		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
 
 		_, err = jobObserver.Stop()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("multi-node cluster nodes are cleaned up right after provisioning", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-		defer cancel()
-
+	g.It("multi-node cluster nodes are cleaned up right after provisioning", func(ctx g.SpecContext) {
 		jobListWatcher := createJobListWatcher(ctx, f)
 		jobObserver := utils.ObserveObjects[*batchv1.Job](jobListWatcher)
 		err := jobObserver.Start(ctx)
@@ -86,7 +79,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		sc, err := createClusterAndWaitForRollout(ctx, f, 3)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver, []int32{0, 1})
+		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
 
 		_, err = jobObserver.Stop()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -105,48 +98,39 @@ func createJobListWatcher(ctx context.Context, f *framework.Framework) *cache.Li
 	}
 }
 
-// nodeJobMatcher returns a matcher function that checks if a job event is for the given node name.
-func nodeJobMatcher(nodeName string) func(utils.ObserverEvent[*batchv1.Job]) bool {
-	return func(e utils.ObserverEvent[*batchv1.Job]) bool {
-		return e.Obj.Labels[naming.NodeJobLabel] == nodeName
-	}
-}
-
-// verifyCleanupJobsCreatedEventually verifies that cleanup jobs were created for the expected nodes.
-// It polls the observer's events since cleanup jobs may be created asynchronously after the cluster
-// is marked as rolled out - each node service is annotated with the token ring hash independently,
-// which triggers cleanup job creation for that node.
+// verifyCleanupJobsCreatedEventually verifies that a cleanup job was created for every node of the cluster.
+// It polls the observer's events since cleanup jobs may be created asynchronously after the cluster is marked as rolled
+// out - each node service is annotated with the token ring hash independently, which triggers cleanup job creation for
+// that node.
 func verifyCleanupJobsCreatedEventually(
 	ctx context.Context,
 	f *framework.Framework,
 	sc *scyllav1.ScyllaCluster,
 	jobObserver *utils.ObjectObserver[*batchv1.Job],
-	expectedNodeIndices []int32,
 ) {
 	tokenRingHash, err := utils.GetCurrentTokenRingHash(ctx, f.KubeClient().CoreV1(), sc)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	framework.Infof("Current token ring hash of the cluster is %q", tokenRingHash)
 
-	framework.Infof("Verifying cleanup jobs were created for nodes: %v", expectedNodeIndices)
-
-	expectedMatchers := make([]interface{}, len(expectedNodeIndices))
-	for i, nodeIndex := range expectedNodeIndices {
-		nodeName := naming.MemberServiceNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, int(nodeIndex))
-		expectedMatchers[i] = o.Satisfy(nodeJobMatcher(nodeName))
+	var memberServiceNames []string
+	for _, r := range sc.Spec.Datacenter.Racks {
+		for i := range int(r.Members) {
+			memberServiceNames = append(memberServiceNames, naming.MemberServiceNameForScyllaCluster(r, sc, i))
+		}
 	}
 
-	o.Eventually(func(g o.Gomega) {
-		jobEvents := jobObserver.Events()
-		cleanupJobsCreated := oslices.Filter(jobEvents, func(e utils.ObserverEvent[*batchv1.Job]) bool {
-			return e.Action == watch.Added &&
+	framework.Infof("Verifying cleanup jobs were created for nodes: %v", memberServiceNames)
+	o.Eventually(func(eo o.Gomega) {
+		var cleanedUpNodes []string
+		for _, e := range jobObserver.Events() {
+			if e.Action == watch.Added &&
 				e.Obj.Labels[naming.NodeJobTypeLabel] == string(naming.JobTypeCleanup) &&
-				e.Obj.Annotations[naming.CleanupJobTokenRingHashAnnotation] == tokenRingHash
-		})
+				e.Obj.Annotations[naming.CleanupJobTokenRingHashAnnotation] == tokenRingHash {
+				cleanedUpNodes = append(cleanedUpNodes, e.Obj.Labels[naming.NodeJobLabel])
+			}
+		}
 
-		g.Expect(cleanupJobsCreated).To(o.HaveLen(len(expectedNodeIndices)),
-			"expected %d cleanup jobs with token ring hash %q, got %d",
-			len(expectedNodeIndices), tokenRingHash, len(cleanupJobsCreated))
-		g.Expect(cleanupJobsCreated).To(o.ConsistOf(expectedMatchers...))
+		eo.Expect(cleanedUpNodes).To(o.ConsistOf(memberServiceNames))
 	}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(o.Succeed())
 }
 

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -31,13 +31,17 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		f = framework.NewFramework(ctx, "scyllacluster")
 	})
 
-	g.It("nodes are cleaned up after horizontal scaling", func(ctx g.SpecContext) {
+	type horizontalScalingEntry struct {
+		initialMembers int32
+		targetMembers  int32
+	}
+	g.DescribeTable("nodes are cleaned up", func(ctx g.SpecContext, e *horizontalScalingEntry) {
 		jobListWatcher := createJobListWatcher(ctx, f)
 		jobObserver := utils.ObserveObjects[*batchv1.Job](jobListWatcher)
 		err := jobObserver.Start(ctx)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc, err := createClusterAndWaitForRollout(ctx, f, 1)
+		sc, err := createClusterAndWaitForRollout(ctx, f, e.initialMembers)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
@@ -49,26 +53,23 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		err = jobObserver.Start(ctx)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc, err = scaleClusterAndWaitForRollout(ctx, f, sc, 3)
+		sc, err = scaleClusterAndWaitForRollout(ctx, f, sc, e.targetMembers)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
 
 		_, err = jobObserver.Stop()
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		jobObserver = utils.ObserveObjects[*batchv1.Job](jobListWatcher)
-		err = jobObserver.Start(ctx)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		sc, err = scaleClusterAndWaitForRollout(ctx, f, sc, 2)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
-
-		_, err = jobObserver.Stop()
-		o.Expect(err).NotTo(o.HaveOccurred())
-	})
+	},
+		g.Entry("after scaling the cluster out", &horizontalScalingEntry{
+			initialMembers: 1,
+			targetMembers:  3,
+		}),
+		g.Entry("after scaling the cluster in", &horizontalScalingEntry{
+			initialMembers: 3,
+			targetMembers:  1,
+		}),
+	)
 
 	g.It("multi-node cluster nodes are cleaned up right after provisioning", func(ctx g.SpecContext) {
 		jobListWatcher := createJobListWatcher(ctx, f)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Cleanup of a node is triggered by its member Service's current token ring hash differing from the last cleaned up one. The latter is seeded with the current hash the first time the Service is seen carrying one, which exempts the node from cleanup of the ring it first observed. The seeded value is whatever ring state the node's sidecar sampled first, so which nodes end up exempt depends on the race between how far apart the nodes join and the sidecar's 5s poll, not on the nodes themselves. Ordered pod management spaced the joins out enough that the exempt node was always (usually?) only the last one, but parallel pod management removes that spacing and the number of created cleanup jobs varies wildly.

This PR changes this to seed a `NeverCleanedUp` value instead, meaning the node has never been cleaned up. It never matches a current hash, so every node is cleaned up once the ring changes and the count follows the member count.

PR also removes the wait for the annotation before scaling. It only guarded against the ring hash changing before the cleanup logic first observed a node, which could freeze a post-scale hash and exempt the node from cleanup. An absent annotation can now only ever become `NeverCleanedUp`, so scaling early can at most delay a cleanup, never lose it.

The E2E assertions pinned which ordinals get a cleanup job. They now assert that a cleanup job is created for every node.

This fix makes the existing cleanup burst worse by one job per rack: an N node cluster previously got N-1 jobs and now gets N (including the edge-case of a one-node cluster). What's worse, however, is that with parallel bootstrap we can create multiple StatefulSets at once, so a potential burst can grow to RACKS x NODES.

Nothing limits how many cleanup jobs are created at the same time. We can consider capping the number of in-flight jobs (or any other improvement proposed in https://scylladb.atlassian.net/browse/OPERATOR-48).

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-291