### PR TITLE
feat: support parallel bootstrap of ScyllaDB nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@
 - The webhook server now serves a mutating admission webhook that applies API defaults to `ScyllaClusters` and
   `ScyllaDBDatacenters` on creation. Matching `MutatingWebhookConfiguration` is added to the operator's manifests.
   [#3579](https://github.com/scylladb/scylla-operator/pull/3579)
+- ScyllaDB nodes can now bootstrap in parallel. With `bootstrapPolicy: Parallel`, the nodes of a rack are started
+  without each one waiting for the previous ordinal to become ready, and all missing racks are created in a single sync
+  rather than one per requeue, which cuts the time to bring up a cluster. Creating them still waits for any in-flight
+  scaling, update or upgrade of the existing racks to settle. Newly created clusters use `Parallel` by default, while
+  existing ones stay on `Sequential` and can opt in. The policy can be changed on a running cluster without disruptions
+  to existing nodes. Parallel bootstrap isn't available for datacenters managed by `ScyllaDBCluster`, which always
+  bootstraps sequentially.
+  [#3578](https://github.com/scylladb/scylla-operator/pull/3578)
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
   existing ones stay on `Sequential` and can opt in. The policy can be changed on a running cluster without disruptions
   to existing nodes. Parallel bootstrap isn't available for datacenters managed by `ScyllaDBCluster`, which always
   bootstraps sequentially.
-  [#3578](https://github.com/scylladb/scylla-operator/pull/3578)
+  [#3578](https://github.com/scylladb/scylla-operator/pull/3578), [#3588](https://github.com/scylladb/scylla-operator/pull/3588)
 
 ### Other changes
 

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -338,6 +338,57 @@ func getServicePorts(sdc *scyllav1alpha1.ScyllaDBDatacenter) ([]corev1.ServicePo
 	return ports, nil
 }
 
+// getPodManagementPolicy resolves the PodManagementPolicyType for StatefulSets of a given ScyllaDBDatacenter.
+func getPodManagementPolicy(sdc *scyllav1alpha1.ScyllaDBDatacenter) (appsv1.PodManagementPolicyType, error) {
+	bootstrapPolicy, err := effectiveBootstrapPolicy(sdc)
+	if err != nil {
+		return "", fmt.Errorf("can't get effective bootstrap policy: %w", err)
+	}
+
+	if bootstrapPolicy == scyllav1alpha1.BootstrapPolicyParallel {
+		return appsv1.ParallelPodManagement, nil
+	}
+
+	return appsv1.OrderedReadyPodManagement, nil
+}
+
+// effectiveBootstrapPolicy resolves the bootstrap policy of the given ScyllaDBDatacenter.
+func effectiveBootstrapPolicy(sdc *scyllav1alpha1.ScyllaDBDatacenter) (scyllav1alpha1.BootstrapPolicy, error) {
+	if sdc.Spec.BootstrapPolicy == nil {
+		return scyllav1alpha1.BootstrapPolicySequential, nil
+	}
+
+	switch *sdc.Spec.BootstrapPolicy {
+	case scyllav1alpha1.BootstrapPolicySequential:
+		return scyllav1alpha1.BootstrapPolicySequential, nil
+
+	case scyllav1alpha1.BootstrapPolicyParallel:
+		scyllaDBVersion, err := naming.ImageToVersion(sdc.Spec.ScyllaDB.Image)
+		if err != nil {
+			return "", fmt.Errorf("can't get version of image %q: %w", sdc.Spec.ScyllaDB.Image, err)
+		}
+
+		// A ScyllaDB version lower than the one required for parallel bootstrap shouldn't get past admission, which
+		// rejects it on both create and update. This is only a sanity check guarding against version skew, e.g. a
+		// bypassed or failing webhook. A version which can't be parsed is deliberately treated as not supporting
+		// parallel bootstrap.
+		if !semver.NewScyllaVersion(scyllaDBVersion).SupportFeatureSafe(semver.ScyllaDBVersionRequiredForParallelBootstrap) {
+			return "", fmt.Errorf(
+				"bootstrap policy %q requires a semver-parseable ScyllaDB version >= %d.%d, got %q",
+				scyllav1alpha1.BootstrapPolicyParallel,
+				semver.ScyllaDBVersionRequiredForParallelBootstrap.Major,
+				semver.ScyllaDBVersionRequiredForParallelBootstrap.Minor,
+				scyllaDBVersion,
+			)
+		}
+
+		return scyllav1alpha1.BootstrapPolicyParallel, nil
+
+	default:
+		return "", fmt.Errorf("unsupported bootstrap policy %q", *sdc.Spec.BootstrapPolicy)
+	}
+}
+
 // StatefulSetForRack make a StatefulSet for the rack.
 // existingSts may be nil if it doesn't exist yet.
 func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.ScyllaDBDatacenter, existingSts *appsv1.StatefulSet, sidecarImage string, nodeExporterImage string, rackOrdinal int, inputsHash string) (*appsv1.StatefulSet, error) {
@@ -491,6 +542,11 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 		return nil, fmt.Errorf("can't make init containers: %w", err)
 	}
 
+	podManagementPolicy, err := getPodManagementPolicy(sdc)
+	if err != nil {
+		return nil, fmt.Errorf("can't get pod management policy: %w", err)
+	}
+
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        naming.StatefulSetNameForRack(rack, sdc),
@@ -508,7 +564,7 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},
-			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+			PodManagementPolicy: podManagementPolicy,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -2184,6 +2184,73 @@ exec scylla-manager-agent \
 			}(),
 			expectedError: nil,
 		},
