### PR TITLE
test(e2e): add kind-cluster-topology e2e suite

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -379,6 +379,7 @@ function run-e2e {
     "--scyllacluster-clients-broadcast-address-type=${SO_SCYLLACLUSTER_CLIENTS_BROADCAST_ADDRESS_TYPE}"
     "--scyllacluster-storageclass-name=${SO_SCYLLACLUSTER_STORAGECLASS_NAME}"
     "--scyllacluster-reactor-backend=${SO_SCYLLACLUSTER_REACTOR_BACKEND:-}"
+    "--scyllacluster-bootstrap-policy=${SO_SCYLLACLUSTER_BOOTSTRAP_POLICY:-}"
     "--object-storage-bucket=${SO_BUCKET_NAME}"
     "--gcs-service-account-key-path=${gcs_sa_in_container_path}"
     "--s3-credentials-file-path=${s3_credentials_in_container_path}"

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -40,6 +40,7 @@ type ScyllaClusterOptions struct {
 	ClientsBroadcastAddressType string
 	StorageClassName            string
 	ReactorBackend              string
+	BootstrapPolicy             string
 }
 
 var supportedNodeServiceTypes = []scyllav1.NodeServiceType{
@@ -55,6 +56,11 @@ var supportedBroadcastAddressTypes = []scyllav1.BroadcastAddressType{
 var supportedReactorBackends = []string{
 	"io_uring",
 	"linux-aio",
+}
+
+var supportedBootstrapPolicies = []scyllav1.BootstrapPolicy{
+	scyllav1.BootstrapPolicySequential,
+	scyllav1.BootstrapPolicyParallel,
 }
 
 type TestFrameworkOptions struct {
@@ -92,6 +98,7 @@ func NewTestFrameworkOptions(streams genericclioptions.IOStreams, userAgent stri
 			ClientsBroadcastAddressType: string(scyllav1.BroadcastAddressTypePodIP),
 			StorageClassName:            "",
 			ReactorBackend:              "", // Leaving empty to rely on ScyllaDB default.
+			BootstrapPolicy:             "", // Leaving empty to rely on the operator's default.
 		},
 		ObjectStorageOptions:        NewObjectStorageOptions(),
 		ScyllaDBVersion:             configassets.Project.Operator.ScyllaDBVersion,
@@ -143,6 +150,10 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 	)))
 	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.StorageClassName, "scyllacluster-storageclass-name", "", o.ScyllaClusterOptionsUntyped.StorageClassName, fmt.Sprintf("Name of the StorageClass to request for ScyllaCluster storage."))
 	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.ReactorBackend, "scyllacluster-reactor-backend", "", o.ScyllaClusterOptionsUntyped.ReactorBackend, fmt.Sprintf("Name of the reactor backend to use for ScyllaCluster."))
+	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.BootstrapPolicy, "scyllacluster-bootstrap-policy", "", o.ScyllaClusterOptionsUntyped.BootstrapPolicy, fmt.Sprintf("Bootstrap policy to set on ScyllaClusters and ScyllaDBDatacenters created by tests. Leave empty to rely on the operator's defaulting. Allowed values are [%s].", strings.Join(
+		oslices.ConvertSlice(supportedBootstrapPolicies, oslices.ToString[scyllav1.BootstrapPolicy]),
+		", ",
+	)))
 	cmd.PersistentFlags().StringVarP(&o.ScyllaDBVersion, "scylladb-version", "", o.ScyllaDBVersion, "Version of ScyllaDB to use.")
 	cmd.PersistentFlags().StringVarP(&o.ScyllaDBImageRef, "scylladb-image-ref", "", o.ScyllaDBImageRef, "Optional full image reference of ScyllaDB to use instead of --scylladb-version, e.g. docker.io/scylladb/scylla:2026.1.0.")
 	cmd.PersistentFlags().StringVarP(&o.ScyllaDBManagerVersion, "scylladb-manager-version", "", o.ScyllaDBManagerVersion, "Version of Scylla Manager to use.")
