### PR TITLE
feat: set bootstrapPolicy to parallel for new clusters >= 2026.2

### DIFF
--- a/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
@@ -242,6 +242,9 @@ spec:
                   bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
                   parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
                   If not provided, it's treated as Sequential.
+                  On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel
+                  bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's
+                  explicitly changed. It's otherwise left unset, and never set on an already existing object.
                 enum:
                 - Sequential
                 - Parallel

--- a/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -58,6 +58,10 @@ spec:
                   bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
                   parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
                   If not provided, it's treated as Sequential.
+                  On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version
+                  supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image
+                  changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing
+                  object.
                 enum:
                 - Sequential
                 - Parallel

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2021,6 +2021,9 @@ spec:
                     bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
                     parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
                     If not provided, it's treated as Sequential.
+                    On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel
+                    bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's
+                    explicitly changed. It's otherwise left unset, and never set on an already existing object.
                   enum:
                     - Sequential
                     - Parallel
@@ -35620,6 +35623,10 @@ spec:
                     bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
                     parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
                     If not provided, it's treated as Sequential.
+                    On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version
+                    supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image
+                    changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing
+                    object.
                   enum:
                     - Sequential
                     - Parallel

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -92,7 +92,7 @@ object
      - backups specifies backup tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
    * - bootstrapPolicy
      - string
-     - bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later. If not provided, it's treated as Sequential.
+     - bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later. If not provided, it's treated as Sequential. On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
    * - cpuset
      - boolean
      - cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
@@ -77,7 +77,7 @@ object
      - Description
    * - bootstrapPolicy
      - string