+		{
+			name: "new StatefulSet with sequential bootstrap policy uses OrderedReady pod management",
+			rack: newBasicRack(),
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newBasicScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicySequential)
+				return sdc
+			}(),
+			existingStatefulSet: nil,
+			expectedStatefulSet: func() *appsv1.StatefulSet {
+				sts := newBasicStatefulSet()
+
+				sts.Labels["scylla/scylla-version"] = unit.ScyllaDBImageAtParallelBootstrapThresholdTag
+				sts.Spec.Template.Labels["scylla/scylla-version"] = unit.ScyllaDBImageAtParallelBootstrapThresholdTag
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+
+				if utilfeature.DefaultMutableFeatureGate.Enabled(features.BootstrapSynchronisation) {
+					sts.Spec.Template.Spec.InitContainers[runBootstrapBarrierInitContainerIndex].Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+				}
+
+				sts.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
+
+				return sts
+			}(),
+			expectedError: nil,
+		},
+		{
+			name: "new StatefulSet with parallel bootstrap policy uses Parallel pod management",
+			rack: newBasicRack(),
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newBasicScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			existingStatefulSet: nil,
+			expectedStatefulSet: func() *appsv1.StatefulSet {
+				sts := newBasicStatefulSet()
+
+				sts.Labels["scylla/scylla-version"] = unit.ScyllaDBImageAtParallelBootstrapThresholdTag
+				sts.Spec.Template.Labels["scylla/scylla-version"] = unit.ScyllaDBImageAtParallelBootstrapThresholdTag
+				sts.Spec.Template.Spec.Containers[scyllaContainerIndex].Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+
+				if utilfeature.DefaultMutableFeatureGate.Enabled(features.BootstrapSynchronisation) {
+					sts.Spec.Template.Spec.InitContainers[runBootstrapBarrierInitContainerIndex].Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+				}
+
+				sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+
+				return sts
+			}(),
+			expectedError: nil,
+		},
+		{
+			name: "parallel bootstrap policy with an unsupported ScyllaDB version errors out",
+			rack: newBasicRack(),
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newBasicScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageBelowParallelBootstrapThreshold
+				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			existingStatefulSet: nil,
+			expectedStatefulSet: nil,
+			expectedError:       fmt.Errorf(`can't get pod management policy: %w`, fmt.Errorf(`can't get effective bootstrap policy: %w`, fmt.Errorf(`bootstrap policy "Parallel" requires a semver-parseable ScyllaDB version >= 2026.2, got "2026.1.0"`))),
+		},
 	}
 
 	for _, tc := range tt {
@@ -2220,6 +2287,101 @@ func TestStatefulSetForRack(t *testing.T) {
 				runTestStatefulSetForRack(t)
 			})
 		}
+	}
+}
+
+func Test_effectiveBootstrapPolicy(t *testing.T) {
+	t.Parallel()
+
+	newSDC := func(bootstrapPolicy *scyllav1alpha1.BootstrapPolicy, image string) *scyllav1alpha1.ScyllaDBDatacenter {
+		return &scyllav1alpha1.ScyllaDBDatacenter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "basic",
+			},
+			Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
+				ClusterName: "basic",
+				ScyllaDB: scyllav1alpha1.ScyllaDB{
+					Image: image,
+				},
+				BootstrapPolicy: bootstrapPolicy,
+			},
+		}
+	}
+
+	tt := []struct {
+		name                    string
+		scyllaDBDatacenter      *scyllav1alpha1.ScyllaDBDatacenter
+		expectedBootstrapPolicy scyllav1alpha1.BootstrapPolicy
+		expectedErrorString     string
+	}{
+		{
+			name:                    "unset policy is sequential",
+			scyllaDBDatacenter:      newSDC(nil, unit.ScyllaDBImageAtParallelBootstrapThreshold),
+			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicySequential,
+			expectedErrorString:     "",
+		},
+		{
+			name:                    "sequential policy is sequential",
+			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicySequential), unit.ScyllaDBImageAtParallelBootstrapThreshold),
+			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicySequential,
+			expectedErrorString:     "",
+		},
+		{
+			name:                    "sequential policy is sequential regardless of an unparseable version",
+			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicySequential), unit.ScyllaDBImage),
+			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicySequential,
+			expectedErrorString:     "",
+		},
+		{
+			name:                    "parallel policy is parallel at the required version",
+			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicyParallel), unit.ScyllaDBImageAtParallelBootstrapThreshold),
+			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicyParallel,
+			expectedErrorString:     "",
+		},
+		{
+			name:                    "parallel policy is parallel above the required version",
+			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicyParallel), unit.ScyllaDBImageAboveNodeExporterThreshold),
+			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicyParallel,
+			expectedErrorString:     "",
+		},
+		{
+			name:                    "parallel policy errors out below the required version",
+			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicyParallel), unit.ScyllaDBImageBelowParallelBootstrapThreshold),
+			expectedBootstrapPolicy: "",
+			expectedErrorString:     `bootstrap policy "Parallel" requires a semver-parseable ScyllaDB version >= 2026.2, got "2026.1.0"`,
+		},
+		{
+			name:                    "parallel policy errors out with an unparseable version",
+			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicyParallel), unit.ScyllaDBImage),
+			expectedBootstrapPolicy: "",
+			expectedErrorString:     `bootstrap policy "Parallel" requires a semver-parseable ScyllaDB version >= 2026.2, got "latest"`,
+		},
+		{
+			name:                    "unsupported policy errors out",
+			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicy("Unsupported")), unit.ScyllaDBImageAtParallelBootstrapThreshold),
+			expectedBootstrapPolicy: "",
+			expectedErrorString:     `unsupported bootstrap policy "Unsupported"`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := effectiveBootstrapPolicy(tc.scyllaDBDatacenter)
+
+			errString := ""
+			if err != nil {
+				errString = err.Error()
+			}
+			if !cmp.Equal(errString, tc.expectedErrorString) {
+				t.Fatalf("expected and got error strings differ: %s", cmp.Diff(tc.expectedErrorString, errString))
+			}
+
+			if got != tc.expectedBootstrapPolicy {
+				t.Errorf("expected bootstrap policy %q, got %q", tc.expectedBootstrapPolicy, got)
+			}
+		})
 	}
 }
 

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -437,8 +437,10 @@ func (sdcc *Controller) checkExistingStatefulSetsRolloutStatus(
 }
 
 // createMissingStatefulSets creates the missing StatefulSets from requiredStatefulSets.
