### PR TITLE
ci: wait for cert-manager webhook to be callable before installing operator

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -88,6 +88,11 @@ function _install-operator-manifests() {
       kubectl -n cert-manager rollout status --timeout=5m deployment.apps/"${d}"
   done
   wait-for-object-creation cert-manager secret/cert-manager-webhook-ca
+  # Rollouts and the CA secret existing don't yet mean the webhook is callable: cainjector
+  # still has to sync the CA into the webhook's caBundle. Probe the real apiserver->webhook
+  # path with a server-side dry-run until it works, so the first actual object can't hit
+  # "x509: certificate signed by unknown authority".
+  timeout 5m bash -c "until kubectl create --dry-run=server -f=- <<< '{\"apiVersion\":\"cert-manager.io/v1\",\"kind\":\"Issuer\",\"metadata\":{\"name\":\"webhook-probe\",\"namespace\":\"cert-manager\"},\"spec\":{\"selfSigned\":{}}}'; do sleep 1; done"
 
   mkdir -p "${ARTIFACTS_DEPLOY_DIR}"/operator
   cat > "${ARTIFACTS_DEPLOY_DIR}/operator/kustomization.yaml" << EOF


### PR DESCRIPTION
**Description of your changes:**
- Probe cert-manager apiserver-to-webhook path on webhook deploy: retry a server-side dry-run create of a self-signed Issuer until it succeeds. This mutates nothing and covers both the caBundle-lag and CA-rotation variants of the race.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-303

Solves racy deployments like https://prow.scylla-operator.scylladb.com/view/gs/scylla-operator-prow/pr-logs/pull/scylladb_scylla-operator/3584/pull-scylla-operator-master-e2e-gke-parallel/2087169673371062272