-     - bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later. If not provided, it's treated as Sequential.
+     - bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later. If not provided, it's treated as Sequential. On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
    * - clusterName
      - string
      - clusterName specifies the name of the ScyllaDB cluster. When joining two DCs, their cluster name must match. This field is immutable.

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -231,7 +231,7 @@
           "type": "array"
         },
         "bootstrapPolicy": {
-          "description": "bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in\nparallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as Sequential.",
+          "description": "bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in\nparallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as Sequential.\nOn creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel\nbootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's\nexplicitly changed. It's otherwise left unset, and never set on an already existing object.",
           "enum": [
             "Sequential",
             "Parallel"

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -174,7 +174,7 @@
       "type": "array"
     },
     "bootstrapPolicy": {
-      "description": "bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in\nparallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as Sequential.",
+      "description": "bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in\nparallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as Sequential.\nOn creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel\nbootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's\nexplicitly changed. It's otherwise left unset, and never set on an already existing object.",
       "enum": [
         "Sequential",
         "Parallel"

--- a/pkg/api/scylla/defaulting/cluster_defaulting.go
+++ b/pkg/api/scylla/defaulting/cluster_defaulting.go
@@ -4,9 +4,35 @@ package defaulting
 
 import (
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/semver"
 )
 
 // SetDefaultsScyllaCluster sets the create-time defaults on a ScyllaCluster.
 // It must not fail: under failurePolicy: Fail, a defaulter returning an error would block object creation.
+// Mutating admission runs before the object is validated against the CRD schema, so it must also tolerate specs
+// missing fields that validation guarantees.
 func SetDefaultsScyllaCluster(sc *scyllav1.ScyllaCluster) {
+	setDefaultScyllaClusterBootstrapPolicy(sc)
+}
+
+// setDefaultScyllaClusterBootstrapPolicy stamps an explicit Parallel bootstrapPolicy on creation when the ScyllaDB
+// version in the spec supports bootstrapping nodes in parallel.
+// Sequential is deliberately never stamped. Leaving the field unset keeps the object on whatever the resolution of an
+// unset bootstrapPolicy is, rather than pinning it to today's one, so that objects whose owners never made a choice
+// can be moved to a new default later without rewriting their specs.
+// An explicitly set value, including one the validation rejects, is left untouched: correcting the user's own value is
+// the validating webhook's job, not the defaulter's.
+func setDefaultScyllaClusterBootstrapPolicy(sc *scyllav1.ScyllaCluster) {
+	if sc.Spec.BootstrapPolicy != nil {
+		return
+	}
+
+	// spec.version is used verbatim as the tag of the ScyllaDB image, so there's no image reference to strip the
+	// version from. It's also the very value an explicitly set Parallel bootstrapPolicy is validated against, so the
+	// stamped value can never be rejected by the validating webhook, which runs after this one.
+	if !semver.SupportsParallelBootstrap(sc.Spec.Version) {
+		return
+	}
+
+	sc.Spec.BootstrapPolicy = new(scyllav1.BootstrapPolicyParallel)
 }

--- a/pkg/api/scylla/defaulting/cluster_defaulting_test.go
+++ b/pkg/api/scylla/defaulting/cluster_defaulting_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 ScyllaDB.
+
+package defaulting_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/api/scylla/defaulting"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/test/unit"
+)
+
+func TestSetDefaultsScyllaCluster(t *testing.T) {
+	t.Parallel()
+
+	newScyllaCluster := func(version string, bootstrapPolicy *scyllav1.BootstrapPolicy) *scyllav1.ScyllaCluster {
+		sc := unit.NewSingleRackCluster(3)
+		sc.Spec.Version = version
+		sc.Spec.BootstrapPolicy = bootstrapPolicy
+
+		return sc
+	}
+
+	tt := []struct {
+		name     string
+		cluster  *scyllav1.ScyllaCluster
+		expected *scyllav1.ScyllaCluster
+	}{
+		{
+			name:     "unset bootstrapPolicy with the minimal version supporting parallel bootstrap is defaulted to Parallel",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, nil),
+			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+		},
+		{
+			name:     "unset bootstrapPolicy with a version newer than the minimal one supporting parallel bootstrap is defaulted to Parallel",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageAboveParallelBootstrapThresholdTag, nil),
+			expected: newScyllaCluster(unit.ScyllaDBImageAboveParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+		},
+		{
+			name:     "unset bootstrapPolicy with an older version is left unset",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, nil),
+			expected: newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, nil),
+		},
+		{
+			// Per semver precedence a pre-release version is lower than the same version without one, matching how
+			// an explicitly set Parallel bootstrapPolicy is validated.
+			name:     "unset bootstrapPolicy with a pre-release of the minimal version supporting parallel bootstrap is left unset",
+			cluster:  newScyllaCluster(unit.ScyllaDBImagePreReleaseOfParallelBootstrapThresholdTag, nil),
+			expected: newScyllaCluster(unit.ScyllaDBImagePreReleaseOfParallelBootstrapThresholdTag, nil),
+		},
+		{
+			name:     "unset bootstrapPolicy with an unparseable version is left unset",
+			cluster:  newScyllaCluster("latest", nil),
+			expected: newScyllaCluster("latest", nil),
+		},
+		{
+			// The version is used verbatim as the image tag, so a digest pinned image makes it unparseable.
+			name:     "unset bootstrapPolicy with a digest pinned version is left unset",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
+			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
+		},
+		{
+			// Mutating admission runs before the object is validated against the CRD schema, so the defaulter has to
+			// tolerate a spec missing the fields it reads.
+			name:     "unset bootstrapPolicy with an empty version is left unset",
+			cluster:  newScyllaCluster("", nil),
+			expected: newScyllaCluster("", nil),
+		},
+		{
+			name:     "explicit Sequential bootstrapPolicy is preserved",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicySequential)),
+			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicySequential)),
+		},
+		{
+			name:     "explicit Parallel bootstrapPolicy is preserved",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+		},
+		{
+			// Rejecting a value the user set themselves is the validating webhook's job. The defaulter must not
+			// silently turn an invalid request into a valid one.
+			name:     "explicit Parallel bootstrapPolicy with a version not supporting it is preserved",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+			expected: newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.cluster.DeepCopy()
+			defaulting.SetDefaultsScyllaCluster(got)
+
+			if !cmp.Equal(tc.expected, got) {
+				t.Errorf("expected and actual ScyllaClusters differ: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}

--- a/pkg/api/scylla/defaulting/consistency_test.go
+++ b/pkg/api/scylla/defaulting/consistency_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 ScyllaDB.
+
+package defaulting_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/api/scylla/defaulting"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
+	"github.com/scylladb/scylla-operator/pkg/semver"
+	"github.com/scylladb/scylla-operator/pkg/test/unit"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// consistencyTestScyllaDBVersions covers both sides of every branch the defaulters decide on, including the versions
+// they can't parse. The expectation is derived from the same predicate the defaulters use, so the table only has to
+// cover the versions, not restate which of them support parallel bootstrap.
+var consistencyTestScyllaDBVersions = []string{
+	unit.ScyllaDBImageAtParallelBootstrapThresholdTag,
+	unit.ScyllaDBImageAboveParallelBootstrapThresholdTag,
+	unit.ScyllaDBImagePreReleaseOfParallelBootstrapThresholdTag,
+	unit.ScyllaDBImageBelowParallelBootstrapThresholdTag,
+	"latest",
+	"",
+}
+
+// TestDefaultingIsConsistentWithValidation asserts that defaulting a bootstrapPolicy never adds a validation error.
+// Parallel is only ever stamped for versions the validation accepts it for, which this covers from both sides.
+// The mutating webhook runs before the validating one, so a value stamped by the former and rejected by the latter
+// would fail a creation the user could have made themselves.
+func TestDefaultingIsConsistentWithValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ScyllaCluster", func(t *testing.T) {
+		t.Parallel()
+
+		for _, version := range consistencyTestScyllaDBVersions {
+			t.Run(version, func(t *testing.T) {
+				t.Parallel()
+
+				sc := unit.NewSingleRackCluster(3)
+				// spec.version is used verbatim as the tag of the ScyllaDB image.
+				sc.Spec.Version = version
+				sc.Spec.BootstrapPolicy = nil
+
+				errListBeforeDefaulting := validation.ValidateScyllaCluster(sc)
+
+				defaulting.SetDefaultsScyllaCluster(sc)
+				verifyDefaultedBootstrapPolicy(t, version, sc.Spec.BootstrapPolicy, scyllav1.BootstrapPolicyParallel)
+
+				errListAfterDefaulting := validation.ValidateScyllaCluster(sc)
+				if !reflect.DeepEqual(errListBeforeDefaulting, errListAfterDefaulting) {
+					t.Errorf("defaulting bootstrapPolicy changed the validation result: %s", cmp.Diff(errListBeforeDefaulting, errListAfterDefaulting))
+				}
+			})
+		}
+	})
+
+	t.Run("ScyllaDBDatacenter", func(t *testing.T) {
+		t.Parallel()
+
+		for _, version := range consistencyTestScyllaDBVersions {
+			t.Run(version, func(t *testing.T) {
+				t.Parallel()
+
+				sdc := newConsistencyTestScyllaDBDatacenter(version)
+				sdc.Spec.BootstrapPolicy = nil
+
+				errListBeforeDefaulting := validation.ValidateScyllaDBDatacenter(sdc)
+
+				defaulting.SetDefaultsScyllaDBDatacenter(sdc)
+				verifyDefaultedBootstrapPolicy(t, version, sdc.Spec.BootstrapPolicy, scyllav1alpha1.BootstrapPolicyParallel)
+
+				errListAfterDefaulting := validation.ValidateScyllaDBDatacenter(sdc)
+				if !reflect.DeepEqual(errListBeforeDefaulting, errListAfterDefaulting) {
+					t.Errorf("defaulting bootstrapPolicy changed the validation result: %s", cmp.Diff(errListBeforeDefaulting, errListAfterDefaulting))
+				}
+			})
+		}
+	})
+}
+
+// verifyDefaultedBootstrapPolicy asserts that defaulting stamped Parallel exactly for the ScyllaDB versions supporting
+// parallel bootstrap, and left bootstrapPolicy unset for every other one. Sequential is never stamped, so that objects
+// whose owners never made a choice keep resolving an unset bootstrapPolicy rather than being pinned to today's
+// resolution of it.
+func verifyDefaultedBootstrapPolicy[P ~string](t *testing.T, scyllaDBVersion string, got *P, parallel P) {
+	t.Helper()
+
+	if !semver.SupportsParallelBootstrap(scyllaDBVersion) {
+		if got != nil {
+			t.Errorf("expected bootstrapPolicy to be left unset, got %q", *got)
+		}
+		return
+	}
+
+	if got == nil {
+		t.Errorf("expected bootstrapPolicy to be stamped with %q, got none", parallel)
+		return
+	}
+
+	if *got != parallel {
+		t.Errorf("expected bootstrapPolicy to be stamped with %q, got %q", parallel, *got)
+	}
+}
+
+// newConsistencyTestScyllaDBDatacenter returns a ScyllaDBDatacenter whose only source of validation errors can be the
+// ScyllaDB image, so that the comparison of the validation results isolates the effect of the defaulted field.
+func newConsistencyTestScyllaDBDatacenter(scyllaDBVersion string) *scyllav1alpha1.ScyllaDBDatacenter {
+	image := unit.ScyllaDBImageRepository
+	if len(scyllaDBVersion) != 0 {
+		image = image + ":" + scyllaDBVersion
+	}
+
+	return &scyllav1alpha1.ScyllaDBDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "basic",
+			UID:  "the-uid",
+		},
+		Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
+			ClusterName:    "basic",
+			DatacenterName: new("dc"),
+			ScyllaDB: scyllav1alpha1.ScyllaDB{
+				Image: image,
+			},
+			Racks: []scyllav1alpha1.RackSpec{
+				{
+					Name: "rack",
+					RackTemplate: scyllav1alpha1.RackTemplate{
+						ScyllaDB: &scyllav1alpha1.ScyllaDBTemplate{
+							Storage: &scyllav1alpha1.StorageOptions{
+								Capacity: "1Gi",
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: scyllav1alpha1.ScyllaDBDatacenterStatus{
+			Racks: []scyllav1alpha1.RackStatus{},
+		},
+	}
+}

--- a/pkg/api/scylla/defaulting/scylladbdatacenter_defaulting.go
+++ b/pkg/api/scylla/defaulting/scylladbdatacenter_defaulting.go
@@ -4,9 +4,39 @@ package defaulting
 
 import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/semver"
 )
 
 // SetDefaultsScyllaDBDatacenter sets the create-time defaults on a ScyllaDBDatacenter.
 // It must not fail: under failurePolicy: Fail, a defaulter returning an error would block object creation.
+// Mutating admission runs before the object is validated against the CRD schema, so it must also tolerate specs
+// missing fields that validation guarantees.
 func SetDefaultsScyllaDBDatacenter(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
+	setDefaultScyllaDBDatacenterBootstrapPolicy(sdc)
+}
+
+// setDefaultScyllaDBDatacenterBootstrapPolicy stamps an explicit Parallel bootstrapPolicy on creation when the ScyllaDB
+// image in the spec supports bootstrapping nodes in parallel.
+// Sequential is deliberately never stamped. Leaving the field unset keeps the object on whatever the resolution of an
+// unset bootstrapPolicy is, rather than pinning it to today's one, so that objects whose owners never made a choice
+// can be moved to a new default later without rewriting their specs.
+// An explicitly set value, including one the validation rejects, is left untouched: correcting the user's own value is
+// the validating webhook's job, not the defaulter's.
+// ScyllaDBDatacenters managed by a parent controller always arrive at admission with the field explicitly set, so this
+// only ever takes effect for directly created ones.
+func setDefaultScyllaDBDatacenterBootstrapPolicy(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
+	if sdc.Spec.BootstrapPolicy != nil {
+		return
+	}
+
+	// An image whose version can't be determined, e.g. one pinned by a digest, is deliberately treated as not
+	// supporting parallel bootstrap. This is the very value an explicitly set Parallel bootstrapPolicy is validated
+	// against, so the stamped value can never be rejected by the validating webhook, which runs after this one.
+	scyllaDBVersion, _ := naming.ImageToVersion(sdc.Spec.ScyllaDB.Image)
+	if !semver.SupportsParallelBootstrap(scyllaDBVersion) {
+		return
+	}
+
+	sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
 }

--- a/pkg/api/scylla/defaulting/scylladbdatacenter_defaulting_test.go
+++ b/pkg/api/scylla/defaulting/scylladbdatacenter_defaulting_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 ScyllaDB.
+
+package defaulting_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/scylla-operator/pkg/api/scylla/defaulting"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/test/unit"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetDefaultsScyllaDBDatacenter(t *testing.T) {
+	t.Parallel()
+
+	newScyllaDBDatacenter := func(image string, bootstrapPolicy *scyllav1alpha1.BootstrapPolicy) *scyllav1alpha1.ScyllaDBDatacenter {
+		return &scyllav1alpha1.ScyllaDBDatacenter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "basic",
+				Namespace: "test",
+			},
+			Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
+				ClusterName: "basic",
+				ScyllaDB: scyllav1alpha1.ScyllaDB{
+					Image: image,
+				},
+				Racks: []scyllav1alpha1.RackSpec{
+					{
+						Name: "rack",
+					},
+				},
+				BootstrapPolicy: bootstrapPolicy,
+			},
+		}
+	}
+
+	tt := []struct {
+		name       string
+		datacenter *scyllav1alpha1.ScyllaDBDatacenter
+		expected   *scyllav1alpha1.ScyllaDBDatacenter
+	}{
+		{
+			name:       "unset bootstrapPolicy with the minimal version supporting parallel bootstrap is defaulted to Parallel",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, nil),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+		},
+		{
+			name:       "unset bootstrapPolicy with a version newer than the minimal one supporting parallel bootstrap is defaulted to Parallel",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAboveParallelBootstrapThreshold, nil),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAboveParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+		},
+		{
+			name:       "unset bootstrapPolicy with an older version is left unset",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, nil),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, nil),
+		},
+		{
+			// Per semver precedence a pre-release version is lower than the same version without one, matching how
+			// an explicitly set Parallel bootstrapPolicy is validated.
+			name:       "unset bootstrapPolicy with a pre-release of the minimal version supporting parallel bootstrap is left unset",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImagePreReleaseOfParallelBootstrapThreshold, nil),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImagePreReleaseOfParallelBootstrapThreshold, nil),
+		},
+		{
+			name:       "unset bootstrapPolicy with an unparseable tag is left unset",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImage, nil),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImage, nil),
+		},
+		{
+			// A digest pinned image carries no tag to determine the version from.
+			name:       "unset bootstrapPolicy with a digest pinned image is left unset",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageRepository+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageRepository+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
+		},
+		{
+			name:       "unset bootstrapPolicy with a tagged and digest pinned image is defaulted from the tag",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", new(scyllav1alpha1.BootstrapPolicyParallel)),
+		},
+		{
+			// Mutating admission runs before the object is validated against the CRD schema, so the defaulter has to
+			// tolerate a spec missing the fields it reads.
+			name:       "unset bootstrapPolicy with an empty image is left unset",
+			datacenter: newScyllaDBDatacenter("", nil),
+			expected:   newScyllaDBDatacenter("", nil),
+		},
+		{
+			name:       "explicit Sequential bootstrapPolicy is preserved",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicySequential)),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicySequential)),
+		},
+		{
+			name:       "explicit Parallel bootstrapPolicy is preserved",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+		},
+		{
+			// Rejecting a value the user set themselves is the validating webhook's job. The defaulter must not
+			// silently turn an invalid request into a valid one.
+			name:       "explicit Parallel bootstrapPolicy with a version not supporting it is preserved",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.datacenter.DeepCopy()
+			defaulting.SetDefaultsScyllaDBDatacenter(got)
+
+			if !cmp.Equal(tc.expected, got) {
+				t.Errorf("expected and actual ScyllaDBDatacenters differ: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -227,6 +227,9 @@ spec:
                     bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
                     parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
                     If not provided, it's treated as Sequential.
+                    On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel
+                    bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's
+                    explicitly changed. It's otherwise left unset, and never set on an already existing object.
                   enum:
                     - Sequential
                     - Parallel

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -155,7 +155,9 @@ type ScyllaClusterSpec struct {
 	// bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
 	// parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
 	// If not provided, it's treated as Sequential.
-	// TODO(https://scylladb.atlassian.net/browse/OPERATOR-290): Update the description above when this field starts being defaulted on creation.
+	// On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel
+	// bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's
+	// explicitly changed. It's otherwise left unset, and never set on an already existing object.
 	// +kubebuilder:validation:Enum=Sequential;Parallel
 	// +optional
 	BootstrapPolicy *BootstrapPolicy `json:"bootstrapPolicy,omitempty"`

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -57,6 +57,10 @@ spec:
                     bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
                     parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
                     If not provided, it's treated as Sequential.
+                    On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version
+                    supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image
+                    changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing
+                    object.
                   enum:
                     - Sequential
                     - Parallel

--- a/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
+++ b/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
@@ -105,7 +105,10 @@ type ScyllaDBDatacenterSpec struct {
 	// bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
 	// parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
 	// If not provided, it's treated as Sequential.
-	// TODO(https://scylladb.atlassian.net/browse/OPERATOR-290): Update the description above when this field starts being defaulted on creation.
+	// On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version
+	// supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image
+	// changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing
+	// object.
 	// +kubebuilder:validation:Enum=Sequential;Parallel
 	// +optional
 	BootstrapPolicy *BootstrapPolicy `json:"bootstrapPolicy,omitempty"`

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation.go
@@ -607,7 +607,7 @@ func validateEnum[E ~string](value E, supported []E, fldPath *field.Path) field.
 func validateParallelBootstrapPolicyScyllaDBVersion[P ~string](bootstrapPolicy P, scyllaDBVersion string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if !semver.NewScyllaVersion(scyllaDBVersion).SupportFeatureSafe(semver.ScyllaDBVersionRequiredForParallelBootstrap) {
+	if !semver.SupportsParallelBootstrap(scyllaDBVersion) {
 		allErrs = append(allErrs, field.Invalid(fldPath, bootstrapPolicy, fmt.Sprintf(
 			"requires a semver-parseable ScyllaDB version >= %d.%d",
 			semver.ScyllaDBVersionRequiredForParallelBootstrap.Major,

--- a/pkg/cmd/operator/webhooks_mutating_test.go
+++ b/pkg/cmd/operator/webhooks_mutating_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/scheme"
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -160,33 +161,90 @@ func Test_mutate(t *testing.T) {
 }
 
 // Test_mutate_withDefaultDefaulters covers mutate against DefaultDefaulters, the registry served by the webhook
-// server, asserting which resources it defaults and that the registered defaulters are no-ops.
-// The dispatcher machinery itself is covered by Test_mutate.
+// server, asserting which resources it defaults and what the registered defaulters stamp.
+// The defaulters themselves are covered by the defaulting package's tests, the dispatcher machinery by Test_mutate.
 func Test_mutate_withDefaultDefaulters(t *testing.T) {
 	t.Parallel()
 
 	tt := []struct {
-		name          string
-		req           *admissionv1.AdmissionRequest
-		expectedError error
+		name            string
+		req             *admissionv1.AdmissionRequest
+		expectedPatches []jsonpatch.Operation
+		expectedError   error
 	}{
 		{
-			name: "a ScyllaCluster passes through unchanged",
+			// Sequential is never stamped: an unset bootstrapPolicy is left unset, so that objects whose owners
+			// never made a choice keep resolving it rather than being pinned to today's resolution.
+			name: "a ScyllaCluster with a version not supporting parallel bootstrap is admitted unchanged",
 			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
 				Group:    "scylla.scylladb.com",
 				Version:  "v1",
 				Resource: "scyllaclusters",
-			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1","kind":"ScyllaCluster","metadata":{"name":"basic","namespace":"test"},"spec":{"version":"6.2.0","agentVersion":"3.4.0","datacenter":{"name":"dc1","racks":[{"name":"rack1","members":3,"storage":{"capacity":"1Gi"}}]}}}`)),
+			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1","kind":"ScyllaCluster","metadata":{"name":"basic","namespace":"test"},"spec":{"version":"2026.1.0","agentVersion":"3.4.0","datacenter":{"name":"dc1","racks":[{"name":"rack1","members":3,"storage":{"capacity":"1Gi"}}]}}}`)),
+			expectedPatches: nil,
+			expectedError:   nil,
+		},
+		{
+			name: "a ScyllaCluster with a version supporting parallel bootstrap is stamped with a Parallel bootstrapPolicy",
+			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
+				Group:    "scylla.scylladb.com",
+				Version:  "v1",
+				Resource: "scyllaclusters",
+			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1","kind":"ScyllaCluster","metadata":{"name":"basic","namespace":"test"},"spec":{"version":"2026.2.0","agentVersion":"3.4.0","datacenter":{"name":"dc1","racks":[{"name":"rack1","members":3,"storage":{"capacity":"1Gi"}}]}}}`)),
+			expectedPatches: []jsonpatch.Operation{
+				{
+					Operation: "add",
+					Path:      "/spec/bootstrapPolicy",
+					Value:     string(scyllav1.BootstrapPolicyParallel),
+				},
+			},
 			expectedError: nil,
 		},
 		{
-			name: "a ScyllaDBDatacenter passes through unchanged",
+			name: "a ScyllaCluster with an explicit bootstrapPolicy passes through unchanged",
+			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
+				Group:    "scylla.scylladb.com",
+				Version:  "v1",
+				Resource: "scyllaclusters",
+			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1","kind":"ScyllaCluster","metadata":{"name":"basic","namespace":"test"},"spec":{"version":"2026.2.0","agentVersion":"3.4.0","bootstrapPolicy":"Sequential","datacenter":{"name":"dc1","racks":[{"name":"rack1","members":3,"storage":{"capacity":"1Gi"}}]}}}`)),
+			expectedPatches: nil,
+			expectedError:   nil,
+		},
+		{
+			name: "a ScyllaDBDatacenter with an image not supporting parallel bootstrap is admitted unchanged",
 			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
 				Group:    "scylla.scylladb.com",
 				Version:  "v1alpha1",
 				Resource: "scylladbdatacenters",
-			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1alpha1","kind":"ScyllaDBDatacenter","metadata":{"name":"basic","namespace":"test"},"spec":{"clusterName":"basic","scyllaDB":{"image":"docker.io/scylladb/scylla:6.2.0"},"racks":[{"name":"rack1"}]}}`)),
+			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1alpha1","kind":"ScyllaDBDatacenter","metadata":{"name":"basic","namespace":"test"},"spec":{"clusterName":"basic","scyllaDB":{"image":"docker.io/scylladb/scylla:2026.1.0"},"racks":[{"name":"rack1"}]}}`)),
+			expectedPatches: nil,
+			expectedError:   nil,
+		},
+		{
+			name: "a ScyllaDBDatacenter with an image supporting parallel bootstrap is stamped with a Parallel bootstrapPolicy",
+			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
+				Group:    "scylla.scylladb.com",
+				Version:  "v1alpha1",
+				Resource: "scylladbdatacenters",
+			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1alpha1","kind":"ScyllaDBDatacenter","metadata":{"name":"basic","namespace":"test"},"spec":{"clusterName":"basic","scyllaDB":{"image":"docker.io/scylladb/scylla:2026.2.0"},"racks":[{"name":"rack1"}]}}`)),
+			expectedPatches: []jsonpatch.Operation{
+				{
+					Operation: "add",
+					Path:      "/spec/bootstrapPolicy",
+					Value:     string(scyllav1alpha1.BootstrapPolicyParallel),
+				},
+			},
 			expectedError: nil,
+		},
+		{
+			name: "a ScyllaDBDatacenter with an explicit bootstrapPolicy passes through unchanged",
+			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
+				Group:    "scylla.scylladb.com",
+				Version:  "v1alpha1",
+				Resource: "scylladbdatacenters",
+			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1alpha1","kind":"ScyllaDBDatacenter","metadata":{"name":"basic","namespace":"test"},"spec":{"clusterName":"basic","scyllaDB":{"image":"docker.io/scylladb/scylla:2026.2.0"},"bootstrapPolicy":"Sequential","racks":[{"name":"rack1"}]}}`)),
+			expectedPatches: nil,
+			expectedError:   nil,
 		},
 		{
 			// ScyllaDBClusters are deliberately not registered, as parallel bootstrap is not supported in
@@ -197,7 +255,8 @@ func Test_mutate_withDefaultDefaulters(t *testing.T) {
 				Version:  "v1alpha1",
 				Resource: "scylladbclusters",
 			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1alpha1","kind":"ScyllaDBCluster","metadata":{"name":"basic","namespace":"test"}}`)),
-			expectedError: fmt.Errorf(`unsupported GVR "scylla.scylladb.com/v1alpha1, Resource=scylladbclusters"`),
+			expectedPatches: nil,
+			expectedError:   fmt.Errorf(`unsupported GVR "scylla.scylladb.com/v1alpha1, Resource=scylladbclusters"`),
 		},
 		{
 			name: "a resource outside of the ScyllaDB API group is rejected as an unsupported GVR",
@@ -206,7 +265,8 @@ func Test_mutate_withDefaultDefaulters(t *testing.T) {
 				Version:  "v1",
 				Resource: "pods",
 			}, admissionv1.Create, []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod","namespace":"test"},"spec":{"containers":null}}`)),
-			expectedError: fmt.Errorf(`unsupported GVR "/v1, Resource=pods"`),
+			expectedPatches: nil,
+			expectedError:   fmt.Errorf(`unsupported GVR "/v1, Resource=pods"`),
 		},
 	}
 
@@ -219,8 +279,8 @@ func Test_mutate_withDefaultDefaulters(t *testing.T) {
 				t.Fatalf("expected and actual errors differ: %s", cmp.Diff(tc.expectedError, err, cmpopts.EquateErrors()))
 			}
 
-			if patches != nil {
-				t.Errorf("expected no patches, got %v: the registered defaulters must be no-ops", patches)
+			if !reflect.DeepEqual(tc.expectedPatches, patches) {
+				t.Errorf("expected and actual patches differ: %s", cmp.Diff(tc.expectedPatches, patches))
 			}
 		})
 	}

--- a/pkg/controller/scyllacluster/migrate.go
+++ b/pkg/controller/scyllacluster/migrate.go
@@ -276,11 +276,12 @@ func MigrateV1ScyllaClusterSpecToV1Alpha1ScyllaDBDatacenterSpec(scName string, s
 		MinReadySeconds:                         scSpec.MinReadySeconds,
 		ReadinessGates:                          scSpec.ReadinessGates,
 		BootstrapPolicy: func() *scyllav1alpha1.BootstrapPolicy {
-			// A managed ScyllaDBDatacenter always carries an explicit bootstrapPolicy.
-			// An unset bootstrapPolicy in the parent ScyllaCluster means it was created before the field was defaulted on
-			// creation, hence it must keep bootstrapping its nodes sequentially. This resolution is permanently frozen and
-			// must not be changed when the create-time default becomes Parallel, as that would silently parallelize
-			// bootstrap of pre-existing clusters.
+			// A managed ScyllaDBDatacenter always carries an explicit bootstrapPolicy, so an unset bootstrapPolicy in
+			// the parent ScyllaCluster has to be resolved here. It's resolved to Sequential: an unset value covers
+			// both ScyllaClusters created before the field existed and ones created with a ScyllaDB version that
+			// doesn't support bootstrapping nodes in parallel, and neither may start doing so on an operator upgrade.
+			// Changing this resolution changes the behavior of every such existing cluster, so it must not be treated
+			// as an implementation detail of the create time defaulting.
 			if scSpec.BootstrapPolicy == nil {
 				return pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
 			}

--- a/pkg/semver/version.go
+++ b/pkg/semver/version.go
@@ -53,3 +53,12 @@ func (sv ScyllaVersion) SupportFeatureUnsafe(featureVersion semver.Version) bool
 func (sv ScyllaVersion) SupportFeatureSafe(featureVersion semver.Version) bool {
 	return !sv.unknown && sv.version.GTE(featureVersion)
 }
+
+// SupportsParallelBootstrap returns whether the given ScyllaDB version supports bootstrapping nodes in parallel.
+// A version which can't be parsed, e.g. one of an image pinned by a digest, is deliberately treated as not supporting
+// it, so that parallel bootstrap is only ever enabled for versions known to support it.
+// This is the single predicate both the validation of an explicitly set bootstrapPolicy and its create time defaulting
+// are evaluated against, so that the defaulting can never stamp a value the validation rejects.
+func SupportsParallelBootstrap(scyllaDBVersion string) bool {
+	return NewScyllaVersion(scyllaDBVersion).SupportFeatureSafe(ScyllaDBVersionRequiredForParallelBootstrap)
+}

--- a/pkg/test/unit/const.go
+++ b/pkg/test/unit/const.go
@@ -19,4 +19,18 @@ const (
 
 	ScyllaDBImageAboveNodeExporterThresholdTag = "2026.3.0"
 	ScyllaDBImageAboveNodeExporterThreshold    = ScyllaDBImageRepository + ":" + ScyllaDBImageAboveNodeExporterThresholdTag
+
+	ScyllaDBImageBelowParallelBootstrapThresholdTag = "2026.1.0"
+	ScyllaDBImageBelowParallelBootstrapThreshold    = ScyllaDBImageRepository + ":" + ScyllaDBImageBelowParallelBootstrapThresholdTag
+
+	ScyllaDBImageAtParallelBootstrapThresholdTag = "2026.2.0"
+	ScyllaDBImageAtParallelBootstrapThreshold    = ScyllaDBImageRepository + ":" + ScyllaDBImageAtParallelBootstrapThresholdTag
+
+	ScyllaDBImageAboveParallelBootstrapThresholdTag = "2026.3.0"
+	ScyllaDBImageAboveParallelBootstrapThreshold    = ScyllaDBImageRepository + ":" + ScyllaDBImageAboveParallelBootstrapThresholdTag
+
+	// Per semver precedence a pre-release version is lower than the same version without one, so a pre-release of the
+	// threshold is below it.
+	ScyllaDBImagePreReleaseOfParallelBootstrapThresholdTag = "2026.2.0-rc0"
+	ScyllaDBImagePreReleaseOfParallelBootstrapThreshold    = ScyllaDBImageRepository + ":" + ScyllaDBImagePreReleaseOfParallelBootstrapThresholdTag
 )

--- a/test/e2e/set/scyllacluster/scyllacluster_defaulting.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_defaulting.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 ScyllaDB.
+
+package scyllacluster
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/semver"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("ScyllaCluster's mutating admission webhook", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scyllacluster")
+	})
+
+	g.It("should default bootstrapPolicy on creation", func(ctx g.SpecContext) {
+		sc := f.GetDefaultScyllaCluster()
+		// The fixture carries an explicit bootstrapPolicy when the suite is invoked with one.
+		sc.Spec.BootstrapPolicy = nil
+
+		// Parallel is only stamped for ScyllaDB versions known to support bootstrapping nodes in parallel, and
+		// Sequential is never stamped, so the expected value depends on the version under test. It's deliberately
+		// not hardcoded: the version can carry a digest, which makes it unparseable and hence not supporting
+		// parallel bootstrap.
+		var expectedBootstrapPolicy *scyllav1.BootstrapPolicy
+		if semver.SupportsParallelBootstrap(sc.Spec.Version) {
+			expectedBootstrapPolicy = new(scyllav1.BootstrapPolicyParallel)
+		}
+
+		framework.By("Creating a ScyllaCluster without a bootstrapPolicy")
+		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sc.Spec.BootstrapPolicy).To(o.Equal(expectedBootstrapPolicy))
+	})
+
+	g.It("should preserve an explicitly set bootstrapPolicy on creation", func(ctx g.SpecContext) {
+		sc := f.GetDefaultScyllaCluster()
+		// Sequential is valid for every ScyllaDB version, so this holds regardless of the version under test.
+		sc.Spec.BootstrapPolicy = new(scyllav1.BootstrapPolicySequential)
+
+		framework.By("Creating a ScyllaCluster with an explicit bootstrapPolicy")
+		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sc.Spec.BootstrapPolicy).To(o.Equal(new(scyllav1.BootstrapPolicySequential)))
+	})
+})

--- a/test/e2e/set/scylladbdatacenter/scylladbdatacenter_defaulting.go
+++ b/test/e2e/set/scylladbdatacenter/scylladbdatacenter_defaulting.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 ScyllaDB.
+
+package scylladbdatacenter
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/pkg/semver"
+	"github.com/scylladb/scylla-operator/test/e2e/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("ScyllaDBDatacenter's mutating admission webhook", framework.SuiteParallel, framework.SuiteParallelOpenShift, framework.SuiteKindFast, func() {
+	var f *framework.Framework
+
+	g.BeforeEach(func(ctx context.Context) {
+		f = framework.NewFramework(ctx, "scylladbdatacenter")
+	})
+
+	g.It("should default bootstrapPolicy on creation", func(ctx g.SpecContext) {
+		sdc := f.GetDefaultScyllaDBDatacenter()
+		// The fixture carries an explicit bootstrapPolicy when the suite is invoked with one.
+		sdc.Spec.BootstrapPolicy = nil
+
+		// Parallel is only stamped for ScyllaDB versions known to support bootstrapping nodes in parallel, and
+		// Sequential is never stamped, so the expected value depends on the image under test. It's deliberately not
+		// hardcoded: the tag the tests run against doesn't have to be a semver-parseable version.
+		scyllaDBVersion, err := naming.ImageToVersion(sdc.Spec.ScyllaDB.Image)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var expectedBootstrapPolicy *scyllav1alpha1.BootstrapPolicy
+		if semver.SupportsParallelBootstrap(scyllaDBVersion) {
+			expectedBootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+		}
+
+		framework.By("Creating a ScyllaDBDatacenter without a bootstrapPolicy")
+		sdc, err = f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBDatacenters(f.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sdc.Spec.BootstrapPolicy).To(o.Equal(expectedBootstrapPolicy))
+	})
+
+	g.It("should preserve an explicitly set bootstrapPolicy on creation", func(ctx g.SpecContext) {
+		sdc := f.GetDefaultScyllaDBDatacenter()
+		// Sequential is valid for every ScyllaDB version, so this holds regardless of the image under test.
+		sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicySequential)
+
+		framework.By("Creating a ScyllaDBDatacenter with an explicit bootstrapPolicy")
+		sdc, err := f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBDatacenters(f.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sdc.Spec.BootstrapPolicy).To(o.Equal(new(scyllav1alpha1.BootstrapPolicySequential)))
+	})
+})

--- a/test/envtest/controllers/mutating_webhook_test.go
+++ b/test/envtest/controllers/mutating_webhook_test.go
@@ -6,12 +6,15 @@ package controllers
 
 import (
 	"context"
+	"maps"
 	"sync/atomic"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	operatorcmd "github.com/scylladb/scylla-operator/pkg/cmd/operator"
+	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	"github.com/scylladb/scylla-operator/test/envtest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +38,9 @@ var _ = g.Describe("Mutating admission webhook", func() {
 		expectedIntercepted bool
 		// newObject returns an object of the tested kind, valid enough to be created against the installed CRDs.
 		newObject func(name, namespace string) client.Object
+		// expectedDefaultedSpecFields are the spec fields the defaulters are expected to stamp on the created object,
+		// on top of the spec it was submitted with. An empty map asserts the object is admitted unchanged.
+		expectedDefaultedSpecFields map[string]any
 	}
 
 	g.DescribeTable("with the shipped MutatingWebhookConfiguration installed", func(ctx g.SpecContext, e *entry) {
@@ -77,38 +83,105 @@ var _ = g.Describe("Mutating admission webhook", func() {
 		}
 
 		o.Expect(resourceInvocations.Load()).To(o.BeNumerically(">=", 1), "the mutating webhook should have been invoked on CREATE")
-		o.Expect(getUnstructuredSpec(obj)).To(o.Equal(getUnstructuredSpec(baseline)), "the spec should be admitted unchanged")
+
+		// The baseline was created before the webhook was installed, so its spec is the submitted one. Anything the
+		// defaulters didn't stamp has to match it verbatim.
+		expectedSpec := getUnstructuredSpec(baseline).(map[string]any)
+		maps.Copy(expectedSpec, e.expectedDefaultedSpecFields)
+		o.Expect(getUnstructuredSpec(obj)).To(o.Equal(expectedSpec), "only the defaulted fields should differ from the submitted spec")
 		o.Expect(obj.GetLabels()).To(o.Equal(baseline.GetLabels()), "the labels should be admitted unchanged")
 		o.Expect(obj.GetAnnotations()).To(o.Equal(baseline.GetAnnotations()), "the annotations should be admitted unchanged")
 
 		g.By("Updating the object and expecting the mutating webhook not to be invoked")
 		resourceInvocationsBeforeUpdate := resourceInvocations.Load()
-		labels := obj.GetLabels()
-		if labels == nil {
-			labels = map[string]string{}
-		}
-		labels["update-trigger"] = "true"
-		obj.SetLabels(labels)
+		setUpdateTriggerLabel(obj)
 		err = env.KubeClient().Update(ctx, obj)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		o.Expect(resourceInvocations.Load()).To(o.Equal(resourceInvocationsBeforeUpdate), "the shipped rules should be CREATE-only")
+
+		// An object created before the defaulters existed keeps its fields unset forever: the value is a statement
+		// about the era the object was created in, so an unrelated update must not backfill it.
+		g.By("Updating the baseline object and expecting the defaulted fields to stay unset")
+		setUpdateTriggerLabel(baseline)
+		err = env.KubeClient().Update(ctx, baseline)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		updatedBaselineSpec := getUnstructuredSpec(baseline).(map[string]any)
+		for field := range e.expectedDefaultedSpecFields {
+			o.Expect(updatedBaselineSpec).NotTo(o.HaveKey(field), "the defaulters must never stamp %q on an already existing object", field)
+		}
 	},
-		g.Entry("admits a ScyllaCluster unchanged", &entry{
+		// Sequential is never stamped: an unset bootstrapPolicy is left unset, so that objects whose owners never
+		// made a choice keep resolving it rather than being pinned to today's resolution.
+		g.Entry("admits a ScyllaCluster with a version not supporting parallel bootstrap unchanged", &entry{
 			resource:            "scyllaclusters",
 			expectedIntercepted: true,
 			newObject: func(name, namespace string) client.Object {
-				return newBasicScyllaCluster(name, namespace)
+				sc := newBasicScyllaCluster(name, namespace)
+				sc.Spec.Version = unit.ScyllaDBImageBelowParallelBootstrapThresholdTag
+				return sc
+			},
+			expectedDefaultedSpecFields: nil,
+		}),
+		g.Entry("stamps a Parallel bootstrapPolicy on a ScyllaCluster with a version supporting parallel bootstrap", &entry{
+			resource:            "scyllaclusters",
+			expectedIntercepted: true,
+			newObject: func(name, namespace string) client.Object {
+				sc := newBasicScyllaCluster(name, namespace)
+				sc.Spec.Version = unit.ScyllaDBImageAtParallelBootstrapThresholdTag
+				return sc
+			},
+			expectedDefaultedSpecFields: map[string]any{
+				"bootstrapPolicy": string(scyllav1.BootstrapPolicyParallel),
 			},
 		}),
-		g.Entry("admits a ScyllaDBDatacenter unchanged", &entry{
+		g.Entry("admits a ScyllaCluster with an explicit bootstrapPolicy unchanged", &entry{
+			resource:            "scyllaclusters",
+			expectedIntercepted: true,
+			newObject: func(name, namespace string) client.Object {
+				sc := newBasicScyllaCluster(name, namespace)
+				sc.Spec.Version = unit.ScyllaDBImageAtParallelBootstrapThresholdTag
+				sc.Spec.BootstrapPolicy = new(scyllav1.BootstrapPolicySequential)
+				return sc
+			},
+			expectedDefaultedSpecFields: nil,
+		}),
+		g.Entry("admits a ScyllaDBDatacenter with an image not supporting parallel bootstrap unchanged", &entry{
 			resource:            "scylladbdatacenters",
 			expectedIntercepted: true,
 			newObject: func(name, namespace string) client.Object {
 				sdc := makeEnvtestScyllaDBDatacenter(namespace, []string{"rack1"})
 				sdc.Name = name
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageBelowParallelBootstrapThreshold
 				return sdc
 			},
+			expectedDefaultedSpecFields: nil,
+		}),
+		g.Entry("stamps a Parallel bootstrapPolicy on a ScyllaDBDatacenter with an image supporting parallel bootstrap", &entry{
+			resource:            "scylladbdatacenters",
+			expectedIntercepted: true,
+			newObject: func(name, namespace string) client.Object {
+				sdc := makeEnvtestScyllaDBDatacenter(namespace, []string{"rack1"})
+				sdc.Name = name
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+				return sdc
+			},
+			expectedDefaultedSpecFields: map[string]any{
+				"bootstrapPolicy": string(scyllav1alpha1.BootstrapPolicyParallel),
+			},
+		}),
+		g.Entry("admits a ScyllaDBDatacenter with an explicit bootstrapPolicy unchanged", &entry{
+			resource:            "scylladbdatacenters",
+			expectedIntercepted: true,
+			newObject: func(name, namespace string) client.Object {
+				sdc := makeEnvtestScyllaDBDatacenter(namespace, []string{"rack1"})
+				sdc.Name = name
+				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
+				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicySequential)
+				return sdc
+			},
+			expectedDefaultedSpecFields: nil,
 		}),
 		// ScyllaDBClusters are deliberately left out of the shipped rules, as parallel bootstrap is not
 		// supported in automated multi-datacenter setups.
@@ -159,4 +232,14 @@ func getUnstructuredSpec(obj client.Object) any {
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to convert object to unstructured")
 
 	return u["spec"]
+}
+
+// setUpdateTriggerLabel labels obj so that updating it is a no-op for everything but the resource version.
+func setUpdateTriggerLabel(obj client.Object) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["update-trigger"] = "true"
+	obj.SetLabels(labels)
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Implements mutating webhook defaulters for `ScyllaDBDatacenter` and `ScyllaCluster` that set their `bootstrapPolicy` to `Parallel` on creation, when their version is a valid semver >= 2026.2. For other cases, leaves the policy set to `nil`. It will allow us to change the default deduced in controllers to `Parallel` at some point, effectively migrating users that didn't specify the policy explicitly and had clusters created before Operator v1.22.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-290

/hold for https://github.com/scylladb/scylla-operator/pull/3578 so the changelog entry can be updated with this PR link