-// Existing StatefulSets are skipped and at most one missing StatefulSet is created so racks bootstrap sequentially.
-// It returns the created StatefulSet and its progressing conditions, or an error if creation failed.
+// Existing StatefulSets are skipped. With the Sequential bootstrap policy at most one missing StatefulSet is created so
+// that racks bootstrap one by one, while with the Parallel one all of them are created at once.
+// It returns the StatefulSets created so far and their progressing conditions, together with an error if a creation
+// failed.
 func createMissingStatefulSets(
 	ctx context.Context,
 	applyStatefulSet func(context.Context, *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error),
@@ -446,6 +448,13 @@ func createMissingStatefulSets(
 	requiredStatefulSets []*appsv1.StatefulSet,
 	statefulSets map[string]*appsv1.StatefulSet,
 ) ([]*appsv1.StatefulSet, []metav1.Condition, error) {
+	bootstrapPolicy, err := effectiveBootstrapPolicy(sdc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't get effective bootstrap policy: %w", err)
+	}
+
+	createdStatefulSets := make([]*appsv1.StatefulSet, 0)
+	progressingConditions := make([]metav1.Condition, 0)
 	for _, req := range requiredStatefulSets {
 		sts, found := statefulSets[req.Name]
 		if found {
@@ -457,20 +466,22 @@ func createMissingStatefulSets(
 		var err error
 		sts, changed, err = applyStatefulSet(ctx, req)
 		if err != nil {
-			return nil, nil, fmt.Errorf("can't create missing statefulset %q: %w", naming.ManualRef(sdc.Namespace, req.Name), err)
+			return createdStatefulSets, progressingConditions, fmt.Errorf("can't create missing statefulset %q: %w", naming.ManualRef(sdc.Namespace, req.Name), err)
 		}
 		if !changed {
 			continue
 		}
 
-		var progressingConditions []metav1.Condition
+		createdStatefulSets = append(createdStatefulSets, sts)
 		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, statefulSetControllerProgressingCondition, req, "apply", sdc.Generation)
 
-		// StatefulSets must be created sequentially. Return early.
-		return []*appsv1.StatefulSet{sts}, progressingConditions, nil
+		if bootstrapPolicy != scyllav1alpha1.BootstrapPolicyParallel {
+			// StatefulSets must be created sequentially. Return early.
+			return createdStatefulSets, progressingConditions, nil
+		}
 	}
 
-	return []*appsv1.StatefulSet{}, []metav1.Condition{}, nil
+	return createdStatefulSets, progressingConditions, nil
 }
 
 // ensureRackNamesInRackStatuses records statuses for newly created racks before informer caches catch up.
@@ -617,13 +628,19 @@ func (sdcc *Controller) syncStatefulSets(
 			time.Sleep(sdcc.statefulSetCachePropagationDelay)
 		}
 	}()
+	var createErrs []error
 	if err != nil {
-		return progressingConditions, fmt.Errorf("can't create StatefulSet(s): %w", err)
+		createErrs = append(createErrs, fmt.Errorf("can't create StatefulSet(s): %w", err))
 	}
 
+	// Record the statuses of the StatefulSets that were created, even if creating another one failed.
 	err = ensureRackNamesInRackStatuses(sdcc.podLister, sdc, status, createdStatefulSets)
 	if err != nil {
-		return progressingConditions, fmt.Errorf("can't update status with rack statuses: %w", err)
+		createErrs = append(createErrs, fmt.Errorf("can't update status with rack statuses: %w", err))
+	}
+
+	if len(createErrs) > 0 {
+		return progressingConditions, apimachineryutilerrors.NewAggregate(createErrs)
 	}
 
 	// Return to wait for created StatefulSets to roll out before proceeding.

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -570,17 +570,18 @@ func (sdcc *Controller) syncStatefulSets(
 		return progressingConditions, fmt.Errorf("can't delete StatefulSet(s): %w", err)
 	}
 
-	// Wait for ScyllaDBDatacenterNodesStatusReport controller to finish progressing before proceeding.
+	// Wait for the ScyllaDBDatacenterNodesStatusReport controller to settle before proceeding.
 	// This ensures that the status report is up to date before we start making changes,
 	// which lowers the chance of a new node being bootstrapped while the cluster is unhealthy.
 	isScyllaDBDatacenterNodesStatusReportControllerProgressing := apimeta.IsStatusConditionTrue(status.Conditions, scyllaDBDatacenterNodesStatusReportControllerProgressingCondition)
-	if isScyllaDBDatacenterNodesStatusReportControllerProgressing {
-		klog.V(4).InfoS("Waiting for ScyllaDBDatacenterNodesStatusReport controller to finish progressing", "ScyllaDBDatacenter", klog.KObj(sdc))
+	isScyllaDBDatacenterNodesStatusReportControllerDegraded := apimeta.IsStatusConditionTrue(status.Conditions, scyllaDBDatacenterNodesStatusReportControllerDegradedCondition)
+	if isScyllaDBDatacenterNodesStatusReportControllerProgressing || isScyllaDBDatacenterNodesStatusReportControllerDegraded {
+		klog.V(4).InfoS("Waiting for ScyllaDBDatacenterNodesStatusReport controller to settle", "ScyllaDBDatacenter", klog.KObj(sdc), "Progressing", isScyllaDBDatacenterNodesStatusReportControllerProgressing, "Degraded", isScyllaDBDatacenterNodesStatusReportControllerDegraded)
 		progressingConditions = append(progressingConditions, metav1.Condition{
 			Type:               statefulSetControllerProgressingCondition,
 			Status:             metav1.ConditionTrue,
 			Reason:             "WaitingForScyllaDBDatacenterNodesStatusReportController",
-			Message:            fmt.Sprintf("Waiting for ScyllaDBDatacenterNodesStatusReport controller to finish progressing"),
+			Message:            "Waiting for ScyllaDBDatacenterNodesStatusReport controller to settle.",
 			ObservedGeneration: sdc.Generation,
 		})
 	}

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
@@ -10,6 +10,7 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,9 +104,146 @@ func Test_createMissingStatefulSets(t *testing.T) {
 			applyStatefulSet: func(context.Context, *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
 				return nil, false, errors.New("apply failed")
 			},
+			expectedCreated:     []*appsv1.StatefulSet{},
+			expectedConditions:  []metav1.Condition{},
+			expectedErrorString: `can't create missing statefulset "default/foo": apply failed`,
+		},
+		{
+			name: "returns the StatefulSets created before an apply error with parallel bootstrap policy",
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newScyllaDBDatacenter()
+				sdc.Generation = 3
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			required: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+				newStatefulSet("bar"),
+				newStatefulSet("baz"),
+			},
+			existing: map[string]*appsv1.StatefulSet{},
+			applyStatefulSet: func(_ context.Context, required *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
+				switch required.Name {
+				case "bar":
+					return nil, false, errors.New("apply failed")
+
+				case "baz":
+					t.Fatal("applyStatefulSet called after an apply error")
+					return nil, false, nil
+
+				default:
+					return newStatefulSet(required.Name), true, nil
+				}
+			},
+			expectedCreated: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             internalapi.ProgressingReason,
+					Message:            `Progressing: Running "apply" on "apps/v1, Kind=StatefulSet"`,
+					ObservedGeneration: 3,
+				},
+			},
+			expectedErrorString: `can't create missing statefulset "default/bar": apply failed`,
+		},
+		{
+			name: "creates all missing StatefulSets with parallel bootstrap policy",
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newScyllaDBDatacenter()
+				sdc.Generation = 3
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			required: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+				newStatefulSet("bar"),
+			},
+			existing: map[string]*appsv1.StatefulSet{},
+			applyStatefulSet: func(_ context.Context, required *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
+				return newStatefulSet(required.Name), true, nil
+			},
+			expectedCreated: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+				newStatefulSet("bar"),
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             internalapi.ProgressingReason,
+					Message:            `Progressing: Running "apply" on "apps/v1, Kind=StatefulSet"`,
+					ObservedGeneration: 3,
+				},
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             internalapi.ProgressingReason,
+					Message:            `Progressing: Running "apply" on "apps/v1, Kind=StatefulSet"`,
+					ObservedGeneration: 3,
+				},
+			},
+			expectedErrorString: "",
+		},
+		{
+			name: "creates only the missing StatefulSets with parallel bootstrap policy",
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newScyllaDBDatacenter()
+				sdc.Generation = 3
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			required: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+				newStatefulSet("bar"),
+			},
+			existing: map[string]*appsv1.StatefulSet{
+				"foo": newStatefulSet("foo"),
+			},
+			applyStatefulSet: func(_ context.Context, required *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
+				if required.Name != "bar" {
+					t.Fatalf("applyStatefulSet called for an existing StatefulSet %q", required.Name)
+				}
+				return newStatefulSet(required.Name), true, nil
+			},
+			expectedCreated: []*appsv1.StatefulSet{
+				newStatefulSet("bar"),
+			},
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             internalapi.ProgressingReason,
+					Message:            `Progressing: Running "apply" on "apps/v1, Kind=StatefulSet"`,
+					ObservedGeneration: 3,
+				},
+			},
+			expectedErrorString: "",
+		},
+		{
+			name: "returns an error with parallel bootstrap policy and an unsupported ScyllaDB version",
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newScyllaDBDatacenter()
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageBelowParallelBootstrapThreshold
+				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				return sdc
+			}(),
+			required: []*appsv1.StatefulSet{
+				newStatefulSet("foo"),
+			},
+			existing: map[string]*appsv1.StatefulSet{},
+			applyStatefulSet: func(context.Context, *appsv1.StatefulSet) (*appsv1.StatefulSet, bool, error) {
+				t.Fatal("applyStatefulSet called with an unsupported ScyllaDB version")
+				return nil, false, nil
+			},
 			expectedCreated:     nil,
 			expectedConditions:  nil,