@@ -189,6 +200,10 @@ func (o *TestFrameworkOptions) Validate(args []string) error {
 
 	if backend := o.ScyllaClusterOptionsUntyped.ReactorBackend; backend != "" && !oslices.ContainsItem(supportedReactorBackends, backend) {
 		errors = append(errors, fmt.Errorf("invalid scyllacluster-reactor-backend: %q", o.ScyllaClusterOptionsUntyped.ReactorBackend))
+	}
+
+	if bootstrapPolicy := o.ScyllaClusterOptionsUntyped.BootstrapPolicy; bootstrapPolicy != "" && !oslices.ContainsItem(supportedBootstrapPolicies, scyllav1.BootstrapPolicy(bootstrapPolicy)) {
+		errors = append(errors, fmt.Errorf("invalid scyllacluster-bootstrap-policy: %q", o.ScyllaClusterOptionsUntyped.BootstrapPolicy))
 	}
 
 	if !tagWithOptionalDigestRegexp.MatchString(o.ScyllaDBVersion) {
@@ -300,6 +315,7 @@ func (o *TestFrameworkOptions) Complete(args []string) error {
 		},
 		StorageClassName: o.ScyllaClusterOptionsUntyped.StorageClassName,
 		ReactorBackend:   o.ScyllaClusterOptionsUntyped.ReactorBackend,
+		BootstrapPolicy:  o.ScyllaClusterOptionsUntyped.BootstrapPolicy,
 	}
 
 	workerRestConfigs := make(map[string]*rest.Config, len(o.WorkerClientConfigs))

--- a/pkg/cmd/tests/tests.go
+++ b/pkg/cmd/tests/tests.go
@@ -89,6 +89,14 @@ var Suites = ginkgotest.TestSuites{
 		DefaultParallelism: defaultParallelParallelism,
 	},
 	{
+		Name: "kind-cluster-topology",
+		Description: templates.LongDesc(`
+		Tests related to single-DC cluster topology operations, possible to be run on kind clusters.
+		`),
+		LabelFilter:        framework.SuiteKindClusterTopologyLabelName,
+		DefaultParallelism: defaultParallelParallelism,
+	},
+	{
 		Name: "kind-operator-upgrade",
 		Description: templates.LongDesc(`
 		Tests that verify operator upgrade from a released version to the current one. Runs in CI outside of k8s

--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -8,6 +8,9 @@ metadata:
    bar: foo
 spec:
   agentVersion: "{{ .scyllaDBManagerVersion }}"
+  {{- if .bootstrapPolicy }}
+  bootstrapPolicy: {{ .bootstrapPolicy }}
+  {{- end }}
   repository: "{{ .scyllaDBRepository }}"
   version: "{{ .scyllaDBVersion }}"
   developerMode: true

--- a/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
@@ -9,6 +9,9 @@ metadata:
 spec:
   clusterName: basic
   datacenterName: us-east-1
+  {{- if .bootstrapPolicy }}
+  bootstrapPolicy: {{ .bootstrapPolicy }}
+  {{- end }}
   scyllaDB:
     image: "{{ .scyllaDBImageRef }}"
     enableDeveloperMode: true

--- a/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
@@ -8,6 +8,9 @@ metadata:
    bar: foo
 spec:
   agentVersion: "{{ .scyllaDBManagerVersion }}"
+  {{- if .bootstrapPolicy }}
+  bootstrapPolicy: {{ .bootstrapPolicy }}
+  {{- end }}
   repository: "{{ .scyllaDBRepository }}"
   version: "{{ .scyllaDBVersion }}"
   developerMode: true

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -224,6 +224,7 @@ func (f *Framework) GetDefaultScyllaCluster() *scyllav1.ScyllaCluster {
 		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
 		"storageClassName":            TestContext.ScyllaClusterOptions.StorageClassName,
 		"scyllaArgs":                  TestContext.ScyllaClusterOptions.ScyllaArgs(),
+		"bootstrapPolicy":             TestContext.ScyllaClusterOptions.BootstrapPolicy,
 	}
 
 	sc, _, err := scyllafixture.ScyllaClusterTemplate.RenderObject(renderArgs)
@@ -254,6 +255,7 @@ func (f *Framework) GetDefaultZonalScyllaClusterWithThreeRacks() *scyllav1.Scyll
 		"storageClassName":            TestContext.ScyllaClusterOptions.StorageClassName,
 		"scyllaArgs":                  TestContext.ScyllaClusterOptions.ScyllaArgs(),
 		"rackNames":                   []string{"a", "b", "c"},
+		"bootstrapPolicy":             TestContext.ScyllaClusterOptions.BootstrapPolicy,
 	}
 
 	sc, _, err := scyllafixture.ZonalScyllaClusterTemplate.RenderObject(renderArgs)
@@ -272,6 +274,7 @@ func (f *Framework) GetDefaultScyllaDBDatacenter() *scyllav1alpha1.ScyllaDBDatac
 		"storageClassName":               TestContext.ScyllaClusterOptions.StorageClassName,
 		"scyllaArgs":                     TestContext.ScyllaClusterOptions.ScyllaArgs(),
 		"scyllaDBManagerAgentRepository": configassets.ScyllaDBManagerAgentImageRepository,
+		"bootstrapPolicy":                TestContext.ScyllaClusterOptions.BootstrapPolicy,
 	}
 
 	sdc, _, err := scyllafixture.ScyllaDBDatacenterTemplate.RenderObject(renderArgs)

--- a/test/e2e/framework/meta.go
+++ b/test/e2e/framework/meta.go
@@ -16,6 +16,7 @@ const (
 	SuiteParallelIPv6LabelName            = "SuiteParallelIPv6"
 	SuiteKindFastLabelName                = "SuiteKindFast"
 	SuiteKindScyllaDBMonitoringLabelName  = "SuiteKindScyllaDBMonitoring"
+	SuiteKindClusterTopologyLabelName     = "SuiteKindClusterTopology"
 	SuiteOperatorUpgradeLabelName         = "SuiteOperatorUpgrade"
 )
 
@@ -26,6 +27,7 @@ var (
 	SuiteParallelIPv6            = g.Label(SuiteParallelIPv6LabelName)
 	SuiteKindFast                = g.Label(SuiteKindFastLabelName)
 	SuiteKindScyllaDBMonitoring  = g.Label(SuiteKindScyllaDBMonitoringLabelName)
+	SuiteKindClusterTopology     = g.Label(SuiteKindClusterTopologyLabelName)
 	SuiteOperatorUpgrade         = g.Label(SuiteOperatorUpgradeLabelName)
 
 	// SuiteSerial bundles the Ginkgo serial-execution decorator with the

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -27,6 +27,7 @@ type ScyllaClusterOptions struct {
 	ExposeOptions    ExposeOptions
 	StorageClassName string
 	ReactorBackend   string
+	BootstrapPolicy  string
 }
 
 func (o *ScyllaClusterOptions) ScyllaArgs() []string {

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -35,7 +35,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		initialMembers int32
 		targetMembers  int32
 	}
-	g.DescribeTable("nodes are cleaned up", func(ctx g.SpecContext, e *horizontalScalingEntry) {
+	g.DescribeTable("nodes are cleaned up", framework.SuiteKindClusterTopology, func(ctx g.SpecContext, e *horizontalScalingEntry) {
 		jobListWatcher := createJobListWatcher(ctx, f)
 		jobObserver := utils.ObserveObjects[*batchv1.Job](jobListWatcher)
 		err := jobObserver.Start(ctx)

--- a/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
@@ -17,7 +17,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var _ = g.Describe("MultiDC cluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
+var _ = g.Describe("MultiDC cluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, framework.SuiteKindClusterTopology, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/component-helpers/storage/volume"
 )
 
-var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
+var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, framework.SuiteKindClusterTopology, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_rebootstrap.go
@@ -19,7 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, framework.SuiteKindClusterTopology, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, framework.SuiteKindClusterTopology, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
+var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, framework.SuiteKindClusterTopology, func() {
 	var f *framework.Framework
 
 	g.BeforeEach(func(ctx context.Context) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
When https://scylladb.atlassian.net/browse/OPERATOR-290 lands, we expect that all existing E2E tests will run with bootstrap policy Parallel by default.
This PR adds a small suite containing tests related to cluster topology changes.
It also adds wiring for configuring the bootstrap policy.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-292.

/hold
This PR should go in hand with the CI counterpart, let's wait for it to exist and be tested on this PR.
