### PR TITLE
test(envtest): install operator validating webhook in every envtest

### DIFF
--- a/pkg/cmd/operator/webhooks.go
+++ b/pkg/cmd/operator/webhooks.go
@@ -312,9 +312,7 @@ func (o *WebhookOptions) run(ctx context.Context, streams genericclioptions.IOSt
 			klog.Error(err)
 		}
 	})
-	handler.Handle("/validate", admissionreview.NewHandler(func(review *admissionv1.AdmissionReview) ([]string, error) {
-		return validate(review, o.Validators)
-	}))
+	handler.Handle("/validate", admissionreview.NewHandler(NewValidatingWebhookHandleFunc(o.Validators)))
 	handler.Handle("/mutate", &admission.Webhook{
 		Handler: NewMutatingWebhookHandler(o.Defaulters),
 	})
@@ -361,6 +359,13 @@ func (o *WebhookOptions) run(ctx context.Context, streams genericclioptions.IOSt
 	}
 
 	return nil
+}
+
+// NewValidatingWebhookHandleFunc returns a function handling admission reviews with the given validators.
+func NewValidatingWebhookHandleFunc(validators map[schema.GroupVersionResource]Validator) admissionreview.HandleFunc {
+	return func(review *admissionv1.AdmissionReview) ([]string, error) {
+		return validate(review, validators)
+	}
 }
 
 type ValidatableObject interface {

--- a/test/envtest/controllers/controllers_suite_test.go
+++ b/test/envtest/controllers/controllers_suite_test.go
@@ -10,6 +10,13 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// Placeholder images for objects that are never rolled out in envtests, where no container ever has to be pulled,
+// but the Operator's validation requires the image references to be set and parsable.
+const (
+	envtestScyllaDBImage             = "scylladb/scylla:envtest"
+	envtestScyllaDBManagerAgentImage = "scylladb/scylla-manager-agent:envtest"
+)
+
 func init() {
 	klog.InitFlags(nil)
 }

--- a/test/envtest/controllers/mutating_webhook_test.go
+++ b/test/envtest/controllers/mutating_webhook_test.go
@@ -194,6 +194,14 @@ var _ = g.Describe("Mutating admission webhook", func() {
 						Name:      name,
 						Namespace: namespace,
 					},
+					Spec: scyllav1alpha1.ScyllaDBClusterSpec{
+						ScyllaDB: scyllav1alpha1.ScyllaDB{
+							Image: envtestScyllaDBImage,
+						},
+						ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgent{
+							Image: new(envtestScyllaDBManagerAgentImage),
+						},
+					},
 				}
 			},
 		}),