-			expectedErrorString: `can't create missing statefulset "default/foo": apply failed`,
+			expectedErrorString: `can't get effective bootstrap policy: bootstrap policy "Parallel" requires a semver-parseable ScyllaDB version >= 2026.2, got "2026.1.0"`,
 		},
 	}
 

--- a/pkg/resourceapply/apps.go
+++ b/pkg/resourceapply/apps.go
@@ -43,6 +43,12 @@ func ApplyStatefulSetWithControl(
 				return "spec.selector is immutable", pointer.Ptr(metav1.DeletePropagationOrphan), nil
 			}
 
+			if existing.Spec.PodManagementPolicy != required.Spec.PodManagementPolicy {
+				// Orphan the Pods so that toggling the policy doesn't disrupt running nodes. They are adopted back by
+				// the recreated StatefulSet.
+				return "spec.podManagementPolicy is immutable", pointer.Ptr(metav1.DeletePropagationOrphan), nil
+			}
+
 			return "", nil, nil
 		},
 	)

--- a/pkg/resourceapply/apps_test.go
+++ b/pkg/resourceapply/apps_test.go
@@ -590,6 +590,85 @@ func TestApplyStatefulSet(t *testing.T) {
 			expectedErr:     fmt.Errorf("can't get recreate reason: %w", fmt.Errorf(`required StatefulSet selector "bar=foo,foo=bar" doesn't match existing Pod Labels set map[foo:bar]`)),
 			expectedEvents:  nil,
 		},
