### PR TITLE
ci: do not collect OLM package manifests with must-gather

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -126,6 +126,8 @@ spec:
     args:
     - must-gather
     - --all-resources
+    # PackageManifests (OpenShift/OLM) are huge (hundreds of files per namespace) and irrelevant to e2e debugging.
+    - --exclude-resource=PackageManifest.packages.operators.coreos.com
     - --loglevel=2
     - --dest-dir=/tmp/artifacts
     image: "${must_gather_image}"


### PR DESCRIPTION
**Description of your changes:**
- must-gather collects hundreds of manifests in each namespace - huge space and file count hog with no gain

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-312
