### PR TITLE
fix(test/e2e): pair ScyllaDB Pods with their own PVC clone consumer Pods

### DIFF
--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -336,6 +336,9 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 					o.Expect(err).To(framework.NotHaveOccurredExceptNotFound())
 
 					err = framework.WaitForObjectDeletion(ctx, f.DynamicAdminClient(), corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"), f.Namespace(), clonePVC.Name, &clonePVC.UID)
+					if err != nil {
+						return false, fmt.Errorf("couldn't wait for clone PVC %q to be deleted: %v", naming.ManualRef(f.Namespace(), clonePVCName), err)
+					}
 				}
 				return false, nil
 			})

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -16,7 +16,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/helpers"
 	"github.com/scylladb/scylla-operator/pkg/naming"
-	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
@@ -58,8 +57,8 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 				Labels: f.CommonLabels(),
 			},
 			Provisioner:       volume.NotSupportedProvisioner,
-			ReclaimPolicy:     pointer.Ptr(corev1.PersistentVolumeReclaimDelete),
-			VolumeBindingMode: pointer.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			ReclaimPolicy:     new(corev1.PersistentVolumeReclaimDelete),
+			VolumeBindingMode: new(storagev1.VolumeBindingWaitForFirstConsumer),
 		}
 
 		_, err := f.KubeAdminClient().StorageV1().StorageClasses().Create(ctx, testStorageClass, metav1.CreateOptions{})
@@ -81,16 +80,13 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 		o.Expect(apimachineryutilerrors.NewAggregate(errs)).NotTo(o.HaveOccurred())
 	})
 