--- a/test/envtest/controllers/orphanedpv_test.go
+++ b/test/envtest/controllers/orphanedpv_test.go
@@ -87,6 +87,9 @@ var _ = g.Describe("OrphanedPVController", func() {
 				ScyllaDB: scyllav1alpha1.ScyllaDB{
 					Image: unit.ScyllaDBImage,
 				},
+				ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgent{
+					Image: pointer.Ptr(envtestScyllaDBManagerAgentImage),
+				},
 				Racks: []scyllav1alpha1.RackSpec{
 					{
 						RackTemplate: scyllav1alpha1.RackTemplate{

--- a/test/envtest/controllers/scylladbdatacenter_controller_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_test.go
@@ -185,10 +185,13 @@ func makeEnvtestScyllaDBDatacenter(namespace string, racks []string, mutators ..
 		},
 		Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
 			ClusterName: "envtest-cluster",
-			DNSDomains:  []string{"envtest.local"},
+			DNSDomains:  []string{"envtest.scylladb.local"},
 			ScyllaDB: scyllav1alpha1.ScyllaDB{
 				Image:               unit.ScyllaDBImageRepository + ":" + configassets.Project.Operator.ScyllaDBVersion,
 				EnableDeveloperMode: new(true),
+			},
+			ScyllaDBManagerAgent: &scyllav1alpha1.ScyllaDBManagerAgent{
+				Image: new(envtestScyllaDBManagerAgentImage),
 			},
 			RackTemplate: &scyllav1alpha1.RackTemplate{
 				Nodes: new(int32(1)),

--- a/test/envtest/controllers/scylladbmonitoring_controller_test.go
+++ b/test/envtest/controllers/scylladbmonitoring_controller_test.go
@@ -443,6 +443,14 @@ func newBasicScyllaDBMonitoring(name, namespace string) *scyllav1alpha1.ScyllaDB
 					Authentication: scyllav1alpha1.GrafanaAuthentication{
 						InsecureEnableAnonymousAccess: true,
 					},
+					Datasources: []scyllav1alpha1.GrafanaDatasourceSpec{
+						{
+							Name:              "prometheus",
+							Type:              scyllav1alpha1.GrafanaDatasourceTypePrometheus,
+							URL:               "https://prometheus.example:9090",
+							PrometheusOptions: &scyllav1alpha1.GrafanaPrometheusDatasourceOptions{},
+						},
+					},
 				},
 			},
 		},

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -80,8 +80,9 @@ func WithoutMutatingWebhook() SetupOption {
 // Setup sets up an envtest environment with the ScyllaDB CRDs installed. It will be cleaned up automatically when the test ends.
 // It returns an Environment struct that provides access to the Kubernetes and ScyllaDB clients, as well as the test namespace
 // for convenience.
-// The mutating admission webhook shipped in deploy/operator/ is installed and served by default, so that objects created by
-// any spec go through the same defaulting as in a real deployment. Opt out with WithoutMutatingWebhook.
+// The mutating and validating admission webhooks shipped in deploy/operator/ are installed and served, so that objects
+// created by any spec go through the same defaulting and validation as in a real deployment. The mutating one can be
+// opted out of with WithoutMutatingWebhook.
 func Setup(ctx context.Context, opts ...SetupOption) *Environment {
 	g.GinkgoHelper()
 
@@ -163,6 +164,8 @@ func Setup(ctx context.Context, opts ...SetupOption) *Environment {
 		SetupOperatorMutatingWebhook(ctx, env, operatorcmd.NewMutatingWebhookHandler(operatorcmd.DefaultDefaulters))
 	}
 
+	setupOperatorValidatingWebhook(ctx, env, operatorcmd.NewValidatingWebhookHandleFunc(operatorcmd.DefaultValidators))
+
 	return env
 }
 
@@ -194,6 +197,8 @@ func (e *Environment) Config() *rest.Config {
 // under the scylla.scylladb.com API group (v1 and v1alpha1) and dispatches them to handleFunc.
 // The webhook server is started automatically and cleaned up when the test ends.
 // NOTE: this function starts a test-only mock webhook server, not the validating webhook shipped with the Operator.
+// The shipped one is installed by Setup and decides on admission as well, on its own server, so an object has to
+// satisfy the Operator's validation on top of what handleFunc admits.
 func SetupMockValidatingWebhook(ctx context.Context, e *Environment, handleFunc admissionreview.HandleFunc) {
 	g.GinkgoHelper()
 
@@ -260,6 +265,21 @@ func SetupOperatorMutatingWebhook(ctx context.Context, e *Environment, handler a
 	setupMockWebhook(ctx, e, webhookOpts, "/mutate", &admission.Webhook{
 		Handler: handler,
 	})
+}
+
+// setupOperatorValidatingWebhook installs the ValidatingWebhookConfiguration shipped in deploy/operator/ and dispatches
+// the intercepted admission requests to handleFunc, so the shipped rules and path are exercised.
+// The webhook server is started automatically and cleaned up when the test ends.
+// NOTE: envtest rewrites the manifest's client config to point at a test-local webhook server, not the webhook
+// server shipped with the Operator.
+func setupOperatorValidatingWebhook(ctx context.Context, e *Environment, handleFunc admissionreview.HandleFunc) {
+	g.GinkgoHelper()
+
+	webhookOpts := envtest.WebhookInstallOptions{
+		Paths: []string{filepath.Join(repoRoot, "deploy", "operator", "10_validatingwebhook.yaml")},
+	}
+
+	setupMockWebhook(ctx, e, webhookOpts, "/validate", admissionreview.NewHandler(handleFunc))
 }
 
 func setupMockWebhook(ctx context.Context, e *Environment, webhookOpts envtest.WebhookInstallOptions, webhookPath string, handler http.Handler) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Makes `envtest.Setup` install the production operator validating webhook in every envtest - similarly to how we added mutating webhook support recently. Required backfilling some invalid specs.

**Which issue is resolved by this Pull Request:**
Closes https://scylladb.atlassian.net/browse/OPERATOR-311
