### PR TITLE
[1.20] docs(slack): update the link with a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To find out more about our releases and support matrix there is a [dedicated doc
 
 If you find a bug please file an [issue](https://github.com/scylladb/scylla-operator/issues) for us.
 
-We are also available on `#scylla-operator` channel on [Slack](https://scylladb-users.slack.com) if you have questions.
+We are also available on `#scylla-operator` channel on [Slack](https://slack.scylladb.com) if you have questions.
 
 ## Contributing
-We would **love** you to contribute to Scylla Operator, help make it even better and learn together! Have a look at the [Contributing Guide](CONTRIBUTING.md) or reach out to us on `#scylla-operator` channel on [Slack](https://scylladb-users.slack.com/) if you have questions.
+We would **love** you to contribute to Scylla Operator, help make it even better and learn together! Have a look at the [Contributing Guide](CONTRIBUTING.md) or reach out to us on `#scylla-operator` channel on [Slack](https://slack.scylladb.com/) if you have questions.

--- a/docs/source/management/networking/ipv6/index.md
+++ b/docs/source/management/networking/ipv6/index.md
@@ -111,7 +111,7 @@ If you need assistance:
 
 1. **Check documentation**: Review the troubleshooting guide and concepts
 2. **Search issues**: Look for similar problems in [GitHub issues](https://github.com/scylladb/scylla-operator/issues)
-3. **Ask the community**: Join [ScyllaDB Slack](https://scylladb-users.slack.com/)
+3. **Ask the community**: Join [ScyllaDB Slack](https://slack.scylladb.com/)
 4. **Open an issue**: Report bugs or request features on [GitHub](https://github.com/scylladb/scylla-operator/issues/new)
 
 ## Related documentation


### PR DESCRIPTION
**Description of your changes:**
Backport https://github.com/scylladb/scylla-operator/pull/3594

**Which issue is resolved by this Pull Request:**
Part of https://scylladb.atlassian.net/browse/OPERATOR-320

/cc rzetelskik