+		{
+			name: "deletes and creates the StatefulSet when podManagementPolicy is changed",
+			existing: []runtime.Object{
+				func() *appsv1.StatefulSet {
+					sts := newSts()
+					sts.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
+					return sts
+				}(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents: []string{
+				"Normal StatefulSetDeleted StatefulSet default/test deleted",
+				"Normal StatefulSetCreated StatefulSet default/test created",
+			},
+		},
+		{
+			name: "deletes and creates the StatefulSet when podManagementPolicy is changed back",
+			existing: []runtime.Object{
+				func() *appsv1.StatefulSet {
+					sts := newSts()
+					sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+					return sts
+				}(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: true,
+			expectedErr:     nil,
+			expectedEvents: []string{
+				"Normal StatefulSetDeleted StatefulSet default/test deleted",
+				"Normal StatefulSetCreated StatefulSet default/test created",
+			},
+		},
+		{
+			name: "does nothing when podManagementPolicy matches",
+			existing: []runtime.Object{
+				func() *appsv1.StatefulSet {
+					sts := newSts()
+					sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+					apimachineryutilruntime.Must(SetHashAnnotation(sts))
+					return sts
+				}(),
+			},
+			required: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+				return sts
+			}(),
+			expectedSts: func() *appsv1.StatefulSet {
+				sts := newSts()
+				sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+				apimachineryutilruntime.Must(SetHashAnnotation(sts))
+				return sts
+			}(),
+			expectedChanged: false,
+			expectedErr:     nil,
+			expectedEvents:  nil,
+		},
 	}
 
 	for _, tc := range tt {

--- a/pkg/resourceapply/apps_test.go
+++ b/pkg/resourceapply/apps_test.go
@@ -546,6 +546,8 @@ func TestApplyStatefulSet(t *testing.T) {
 					},
 				}
 				apimachineryutilruntime.Must(SetHashAnnotation(sts))
+				// The object is recreated, so the resourceVersion of the object it was based on is cleared.
+				sts.ResourceVersion = ""
 				return sts
 			}(),
 			expectedChanged: true,
@@ -608,6 +610,8 @@ func TestApplyStatefulSet(t *testing.T) {
 				sts := newSts()
 				sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 				apimachineryutilruntime.Must(SetHashAnnotation(sts))
+				// The object is recreated, so the resourceVersion of the object it was based on is cleared.
+				sts.ResourceVersion = ""
 				return sts
 			}(),
 			expectedChanged: true,
@@ -635,6 +639,8 @@ func TestApplyStatefulSet(t *testing.T) {
 				sts := newSts()
 				sts.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
 				apimachineryutilruntime.Must(SetHashAnnotation(sts))
+				// The object is recreated, so the resourceVersion of the object it was based on is cleared.
+				sts.ResourceVersion = ""
 				return sts
 			}(),
 			expectedChanged: true,

--- a/pkg/resourceapply/helpers.go
+++ b/pkg/resourceapply/helpers.go
@@ -343,6 +343,9 @@ func ApplyGenericWithHandlers[T kubeinterfaces.ObjectInterface](
 		}
 
 		resourcemerge.SanitizeObject(requiredCopy)
+		// Required objects may carry the resourceVersion of the object they are based on to enforce optimistic
+		// concurrency on update. The object is being created anew, so it has to be cleared.
+		requiredCopy.SetResourceVersion("")
 		created, err := control.Create(ctx, requiredCopy, createOptions)
 		ReportCreateEvent(recorder, requiredCopy, err)
 		if err != nil {

--- a/pkg/resourceapply/rbac_test.go
+++ b/pkg/resourceapply/rbac_test.go
@@ -654,6 +654,8 @@ func TestApplyClusterRoleBinding(t *testing.T) {
 					Name:     "different-name",
 				}
 				apimachineryutilruntime.Must(SetHashAnnotation(crb))
+				// The object is recreated, so the resourceVersion of the object it was based on is cleared.
+				crb.ResourceVersion = ""
 				return crb
 			}(),
 			expectedChanged: true,
@@ -1127,6 +1129,8 @@ func TestApplyRoleBinding(t *testing.T) {
 				rb := newRB()
 				rb.RoleRef.Name = "changed"
 				apimachineryutilruntime.Must(SetHashAnnotation(rb))
+				// The object is recreated, so the resourceVersion of the object it was based on is cleared.
+				rb.ResourceVersion = ""
 				return rb
 			}(),
 			expectedChanged: true,

--- a/test/e2e/set/scylladbdatacenter/scylladbdatacenter_bootstrappolicy.go
+++ b/test/e2e/set/scylladbdatacenter/scylladbdatacenter_bootstrappolicy.go
@@ -1,0 +1,178 @@
+// Copyright (C) 2026 ScyllaDB
+
+package scylladbdatacenter
+
+import (
+	"context"
+	"fmt"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	"github.com/scylladb/scylla-operator/pkg/helpers"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	"github.com/scylladb/scylla-operator/test/e2e/utils"
+	utilsv1alpha1 "github.com/scylladb/scylla-operator/test/e2e/utils/v1alpha1"
+	scylladbdatacenterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scylladbdatacenter"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ = g.Describe("ScyllaDBDatacenter", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbdatacenter")
+	})
+
+	// getRackPodUIDs returns the UIDs of the Pods of every rack StatefulSet, keyed by Pod name.
+	getRackPodUIDs := func(ctx context.Context, client framework.Client, statefulSets map[string]*appsv1.StatefulSet) map[string]types.UID {
+		uids := map[string]types.UID{}
+		for _, sts := range statefulSets {
+			pods, err := utilsv1alpha1.GetPodsForStatefulSet(ctx, client.KubeClient().CoreV1(), sts)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(pods).NotTo(o.BeEmpty())
+
+			for podName, pod := range pods {
+				uids[podName] = pod.UID
+			}
+		}
+
+		return uids
+	}
+
+	type entry struct {
+		initialBootstrapPolicy scyllav1alpha1.BootstrapPolicy
+		targetBootstrapPolicy  scyllav1alpha1.BootstrapPolicy
+	}
+
+	describeEntry := func(e *entry) string {
+		return fmt.Sprintf("from %s to %s", e.initialBootstrapPolicy, e.targetBootstrapPolicy)
+	}
+
+	podManagementPolicyForBootstrapPolicy := func(bootstrapPolicy scyllav1alpha1.BootstrapPolicy) appsv1.PodManagementPolicyType {
+		if bootstrapPolicy == scyllav1alpha1.BootstrapPolicyParallel {
+			return appsv1.ParallelPodManagement
+		}
+
+		return appsv1.OrderedReadyPodManagement
+	}
+
+	g.DescribeTable("should recreate StatefulSets without disrupting nodes when the bootstrap policy is changed",
+		func(ctx g.SpecContext, e *entry) {
+			ns, nsClient, ok := f.DefaultNamespaceIfAny()
+			o.Expect(ok).To(o.BeTrue())
+
+			sdc := f.GetDefaultScyllaDBDatacenter()
+			sdc.Spec.BootstrapPolicy = &e.initialBootstrapPolicy
+
+			framework.By("Creating a ScyllaDBDatacenter with the %s bootstrap policy", e.initialBootstrapPolicy)
+			sdc, err := nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(ns.Name).Create(ctx, sdc, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			framework.By("Waiting for the ScyllaDBDatacenter to roll out (RV=%s)", sdc.ResourceVersion)
+			initialRolloutCtx, initialRolloutCtxCancel := utilsv1alpha1.ContextForRollout(ctx, sdc)
+			defer initialRolloutCtxCancel()
+			sdc, err = controllerhelpers.WaitForScyllaDBDatacenterState(initialRolloutCtx, nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(ns.Name), sdc.Name, controllerhelpers.WaitForStateOptions{}, utilsv1alpha1.IsScyllaDBDatacenterRolledOut)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			scylladbdatacenterverification.Verify(ctx, nsClient.KubeClient(), nsClient.ScyllaClient(), sdc)
+			scylladbdatacenterverification.WaitForFullQuorum(ctx, nsClient.KubeClient().CoreV1(), sdc)
+
+			framework.By("Verifying the rack StatefulSets are created with the %s pod management policy", podManagementPolicyForBootstrapPolicy(e.initialBootstrapPolicy))
+			statefulSets, err := utilsv1alpha1.GetStatefulSetsForScyllaDBDatacenter(ctx, nsClient.KubeClient().AppsV1(), sdc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(statefulSets).To(o.HaveLen(len(sdc.Spec.Racks)))
+			for _, sts := range statefulSets {
+				o.Expect(sts.Spec.PodManagementPolicy).To(o.Equal(podManagementPolicyForBootstrapPolicy(e.initialBootstrapPolicy)))
+			}
+
+			initialPodUIDs := getRackPodUIDs(ctx, nsClient, statefulSets)
+
+			// Observe the ScyllaDB node Pods for the entire duration of the change. Comparing the Pods before and after
+			// the change only samples the steady states, so it can't tell whether any of them was disrupted in between.
+			podObserver := utils.ObserveObjects[*corev1.Pod](createScyllaDBNodePodListWatcher(ctx, nsClient, ns.Name, sdc))
+			err = podObserver.Start(ctx)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			framework.By("Changing the bootstrap policy to %s", e.targetBootstrapPolicy)
+			sdc, err = nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(ns.Name).Patch(
+				ctx,
+				sdc.Name,
+				types.MergePatchType,
+				[]byte(fmt.Sprintf(`{"spec":{"bootstrapPolicy":%q}}`, e.targetBootstrapPolicy)),
+				metav1.PatchOptions{},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(sdc.Spec.BootstrapPolicy).NotTo(o.BeNil())
+			o.Expect(*sdc.Spec.BootstrapPolicy).To(o.Equal(e.targetBootstrapPolicy))
+
+			framework.By("Waiting for the ScyllaDBDatacenter to roll out (RV=%s)", sdc.ResourceVersion)
+			patchRolloutCtx, patchRolloutCtxCancel := utilsv1alpha1.ContextForRollout(ctx, sdc)
+			defer patchRolloutCtxCancel()
+			sdc, err = controllerhelpers.WaitForScyllaDBDatacenterState(patchRolloutCtx, nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(ns.Name), sdc.Name, controllerhelpers.WaitForStateOptions{}, utilsv1alpha1.IsScyllaDBDatacenterRolledOut)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			scylladbdatacenterverification.Verify(ctx, nsClient.KubeClient(), nsClient.ScyllaClient(), sdc)
+			scylladbdatacenterverification.WaitForFullQuorum(ctx, nsClient.KubeClient().CoreV1(), sdc)
+
+			framework.By("Verifying the rack StatefulSets are recreated with the %s pod management policy", podManagementPolicyForBootstrapPolicy(e.targetBootstrapPolicy))
+			statefulSets, err = utilsv1alpha1.GetStatefulSetsForScyllaDBDatacenter(ctx, nsClient.KubeClient().AppsV1(), sdc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(statefulSets).To(o.HaveLen(len(sdc.Spec.Racks)))
+			for _, sts := range statefulSets {
+				o.Expect(sts.Spec.PodManagementPolicy).To(o.Equal(podManagementPolicyForBootstrapPolicy(e.targetBootstrapPolicy)))
+			}
+
+			framework.By("Verifying the nodes were not disrupted")
+			observedPodEvents, err := podObserver.Stop()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			framework.Infof("Observed %d Pod events during the bootstrap policy change.", len(observedPodEvents))
+
+			// The StatefulSets are deleted with an orphan propagation policy, so their Pods survive the recreation and
+			// are adopted back. Any Pod being deleted or replaced at any point during the change means the running nodes were disrupted.
+			// The observer's initial list shows up as an Added event for every Pod that was already running, so every
+			// observed Pod is expected to match the ones observed before the change.
+			for _, observedPodEvent := range observedPodEvents {
+				o.Expect(observedPodEvent.Action).NotTo(o.Equal(watch.Deleted), fmt.Sprintf("Pod %q should not have been deleted", observedPodEvent.Obj.Name))
+				o.Expect(observedPodEvent.Obj.DeletionTimestamp).To(o.BeNil(), fmt.Sprintf("Pod %q should not have been marked for deletion", observedPodEvent.Obj.Name))
+
+				initialPodUID, ok := initialPodUIDs[observedPodEvent.Obj.Name]
+				o.Expect(ok).To(o.BeTrue(), fmt.Sprintf("Pod %q should have existed before the bootstrap policy change", observedPodEvent.Obj.Name))
+				o.Expect(observedPodEvent.Obj.UID).To(o.Equal(initialPodUID), fmt.Sprintf("Pod %q should not have been recreated", observedPodEvent.Obj.Name))
+			}
+		},
+		g.Entry(describeEntry, &entry{
+			initialBootstrapPolicy: scyllav1alpha1.BootstrapPolicySequential,
+			targetBootstrapPolicy:  scyllav1alpha1.BootstrapPolicyParallel,
+		}),
+		g.Entry(describeEntry, &entry{
+			initialBootstrapPolicy: scyllav1alpha1.BootstrapPolicyParallel,
+			targetBootstrapPolicy:  scyllav1alpha1.BootstrapPolicySequential,
+		}),
+	)
+})
+
+// createScyllaDBNodePodListWatcher creates a ListWatch for observing the ScyllaDB node Pods of the given
+// ScyllaDBDatacenter. The selector excludes Pods which aren't ScyllaDB nodes, like the cleanup job Pods, as those are
+// created and deleted independently of the nodes.
+func createScyllaDBNodePodListWatcher(ctx context.Context, client framework.Client, namespace string, sdc *scyllav1alpha1.ScyllaDBDatacenter) *cache.ListWatch {
+	labelSelector := labels.SelectorFromSet(naming.ScyllaDBNodePodsSelectorLabels(sdc)).String()
+
+	return &cache.ListWatch{
+		ListFunc: helpers.UncachedListFunc(func(options metav1.ListOptions) (runtime.Object, error) {
+			options.LabelSelector = labelSelector
+			return client.KubeClient().CoreV1().Pods(namespace).List(ctx, options)
+		}),
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.LabelSelector = labelSelector
+			return client.KubeClient().CoreV1().Pods(namespace).Watch(ctx, options)
+		},
+	}
+}

--- a/test/envtest/controllers/scylladbdatacenter_controller_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_test.go
@@ -14,12 +14,14 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	configassets "github.com/scylladb/scylla-operator/assets/config"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	scyllainformers "github.com/scylladb/scylla-operator/pkg/client/scylla/informers/externalversions"
 	"github.com/scylladb/scylla-operator/pkg/controller/scylladbdatacenter"
 	"github.com/scylladb/scylla-operator/pkg/crypto"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/scylla"
+	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	"github.com/scylladb/scylla-operator/test/envtest"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -55,7 +57,7 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 		env = envtest.Setup(ctx)
 	})
 
