### PR TITLE
test: reserve orphaned-PV clone PVs for their intended PVC

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -247,18 +247,31 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 						pv, err := f.KubeAdminClient().CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
 						o.Expect(err).NotTo(o.HaveOccurred())
 
+						realPVCName := strings.TrimPrefix(pvc.Name, "clone-")
+
 						pvClone := &corev1.PersistentVolume{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:   fmt.Sprintf("clone-%s", pv.Name),
 								Labels: f.CommonLabels(),
 							},
-							Spec:   *pv.Spec.DeepCopy(),
-							Status: *pv.Status.DeepCopy(),
+							Spec: *pv.Spec.DeepCopy(),
 						}
 						pvClone.Labels[cloneLabelKey] = f.Namespace()
 						pvClone.Spec.StorageClassName = testStorageClassName
 						pvClone.Spec.NodeAffinity = nil
-						pvClone.Spec.ClaimRef = nil
+						// Reserve the clone PV for the PVC that it's meant for. A PVC's spec.volumeName is only a request,
+						// while the PV's spec.claimRef is what reserves it, so an unclaimed PV can be bound by the PV
+						// controller to any other unbound PVC of the same StorageClass.
+						// UID is deliberately left unset. This test replaces the PVC, and a claimRef holding only a
+						// namespace and a name keeps matching it across the replacement.
+						pvClone.Spec.ClaimRef = &corev1.ObjectReference{
+							Namespace: f.Namespace(),
+							Name:      realPVCName,
+						}
+						// The clone PV is a fabricated object with no lifecycle of its own, and it shares the backing volume
+						// with the clone PVC's PV. Reclaiming it would make the provisioner delete storage which is still in
+						// use, so it's retained and deleted explicitly on cleanup.
+						pvClone.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimRetain
 						if pvClone.Spec.PersistentVolumeSource.Local != nil {
 							pvClone.Spec.PersistentVolumeSource.HostPath = &corev1.HostPathVolumeSource{
 								Path: pvClone.Spec.PersistentVolumeSource.Local.Path,
@@ -285,7 +298,6 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 						)
 						o.Expect(err).NotTo(o.HaveOccurred())
 
-						realPVCName := strings.TrimPrefix(pvc.Name, "clone-")
 						err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 							realPvc, err := f.KubeClient().CoreV1().PersistentVolumeClaims(f.Namespace()).Get(ctx, realPVCName, metav1.GetOptions{})
 							if err != nil {


### PR DESCRIPTION
The fake clone provisioner binds one-way: it creates the clone PV with an empty claimRef and then sets the real PVC's spec.volumeName. volumeName is only a request, claimRef is what reserves, so the PV controller can match the unclaimed clone PV against a different unbound PVC of the same class and win, leaving the intended PVC permanently Pending.

The race needs two unclaimed clone PVs alive at once. Today, with ordered pod management policy, they are spread out in time enough for it to never trigger. With parallel bootstrap all three land simultanously and the test fails.

Set spec.claimRef to the intended PVC at creation. The UID is left unset because this test replaces the PVC, and the UID is only enforced when it's set.

Retain the clone PV. Pre-binding makes it Bound, which newly activates reclaim, and it shares a backing volume with the clone PVC's PV - on CSI-backed CI a Delete reclaim would delete storage still in use.

<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-295

/hold to test with naive parallel-bootstrap implementation