-	g.It("should replace a node with orphaned PV", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-		defer cancel()
-
+	g.It("should replace a node with orphaned PV", func(ctx g.SpecContext) {
 		testStorageClassName := f.Namespace()
 
 		sc := f.GetDefaultScyllaCluster()
 		sc.Spec.AutomaticOrphanedNodeCleanup = true
 		sc.Spec.Datacenter.Racks[0].Members = 3
-		sc.Spec.Datacenter.Racks[0].Storage.StorageClassName = pointer.Ptr(testStorageClassName)
+		sc.Spec.Datacenter.Racks[0].Storage.StorageClassName = new(testStorageClassName)
 		if sc.Spec.Datacenter.Racks[0].Placement == nil {
 			sc.Spec.Datacenter.Racks[0].Placement = &scyllav1.PlacementSpec{}
 		}
@@ -124,9 +120,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 		provisionerCtx, provisionerCancel := context.WithCancel(context.Background())
 		defer provisionerCancel()
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer g.GinkgoRecover()
 
 			lw := &cache.ListWatch{
@@ -154,7 +148,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 						Status: *pvc.Status.DeepCopy(),
 					}
 					pvcClone.Spec.VolumeName = ""
-					pvcClone.Spec.StorageClassName = pointer.Ptr(framework.TestContext.ScyllaClusterOptions.StorageClassName)
+					pvcClone.Spec.StorageClassName = new(framework.TestContext.ScyllaClusterOptions.StorageClassName)
 
 					framework.Infof("Creating clone PVC for %q", pvc.Name)
 					pvcClone, _, err := resourceapply.ApplyPersistentVolumeClaimWithControl(
@@ -206,7 +200,7 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 									},
 								},
 							},
-							TerminationGracePeriodSeconds: pointer.Ptr(int64(1)),
+							TerminationGracePeriodSeconds: new(int64(1)),
 							RestartPolicy:                 corev1.RestartPolicyNever,
 							Tolerations:                   defaultScyllaClusterPlacement.Tolerations,
 							Affinity: &corev1.Affinity{
@@ -349,16 +343,16 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 				return
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
-		}()
+		})
 
 		framework.By("Creating a ScyllaCluster")
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
-		waitCtx1, waitCtx1Cancel := utils.ContextForRollout(ctx, sc)
-		defer waitCtx1Cancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx1, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		initialRolloutCtx, initialRolloutCtxCancel := utils.ContextForRollout(ctx, sc)
+		defer initialRolloutCtxCancel()
+		sc, err = controllerhelpers.WaitForScyllaClusterState(initialRolloutCtx, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
@@ -417,26 +411,26 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for the PVC to be replaced")
-		waitCtx2, waitCtx2Cancel := utils.ContextForRollout(ctx, sc)
-		defer waitCtx2Cancel()
-		pvc, err = controllerhelpers.WaitForPVCState(waitCtx2, f.KubeClient().CoreV1().PersistentVolumeClaims(pvc.Namespace), pvc.Name, controllerhelpers.WaitForStateOptions{TolerateDelete: true}, func(freshPVC *corev1.PersistentVolumeClaim) (bool, error) {
+		pvcReplacementCtx, pvcReplacementCtxCancel := utils.ContextForRollout(ctx, sc)
+		defer pvcReplacementCtxCancel()
+		pvc, err = controllerhelpers.WaitForPVCState(pvcReplacementCtx, f.KubeClient().CoreV1().PersistentVolumeClaims(pvc.Namespace), pvc.Name, controllerhelpers.WaitForStateOptions{TolerateDelete: true}, func(freshPVC *corev1.PersistentVolumeClaim) (bool, error) {
 			return freshPVC.UID != pvc.UID, nil
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for the ScyllaCluster to observe the degradation")
-		waitCtx3, waitCtx3Cancel := utils.ContextForRollout(ctx, sc)
-		defer waitCtx3Cancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx3, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, func(sc *scyllav1.ScyllaCluster) (bool, error) {
+		degradationCtx, degradationCtxCancel := utils.ContextForRollout(ctx, sc)
+		defer degradationCtxCancel()
+		sc, err = controllerhelpers.WaitForScyllaClusterState(degradationCtx, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, func(sc *scyllav1.ScyllaCluster) (bool, error) {
 			rolledOut, err := utils.IsScyllaClusterRolledOut(sc)
 			return !rolledOut, err
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
-		waitCtx4, waitCtx4Cancel := utils.ContextForRollout(ctx, sc)
-		defer waitCtx4Cancel()
-		sc, err = controllerhelpers.WaitForScyllaClusterState(waitCtx4, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
+		postReplacementRolloutCtx, postReplacementRolloutCtxCancel := utils.ContextForRollout(ctx, sc)
+		defer postReplacementRolloutCtxCancel()
+		sc, err = controllerhelpers.WaitForScyllaClusterState(postReplacementRolloutCtx, f.ScyllaClient().ScyllaV1().ScyllaClusters(sc.Namespace), sc.Name, controllerhelpers.WaitForStateOptions{}, utils.IsScyllaClusterRolledOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -21,6 +21,7 @@ import (
 	"github.com/scylladb/scylla-operator/test/e2e/utils"
 	"github.com/scylladb/scylla-operator/test/e2e/utils/verification"
 	scyllaclusterverification "github.com/scylladb/scylla-operator/test/e2e/utils/verification/scyllacluster"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -96,6 +97,15 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 		if sc.Spec.Datacenter.Racks[0].Placement.PodAffinity == nil {
 			sc.Spec.Datacenter.Racks[0].Placement.PodAffinity = &corev1.PodAffinity{}
 		}
+		// Every ScyllaDB Pod has to be scheduled onto the Node serving the consumer Pod of its own PVC clone, because
+		// that's the only Node holding its data. The clone PVs carry no NodeAffinity - it's immutable once set, and the
+		// test needs to set it later to simulate the orphan - so this PodAffinity is what ties a Pod to its data.
+		//
+		// The term has to resolve per ordinal, while rack placement is shared by the whole rack. MatchLabelKeys provides
+		// that: the scheduler looks the listed keys up in the incoming Pod's own labels and merges them into the selector
+		// as `key in (value)`. ScyllaDB Pods get apps.kubernetes.io/pod-index from the StatefulSet controller, and the
+		// consumer Pods below are labeled with the ordinal of the PVC they back, so each ScyllaDB Pod only matches its
+		// own consumer Pod.
 		sc.Spec.Datacenter.Racks[0].Placement.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
 			sc.Spec.Datacenter.Racks[0].Placement.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
 			corev1.PodAffinityTerm{
@@ -104,7 +114,8 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 						cloneLabelKey: f.Namespace(),
 					},
 				},
-				TopologyKey: corev1.LabelHostname,
+				MatchLabelKeys: []string{appsv1.PodIndexLabel},
+				TopologyKey:    corev1.LabelHostname,
 			},
 		)
 
@@ -169,13 +180,20 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 					)
 					o.Expect(err).NotTo(o.HaveOccurred())
 
+					// The consumer Pod is labelled with the ordinal of the ScyllaDB Pod whose PVC it clones, so that the
+					// rack's PodAffinity term can pair the two through MatchLabelKeys. The ordinal comes from the PVC
+					// name, which the StatefulSet derives from its Pod's name.
+					ordinal, err := naming.IndexFromName(pvc.Name)
+					o.Expect(err).NotTo(o.HaveOccurred())
+
 					framework.Infof("Creating PVC clone consumer Pod")
 					consumerPodName := fmt.Sprintf("consumer-%s", pvcClone.Name)
 					consumerPod := &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: consumerPodName,
 							Labels: map[string]string{
-								cloneLabelKey: f.Namespace(),
+								cloneLabelKey:        f.Namespace(),
+								appsv1.PodIndexLabel: fmt.Sprintf("%d", ordinal),
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -361,6 +379,14 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 		scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
+		// Assert that every ScyllaDB Pod actually landed on the Node serving the consumer Pod of its own PVC clone.
+		// The pairing relies on MatchLabelKeys, which is silently ignored when the corresponding feature gate is
+		// disabled, and on apps.kubernetes.io/pod-index being stamped on StatefulSet Pods. Both would degrade the
+		// PodAffinity term into one satisfied by any consumer Pod, without failing anything, so verify the placement
+		// rather than trusting the term was honoured.
+		framework.By("Verifying that ScyllaDB Pods are co-located with the consumer Pods of their PVC clones")
+		verifyScyllaDBPodsColocatedWithConsumerPods(ctx, f, sc)
+
 		hosts, _, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(3))
@@ -449,3 +475,27 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteParall
 		wg.Wait()
 	})
 })
+
+// verifyScyllaDBPodsColocatedWithConsumerPods asserts that every ScyllaDB Pod of the first rack runs on the same Node as
+// the consumer Pod holding the clone PV bound to that Pod's own PVC.
+func verifyScyllaDBPodsColocatedWithConsumerPods(ctx context.Context, f *framework.Framework, sc *scyllav1.ScyllaCluster) {
+	g.GinkgoHelper()
+
+	for i := int32(0); i < sc.Spec.Datacenter.Racks[0].Members; i++ {
+		podName := naming.PodNameForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc, int(i))
+		pod, err := f.KubeClient().CoreV1().Pods(f.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(pod.Spec.NodeName).NotTo(o.BeEmpty())
+
+		consumerPodName := fmt.Sprintf("consumer-clone-%s", naming.PVCNameForPod(podName))
+		consumerPod, err := f.KubeClient().CoreV1().Pods(f.Namespace()).Get(ctx, consumerPodName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(consumerPod.Spec.NodeName).NotTo(o.BeEmpty())
+
+		o.Expect(pod.Spec.NodeName).To(
+			o.Equal(consumerPod.Spec.NodeName),
+			"ScyllaDB Pod %q runs on Node %q, but the consumer Pod %q holding its data runs on Node %q",
+			podName, pod.Spec.NodeName, consumerPodName, consumerPod.Spec.NodeName,
+		)
+	}
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
`ScyllaCluster Orphaned PV controller > should replace a node with orphaned PV` times out on rollout after the replacement it tests has already succeeded in k8s clusters with >1 node dedicated to run ScyllaDB.

The clone PVs have no `NodeAffinity` - it's immutable, and the test needs to set it later to fake the orphan - so `PodAffinity` is the only thing keeping a ScyllaDB Pod on the Node holding its data. The term from `a79360d6` matched *any* Pod labelled `cloneLabelKey`, and all three consumer Pods share that value. In a failed run the consumer Pod of the replaced ordinal was recreated on another Node, which made that Node satisfy every ScyllaDB Pod's term, and Pod 0 was rescheduled onto it - coming up with empty storage while keeping its old identity, never flagged as orphaned, so bootstrap deadlocked..

`MatchLabelKeys` with `apps.kubernetes.io/pod-index` resolves the term per ordinal, which rack placement can't do on its own. Pod 0 now selects `cloneLabelKey = <namespace> AND pod-index in (0)`. The field is silently ignored when its feature gate is off, so the test asserts each Pod shares a Node with its own consumer Pod.

Still lacking:

Consumer Pods are only a stand-in for where the data is. If one is recreated outside the test's control - eviction, preemption - the paired ScyllaDB Pod follows it onto a Node without storage. This fixes *which* consumer Pod is followed, not the consumer Pod moving.

I dropped a prototype remembering the Node per ordinal - a PVC can bind before its consumer Pod is scheduled, and we only observe PVCs in the goroutine, so it's best effort only. 
Real node pinning on the clone PV is the fix, but it conflicts with the immutability workaround.

So this only fixes the scenario in which the consumer Pods don't involuntarily move between nodes.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-285

/cc