-	g.It("should create rack StatefulSets sequentially", func(ctx g.SpecContext) {
+	g.It("should create rack StatefulSets sequentially with Sequential bootstrap policy", func(ctx g.SpecContext) {
 		g.By("Running ScyllaDBDatacenter controller")
 		runScyllaDBDatacenterController(ctx, env)
 
@@ -63,7 +65,7 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 		createScyllaOperatorConfig(ctx, env)
 
 		g.By("Creating a ScyllaDBDatacenter with two racks")
-		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a", "rack-b"})
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a", "rack-b"}, withBootstrapPolicy(scyllav1alpha1.BootstrapPolicySequential))
 		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -85,52 +87,80 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 		waitForStatefulSet(ctx, env, secondRackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
 	})
 
-	g.DescribeTable("should not create a StatefulSet for a new rack while an existing rack is not rolled out",
-		func(ctx g.SpecContext, initialRacks, updatedRacks []string, existingRack, newRack string) {
-			g.By("Running ScyllaDBDatacenter controller")
-			runScyllaDBDatacenterController(ctx, env)
+	g.It("should create rack StatefulSets in parallel with Parallel bootstrap policy", func(ctx g.SpecContext) {
+		g.By("Running ScyllaDBDatacenter controller")
+		runScyllaDBDatacenterController(ctx, env)
 
-			g.By("Creating ScyllaOperatorConfig singleton")
-			createScyllaOperatorConfig(ctx, env)
+		g.By("Creating ScyllaOperatorConfig singleton")
+		createScyllaOperatorConfig(ctx, env)
 
-			g.By("Creating a ScyllaDBDatacenter")
-			sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), initialRacks)
-			sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Creating a ScyllaDBDatacenter with three racks and the Parallel bootstrap policy")
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a", "rack-b", "rack-c"}, withBootstrapPolicy(scyllav1alpha1.BootstrapPolicyParallel))
+		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Waiting for the first StatefulSet to be created")
-			existingRackStatefulSetName := naming.StatefulSetNameForRack(makeRackSpec(existingRack), sdc)
-			waitForStatefulSet(ctx, env, existingRackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+		g.By("Waiting for all rack StatefulSets to be created without any of them rolling out")
+		for _, rack := range sdc.Spec.Racks {
+			statefulSet := waitForStatefulSet(ctx, env, naming.StatefulSetNameForRack(rack, sdc), scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+			o.Expect(statefulSet.Spec.PodManagementPolicy).To(o.Equal(appsv1.ParallelPodManagement))
+		}
+	})
 
-			g.By("Marking the first rack StatefulSet as not rolled out")
-			markStatefulSetAsNotRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), existingRackStatefulSetName)
+	g.DescribeTableSubtree("with bootstrap policy",
+		func(bootstrapPolicy scyllav1alpha1.BootstrapPolicy) {
+			g.DescribeTable("should not create a StatefulSet for a new rack while an existing rack is not rolled out",
+				func(ctx g.SpecContext, initialRacks, updatedRacks []string, existingRack, newRack string) {
+					g.By("Running ScyllaDBDatacenter controller")
+					runScyllaDBDatacenterController(ctx, env)
 
-			g.By("Adding a new rack")
-			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				sdc, err = env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
-				if err != nil {
-					return fmt.Errorf("can't get ScyllaDBDatacenter %q: %w", naming.ManualRef(env.Namespace(), sdc.Name), err)
-				}
+					g.By("Creating ScyllaOperatorConfig singleton")
+					createScyllaOperatorConfig(ctx, env)
 
-				sdc.Spec.Racks = makeRackSpecs(updatedRacks...)
-				_, err = env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Update(ctx, sdc, metav1.UpdateOptions{})
-				if err != nil {
-					return fmt.Errorf("can't update ScyllaDBDatacenter %q: %w", naming.ObjRef(sdc), err)
-				}
+					g.By("Creating a ScyllaDBDatacenter")
+					sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), initialRacks, withBootstrapPolicy(bootstrapPolicy))
+					sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+					o.Expect(err).NotTo(o.HaveOccurred())
 
-				return nil
-			})
-			o.Expect(err).NotTo(o.HaveOccurred())
+					g.By("Waiting for the first StatefulSet to be created")
+					existingRackStatefulSetName := naming.StatefulSetNameForRack(makeRackSpec(existingRack), sdc)
+					waitForStatefulSet(ctx, env, existingRackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
 
-			g.By("Verifying the new rack StatefulSet is not created")
-			newRackStatefulSetName := naming.StatefulSetNameForRack(makeRackSpec(newRack), sdc)
-			o.Consistently(func(co o.Gomega, ctx context.Context) {
-				_, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, newRackStatefulSetName, metav1.GetOptions{})
-				co.Expect(apierrors.IsNotFound(err)).To(o.BeTrue())
-			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+					g.By("Marking the first rack StatefulSet as not rolled out")
+					markStatefulSetAsNotRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), existingRackStatefulSetName)
+
+					g.By("Adding a new rack")
+					err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						sdc, err = env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+						if err != nil {
+							return fmt.Errorf("can't get ScyllaDBDatacenter %q: %w", naming.ManualRef(env.Namespace(), sdc.Name), err)
+						}
+
+						sdc.Spec.Racks = makeRackSpecs(updatedRacks...)
+						_, err = env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Update(ctx, sdc, metav1.UpdateOptions{})
+						if err != nil {
+							return fmt.Errorf("can't update ScyllaDBDatacenter %q: %w", naming.ObjRef(sdc), err)
+						}
+
+						return nil
+					})
+					o.Expect(err).NotTo(o.HaveOccurred())
+
+					g.By("Verifying the new rack StatefulSet is not created")
+					newRackStatefulSetName := naming.StatefulSetNameForRack(makeRackSpec(newRack), sdc)
+					o.Consistently(func(co o.Gomega, ctx context.Context) {
+						_, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, newRackStatefulSetName, metav1.GetOptions{})
+						co.Expect(apierrors.IsNotFound(err)).To(o.BeTrue())
+					}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+				},
+				g.Entry("when new rack is prepended", []string{"rack-b"}, []string{"rack-a", "rack-b"}, "rack-b", "rack-a"),
+				g.Entry("when new rack is appended", []string{"rack-a"}, []string{"rack-a", "rack-b"}, "rack-a", "rack-b"),
+			)
 		},
