### PR TITLE
fix: propagate ScyllaDBDatacenterNodesStatusReport sync error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
   Every node is now cleaned up once the ring changes. Note that this increases the number of cleanup jobs created at once,
   from N-1 to N for an N node cluster.
   [#3574](https://github.com/scylladb/scylla-operator/pull/3574)
+- Fixed the `ScyllaDBDatacenter` controller discarding failures to sync `ScyllaDBDatacenterNodesStatusReport` objects.
+  The error was dropped instead of being aggregated into the error returned by the reconciliation, so a failed sync was
+  reported as successful and the key was forgotten rather than requeued, losing the retry with backoff. The degraded
+  condition was reported correctly, so this was not visible in the resource status.
+  [#3587](https://github.com/scylladb/scylla-operator/pull/3587)
 
 ### Features & Enhancements
 - Added an optional `bootstrapPolicy` field to `ScyllaCluster.spec` and `ScyllaDBDatacenter.spec`, accepting `Sequential`

--- a/pkg/controller/scylladbdatacenter/sync.go
+++ b/pkg/controller/scylladbdatacenter/sync.go
@@ -293,6 +293,9 @@ func (sdcc *Controller) sync(ctx context.Context, key string) error {
 			return sdcc.syncScyllaDBDatacenterNodesStatusReports(ctx, sdc, serviceMap, scyllaDBDatacenterNodesStatusReportMap)
 		},
 	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("can't sync ScyllaDBDatacenter nodes status reports: %w", err))
+	}
 
 	err = controllerhelpers.RunSync(
 		&status.Conditions,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
The RunSync call for ScyllaDBDatacenterNodesStatusReports assigns to err but never checks it, unlike every other RunSync in sync(). The error is silently dropped and overwritten by the StatefulSet sync that follows, so a failure to sync the reports never makes it into the aggregated error and the sync is reported as successful.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-307

/cc @czeslavo 