-		g.Entry("when new rack is prepended", []string{"rack-b"}, []string{"rack-a", "rack-b"}, "rack-b", "rack-a"),
-		g.Entry("when new rack is appended", []string{"rack-a"}, []string{"rack-a", "rack-b"}, "rack-a", "rack-b"),
+		g.Entry("Sequential", scyllav1alpha1.BootstrapPolicySequential),
+		// The Parallel bootstrap policy only relaxes the initial creation of missing StatefulSets. Adding a rack to an
+		// existing datacenter still waits for the existing racks to roll out, so that racks aren't added while another one
+		// is scaling or updating, regardless of the bootstrap policy.
+		g.Entry("Parallel", scyllav1alpha1.BootstrapPolicyParallel),
 	)
 })
 
@@ -147,7 +177,7 @@ func waitForStatefulSet(ctx context.Context, e *envtest.Environment, name string
 	return statefulSet
 }
 
-func makeEnvtestScyllaDBDatacenter(namespace string, racks []string) *scyllav1alpha1.ScyllaDBDatacenter {
+func makeEnvtestScyllaDBDatacenter(namespace string, racks []string, mutators ...func(*scyllav1alpha1.ScyllaDBDatacenter)) *scyllav1alpha1.ScyllaDBDatacenter {
 	sdc := &scyllav1alpha1.ScyllaDBDatacenter{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "envtest-sdc",
@@ -157,7 +187,7 @@ func makeEnvtestScyllaDBDatacenter(namespace string, racks []string) *scyllav1al
 			ClusterName: "envtest-cluster",
 			DNSDomains:  []string{"envtest.local"},
 			ScyllaDB: scyllav1alpha1.ScyllaDB{
-				Image:               "scylladb/scylla:envtest",
+				Image:               unit.ScyllaDBImageRepository + ":" + configassets.Project.Operator.ScyllaDBVersion,
 				EnableDeveloperMode: new(true),
 			},
 			RackTemplate: &scyllav1alpha1.RackTemplate{
@@ -173,7 +203,17 @@ func makeEnvtestScyllaDBDatacenter(namespace string, racks []string) *scyllav1al
 
 	sdc.Spec.Racks = makeRackSpecs(racks...)
 
+	for _, mutator := range mutators {
+		mutator(sdc)
+	}
+
 	return sdc
+}
+
+func withBootstrapPolicy(bootstrapPolicy scyllav1alpha1.BootstrapPolicy) func(*scyllav1alpha1.ScyllaDBDatacenter) {
+	return func(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
+		sdc.Spec.BootstrapPolicy = new(bootstrapPolicy)
+	}
 }
 
 func makeRackSpecs(names ...string) []scyllav1alpha1.RackSpec {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR wires parallel bootstrap policy through to the rack StatefulSets. Parallel maps to parallel pod management, so a rack's nodes bootstrap without waiting for the previous ordinal, and all missing rack StatefulSets are created in a single sync instead of one per requeue.

Changing the policy on an existing cluster recreates the StatefulSets with DeletePropagationOrphan, so the Pods survive and are adopted back by the new one without any disruptions. 
This PR also clears resourceVersion on the recreate path in resourceapply, which otherwise makes the create fail, and only self-heal on a subsequent reconciliation.

Covered by unit tests, envtests, and an E2E toggling the policy both ways asserting the StatefulSets are replaced without any disruptions. All existing E2Es use the default parallel bootstrap policy for newly created clusters.

One caveat: StatefulSets are still only created (even when in parallel) after all existing StatefulSets have rolled out, since the gate also fronts scaling, updates and upgrades.

**Prerequisites**:
- [x] https://scylladb.atlassian.net/browse/OPERATOR-290

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-288
Resolves https://scylladb.atlassian.net/browse/OPERATOR-152

/cc