### PR TITLE
chore: replace bootstrapPolicy with enableParallelNodeOperations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,19 +33,22 @@
   [#3587](https://github.com/scylladb/scylla-operator/pull/3587)
 
 ### Features & Enhancements
-- Added an optional `bootstrapPolicy` field to `ScyllaCluster.spec` and `ScyllaDBDatacenter.spec`, accepting `Sequential`
-  or `Parallel`. `Parallel` requires ScyllaDB 2026.2 or later, declared with a semver-parseable image tag.
+- Added an optional `enableParallelNodeOperations` boolean field to `ScyllaCluster.spec` and
+  `ScyllaDBDatacenter.spec`. Enabling it requires ScyllaDB 2026.2 or later, declared with a semver-parseable image tag.
+  In this release it only controls how nodes are started. Its scope is expected to widen in a future release, where it
+  will most likely also allow decommissioning nodes in parallel, so setting it to `true` now may take effect for more
+  operations after an upgrade.
   [#3568](https://github.com/scylladb/scylla-operator/pull/3568)
 - The webhook server now serves a mutating admission webhook that applies API defaults to `ScyllaClusters` and
   `ScyllaDBDatacenters` on creation. Matching `MutatingWebhookConfiguration` is added to the operator's manifests.
   [#3579](https://github.com/scylladb/scylla-operator/pull/3579)
-- ScyllaDB nodes can now bootstrap in parallel. With `bootstrapPolicy: Parallel`, the nodes of a rack are started
-  without each one waiting for the previous ordinal to become ready, and all missing racks are created in a single sync
-  rather than one per requeue, which cuts the time to bring up a cluster. Creating them still waits for any in-flight
-  scaling, update or upgrade of the existing racks to settle. Newly created clusters use `Parallel` by default, while
-  existing ones stay on `Sequential` and can opt in. The policy can be changed on a running cluster without disruptions
-  to existing nodes. Parallel bootstrap isn't available for datacenters managed by `ScyllaDBCluster`, which always
-  bootstraps sequentially.
+- ScyllaDB nodes can now bootstrap in parallel. With `enableParallelNodeOperations: true`, the nodes of a rack are
+  started without each one waiting for the previous ordinal to become ready, and all missing racks are created in a
+  single sync rather than one per requeue, which cuts the time to bring up a cluster. Creating them still waits for any
+  in-flight scaling, update or upgrade of the existing racks to settle. Newly created clusters have it enabled by
+  default, while existing ones keep bootstrapping sequentially and can opt in. It can be changed on a running cluster
+  without disruptions to existing nodes. Parallel bootstrap isn't available for datacenters managed by
+  `ScyllaDBCluster`, which always bootstraps sequentially.
   [#3578](https://github.com/scylladb/scylla-operator/pull/3578), [#3588](https://github.com/scylladb/scylla-operator/pull/3588)
 
 ### Other changes

--- a/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
@@ -237,18 +237,6 @@ spec:
                       type: array
                   type: object
                 type: array
-              bootstrapPolicy:
-                description: |-
-                  bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
-                  parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
-                  If not provided, it's treated as Sequential.
-                  On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel
-                  bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's
-                  explicitly changed. It's otherwise left unset, and never set on an already existing object.
-                enum:
-                - Sequential
-                - Parallel
-                type: string
               cpuset:
                 description: |-
                   cpuset determines if the cluster will use cpu-pinning.
@@ -3500,6 +3488,15 @@ spec:
                 items:
                   type: string
                 type: array
+              enableParallelNodeOperations:
+                description: |-
+                  enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.
+                  When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.
+                  If not provided, it's treated as disabled.
+                  On creation, it's set to true when spec.version is a semver-parseable version supporting parallel bootstrap.
+                  The set value is persisted, so it stays in effect across ScyllaDB version changes until it's explicitly
+                  changed. It's otherwise left unset, and never set on an already existing object.
+                type: boolean
               exposeOptions:
                 description: |-
                   exposeOptions specifies options for exposing ScyllaCluster services.

--- a/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -53,19 +53,6 @@ spec:
           spec:
             description: spec defines the desired state of this ScyllaDBDatacenter.
             properties:
-              bootstrapPolicy:
-                description: |-
-                  bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
-                  parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
-                  If not provided, it's treated as Sequential.
-                  On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version
-                  supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image
-                  changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing
-                  object.
-                enum:
-                - Sequential
-                - Parallel
-                type: string
               clusterName:
                 description: |-
                   clusterName specifies the name of the ScyllaDB cluster.
@@ -91,6 +78,15 @@ spec:
               dnsPolicy:
                 description: dnsPolicy defines how a pod's DNS will be configured.
                 type: string
+              enableParallelNodeOperations:
+                description: |-
+                  enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.
+                  When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.
+                  If not provided, it's treated as disabled.
+                  On creation, it's set to true when the tag of spec.scyllaDB.image is a semver-parseable version supporting
+                  parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image changes until
+                  it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
+                type: boolean
               exposeOptions:
                 description: exposeOptions specifies parameters related to exposing
                   ScyllaDBDatacenter backends.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2016,18 +2016,6 @@ spec:
                         type: array
                     type: object
                   type: array
-                bootstrapPolicy:
-                  description: |-
-                    bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
-                    parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
-                    If not provided, it's treated as Sequential.
-                    On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel
-                    bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's
-                    explicitly changed. It's otherwise left unset, and never set on an already existing object.
-                  enum:
-                    - Sequential
-                    - Parallel
-                  type: string
                 cpuset:
                   description: |-
                     cpuset determines if the cluster will use cpu-pinning.
@@ -5094,6 +5082,15 @@ spec:
                   items:
                     type: string
                   type: array
+                enableParallelNodeOperations:
+                  description: |-
+                    enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.
+                    When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.
+                    If not provided, it's treated as disabled.
+                    On creation, it's set to true when spec.version is a semver-parseable version supporting parallel bootstrap.
+                    The set value is persisted, so it stays in effect across ScyllaDB version changes until it's explicitly
+                    changed. It's otherwise left unset, and never set on an already existing object.
+                  type: boolean
                 exposeOptions:
                   description: |-
                     exposeOptions specifies options for exposing ScyllaCluster services.
@@ -35618,19 +35615,6 @@ spec:
             spec:
               description: spec defines the desired state of this ScyllaDBDatacenter.
               properties:
-                bootstrapPolicy:
-                  description: |-
-                    bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
-                    parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
-                    If not provided, it's treated as Sequential.
-                    On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version
-                    supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image
-                    changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing
-                    object.
-                  enum:
-                    - Sequential
-                    - Parallel
-                  type: string
                 clusterName:
                   description: |-
                     clusterName specifies the name of the ScyllaDB cluster.
@@ -35655,6 +35639,15 @@ spec:
                 dnsPolicy:
                   description: dnsPolicy defines how a pod's DNS will be configured.
                   type: string
+                enableParallelNodeOperations:
+                  description: |-
+                    enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.
+                    When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.
+                    If not provided, it's treated as disabled.
+                    On creation, it's set to true when the tag of spec.scyllaDB.image is a semver-parseable version supporting
+                    parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image changes until
+                    it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
+                  type: boolean
                 exposeOptions:
                   description: exposeOptions specifies parameters related to exposing ScyllaDBDatacenter backends.
                   properties:

--- a/docs/source/operate/scale-add-remove-racks.md
+++ b/docs/source/operate/scale-add-remove-racks.md
@@ -19,26 +19,26 @@ For background on the StatefulSet-per-rack architecture, see [StatefulSets and r
 
 ## Sequential and parallel node provisioning
 
-The Operator controls how it provisions new nodes with bootstrap policies. The policy determines whether Operator bootstraps ScyllaDB nodes one at a time or all at once: when you create a cluster, add, or scale-out a rack.
+The Operator controls how it provisions new nodes with parallel node operations. They determine whether Operator starts ScyllaDB nodes one at a time or all at once: when you create a cluster, add, or scale-out a rack.
 
-With the `Sequential` policy, Operator bootstraps ScyllaDB nodes one at a time. Within a rack, each Pod must become ready before Operator starts the next one. Operator creates racks one at a time. Bringing up a cluster takes as long as the sum of every node's startup time.
+With parallel node operations disabled, Operator starts ScyllaDB nodes one at a time. Within a rack, each Pod must become ready before Operator starts the next one. Operator creates racks one at a time. Bringing up a cluster takes as long as the sum of every node's startup time.
 
-With the `Parallel` policy, Operator starts all ScyllaDB nodes at once. Operator starts Pods of a rack without waiting for the previous ones to become ready. Operator creates all racks at the same time. Bringing up a cluster is faster, and the difference grows with the number of nodes.
+With parallel node operations enabled, Operator starts all ScyllaDB nodes at once. Operator starts Pods of a rack without waiting for the previous ones to become ready. Operator creates all racks at the same time. Bringing up a cluster is faster, and the difference grows with the number of nodes.
 
-`Parallel` provides better performance when your keyspaces are backed by tablets (the default since ScyllaDB 2025.2), as opposed to vnodes. Therefore, we strongly recommend that you only use tablets for your data keyspaces. This is because with vnode-based keyspaces, a joining node streams its data before it finishes joining, which slows down bringing up new nodes. With tablets, the data is moved in the background after the node joins, so the time to bring up new nodes is not affected by data streaming.
+Parallel node operations provide better performance when your keyspaces are backed by tablets (the default since ScyllaDB 2025.2), as opposed to vnodes. Therefore, we strongly recommend that you only use tablets for your data keyspaces. This is because with vnode-based keyspaces, a joining node streams its data before it finishes joining, which slows down bringing up new nodes. With tablets, the data is moved in the background after the node joins, so the time to bring up new nodes is not affected by data streaming.
 Consider setting [`tablets_mode_for_new_keyspaces`](https://docs.scylladb.com/manual/stable/architecture/tablets.html#enabling-tablets) to `enforced` in your [ScyllaDB configuration](../deploy-scylladb/deploy-your-first-cluster.md#create-a-scylladb-configuration) to prevent individual keyspaces from opting out of tablets.
 
 :::{note}
-The Operator waits for the cluster to settle before creating new racks. An in-flight scaling operation, configuration update, or version upgrade delays the creation of new nodes under both policies.
+The Operator waits for the cluster to settle before creating new racks. An in-flight scaling operation, configuration update, or version upgrade delays the creation of new nodes either way.
 :::
 
-### Configure the bootstrap policy
+### Configure parallel node operations
 
 :::{tip}
-You can change the bootstrap policy at any time, in either direction. Changing it does not disrupt the running nodes.
+You can enable or disable parallel node operations at any time. Changing it does not disrupt the running nodes.
 :::
 
-You can configure the bootstrap policy with the `spec.bootstrapPolicy` field of a `ScyllaCluster`, which accepts `Sequential` and `Parallel`.
+You can configure parallel node operations with the `spec.enableParallelNodeOperations` field of a `ScyllaCluster`, which accepts `true` and `false`.
 
 ```yaml
 apiVersion: scylla.scylladb.com/v1
@@ -47,25 +47,25 @@ metadata:
   name: scylla
   namespace: scylla
 spec:
-  bootstrapPolicy: Parallel
+  enableParallelNodeOperations: true
 ```
 
 :::{caution}
-The minimum ScyllaDB version required by Operator for `Parallel` bootstrap policy is 2026.2.
-The Operator determines the ScyllaDB version from the ScyllaDB container image tag and rejects `Parallel` when the version doesn't satisfy the requirement. An image whose version cannot be determined, such as one pinned by digest, is treated as not supporting parallel bootstrap.
+The minimum ScyllaDB version required by Operator for parallel node operations is 2026.2.
+The Operator determines the ScyllaDB version from the ScyllaDB container image tag and rejects `true` when the version doesn't satisfy the requirement. An image whose version cannot be determined, such as one pinned by digest, is treated as not supporting parallel bootstrap.
 :::
 
-If you don't specify the field, the Operator defaults to `Parallel` on creation, provided the ScyllaDB version is higher or equal to 2026.2.
+If you don't specify the field, the Operator defaults it to `true` on creation, provided the ScyllaDB version is higher or equal to 2026.2.
 
 Operator keeps bootstrapping the nodes of clusters that already existed before the addition of this feature sequentially. 
-It is recommended that you configure the field to `Parallel` explicitly to bootstrap new nodes in parallel.
+It is recommended that you set the field to `true` explicitly to bootstrap new nodes in parallel.
 
 ## Bootstrap synchronisation
 
 In Kubernetes, Pods can start simultaneously, and a new node could attempt to bootstrap while another node is still restarting and appears down to its peers. ScyllaDB denies such a join request and leaves the new node in a state that is not recoverable automatically.
 
 Enabling the `BootstrapSynchronisation` feature gate protects against this by holding each node's startup until all nodes in the cluster are UP. 
-It is recommended that you enable it with either bootstrap policy. See [Bootstrap synchronisation](../understand/bootstrap-sync.md) for details on the mechanism and [Feature gates](../reference/feature-gates.md) for instructions on enabling feature gates.
+It is recommended that you enable it whether or not parallel node operations are enabled. See [Bootstrap synchronisation](../understand/bootstrap-sync.md) for details on the mechanism and [Feature gates](../reference/feature-gates.md) for instructions on enabling feature gates.
 
 ## Scale a ScyllaCluster
 

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scyllaclusters.rst
@@ -90,9 +90,6 @@ object
    * - :ref:`backups<api-scylla.scylladb.com-scyllaclusters-v1-.spec.backups[]>`
      - array (object)
      - backups specifies backup tasks in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
-   * - bootstrapPolicy
-     - string
-     - bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later. If not provided, it's treated as Sequential. On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
    * - cpuset
      - boolean
      - cpuset determines if the cluster will use cpu-pinning. Deprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.
@@ -105,6 +102,9 @@ object
    * - dnsDomains
      - array (string)
      - dnsDomains is a list of DNS domains this cluster is reachable by. These domains are used when setting up the infrastructure, like certificates. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.
+   * - enableParallelNodeOperations
+     - boolean
+     - enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently. When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later. If not provided, it's treated as disabled. On creation, it's set to true when spec.version is a semver-parseable version supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
    * - :ref:`exposeOptions<api-scylla.scylladb.com-scyllaclusters-v1-.spec.exposeOptions>`
      - object
      - exposeOptions specifies options for exposing ScyllaCluster services. This field is immutable. EXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
@@ -75,9 +75,6 @@ object
    * - Property
      - Type
      - Description
-   * - bootstrapPolicy
-     - string
-     - bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later. If not provided, it's treated as Sequential. On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
    * - clusterName
      - string
      - clusterName specifies the name of the ScyllaDB cluster. When joining two DCs, their cluster name must match. This field is immutable.
@@ -93,6 +90,9 @@ object
    * - dnsPolicy
      - string
      - dnsPolicy defines how a pod's DNS will be configured.
+   * - enableParallelNodeOperations
+     - boolean
+     - enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently. When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later. If not provided, it's treated as disabled. On creation, it's set to true when the tag of spec.scyllaDB.image is a semver-parseable version supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
    * - :ref:`exposeOptions<api-scylla.scylladb.com-scylladbdatacenters-v1alpha1-.spec.exposeOptions>`
      - object
      - exposeOptions specifies parameters related to exposing ScyllaDBDatacenter backends.

--- a/docs/source/understand/statefulsets-and-racks.md
+++ b/docs/source/understand/statefulsets-and-racks.md
@@ -30,10 +30,10 @@ StatefulSets provide two guarantees that are essential for running ScyllaDB:
 
 2. **Stable persistent storage** — each pod's PersistentVolumeClaim (PVC) is named deterministically (`data-<pod-name>`) and is **not** deleted when the pod is deleted or the StatefulSet is scaled down. When a pod comes back (restart or scale-up), it reattaches to the same PVC and recovers its data.
 
-The pod management policy of the StatefulSet follows the cluster's bootstrap policy. 
-With the `Sequential` bootstrap policy, the Operator uses `OrderedReady`: pods are created in order (0, 1, 2, …) and each pod must become Ready before the next one is created. 
-With `Parallel`, the Operator uses the `Parallel` pod management policy and pods are created without waiting for the previous ordinal to become Ready. 
-On shutdown, pods are terminated in reverse order under both policies.
+The pod management policy of the StatefulSet is determined by whether the cluster has parallel node operations enabled. 
+With parallel node operations disabled, the Operator uses `OrderedReady`: pods are created in order (0, 1, 2, …) and each pod must become Ready before the next one is created. 
+With parallel node operations enabled, the Operator uses the `Parallel` pod management policy and pods are created without waiting for the previous ordinal to become Ready. 
+On shutdown, pods are terminated in reverse order either way.
 Please refer to [sequential and parallel node provisioning](../operate/scale-add-remove-racks.md#sequential-and-parallel-node-provisioning) for details.
 
 ## Scaling

--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -379,7 +379,7 @@ function run-e2e {
     "--scyllacluster-clients-broadcast-address-type=${SO_SCYLLACLUSTER_CLIENTS_BROADCAST_ADDRESS_TYPE}"
     "--scyllacluster-storageclass-name=${SO_SCYLLACLUSTER_STORAGECLASS_NAME}"
     "--scyllacluster-reactor-backend=${SO_SCYLLACLUSTER_REACTOR_BACKEND:-}"
-    "--scyllacluster-bootstrap-policy=${SO_SCYLLACLUSTER_BOOTSTRAP_POLICY:-}"
+    "--scyllacluster-enable-parallel-node-operations=${SO_SCYLLACLUSTER_ENABLE_PARALLEL_NODE_OPERATIONS:-}"
     "--object-storage-bucket=${SO_BUCKET_NAME}"
     "--gcs-service-account-key-path=${gcs_sa_in_container_path}"
     "--s3-credentials-file-path=${s3_credentials_in_container_path}"

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -230,14 +230,6 @@
           },
           "type": "array"
         },
-        "bootstrapPolicy": {
-          "description": "bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in\nparallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as Sequential.\nOn creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel\nbootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's\nexplicitly changed. It's otherwise left unset, and never set on an already existing object.",
-          "enum": [
-            "Sequential",
-            "Parallel"
-          ],
-          "type": "string"
-        },
         "cpuset": {
           "description": "cpuset determines if the cluster will use cpu-pinning.\nDeprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.",
           "type": "boolean"
@@ -255,6 +247,10 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "enableParallelNodeOperations": {
+          "description": "enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.\nWhen it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as disabled.\nOn creation, it's set to true when spec.version is a semver-parseable version supporting parallel bootstrap.\nThe set value is persisted, so it stays in effect across ScyllaDB version changes until it's explicitly\nchanged. It's otherwise left unset, and never set on an already existing object.",
+          "type": "boolean"
         },
         "exposeOptions": {
           "description": "exposeOptions specifies options for exposing ScyllaCluster services.\nThis field is immutable.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",

--- a/helm/scylla/values.schema.json
+++ b/helm/scylla/values.schema.json
@@ -173,14 +173,6 @@
       },
       "type": "array"
     },
-    "bootstrapPolicy": {
-      "description": "bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in\nparallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as Sequential.\nOn creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel\nbootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's\nexplicitly changed. It's otherwise left unset, and never set on an already existing object.",
-      "enum": [
-        "Sequential",
-        "Parallel"
-      ],
-      "type": "string"
-    },
     "cpuset": {
       "description": "cpuset determines if the cluster will use cpu-pinning.\nDeprecated: `cpuset` is deprecated. It is now treated as if it is always set to true regardless of its value.",
       "type": "boolean"
@@ -198,6 +190,10 @@
         "type": "string"
       },
       "type": "array"
+    },
+    "enableParallelNodeOperations": {
+      "description": "enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.\nWhen it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.\nIf not provided, it's treated as disabled.\nOn creation, it's set to true when spec.version is a semver-parseable version supporting parallel bootstrap.\nThe set value is persisted, so it stays in effect across ScyllaDB version changes until it's explicitly\nchanged. It's otherwise left unset, and never set on an already existing object.",
+      "type": "boolean"
     },
     "exposeOptions": {
       "description": "exposeOptions specifies options for exposing ScyllaCluster services.\nThis field is immutable.\nEXPERIMENTAL. Do not rely on any particular behaviour controlled by this field.",

--- a/pkg/api/scylla/defaulting/cluster_defaulting.go
+++ b/pkg/api/scylla/defaulting/cluster_defaulting.go
@@ -12,27 +12,27 @@ import (
 // Mutating admission runs before the object is validated against the CRD schema, so it must also tolerate specs
 // missing fields that validation guarantees.
 func SetDefaultsScyllaCluster(sc *scyllav1.ScyllaCluster) {
-	setDefaultScyllaClusterBootstrapPolicy(sc)
+	setDefaultScyllaClusterEnableParallelNodeOperations(sc)
 }
 
-// setDefaultScyllaClusterBootstrapPolicy stamps an explicit Parallel bootstrapPolicy on creation when the ScyllaDB
-// version in the spec supports bootstrapping nodes in parallel.
-// Sequential is deliberately never stamped. Leaving the field unset keeps the object on whatever the resolution of an
-// unset bootstrapPolicy is, rather than pinning it to today's one, so that objects whose owners never made a choice
-// can be moved to a new default later without rewriting their specs.
+// setDefaultScyllaClusterEnableParallelNodeOperations stamps an explicit true enableParallelNodeOperations on creation
+// when the ScyllaDB version in the spec supports bootstrapping nodes in parallel.
+// false is deliberately never stamped. Leaving the field unset keeps the object on whatever the resolution of an unset
+// enableParallelNodeOperations is, rather than pinning it to today's one, so that objects whose owners never made a
+// choice can be moved to a new default later without rewriting their specs.
 // An explicitly set value, including one the validation rejects, is left untouched: correcting the user's own value is
 // the validating webhook's job, not the defaulter's.
-func setDefaultScyllaClusterBootstrapPolicy(sc *scyllav1.ScyllaCluster) {
-	if sc.Spec.BootstrapPolicy != nil {
+func setDefaultScyllaClusterEnableParallelNodeOperations(sc *scyllav1.ScyllaCluster) {
+	if sc.Spec.EnableParallelNodeOperations != nil {
 		return
 	}
 
 	// spec.version is used verbatim as the tag of the ScyllaDB image, so there's no image reference to strip the
-	// version from. It's also the very value an explicitly set Parallel bootstrapPolicy is validated against, so the
-	// stamped value can never be rejected by the validating webhook, which runs after this one.
+	// version from. It's also the very value enabled parallel node operations are validated against, so the stamped
+	// value can never be rejected by the validating webhook, which runs after this one.
 	if !semver.SupportsParallelBootstrap(sc.Spec.Version) {
 		return
 	}
 
-	sc.Spec.BootstrapPolicy = new(scyllav1.BootstrapPolicyParallel)
+	sc.Spec.EnableParallelNodeOperations = new(true)
 }

--- a/pkg/api/scylla/defaulting/cluster_defaulting_test.go
+++ b/pkg/api/scylla/defaulting/cluster_defaulting_test.go
@@ -14,10 +14,10 @@ import (
 func TestSetDefaultsScyllaCluster(t *testing.T) {
 	t.Parallel()
 
-	newScyllaCluster := func(version string, bootstrapPolicy *scyllav1.BootstrapPolicy) *scyllav1.ScyllaCluster {
+	newScyllaCluster := func(version string, enableParallelNodeOperations *bool) *scyllav1.ScyllaCluster {
 		sc := unit.NewSingleRackCluster(3)
 		sc.Spec.Version = version
-		sc.Spec.BootstrapPolicy = bootstrapPolicy
+		sc.Spec.EnableParallelNodeOperations = enableParallelNodeOperations
 
 		return sc
 	}
@@ -28,61 +28,61 @@ func TestSetDefaultsScyllaCluster(t *testing.T) {
 		expected *scyllav1.ScyllaCluster
 	}{
 		{
-			name:     "unset bootstrapPolicy with the minimal version supporting parallel bootstrap is defaulted to Parallel",
+			name:     "unset enableParallelNodeOperations with the minimal version supporting parallel bootstrap is defaulted to Parallel",
 			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, nil),
-			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(true)),
 		},
 		{
-			name:     "unset bootstrapPolicy with a version newer than the minimal one supporting parallel bootstrap is defaulted to Parallel",
+			name:     "unset enableParallelNodeOperations with a version newer than the minimal one supporting parallel bootstrap is defaulted to Parallel",
 			cluster:  newScyllaCluster(unit.ScyllaDBImageAboveParallelBootstrapThresholdTag, nil),
-			expected: newScyllaCluster(unit.ScyllaDBImageAboveParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+			expected: newScyllaCluster(unit.ScyllaDBImageAboveParallelBootstrapThresholdTag, new(true)),
 		},
 		{
-			name:     "unset bootstrapPolicy with an older version is left unset",
+			name:     "unset enableParallelNodeOperations with an older version is left unset",
 			cluster:  newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, nil),
 			expected: newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, nil),
 		},
 		{
 			// Per semver precedence a pre-release version is lower than the same version without one, matching how
-			// an explicitly set Parallel bootstrapPolicy is validated.
-			name:     "unset bootstrapPolicy with a pre-release of the minimal version supporting parallel bootstrap is left unset",
+			// an explicitly set Parallel enableParallelNodeOperations is validated.
+			name:     "unset enableParallelNodeOperations with a pre-release of the minimal version supporting parallel bootstrap is left unset",
 			cluster:  newScyllaCluster(unit.ScyllaDBImagePreReleaseOfParallelBootstrapThresholdTag, nil),
 			expected: newScyllaCluster(unit.ScyllaDBImagePreReleaseOfParallelBootstrapThresholdTag, nil),
 		},
 		{
-			name:     "unset bootstrapPolicy with an unparseable version is left unset",
+			name:     "unset enableParallelNodeOperations with an unparseable version is left unset",
 			cluster:  newScyllaCluster("latest", nil),
 			expected: newScyllaCluster("latest", nil),
 		},
 		{
 			// The version is used verbatim as the image tag, so a digest pinned image makes it unparseable.
-			name:     "unset bootstrapPolicy with a digest pinned version is left unset",
+			name:     "unset enableParallelNodeOperations with a digest pinned version is left unset",
 			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
 			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
 		},
 		{
 			// Mutating admission runs before the object is validated against the CRD schema, so the defaulter has to
 			// tolerate a spec missing the fields it reads.
-			name:     "unset bootstrapPolicy with an empty version is left unset",
+			name:     "unset enableParallelNodeOperations with an empty version is left unset",
 			cluster:  newScyllaCluster("", nil),
 			expected: newScyllaCluster("", nil),
 		},
 		{
-			name:     "explicit Sequential bootstrapPolicy is preserved",
-			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicySequential)),
-			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicySequential)),
+			name:     "explicit false enableParallelNodeOperations is preserved",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(false)),
+			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(false)),
 		},
 		{
-			name:     "explicit Parallel bootstrapPolicy is preserved",
-			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
-			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+			name:     "explicit true enableParallelNodeOperations is preserved",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(true)),
+			expected: newScyllaCluster(unit.ScyllaDBImageAtParallelBootstrapThresholdTag, new(true)),
 		},
 		{
 			// Rejecting a value the user set themselves is the validating webhook's job. The defaulter must not
 			// silently turn an invalid request into a valid one.
-			name:     "explicit Parallel bootstrapPolicy with a version not supporting it is preserved",
-			cluster:  newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
-			expected: newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, new(scyllav1.BootstrapPolicyParallel)),
+			name:     "explicit true enableParallelNodeOperations with a version not supporting it is preserved",
+			cluster:  newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, new(true)),
+			expected: newScyllaCluster(unit.ScyllaDBImageBelowParallelBootstrapThresholdTag, new(true)),
 		},
 	}
 

--- a/pkg/api/scylla/defaulting/consistency_test.go
+++ b/pkg/api/scylla/defaulting/consistency_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/defaulting"
-	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
 	"github.com/scylladb/scylla-operator/pkg/semver"
@@ -28,8 +27,8 @@ var consistencyTestScyllaDBVersions = []string{
 	"",
 }
 
-// TestDefaultingIsConsistentWithValidation asserts that defaulting a bootstrapPolicy never adds a validation error.
-// Parallel is only ever stamped for versions the validation accepts it for, which this covers from both sides.
+// TestDefaultingIsConsistentWithValidation asserts that defaulting enableParallelNodeOperations never adds a validation
+// error. true is only ever stamped for versions the validation accepts it for, which this covers from both sides.
 // The mutating webhook runs before the validating one, so a value stamped by the former and rejected by the latter
 // would fail a creation the user could have made themselves.
 func TestDefaultingIsConsistentWithValidation(t *testing.T) {
@@ -45,16 +44,16 @@ func TestDefaultingIsConsistentWithValidation(t *testing.T) {
 				sc := unit.NewSingleRackCluster(3)
 				// spec.version is used verbatim as the tag of the ScyllaDB image.
 				sc.Spec.Version = version
-				sc.Spec.BootstrapPolicy = nil
+				sc.Spec.EnableParallelNodeOperations = nil
 
 				errListBeforeDefaulting := validation.ValidateScyllaCluster(sc)
 
 				defaulting.SetDefaultsScyllaCluster(sc)
-				verifyDefaultedBootstrapPolicy(t, version, sc.Spec.BootstrapPolicy, scyllav1.BootstrapPolicyParallel)
+				verifyDefaultedEnableParallelNodeOperations(t, version, sc.Spec.EnableParallelNodeOperations)
 
 				errListAfterDefaulting := validation.ValidateScyllaCluster(sc)
 				if !reflect.DeepEqual(errListBeforeDefaulting, errListAfterDefaulting) {
-					t.Errorf("defaulting bootstrapPolicy changed the validation result: %s", cmp.Diff(errListBeforeDefaulting, errListAfterDefaulting))
+					t.Errorf("defaulting enableParallelNodeOperations changed the validation result: %s", cmp.Diff(errListBeforeDefaulting, errListAfterDefaulting))
 				}
 			})
 		}
@@ -68,43 +67,43 @@ func TestDefaultingIsConsistentWithValidation(t *testing.T) {
 				t.Parallel()
 
 				sdc := newConsistencyTestScyllaDBDatacenter(version)
-				sdc.Spec.BootstrapPolicy = nil
+				sdc.Spec.EnableParallelNodeOperations = nil
 
 				errListBeforeDefaulting := validation.ValidateScyllaDBDatacenter(sdc)
 
 				defaulting.SetDefaultsScyllaDBDatacenter(sdc)
-				verifyDefaultedBootstrapPolicy(t, version, sdc.Spec.BootstrapPolicy, scyllav1alpha1.BootstrapPolicyParallel)
+				verifyDefaultedEnableParallelNodeOperations(t, version, sdc.Spec.EnableParallelNodeOperations)
 
 				errListAfterDefaulting := validation.ValidateScyllaDBDatacenter(sdc)
 				if !reflect.DeepEqual(errListBeforeDefaulting, errListAfterDefaulting) {
-					t.Errorf("defaulting bootstrapPolicy changed the validation result: %s", cmp.Diff(errListBeforeDefaulting, errListAfterDefaulting))
+					t.Errorf("defaulting enableParallelNodeOperations changed the validation result: %s", cmp.Diff(errListBeforeDefaulting, errListAfterDefaulting))
 				}
 			})
 		}
 	})
 }
 
-// verifyDefaultedBootstrapPolicy asserts that defaulting stamped Parallel exactly for the ScyllaDB versions supporting
-// parallel bootstrap, and left bootstrapPolicy unset for every other one. Sequential is never stamped, so that objects
-// whose owners never made a choice keep resolving an unset bootstrapPolicy rather than being pinned to today's
-// resolution of it.
-func verifyDefaultedBootstrapPolicy[P ~string](t *testing.T, scyllaDBVersion string, got *P, parallel P) {
+// verifyDefaultedEnableParallelNodeOperations asserts that defaulting stamped true exactly for the ScyllaDB versions
+// supporting parallel bootstrap, and left enableParallelNodeOperations unset for every other one. false is never
+// stamped, so that objects whose owners never made a choice keep resolving an unset enableParallelNodeOperations rather
+// than being pinned to today's resolution of it.
+func verifyDefaultedEnableParallelNodeOperations(t *testing.T, scyllaDBVersion string, got *bool) {
 	t.Helper()
 
 	if !semver.SupportsParallelBootstrap(scyllaDBVersion) {
 		if got != nil {
-			t.Errorf("expected bootstrapPolicy to be left unset, got %q", *got)
+			t.Errorf("expected enableParallelNodeOperations to be left unset, got %t", *got)
 		}
 		return
 	}
 
 	if got == nil {
-		t.Errorf("expected bootstrapPolicy to be stamped with %q, got none", parallel)
+		t.Errorf("expected enableParallelNodeOperations to be stamped with true, got none")
 		return
 	}
 
-	if *got != parallel {
-		t.Errorf("expected bootstrapPolicy to be stamped with %q, got %q", parallel, *got)
+	if !*got {
+		t.Errorf("expected enableParallelNodeOperations to be stamped with true, got %t", *got)
 	}
 }
 

--- a/pkg/api/scylla/defaulting/scylladbdatacenter_defaulting.go
+++ b/pkg/api/scylla/defaulting/scylladbdatacenter_defaulting.go
@@ -13,30 +13,30 @@ import (
 // Mutating admission runs before the object is validated against the CRD schema, so it must also tolerate specs
 // missing fields that validation guarantees.
 func SetDefaultsScyllaDBDatacenter(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
-	setDefaultScyllaDBDatacenterBootstrapPolicy(sdc)
+	setDefaultScyllaDBDatacenterEnableParallelNodeOperations(sdc)
 }
 
-// setDefaultScyllaDBDatacenterBootstrapPolicy stamps an explicit Parallel bootstrapPolicy on creation when the ScyllaDB
-// image in the spec supports bootstrapping nodes in parallel.
-// Sequential is deliberately never stamped. Leaving the field unset keeps the object on whatever the resolution of an
-// unset bootstrapPolicy is, rather than pinning it to today's one, so that objects whose owners never made a choice
-// can be moved to a new default later without rewriting their specs.
+// setDefaultScyllaDBDatacenterEnableParallelNodeOperations stamps an explicit true enableParallelNodeOperations on
+// creation when the ScyllaDB image in the spec supports bootstrapping nodes in parallel.
+// false is deliberately never stamped. Leaving the field unset keeps the object on whatever the resolution of an unset
+// enableParallelNodeOperations is, rather than pinning it to today's one, so that objects whose owners never made a
+// choice can be moved to a new default later without rewriting their specs.
 // An explicitly set value, including one the validation rejects, is left untouched: correcting the user's own value is
 // the validating webhook's job, not the defaulter's.
 // ScyllaDBDatacenters managed by a parent controller always arrive at admission with the field explicitly set, so this
 // only ever takes effect for directly created ones.
-func setDefaultScyllaDBDatacenterBootstrapPolicy(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
-	if sdc.Spec.BootstrapPolicy != nil {
+func setDefaultScyllaDBDatacenterEnableParallelNodeOperations(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
+	if sdc.Spec.EnableParallelNodeOperations != nil {
 		return
 	}
 
 	// An image whose version can't be determined, e.g. one pinned by a digest, is deliberately treated as not
-	// supporting parallel bootstrap. This is the very value an explicitly set Parallel bootstrapPolicy is validated
-	// against, so the stamped value can never be rejected by the validating webhook, which runs after this one.
+	// supporting parallel bootstrap. This is the very value enabled parallel node operations are validated against, so
+	// the stamped value can never be rejected by the validating webhook, which runs after this one.
 	scyllaDBVersion, _ := naming.ImageToVersion(sdc.Spec.ScyllaDB.Image)
 	if !semver.SupportsParallelBootstrap(scyllaDBVersion) {
 		return
 	}
 
-	sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+	sdc.Spec.EnableParallelNodeOperations = new(true)
 }

--- a/pkg/api/scylla/defaulting/scylladbdatacenter_defaulting_test.go
+++ b/pkg/api/scylla/defaulting/scylladbdatacenter_defaulting_test.go
@@ -15,7 +15,7 @@ import (
 func TestSetDefaultsScyllaDBDatacenter(t *testing.T) {
 	t.Parallel()
 
-	newScyllaDBDatacenter := func(image string, bootstrapPolicy *scyllav1alpha1.BootstrapPolicy) *scyllav1alpha1.ScyllaDBDatacenter {
+	newScyllaDBDatacenter := func(image string, enableParallelNodeOperations *bool) *scyllav1alpha1.ScyllaDBDatacenter {
 		return &scyllav1alpha1.ScyllaDBDatacenter{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "basic",
@@ -31,7 +31,7 @@ func TestSetDefaultsScyllaDBDatacenter(t *testing.T) {
 						Name: "rack",
 					},
 				},
-				BootstrapPolicy: bootstrapPolicy,
+				EnableParallelNodeOperations: enableParallelNodeOperations,
 			},
 		}
 	}
@@ -42,66 +42,66 @@ func TestSetDefaultsScyllaDBDatacenter(t *testing.T) {
 		expected   *scyllav1alpha1.ScyllaDBDatacenter
 	}{
 		{
-			name:       "unset bootstrapPolicy with the minimal version supporting parallel bootstrap is defaulted to Parallel",
+			name:       "unset enableParallelNodeOperations with the minimal version supporting parallel bootstrap is defaulted to Parallel",
 			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, nil),
-			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(true)),
 		},
 		{
-			name:       "unset bootstrapPolicy with a version newer than the minimal one supporting parallel bootstrap is defaulted to Parallel",
+			name:       "unset enableParallelNodeOperations with a version newer than the minimal one supporting parallel bootstrap is defaulted to Parallel",
 			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAboveParallelBootstrapThreshold, nil),
-			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAboveParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAboveParallelBootstrapThreshold, new(true)),
 		},
 		{
-			name:       "unset bootstrapPolicy with an older version is left unset",
+			name:       "unset enableParallelNodeOperations with an older version is left unset",
 			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, nil),
 			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, nil),
 		},
 		{
 			// Per semver precedence a pre-release version is lower than the same version without one, matching how
-			// an explicitly set Parallel bootstrapPolicy is validated.
-			name:       "unset bootstrapPolicy with a pre-release of the minimal version supporting parallel bootstrap is left unset",
+			// an explicitly set Parallel enableParallelNodeOperations is validated.
+			name:       "unset enableParallelNodeOperations with a pre-release of the minimal version supporting parallel bootstrap is left unset",
 			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImagePreReleaseOfParallelBootstrapThreshold, nil),
 			expected:   newScyllaDBDatacenter(unit.ScyllaDBImagePreReleaseOfParallelBootstrapThreshold, nil),
 		},
 		{
-			name:       "unset bootstrapPolicy with an unparseable tag is left unset",
+			name:       "unset enableParallelNodeOperations with an unparseable tag is left unset",
 			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImage, nil),
 			expected:   newScyllaDBDatacenter(unit.ScyllaDBImage, nil),
 		},
 		{
 			// A digest pinned image carries no tag to determine the version from.
-			name:       "unset bootstrapPolicy with a digest pinned image is left unset",
+			name:       "unset enableParallelNodeOperations with a digest pinned image is left unset",
 			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageRepository+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
 			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageRepository+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
 		},
 		{
-			name:       "unset bootstrapPolicy with a tagged and digest pinned image is defaulted from the tag",
+			name:       "unset enableParallelNodeOperations with a tagged and digest pinned image is defaulted from the tag",
 			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", nil),
-			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", new(scyllav1alpha1.BootstrapPolicyParallel)),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold+"@sha256:d450d2d8636ab7b511b68180b4c535bf2294d0d6427adf11fc7f4bddfdbff35a", new(true)),
 		},
 		{
 			// Mutating admission runs before the object is validated against the CRD schema, so the defaulter has to
 			// tolerate a spec missing the fields it reads.
-			name:       "unset bootstrapPolicy with an empty image is left unset",
+			name:       "unset enableParallelNodeOperations with an empty image is left unset",
 			datacenter: newScyllaDBDatacenter("", nil),
 			expected:   newScyllaDBDatacenter("", nil),
 		},
 		{
-			name:       "explicit Sequential bootstrapPolicy is preserved",
-			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicySequential)),
-			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicySequential)),
+			name:       "explicit false enableParallelNodeOperations is preserved",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(false)),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(false)),
 		},
 		{
-			name:       "explicit Parallel bootstrapPolicy is preserved",
-			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
-			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+			name:       "explicit true enableParallelNodeOperations is preserved",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(true)),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageAtParallelBootstrapThreshold, new(true)),
 		},
 		{
 			// Rejecting a value the user set themselves is the validating webhook's job. The defaulter must not
 			// silently turn an invalid request into a valid one.
-			name:       "explicit Parallel bootstrapPolicy with a version not supporting it is preserved",
-			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
-			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, new(scyllav1alpha1.BootstrapPolicyParallel)),
+			name:       "explicit true enableParallelNodeOperations with a version not supporting it is preserved",
+			datacenter: newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, new(true)),
+			expected:   newScyllaDBDatacenter(unit.ScyllaDBImageBelowParallelBootstrapThreshold, new(true)),
 		},
 	}
 

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -222,18 +222,6 @@ spec:
                         type: array
                     type: object
                   type: array
-                bootstrapPolicy:
-                  description: |-
-                    bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
-                    parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
-                    If not provided, it's treated as Sequential.
-                    On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel
-                    bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's
-                    explicitly changed. It's otherwise left unset, and never set on an already existing object.
-                  enum:
-                    - Sequential
-                    - Parallel
-                  type: string
                 cpuset:
                   description: |-
                     cpuset determines if the cluster will use cpu-pinning.
@@ -3300,6 +3288,15 @@ spec:
                   items:
                     type: string
                   type: array
+                enableParallelNodeOperations:
+                  description: |-
+                    enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.
+                    When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.
+                    If not provided, it's treated as disabled.
+                    On creation, it's set to true when spec.version is a semver-parseable version supporting parallel bootstrap.
+                    The set value is persisted, so it stays in effect across ScyllaDB version changes until it's explicitly
+                    changed. It's otherwise left unset, and never set on an already existing object.
+                  type: boolean
                 exposeOptions:
                   description: |-
                     exposeOptions specifies options for exposing ScyllaCluster services.

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -152,27 +152,15 @@ type ScyllaClusterSpec struct {
 	// +optional
 	ReadinessGates []corev1.PodReadinessGate `json:"readinessGates,omitempty"`
 
-	// bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
-	// parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
-	// If not provided, it's treated as Sequential.
-	// On creation, it's set to Parallel when spec.version is a semver-parseable version supporting parallel
-	// bootstrap. The set value is persisted, so it stays in effect across ScyllaDB version changes until it's
-	// explicitly changed. It's otherwise left unset, and never set on an already existing object.
-	// +kubebuilder:validation:Enum=Sequential;Parallel
+	// enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.
+	// When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.
+	// If not provided, it's treated as disabled.
+	// On creation, it's set to true when spec.version is a semver-parseable version supporting parallel bootstrap.
+	// The set value is persisted, so it stays in effect across ScyllaDB version changes until it's explicitly
+	// changed. It's otherwise left unset, and never set on an already existing object.
 	// +optional
-	BootstrapPolicy *BootstrapPolicy `json:"bootstrapPolicy,omitempty"`
+	EnableParallelNodeOperations *bool `json:"enableParallelNodeOperations,omitempty"`
 }
-
-// BootstrapPolicy describes the ordering of ScyllaDB nodes bootstrap.
-type BootstrapPolicy string
-
-const (
-	// BootstrapPolicySequential specifies that ScyllaDB nodes are bootstrapped one at a time.
-	BootstrapPolicySequential BootstrapPolicy = "Sequential"
-
-	// BootstrapPolicyParallel specifies that ScyllaDB nodes are started in parallel.
-	BootstrapPolicyParallel BootstrapPolicy = "Parallel"
-)
 
 type PodIPSourceType string
 

--- a/pkg/api/scylla/v1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1/zz_generated.deepcopy.go
@@ -951,9 +951,9 @@ func (in *ScyllaClusterSpec) DeepCopyInto(out *ScyllaClusterSpec) {
 		*out = make([]corev1.PodReadinessGate, len(*in))
 		copy(*out, *in)
 	}
-	if in.BootstrapPolicy != nil {
-		in, out := &in.BootstrapPolicy, &out.BootstrapPolicy
-		*out = new(BootstrapPolicy)
+	if in.EnableParallelNodeOperations != nil {
+		in, out := &in.EnableParallelNodeOperations, &out.EnableParallelNodeOperations
+		*out = new(bool)
 		**out = **in
 	}
 	return

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -52,19 +52,6 @@ spec:
             spec:
               description: spec defines the desired state of this ScyllaDBDatacenter.
               properties:
-                bootstrapPolicy:
-                  description: |-
-                    bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
-                    parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
-                    If not provided, it's treated as Sequential.
-                    On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version
-                    supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image
-                    changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing
-                    object.
-                  enum:
-                    - Sequential
-                    - Parallel
-                  type: string
                 clusterName:
                   description: |-
                     clusterName specifies the name of the ScyllaDB cluster.
@@ -89,6 +76,15 @@ spec:
                 dnsPolicy:
                   description: dnsPolicy defines how a pod's DNS will be configured.
                   type: string
+                enableParallelNodeOperations:
+                  description: |-
+                    enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.
+                    When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.
+                    If not provided, it's treated as disabled.
+                    On creation, it's set to true when the tag of spec.scyllaDB.image is a semver-parseable version supporting
+                    parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image changes until
+                    it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
+                  type: boolean
                 exposeOptions:
                   description: exposeOptions specifies parameters related to exposing ScyllaDBDatacenter backends.
                   properties:

--- a/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
+++ b/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
@@ -102,28 +102,15 @@ type ScyllaDBDatacenterSpec struct {
 	// +optional
 	ReadinessGates []corev1.PodReadinessGate `json:"readinessGates,omitempty"`
 
-	// bootstrapPolicy controls whether ScyllaDB nodes are bootstrapped one at a time (Sequential) or started in
-	// parallel (Parallel). Parallel requires ScyllaDB 2026.2 or later.
-	// If not provided, it's treated as Sequential.
-	// On creation, it's set to Parallel when the tag of spec.scyllaDB.image is a semver-parseable version
-	// supporting parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image
-	// changes until it's explicitly changed. It's otherwise left unset, and never set on an already existing
-	// object.
-	// +kubebuilder:validation:Enum=Sequential;Parallel
+	// enableParallelNodeOperations controls whether operations on ScyllaDB nodes may be performed concurrently.
+	// When it's disabled, ScyllaDB nodes are started one at a time. Enabling it requires ScyllaDB 2026.2 or later.
+	// If not provided, it's treated as disabled.
+	// On creation, it's set to true when the tag of spec.scyllaDB.image is a semver-parseable version supporting
+	// parallel bootstrap. The set value is persisted, so it stays in effect across ScyllaDB image changes until
+	// it's explicitly changed. It's otherwise left unset, and never set on an already existing object.
 	// +optional
-	BootstrapPolicy *BootstrapPolicy `json:"bootstrapPolicy,omitempty"`
+	EnableParallelNodeOperations *bool `json:"enableParallelNodeOperations,omitempty"`
 }
-
-// BootstrapPolicy describes the ordering of ScyllaDB nodes bootstrap.
-type BootstrapPolicy string
-
-const (
-	// BootstrapPolicySequential specifies that ScyllaDB nodes are bootstrapped one at a time.
-	BootstrapPolicySequential BootstrapPolicy = "Sequential"
-
-	// BootstrapPolicyParallel specifies that ScyllaDB nodes are started in parallel.
-	BootstrapPolicyParallel BootstrapPolicy = "Parallel"
-)
 
 type ObjectTemplateMetadata struct {
 	// labels specify a custom key value map that gets merged with managed object labels.

--- a/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
@@ -2169,9 +2169,9 @@ func (in *ScyllaDBDatacenterSpec) DeepCopyInto(out *ScyllaDBDatacenterSpec) {
 		*out = make([]v1.PodReadinessGate, len(*in))
 		copy(*out, *in)
 	}
-	if in.BootstrapPolicy != nil {
-		in, out := &in.BootstrapPolicy, &out.BootstrapPolicy
-		*out = new(BootstrapPolicy)
+	if in.EnableParallelNodeOperations != nil {
+		in, out := &in.EnableParallelNodeOperations, &out.EnableParallelNodeOperations
+		*out = new(bool)
 		**out = **in
 	}
 	return

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -37,11 +37,6 @@ var (
 		scyllav1.BroadcastAddressTypeServiceLoadBalancerIngress,
 	}
 
-	SupportedScyllaV1BootstrapPolicies = []scyllav1.BootstrapPolicy{
-		scyllav1.BootstrapPolicySequential,
-		scyllav1.BootstrapPolicyParallel,
-	}
-
 	schedulerTaskSpecCronParseOptions = cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor
 )
 
@@ -224,13 +219,9 @@ func ValidateScyllaClusterSpec(spec *scyllav1.ScyllaClusterSpec, fldPath *field.
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("minReadySeconds"), *spec.MinReadySeconds, "must be non-negative integer"))
 	}
 
-	if spec.BootstrapPolicy != nil {
-		allErrs = append(allErrs, validateEnum(*spec.BootstrapPolicy, SupportedScyllaV1BootstrapPolicies, fldPath.Child("bootstrapPolicy"))...)
-
-		if *spec.BootstrapPolicy == scyllav1.BootstrapPolicyParallel {
-			// spec.version is used verbatim as the tag of the ScyllaDB image, so there's no image reference to strip the version from.
-			allErrs = append(allErrs, validateParallelBootstrapPolicyScyllaDBVersion(*spec.BootstrapPolicy, spec.Version, fldPath.Child("bootstrapPolicy"))...)
-		}
+	if spec.EnableParallelNodeOperations != nil && *spec.EnableParallelNodeOperations {
+		// spec.version is used verbatim as the tag of the ScyllaDB image, so there's no image reference to strip the version from.
+		allErrs = append(allErrs, validateEnabledParallelNodeOperationsScyllaDBVersion(spec.Version, fldPath.Child("enableParallelNodeOperations"))...)
 	}
 
 	return allErrs

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -1079,122 +1079,110 @@ func TestValidateScyllaCluster(t *testing.T) {
 			expectedErrorString: `spec.alternator.servingCertificate.operatorManagedOptions.additionalIPAddresses: Invalid value: "0.not-an-ip.0.0": must be a valid IP address, (e.g. 10.9.8.7 or 2001:db8::ffff)`,
 		},
 		{
-			name: "unset bootstrapPolicy",
+			name: "unset enableParallelNodeOperations",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
-				cluster.Spec.BootstrapPolicy = nil
+				cluster.Spec.EnableParallelNodeOperations = nil
 				return cluster
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "unsupported bootstrapPolicy",
-			cluster: func() *scyllav1.ScyllaCluster {
-				cluster := validCluster.DeepCopy()
-				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicy("foo"))
-				return cluster
-			}(),
-			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeNotSupported, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicy("foo"), Detail: `supported values: "Sequential", "Parallel"`},
-			},
-			expectedErrorString: `spec.bootstrapPolicy: Unsupported value: "foo": supported values: "Sequential", "Parallel"`,
-		},
-		{
-			name: "Sequential bootstrapPolicy with a version not supporting parallel bootstrap",
+			name: "disabled parallel node operations with a version not supporting parallel bootstrap",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
 				cluster.Spec.Version = "2025.1.0"
-				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				cluster.Spec.EnableParallelNodeOperations = new(false)
 				return cluster
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "Sequential bootstrapPolicy with an unparseable version",
+			name: "disabled parallel node operations with an unparseable version",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
 				cluster.Spec.Version = "latest"
-				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				cluster.Spec.EnableParallelNodeOperations = new(false)
 				return cluster
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "Parallel bootstrapPolicy with the minimal supported version",
+			name: "enabled parallel node operations with the minimal supported version",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
 				cluster.Spec.Version = "2026.2.0"
-				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				cluster.Spec.EnableParallelNodeOperations = new(true)
 				return cluster
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "Parallel bootstrapPolicy with a pre-release of the minimal supported version",
+			name: "enabled parallel node operations with a pre-release of the minimal supported version",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
 				cluster.Spec.Version = "2026.2.0-rc0"
-				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				cluster.Spec.EnableParallelNodeOperations = new(true)
 				return cluster
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 		{
-			name: "Parallel bootstrapPolicy with a version newer than the minimal supported one",
+			name: "enabled parallel node operations with a version newer than the minimal supported one",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
 				cluster.Spec.Version = "2026.3.0"
-				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				cluster.Spec.EnableParallelNodeOperations = new(true)
 				return cluster
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "Parallel bootstrapPolicy with an older major version",
+			name: "enabled parallel node operations with an older major version",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
 				cluster.Spec.Version = "2025.1.0"
-				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				cluster.Spec.EnableParallelNodeOperations = new(true)
 				return cluster
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 		{
-			name: "Parallel bootstrapPolicy with an older minor version",
+			name: "enabled parallel node operations with an older minor version",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
 				cluster.Spec.Version = "2026.1.0"
-				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				cluster.Spec.EnableParallelNodeOperations = new(true)
 				return cluster
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 		{
-			name: "Parallel bootstrapPolicy with an unparseable version",
+			name: "enabled parallel node operations with an unparseable version",
 			cluster: func() *scyllav1.ScyllaCluster {
 				cluster := validCluster.DeepCopy()
 				cluster.Spec.Version = "latest"
-				cluster.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				cluster.Spec.EnableParallelNodeOperations = new(true)
 				return cluster
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 	}
 
@@ -1472,76 +1460,76 @@ func TestValidateScyllaClusterUpdate(t *testing.T) {
 			expectedErrorString: `spec.exposeOptions.broadcastOptions.nodes.type: Invalid value: "PodIP": field is immutable`,
 		},
 		{
-			name: "bootstrapPolicy can be changed to Parallel with a supported version",
+			name: "enableParallelNodeOperations can be enabled with a supported version",
 			old: func() *scyllav1.ScyllaCluster {
 				sc := unit.NewSingleRackCluster(3)
 				sc.Spec.Version = "2026.2.0"
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				sc.Spec.EnableParallelNodeOperations = new(false)
 				return sc
 			}(),
 			new: func() *scyllav1.ScyllaCluster {
 				sc := unit.NewSingleRackCluster(3)
 				sc.Spec.Version = "2026.2.0"
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				sc.Spec.EnableParallelNodeOperations = new(true)
 				return sc
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "bootstrapPolicy can be changed to Sequential with an unsupported version",
+			name: "enableParallelNodeOperations can be disabled with an unsupported version",
 			old: func() *scyllav1.ScyllaCluster {
 				sc := unit.NewSingleRackCluster(3)
 				sc.Spec.Version = "2026.1.0"
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				sc.Spec.EnableParallelNodeOperations = new(true)
 				return sc
 			}(),
 			new: func() *scyllav1.ScyllaCluster {
 				sc := unit.NewSingleRackCluster(3)
 				sc.Spec.Version = "2026.1.0"
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				sc.Spec.EnableParallelNodeOperations = new(false)
 				return sc
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "bootstrapPolicy cannot be changed to Parallel with an unsupported version",
+			name: "enableParallelNodeOperations cannot be enabled with an unsupported version",
 			old: func() *scyllav1.ScyllaCluster {
 				sc := unit.NewSingleRackCluster(3)
 				sc.Spec.Version = "2026.1.0"
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				sc.Spec.EnableParallelNodeOperations = new(false)
 				return sc
 			}(),
 			new: func() *scyllav1.ScyllaCluster {
 				sc := unit.NewSingleRackCluster(3)
 				sc.Spec.Version = "2026.1.0"
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				sc.Spec.EnableParallelNodeOperations = new(true)
 				return sc
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 		{
-			name: "version cannot be downgraded below the one required by Parallel bootstrapPolicy",
+			name: "version cannot be downgraded below the one required by enabled enableParallelNodeOperations",
 			old: func() *scyllav1.ScyllaCluster {
 				sc := unit.NewSingleRackCluster(3)
 				sc.Spec.Version = "2026.2.0"
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				sc.Spec.EnableParallelNodeOperations = new(true)
 				return sc
 			}(),
 			new: func() *scyllav1.ScyllaCluster {
 				sc := unit.NewSingleRackCluster(3)
 				sc.Spec.Version = "2026.1.0"
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				sc.Spec.EnableParallelNodeOperations = new(true)
 				return sc
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 	}
 

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation.go
@@ -52,11 +52,6 @@ var (
 		scyllav1alpha1.NodeServiceTypeClusterIP,
 		scyllav1alpha1.NodeServiceTypeLoadBalancer,
 	}
-
-	SupportedScyllaV1Alpha1BootstrapPolicies = []scyllav1alpha1.BootstrapPolicy{
-		scyllav1alpha1.BootstrapPolicySequential,
-		scyllav1alpha1.BootstrapPolicyParallel,
-	}
 )
 
 func ValidateScyllaDBDatacenter(sdc *scyllav1alpha1.ScyllaDBDatacenter) field.ErrorList {
@@ -107,15 +102,11 @@ func ValidateScyllaDBDatacenterSpec(spec scyllav1alpha1.ScyllaDBDatacenterSpec, 
 		allErrs = append(allErrs, apimachineryvalidation.ValidateNonnegativeField(int64(*spec.MinReadySeconds), fldPath.Child("minReadySeconds"))...)
 	}
 
-	if spec.BootstrapPolicy != nil {
-		allErrs = append(allErrs, validateEnum(*spec.BootstrapPolicy, SupportedScyllaV1Alpha1BootstrapPolicies, fldPath.Child("bootstrapPolicy"))...)
-
-		if *spec.BootstrapPolicy == scyllav1alpha1.BootstrapPolicyParallel {
-			// An image whose version can't be determined, e.g. one pinned by a digest, is deliberately treated as not
-			// supporting parallel bootstrap.
-			scyllaDBVersion, _ := naming.ImageToVersion(spec.ScyllaDB.Image)
-			allErrs = append(allErrs, validateParallelBootstrapPolicyScyllaDBVersion(*spec.BootstrapPolicy, scyllaDBVersion, fldPath.Child("bootstrapPolicy"))...)
-		}
+	if spec.EnableParallelNodeOperations != nil && *spec.EnableParallelNodeOperations {
+		// An image whose version can't be determined, e.g. one pinned by a digest, is deliberately treated as not
+		// supporting parallel bootstrap.
+		scyllaDBVersion, _ := naming.ImageToVersion(spec.ScyllaDB.Image)
+		allErrs = append(allErrs, validateEnabledParallelNodeOperationsScyllaDBVersion(scyllaDBVersion, fldPath.Child("enableParallelNodeOperations"))...)
 	}
 
 	return allErrs
@@ -601,14 +592,14 @@ func validateEnum[E ~string](value E, supported []E, fldPath *field.Path) field.
 	return allErrs
 }
 
-// validateParallelBootstrapPolicyScyllaDBVersion validates that the given ScyllaDB version supports bootstrapping nodes
-// in parallel. A version which can't be parsed is deliberately treated as not supporting it, so that parallel bootstrap
-// can only be enabled for versions known to support it.
-func validateParallelBootstrapPolicyScyllaDBVersion[P ~string](bootstrapPolicy P, scyllaDBVersion string, fldPath *field.Path) field.ErrorList {
+// validateEnabledParallelNodeOperationsScyllaDBVersion validates that the given ScyllaDB version supports
+// bootstrapping nodes in parallel. A version which can't be parsed is deliberately treated as not supporting it, so
+// that parallel node operations can only be enabled for versions known to support it.
+func validateEnabledParallelNodeOperationsScyllaDBVersion(scyllaDBVersion string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if !semver.SupportsParallelBootstrap(scyllaDBVersion) {
-		allErrs = append(allErrs, field.Invalid(fldPath, bootstrapPolicy, fmt.Sprintf(
+		allErrs = append(allErrs, field.Invalid(fldPath, true, fmt.Sprintf(
 			"requires a semver-parseable ScyllaDB version >= %d.%d",
 			semver.ScyllaDBVersionRequiredForParallelBootstrap.Major,
 			semver.ScyllaDBVersionRequiredForParallelBootstrap.Minor,

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
@@ -668,135 +668,123 @@ func TestValidateScyllaDBDatacenter(t *testing.T) {
 			expectedErrorString: `spec.rackTemplate.scyllaDBManagerAgent.customConfigSecretRef: Invalid value: "-hello": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
 		},
 		{
-			name: "unset bootstrapPolicy",
+			name: "unset enableParallelNodeOperations",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
-				sdc.Spec.BootstrapPolicy = nil
+				sdc.Spec.EnableParallelNodeOperations = nil
 				return sdc
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "unsupported bootstrapPolicy",
-			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
-				sdc := newValidScyllaDBDatacenter()
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicy("foo"))
-				return sdc
-			}(),
-			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeNotSupported, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicy("foo"), Detail: `supported values: "Sequential", "Parallel"`},
-			},
-			expectedErrorString: `spec.bootstrapPolicy: Unsupported value: "foo": supported values: "Sequential", "Parallel"`,
-		},
-		{
-			name: "Sequential bootstrapPolicy with an image tag not supporting parallel bootstrap",
+			name: "disabled parallel node operations with an image tag not supporting parallel bootstrap",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2025.1.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				sdc.Spec.EnableParallelNodeOperations = new(false)
 				return sdc
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "Sequential bootstrapPolicy with an unparseable image tag",
+			name: "disabled parallel node operations with an unparseable image tag",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:latest"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				sdc.Spec.EnableParallelNodeOperations = new(false)
 				return sdc
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "Parallel bootstrapPolicy with an image tag of the minimal supported version",
+			name: "enabled parallel node operations with an image tag of the minimal supported version",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "Parallel bootstrapPolicy with an image tag of a pre-release of the minimal supported version",
+			name: "enabled parallel node operations with an image tag of a pre-release of the minimal supported version",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0-rc0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 		{
-			name: "Parallel bootstrapPolicy with an image tag of a version newer than the minimal supported one",
+			name: "enabled parallel node operations with an image tag of a version newer than the minimal supported one",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.3.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "Parallel bootstrapPolicy with an image tag of an older major version",
+			name: "enabled parallel node operations with an image tag of an older major version",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2025.1.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 		{
-			name: "Parallel bootstrapPolicy with an image tag of an older minor version",
+			name: "enabled parallel node operations with an image tag of an older minor version",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 		{
-			name: "Parallel bootstrapPolicy with an unparseable image tag",
+			name: "enabled parallel node operations with an unparseable image tag",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:latest"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 		{
-			name: "Parallel bootstrapPolicy with a digest pinned image",
+			name: "enabled parallel node operations with a digest pinned image",
 			datacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla@sha256:0000000000000000000000000000000000000000000000000000000000000000"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 	}
 
@@ -1346,76 +1334,76 @@ func TestValidateScyllaDBDatacenterUpdate(t *testing.T) {
 			expectedErrorString: `spec.exposeOptions.broadcastOptions.nodes.type: Invalid value: "PodIP": field is immutable`,
 		},
 		{
-			name: "bootstrapPolicy can be changed to Parallel with a supported image tag",
+			name: "enableParallelNodeOperations can be enabled with a supported image tag",
 			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				sdc.Spec.EnableParallelNodeOperations = new(false)
 				return sdc
 			}(),
 			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "bootstrapPolicy can be changed to Sequential with an unsupported image tag",
+			name: "enableParallelNodeOperations can be disabled with an unsupported image tag",
 			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				sdc.Spec.EnableParallelNodeOperations = new(false)
 				return sdc
 			}(),
 			expectedErrorList:   nil,
 			expectedErrorString: "",
 		},
 		{
-			name: "bootstrapPolicy cannot be changed to Parallel with an unsupported image tag",
+			name: "enableParallelNodeOperations cannot be enabled with an unsupported image tag",
 			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				sdc.Spec.EnableParallelNodeOperations = new(false)
 				return sdc
 			}(),
 			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 		{
-			name: "image cannot be downgraded below the version required by Parallel bootstrapPolicy",
+			name: "image cannot be downgraded below the version required by enabled enableParallelNodeOperations",
 			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.2.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = "scylladb/scylla:2026.1.0"
-				sdc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			expectedErrorList: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.bootstrapPolicy", BadValue: scyllav1alpha1.BootstrapPolicyParallel, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
+				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.enableParallelNodeOperations", BadValue: true, Detail: `requires a semver-parseable ScyllaDB version >= 2026.2`},
 			},
-			expectedErrorString: `spec.bootstrapPolicy: Invalid value: "Parallel": requires a semver-parseable ScyllaDB version >= 2026.2`,
+			expectedErrorString: `spec.enableParallelNodeOperations: Invalid value: true: requires a semver-parseable ScyllaDB version >= 2026.2`,
 		},
 	}
 

--- a/pkg/cmd/operator/webhooks_mutating_test.go
+++ b/pkg/cmd/operator/webhooks_mutating_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
-	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/scheme"
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -173,7 +172,7 @@ func Test_mutate_withDefaultDefaulters(t *testing.T) {
 		expectedError   error
 	}{
 		{
-			// Sequential is never stamped: an unset bootstrapPolicy is left unset, so that objects whose owners
+			// Sequential is never stamped: an unset enableParallelNodeOperations is left unset, so that objects whose owners
 			// never made a choice keep resolving it rather than being pinned to today's resolution.
 			name: "a ScyllaCluster with a version not supporting parallel bootstrap is admitted unchanged",
 			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
@@ -185,7 +184,7 @@ func Test_mutate_withDefaultDefaulters(t *testing.T) {
 			expectedError:   nil,
 		},
 		{
-			name: "a ScyllaCluster with a version supporting parallel bootstrap is stamped with a Parallel bootstrapPolicy",
+			name: "a ScyllaCluster with a version supporting parallel bootstrap is stamped with enableParallelNodeOperations",
 			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
 				Group:    "scylla.scylladb.com",
 				Version:  "v1",
@@ -194,19 +193,19 @@ func Test_mutate_withDefaultDefaulters(t *testing.T) {
 			expectedPatches: []jsonpatch.Operation{
 				{
 					Operation: "add",
-					Path:      "/spec/bootstrapPolicy",
-					Value:     string(scyllav1.BootstrapPolicyParallel),
+					Path:      "/spec/enableParallelNodeOperations",
+					Value:     true,
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name: "a ScyllaCluster with an explicit bootstrapPolicy passes through unchanged",
+			name: "a ScyllaCluster with an explicit enableParallelNodeOperations passes through unchanged",
 			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
 				Group:    "scylla.scylladb.com",
 				Version:  "v1",
 				Resource: "scyllaclusters",
-			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1","kind":"ScyllaCluster","metadata":{"name":"basic","namespace":"test"},"spec":{"version":"2026.2.0","agentVersion":"3.4.0","bootstrapPolicy":"Sequential","datacenter":{"name":"dc1","racks":[{"name":"rack1","members":3,"storage":{"capacity":"1Gi"}}]}}}`)),
+			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1","kind":"ScyllaCluster","metadata":{"name":"basic","namespace":"test"},"spec":{"version":"2026.2.0","agentVersion":"3.4.0","enableParallelNodeOperations":false,"datacenter":{"name":"dc1","racks":[{"name":"rack1","members":3,"storage":{"capacity":"1Gi"}}]}}}`)),
 			expectedPatches: nil,
 			expectedError:   nil,
 		},
@@ -221,7 +220,7 @@ func Test_mutate_withDefaultDefaulters(t *testing.T) {
 			expectedError:   nil,
 		},
 		{
-			name: "a ScyllaDBDatacenter with an image supporting parallel bootstrap is stamped with a Parallel bootstrapPolicy",
+			name: "a ScyllaDBDatacenter with an image supporting parallel bootstrap is stamped with enableParallelNodeOperations",
 			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
 				Group:    "scylla.scylladb.com",
 				Version:  "v1alpha1",
@@ -230,19 +229,19 @@ func Test_mutate_withDefaultDefaulters(t *testing.T) {
 			expectedPatches: []jsonpatch.Operation{
 				{
 					Operation: "add",
-					Path:      "/spec/bootstrapPolicy",
-					Value:     string(scyllav1alpha1.BootstrapPolicyParallel),
+					Path:      "/spec/enableParallelNodeOperations",
+					Value:     true,
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name: "a ScyllaDBDatacenter with an explicit bootstrapPolicy passes through unchanged",
+			name: "a ScyllaDBDatacenter with an explicit enableParallelNodeOperations passes through unchanged",
 			req: newMutateAdmissionRequest(metav1.GroupVersionResource{
 				Group:    "scylla.scylladb.com",
 				Version:  "v1alpha1",
 				Resource: "scylladbdatacenters",
-			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1alpha1","kind":"ScyllaDBDatacenter","metadata":{"name":"basic","namespace":"test"},"spec":{"clusterName":"basic","scyllaDB":{"image":"docker.io/scylladb/scylla:2026.2.0"},"bootstrapPolicy":"Sequential","racks":[{"name":"rack1"}]}}`)),
+			}, admissionv1.Create, []byte(`{"apiVersion":"scylla.scylladb.com/v1alpha1","kind":"ScyllaDBDatacenter","metadata":{"name":"basic","namespace":"test"},"spec":{"clusterName":"basic","scyllaDB":{"image":"docker.io/scylladb/scylla:2026.2.0"},"enableParallelNodeOperations":false,"racks":[{"name":"rack1"}]}}`)),
 			expectedPatches: nil,
 			expectedError:   nil,
 		},

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -35,12 +35,12 @@ type IngressControllerOptions struct {
 }
 
 type ScyllaClusterOptions struct {
-	NodeServiceType             string
-	NodesBroadcastAddressType   string
-	ClientsBroadcastAddressType string
-	StorageClassName            string
-	ReactorBackend              string
-	BootstrapPolicy             string
+	NodeServiceType              string
+	NodesBroadcastAddressType    string
+	ClientsBroadcastAddressType  string
+	StorageClassName             string
+	ReactorBackend               string
+	EnableParallelNodeOperations string
 }
 
 var supportedNodeServiceTypes = []scyllav1.NodeServiceType{
@@ -58,9 +58,9 @@ var supportedReactorBackends = []string{
 	"linux-aio",
 }
 
-var supportedBootstrapPolicies = []scyllav1.BootstrapPolicy{
-	scyllav1.BootstrapPolicySequential,
-	scyllav1.BootstrapPolicyParallel,
+var supportedEnableParallelNodeOperationsValues = []string{
+	"true",
+	"false",
 }
 
 type TestFrameworkOptions struct {
@@ -93,12 +93,12 @@ func NewTestFrameworkOptions(streams genericclioptions.IOStreams, userAgent stri
 		CleanupPolicyUntyped:        string(framework.CleanupPolicyAlways),
 		IngressController:           &IngressControllerOptions{},
 		ScyllaClusterOptionsUntyped: &ScyllaClusterOptions{
-			NodeServiceType:             string(scyllav1.NodeServiceTypeHeadless),
-			NodesBroadcastAddressType:   string(scyllav1.BroadcastAddressTypePodIP),
-			ClientsBroadcastAddressType: string(scyllav1.BroadcastAddressTypePodIP),
-			StorageClassName:            "",
-			ReactorBackend:              "", // Leaving empty to rely on ScyllaDB default.
-			BootstrapPolicy:             "", // Leaving empty to rely on the operator's default.
+			NodeServiceType:              string(scyllav1.NodeServiceTypeHeadless),
+			NodesBroadcastAddressType:    string(scyllav1.BroadcastAddressTypePodIP),
+			ClientsBroadcastAddressType:  string(scyllav1.BroadcastAddressTypePodIP),
+			StorageClassName:             "",
+			ReactorBackend:               "", // Leaving empty to rely on ScyllaDB default.
+			EnableParallelNodeOperations: "", // Leaving empty to rely on the operator's default.
 		},
 		ObjectStorageOptions:        NewObjectStorageOptions(),
 		ScyllaDBVersion:             configassets.Project.Operator.ScyllaDBVersion,
@@ -150,8 +150,8 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 	)))
 	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.StorageClassName, "scyllacluster-storageclass-name", "", o.ScyllaClusterOptionsUntyped.StorageClassName, fmt.Sprintf("Name of the StorageClass to request for ScyllaCluster storage."))
 	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.ReactorBackend, "scyllacluster-reactor-backend", "", o.ScyllaClusterOptionsUntyped.ReactorBackend, fmt.Sprintf("Name of the reactor backend to use for ScyllaCluster."))
-	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.BootstrapPolicy, "scyllacluster-bootstrap-policy", "", o.ScyllaClusterOptionsUntyped.BootstrapPolicy, fmt.Sprintf("Bootstrap policy to set on ScyllaClusters and ScyllaDBDatacenters created by tests. Leave empty to rely on the operator's defaulting. Allowed values are [%s].", strings.Join(
-		oslices.ConvertSlice(supportedBootstrapPolicies, oslices.ToString[scyllav1.BootstrapPolicy]),
+	cmd.PersistentFlags().StringVarP(&o.ScyllaClusterOptionsUntyped.EnableParallelNodeOperations, "scyllacluster-enable-parallel-node-operations", "", o.ScyllaClusterOptionsUntyped.EnableParallelNodeOperations, fmt.Sprintf("Whether to enable parallel node operations on ScyllaClusters and ScyllaDBDatacenters created by tests. Leave empty to rely on the operator's defaulting. Allowed values are [%s].", strings.Join(
+		supportedEnableParallelNodeOperationsValues,
 		", ",
 	)))
 	cmd.PersistentFlags().StringVarP(&o.ScyllaDBVersion, "scylladb-version", "", o.ScyllaDBVersion, "Version of ScyllaDB to use.")
@@ -202,8 +202,8 @@ func (o *TestFrameworkOptions) Validate(args []string) error {
 		errors = append(errors, fmt.Errorf("invalid scyllacluster-reactor-backend: %q", o.ScyllaClusterOptionsUntyped.ReactorBackend))
 	}
 
-	if bootstrapPolicy := o.ScyllaClusterOptionsUntyped.BootstrapPolicy; bootstrapPolicy != "" && !oslices.ContainsItem(supportedBootstrapPolicies, scyllav1.BootstrapPolicy(bootstrapPolicy)) {
-		errors = append(errors, fmt.Errorf("invalid scyllacluster-bootstrap-policy: %q", o.ScyllaClusterOptionsUntyped.BootstrapPolicy))
+	if enableParallelNodeOperations := o.ScyllaClusterOptionsUntyped.EnableParallelNodeOperations; enableParallelNodeOperations != "" && !oslices.ContainsItem(supportedEnableParallelNodeOperationsValues, enableParallelNodeOperations) {
+		errors = append(errors, fmt.Errorf("invalid scyllacluster-enable-parallel-node-operations: %q", o.ScyllaClusterOptionsUntyped.EnableParallelNodeOperations))
 	}
 
 	if !tagWithOptionalDigestRegexp.MatchString(o.ScyllaDBVersion) {
@@ -313,9 +313,9 @@ func (o *TestFrameworkOptions) Complete(args []string) error {
 			NodesBroadcastAddressType:   scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.NodesBroadcastAddressType),
 			ClientsBroadcastAddressType: scyllav1.BroadcastAddressType(o.ScyllaClusterOptionsUntyped.ClientsBroadcastAddressType),
 		},
-		StorageClassName: o.ScyllaClusterOptionsUntyped.StorageClassName,
-		ReactorBackend:   o.ScyllaClusterOptionsUntyped.ReactorBackend,
-		BootstrapPolicy:  o.ScyllaClusterOptionsUntyped.BootstrapPolicy,
+		StorageClassName:             o.ScyllaClusterOptionsUntyped.StorageClassName,
+		ReactorBackend:               o.ScyllaClusterOptionsUntyped.ReactorBackend,
+		EnableParallelNodeOperations: o.ScyllaClusterOptionsUntyped.EnableParallelNodeOperations,
 	}
 
 	workerRestConfigs := make(map[string]*rest.Config, len(o.WorkerClientConfigs))

--- a/pkg/controller/scyllacluster/migrate.go
+++ b/pkg/controller/scyllacluster/migrate.go
@@ -275,18 +275,18 @@ func MigrateV1ScyllaClusterSpecToV1Alpha1ScyllaDBDatacenterSpec(scName string, s
 		MinTerminationGracePeriodSeconds:        scSpec.MinTerminationGracePeriodSeconds,
 		MinReadySeconds:                         scSpec.MinReadySeconds,
 		ReadinessGates:                          scSpec.ReadinessGates,
-		BootstrapPolicy: func() *scyllav1alpha1.BootstrapPolicy {
-			// A managed ScyllaDBDatacenter always carries an explicit bootstrapPolicy, so an unset bootstrapPolicy in
-			// the parent ScyllaCluster has to be resolved here. It's resolved to Sequential: an unset value covers
-			// both ScyllaClusters created before the field existed and ones created with a ScyllaDB version that
-			// doesn't support bootstrapping nodes in parallel, and neither may start doing so on an operator upgrade.
-			// Changing this resolution changes the behavior of every such existing cluster, so it must not be treated
-			// as an implementation detail of the create time defaulting.
-			if scSpec.BootstrapPolicy == nil {
-				return pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+		EnableParallelNodeOperations: func() *bool {
+			// A managed ScyllaDBDatacenter always carries an explicit enableParallelNodeOperations, so an unset
+			// enableParallelNodeOperations in the parent ScyllaCluster has to be resolved here. It's resolved to false:
+			// an unset value covers both ScyllaClusters created before the field existed and ones created with a
+			// ScyllaDB version that doesn't support bootstrapping nodes in parallel, and neither may start doing so on
+			// an operator upgrade. Changing this resolution changes the behavior of every such existing cluster, so it
+			// must not be treated as an implementation detail of the create time defaulting.
+			if scSpec.EnableParallelNodeOperations == nil {
+				return new(false)
 			}
 
-			return pointer.Ptr(scyllav1alpha1.BootstrapPolicy(*scSpec.BootstrapPolicy))
+			return new(*scSpec.EnableParallelNodeOperations)
 		}(),
 	}, apimachineryutilerrors.NewAggregate(migrateErrs)
 }

--- a/pkg/controller/scyllacluster/migrate_test.go
+++ b/pkg/controller/scyllacluster/migrate_test.go
@@ -309,41 +309,41 @@ func TestMigrateV1ScyllaClusterToV1Alpha1ScyllaDBDatacenter(t *testing.T) {
 			},
 		},
 		{
-			name: "unset bootstrapPolicy is migrated into Sequential",
+			name: "unset enableParallelNodeOperations is migrated into false",
 			scyllaCluster: func() *scyllav1.ScyllaCluster {
 				sc := newBasicScyllaCluster()
-				sc.Spec.BootstrapPolicy = nil
+				sc.Spec.EnableParallelNodeOperations = nil
 				return sc
 			}(),
 			expectedScyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sd := newBasicScyllaDBDatacenterWithNoStatus()
-				sd.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				sd.Spec.EnableParallelNodeOperations = new(false)
 				return sd
 			}(),
 		},
 		{
-			name: "explicit Sequential bootstrapPolicy is migrated verbatim",
+			name: "explicit false enableParallelNodeOperations is migrated verbatim",
 			scyllaCluster: func() *scyllav1.ScyllaCluster {
 				sc := newBasicScyllaCluster()
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicySequential)
+				sc.Spec.EnableParallelNodeOperations = new(false)
 				return sc
 			}(),
 			expectedScyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sd := newBasicScyllaDBDatacenterWithNoStatus()
-				sd.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential)
+				sd.Spec.EnableParallelNodeOperations = new(false)
 				return sd
 			}(),
 		},
 		{
-			name: "explicit Parallel bootstrapPolicy is migrated verbatim",
+			name: "explicit true enableParallelNodeOperations is migrated verbatim",
 			scyllaCluster: func() *scyllav1.ScyllaCluster {
 				sc := newBasicScyllaCluster()
-				sc.Spec.BootstrapPolicy = pointer.Ptr(scyllav1.BootstrapPolicyParallel)
+				sc.Spec.EnableParallelNodeOperations = new(true)
 				return sc
 			}(),
 			expectedScyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sd := newBasicScyllaDBDatacenterWithNoStatus()
-				sd.Spec.BootstrapPolicy = pointer.Ptr(scyllav1alpha1.BootstrapPolicyParallel)
+				sd.Spec.EnableParallelNodeOperations = new(true)
 				return sd
 			}(),
 		},
@@ -744,7 +744,7 @@ func newBasicScyllaDBDatacenterWithStatus() *scyllav1alpha1.ScyllaDBDatacenter {
 					Name:         "a",
 				},
 			},
-			BootstrapPolicy: pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential),
+			EnableParallelNodeOperations: new(false),
 		},
 		Status: scyllav1alpha1.ScyllaDBDatacenterStatus{
 			ObservedGeneration: pointer.Ptr[int64](123),

--- a/pkg/controller/scylladbcluster/resource.go
+++ b/pkg/controller/scylladbcluster/resource.go
@@ -294,10 +294,10 @@ func MakeRemoteScyllaDBDatacenters(sc *scyllav1alpha1.ScyllaDBCluster, dc *scyll
 			MinTerminationGracePeriodSeconds:        sc.Spec.MinTerminationGracePeriodSeconds,
 			MinReadySeconds:                         sc.Spec.MinReadySeconds,
 			ReadinessGates:                          sc.Spec.ReadinessGates,
-			// A managed ScyllaDBDatacenter always carries an explicit bootstrapPolicy.
+			// A managed ScyllaDBDatacenter always carries an explicit enableParallelNodeOperations.
 			// ScyllaDBCluster has no equivalent field, as bootstrapping nodes in parallel is not supported in automated
-			// multi-datacenter deployments, hence it's always resolved to Sequential.
-			BootstrapPolicy: pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential),
+			// multi-datacenter deployments, hence it's always resolved to false.
+			EnableParallelNodeOperations: new(false),
 			// TODO: not supported yet
 			// Ref: https://github.com/scylladb/scylla-operator/issues/2262
 			ImagePullSecrets: nil,

--- a/pkg/controller/scylladbcluster/resource_test.go
+++ b/pkg/controller/scylladbcluster/resource_test.go
@@ -565,7 +565,7 @@ func TestMakeScyllaDBDatacenters(t *testing.T) {
 						Name: "c",
 					},
 				},
-				BootstrapPolicy: pointer.Ptr(scyllav1alpha1.BootstrapPolicySequential),
+				EnableParallelNodeOperations: new(false),
 			},
 		}
 	}

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -340,53 +340,44 @@ func getServicePorts(sdc *scyllav1alpha1.ScyllaDBDatacenter) ([]corev1.ServicePo
 
 // getPodManagementPolicy resolves the PodManagementPolicyType for StatefulSets of a given ScyllaDBDatacenter.
 func getPodManagementPolicy(sdc *scyllav1alpha1.ScyllaDBDatacenter) (appsv1.PodManagementPolicyType, error) {
-	bootstrapPolicy, err := effectiveBootstrapPolicy(sdc)
+	parallelNodeOperationsEnabled, err := effectiveParallelNodeOperationsEnabled(sdc)
 	if err != nil {
-		return "", fmt.Errorf("can't get effective bootstrap policy: %w", err)
+		return "", fmt.Errorf("can't determine effective parallel node operations enablement: %w", err)
 	}
 
-	if bootstrapPolicy == scyllav1alpha1.BootstrapPolicyParallel {
+	if parallelNodeOperationsEnabled {
 		return appsv1.ParallelPodManagement, nil
 	}
 
 	return appsv1.OrderedReadyPodManagement, nil
 }
 
-// effectiveBootstrapPolicy resolves the bootstrap policy of the given ScyllaDBDatacenter.
-func effectiveBootstrapPolicy(sdc *scyllav1alpha1.ScyllaDBDatacenter) (scyllav1alpha1.BootstrapPolicy, error) {
-	if sdc.Spec.BootstrapPolicy == nil {
-		return scyllav1alpha1.BootstrapPolicySequential, nil
+// effectiveParallelNodeOperationsEnabled resolves whether parallel node operations are effectively enabled for the
+// given ScyllaDBDatacenter.
+func effectiveParallelNodeOperationsEnabled(sdc *scyllav1alpha1.ScyllaDBDatacenter) (bool, error) {
+	if sdc.Spec.EnableParallelNodeOperations == nil || !*sdc.Spec.EnableParallelNodeOperations {
+		return false, nil
 	}
 
-	switch *sdc.Spec.BootstrapPolicy {
-	case scyllav1alpha1.BootstrapPolicySequential:
-		return scyllav1alpha1.BootstrapPolicySequential, nil
-
-	case scyllav1alpha1.BootstrapPolicyParallel:
-		scyllaDBVersion, err := naming.ImageToVersion(sdc.Spec.ScyllaDB.Image)
-		if err != nil {
-			return "", fmt.Errorf("can't get version of image %q: %w", sdc.Spec.ScyllaDB.Image, err)
-		}
-
-		// A ScyllaDB version lower than the one required for parallel bootstrap shouldn't get past admission, which
-		// rejects it on both create and update. This is only a sanity check guarding against version skew, e.g. a
-		// bypassed or failing webhook. A version which can't be parsed is deliberately treated as not supporting
-		// parallel bootstrap.
-		if !semver.NewScyllaVersion(scyllaDBVersion).SupportFeatureSafe(semver.ScyllaDBVersionRequiredForParallelBootstrap) {
-			return "", fmt.Errorf(
-				"bootstrap policy %q requires a semver-parseable ScyllaDB version >= %d.%d, got %q",
-				scyllav1alpha1.BootstrapPolicyParallel,
-				semver.ScyllaDBVersionRequiredForParallelBootstrap.Major,
-				semver.ScyllaDBVersionRequiredForParallelBootstrap.Minor,
-				scyllaDBVersion,
-			)
-		}
-
-		return scyllav1alpha1.BootstrapPolicyParallel, nil
-
-	default:
-		return "", fmt.Errorf("unsupported bootstrap policy %q", *sdc.Spec.BootstrapPolicy)
+	scyllaDBVersion, err := naming.ImageToVersion(sdc.Spec.ScyllaDB.Image)
+	if err != nil {
+		return false, fmt.Errorf("can't get version of image %q: %w", sdc.Spec.ScyllaDB.Image, err)
 	}
+
+	// A ScyllaDB version lower than the one required for parallel bootstrap shouldn't get past admission, which
+	// rejects it on both create and update. This is only a sanity check guarding against version skew, e.g. a
+	// bypassed or failing webhook. A version which can't be parsed is deliberately treated as not supporting
+	// parallel bootstrap.
+	if !semver.NewScyllaVersion(scyllaDBVersion).SupportFeatureSafe(semver.ScyllaDBVersionRequiredForParallelBootstrap) {
+		return false, fmt.Errorf(
+			"parallel node operations require a semver-parseable ScyllaDB version >= %d.%d, got %q",
+			semver.ScyllaDBVersionRequiredForParallelBootstrap.Major,
+			semver.ScyllaDBVersionRequiredForParallelBootstrap.Minor,
+			scyllaDBVersion,
+		)
+	}
+
+	return true, nil
 }
 
 // StatefulSetForRack make a StatefulSet for the rack.

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -2185,12 +2185,12 @@ exec scylla-manager-agent \
 			expectedError: nil,
 		},
 		{
-			name: "new StatefulSet with sequential bootstrap policy uses OrderedReady pod management",
+			name: "new StatefulSet with parallel node operations disabled uses OrderedReady pod management",
 			rack: newBasicRack(),
 			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newBasicScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
-				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicySequential)
+				sdc.Spec.EnableParallelNodeOperations = new(false)
 				return sdc
 			}(),
 			existingStatefulSet: nil,
@@ -2212,12 +2212,12 @@ exec scylla-manager-agent \
 			expectedError: nil,
 		},
 		{
-			name: "new StatefulSet with parallel bootstrap policy uses Parallel pod management",
+			name: "new StatefulSet with parallel node operations enabled uses Parallel pod management",
 			rack: newBasicRack(),
 			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newBasicScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
-				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			existingStatefulSet: nil,
@@ -2239,17 +2239,17 @@ exec scylla-manager-agent \
 			expectedError: nil,
 		},
 		{
-			name: "parallel bootstrap policy with an unsupported ScyllaDB version errors out",
+			name: "enabled parallel node operations with an unsupported ScyllaDB version error out",
 			rack: newBasicRack(),
 			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newBasicScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageBelowParallelBootstrapThreshold
-				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			existingStatefulSet: nil,
 			expectedStatefulSet: nil,
-			expectedError:       fmt.Errorf(`can't get pod management policy: %w`, fmt.Errorf(`can't get effective bootstrap policy: %w`, fmt.Errorf(`bootstrap policy "Parallel" requires a semver-parseable ScyllaDB version >= 2026.2, got "2026.1.0"`))),
+			expectedError:       fmt.Errorf(`can't get pod management policy: %w`, fmt.Errorf(`can't determine effective parallel node operations enablement: %w`, fmt.Errorf(`parallel node operations require a semver-parseable ScyllaDB version >= 2026.2, got "2026.1.0"`))),
 		},
 	}
 
@@ -2290,10 +2290,10 @@ func TestStatefulSetForRack(t *testing.T) {
 	}
 }
 
-func Test_effectiveBootstrapPolicy(t *testing.T) {
+func Test_effectiveParallelNodeOperationsEnabled(t *testing.T) {
 	t.Parallel()
 
-	newSDC := func(bootstrapPolicy *scyllav1alpha1.BootstrapPolicy, image string) *scyllav1alpha1.ScyllaDBDatacenter {
+	newSDC := func(enableParallelNodeOperations *bool, image string) *scyllav1alpha1.ScyllaDBDatacenter {
 		return &scyllav1alpha1.ScyllaDBDatacenter{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "basic",
@@ -2303,64 +2303,58 @@ func Test_effectiveBootstrapPolicy(t *testing.T) {
 				ScyllaDB: scyllav1alpha1.ScyllaDB{
 					Image: image,
 				},
-				BootstrapPolicy: bootstrapPolicy,
+				EnableParallelNodeOperations: enableParallelNodeOperations,
 			},
 		}
 	}
 
 	tt := []struct {
-		name                    string
-		scyllaDBDatacenter      *scyllav1alpha1.ScyllaDBDatacenter
-		expectedBootstrapPolicy scyllav1alpha1.BootstrapPolicy
-		expectedErrorString     string
+		name                                  string
+		scyllaDBDatacenter                    *scyllav1alpha1.ScyllaDBDatacenter
+		expectedParallelNodeOperationsEnabled bool
+		expectedErrorString                   string
 	}{
 		{
-			name:                    "unset policy is sequential",
-			scyllaDBDatacenter:      newSDC(nil, unit.ScyllaDBImageAtParallelBootstrapThreshold),
-			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicySequential,
-			expectedErrorString:     "",
+			name:                                  "unset field is disabled",
+			scyllaDBDatacenter:                    newSDC(nil, unit.ScyllaDBImageAtParallelBootstrapThreshold),
+			expectedParallelNodeOperationsEnabled: false,
+			expectedErrorString:                   "",
 		},
 		{
-			name:                    "sequential policy is sequential",
-			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicySequential), unit.ScyllaDBImageAtParallelBootstrapThreshold),
-			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicySequential,
-			expectedErrorString:     "",
+			name:                                  "disabled stays disabled",
+			scyllaDBDatacenter:                    newSDC(new(false), unit.ScyllaDBImageAtParallelBootstrapThreshold),
+			expectedParallelNodeOperationsEnabled: false,
+			expectedErrorString:                   "",
 		},
 		{
-			name:                    "sequential policy is sequential regardless of an unparseable version",
-			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicySequential), unit.ScyllaDBImage),
-			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicySequential,
-			expectedErrorString:     "",
+			name:                                  "disabled stays disabled regardless of an unparseable version",
+			scyllaDBDatacenter:                    newSDC(new(false), unit.ScyllaDBImage),
+			expectedParallelNodeOperationsEnabled: false,
+			expectedErrorString:                   "",
 		},
 		{
-			name:                    "parallel policy is parallel at the required version",
-			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicyParallel), unit.ScyllaDBImageAtParallelBootstrapThreshold),
-			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicyParallel,
-			expectedErrorString:     "",
+			name:                                  "enabled stays enabled at the required version",
+			scyllaDBDatacenter:                    newSDC(new(true), unit.ScyllaDBImageAtParallelBootstrapThreshold),
+			expectedParallelNodeOperationsEnabled: true,
+			expectedErrorString:                   "",
 		},
 		{
-			name:                    "parallel policy is parallel above the required version",
-			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicyParallel), unit.ScyllaDBImageAboveNodeExporterThreshold),
-			expectedBootstrapPolicy: scyllav1alpha1.BootstrapPolicyParallel,
-			expectedErrorString:     "",
+			name:                                  "enabled stays enabled above the required version",
+			scyllaDBDatacenter:                    newSDC(new(true), unit.ScyllaDBImageAboveNodeExporterThreshold),
+			expectedParallelNodeOperationsEnabled: true,
+			expectedErrorString:                   "",
 		},
 		{
-			name:                    "parallel policy errors out below the required version",
-			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicyParallel), unit.ScyllaDBImageBelowParallelBootstrapThreshold),
-			expectedBootstrapPolicy: "",
-			expectedErrorString:     `bootstrap policy "Parallel" requires a semver-parseable ScyllaDB version >= 2026.2, got "2026.1.0"`,
+			name:                                  "enabled errors out below the required version",
+			scyllaDBDatacenter:                    newSDC(new(true), unit.ScyllaDBImageBelowParallelBootstrapThreshold),
+			expectedParallelNodeOperationsEnabled: false,
+			expectedErrorString:                   `parallel node operations require a semver-parseable ScyllaDB version >= 2026.2, got "2026.1.0"`,
 		},
 		{
-			name:                    "parallel policy errors out with an unparseable version",
-			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicyParallel), unit.ScyllaDBImage),
-			expectedBootstrapPolicy: "",
-			expectedErrorString:     `bootstrap policy "Parallel" requires a semver-parseable ScyllaDB version >= 2026.2, got "latest"`,
-		},
-		{
-			name:                    "unsupported policy errors out",
-			scyllaDBDatacenter:      newSDC(new(scyllav1alpha1.BootstrapPolicy("Unsupported")), unit.ScyllaDBImageAtParallelBootstrapThreshold),
-			expectedBootstrapPolicy: "",
-			expectedErrorString:     `unsupported bootstrap policy "Unsupported"`,
+			name:                                  "enabled errors out with an unparseable version",
+			scyllaDBDatacenter:                    newSDC(new(true), unit.ScyllaDBImage),
+			expectedParallelNodeOperationsEnabled: false,
+			expectedErrorString:                   `parallel node operations require a semver-parseable ScyllaDB version >= 2026.2, got "latest"`,
 		},
 	}
 
@@ -2368,7 +2362,7 @@ func Test_effectiveBootstrapPolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := effectiveBootstrapPolicy(tc.scyllaDBDatacenter)
+			got, err := effectiveParallelNodeOperationsEnabled(tc.scyllaDBDatacenter)
 
 			errString := ""
 			if err != nil {
@@ -2378,8 +2372,8 @@ func Test_effectiveBootstrapPolicy(t *testing.T) {
 				t.Fatalf("expected and got error strings differ: %s", cmp.Diff(tc.expectedErrorString, errString))
 			}
 
-			if got != tc.expectedBootstrapPolicy {
-				t.Errorf("expected bootstrap policy %q, got %q", tc.expectedBootstrapPolicy, got)
+			if got != tc.expectedParallelNodeOperationsEnabled {
+				t.Errorf("expected parallel node operations enabled to be %t, got %t", tc.expectedParallelNodeOperationsEnabled, got)
 			}
 		})
 	}

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -437,8 +437,8 @@ func (sdcc *Controller) checkExistingStatefulSetsRolloutStatus(
 }
 
 // createMissingStatefulSets creates the missing StatefulSets from requiredStatefulSets.
-// Existing StatefulSets are skipped. With the Sequential bootstrap policy at most one missing StatefulSet is created so
-// that racks bootstrap one by one, while with the Parallel one all of them are created at once.
+// Existing StatefulSets are skipped. With parallel node operations disabled at most one missing StatefulSet is created
+// so that racks bootstrap one by one, while with parallel node operations enabled all of them are created at once.
 // It returns the StatefulSets created so far and their progressing conditions, together with an error if a creation
 // failed.
 func createMissingStatefulSets(
@@ -448,9 +448,9 @@ func createMissingStatefulSets(
 	requiredStatefulSets []*appsv1.StatefulSet,
 	statefulSets map[string]*appsv1.StatefulSet,
 ) ([]*appsv1.StatefulSet, []metav1.Condition, error) {
-	bootstrapPolicy, err := effectiveBootstrapPolicy(sdc)
+	parallelNodeOperationsEnabled, err := effectiveParallelNodeOperationsEnabled(sdc)
 	if err != nil {
-		return nil, nil, fmt.Errorf("can't get effective bootstrap policy: %w", err)
+		return nil, nil, fmt.Errorf("can't determine effective parallel node operations enablement: %w", err)
 	}
 
 	createdStatefulSets := make([]*appsv1.StatefulSet, 0)
@@ -475,7 +475,7 @@ func createMissingStatefulSets(
 		createdStatefulSets = append(createdStatefulSets, sts)
 		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, statefulSetControllerProgressingCondition, req, "apply", sdc.Generation)
 
-		if bootstrapPolicy != scyllav1alpha1.BootstrapPolicyParallel {
+		if !parallelNodeOperationsEnabled {
 			// StatefulSets must be created sequentially. Return early.
 			return createdStatefulSets, progressingConditions, nil
 		}

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
@@ -109,12 +109,12 @@ func Test_createMissingStatefulSets(t *testing.T) {
 			expectedErrorString: `can't create missing statefulset "default/foo": apply failed`,
 		},
 		{
-			name: "returns the StatefulSets created before an apply error with parallel bootstrap policy",
+			name: "returns the StatefulSets created before an apply error with parallel node operations enabled",
 			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newScyllaDBDatacenter()
 				sdc.Generation = 3
 				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
-				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			required: []*appsv1.StatefulSet{
@@ -151,12 +151,12 @@ func Test_createMissingStatefulSets(t *testing.T) {
 			expectedErrorString: `can't create missing statefulset "default/bar": apply failed`,
 		},
 		{
-			name: "creates all missing StatefulSets with parallel bootstrap policy",
+			name: "creates all missing StatefulSets with parallel node operations enabled",
 			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newScyllaDBDatacenter()
 				sdc.Generation = 3
 				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
-				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			required: []*appsv1.StatefulSet{
@@ -190,12 +190,12 @@ func Test_createMissingStatefulSets(t *testing.T) {
 			expectedErrorString: "",
 		},
 		{
-			name: "creates only the missing StatefulSets with parallel bootstrap policy",
+			name: "creates only the missing StatefulSets with parallel node operations enabled",
 			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newScyllaDBDatacenter()
 				sdc.Generation = 3
 				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
-				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			required: []*appsv1.StatefulSet{
@@ -226,11 +226,11 @@ func Test_createMissingStatefulSets(t *testing.T) {
 			expectedErrorString: "",
 		},
 		{
-			name: "returns an error with parallel bootstrap policy and an unsupported ScyllaDB version",
+			name: "returns an error with parallel node operations enabled and an unsupported ScyllaDB version",
 			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newScyllaDBDatacenter()
 				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageBelowParallelBootstrapThreshold
-				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+				sdc.Spec.EnableParallelNodeOperations = new(true)
 				return sdc
 			}(),
 			required: []*appsv1.StatefulSet{
@@ -243,7 +243,7 @@ func Test_createMissingStatefulSets(t *testing.T) {
 			},
 			expectedCreated:     nil,
 			expectedConditions:  nil,
-			expectedErrorString: `can't get effective bootstrap policy: bootstrap policy "Parallel" requires a semver-parseable ScyllaDB version >= 2026.2, got "2026.1.0"`,
+			expectedErrorString: `can't determine effective parallel node operations enablement: parallel node operations require a semver-parseable ScyllaDB version >= 2026.2, got "2026.1.0"`,
 		},
 	}
 

--- a/pkg/semver/version.go
+++ b/pkg/semver/version.go
@@ -57,8 +57,9 @@ func (sv ScyllaVersion) SupportFeatureSafe(featureVersion semver.Version) bool {
 // SupportsParallelBootstrap returns whether the given ScyllaDB version supports bootstrapping nodes in parallel.
 // A version which can't be parsed, e.g. one of an image pinned by a digest, is deliberately treated as not supporting
 // it, so that parallel bootstrap is only ever enabled for versions known to support it.
-// This is the single predicate both the validation of an explicitly set bootstrapPolicy and its create time defaulting
-// are evaluated against, so that the defaulting can never stamp a value the validation rejects.
+// This is the single predicate both the validation of an explicitly enabled enableParallelNodeOperations and its
+// create time defaulting are evaluated against, so that the defaulting can never stamp a value the validation
+// rejects.
 func SupportsParallelBootstrap(scyllaDBVersion string) bool {
 	return NewScyllaVersion(scyllaDBVersion).SupportFeatureSafe(ScyllaDBVersionRequiredForParallelBootstrap)
 }

--- a/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scyllacluster.yaml.tmpl
@@ -8,8 +8,8 @@ metadata:
    bar: foo
 spec:
   agentVersion: "{{ .scyllaDBManagerVersion }}"
-  {{- if .bootstrapPolicy }}
-  bootstrapPolicy: {{ .bootstrapPolicy }}
+  {{- if .enableParallelNodeOperations }}
+  enableParallelNodeOperations: {{ .enableParallelNodeOperations }}
   {{- end }}
   repository: "{{ .scyllaDBRepository }}"
   version: "{{ .scyllaDBVersion }}"

--- a/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
+++ b/test/e2e/fixture/scylla/scylladbdatacenter.yaml.tmpl
@@ -9,8 +9,8 @@ metadata:
 spec:
   clusterName: basic
   datacenterName: us-east-1
-  {{- if .bootstrapPolicy }}
-  bootstrapPolicy: {{ .bootstrapPolicy }}
+  {{- if .enableParallelNodeOperations }}
+  enableParallelNodeOperations: {{ .enableParallelNodeOperations }}
   {{- end }}
   scyllaDB:
     image: "{{ .scyllaDBImageRef }}"

--- a/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
+++ b/test/e2e/fixture/scylla/zonal.scyllacluster.yaml.tmpl
@@ -8,8 +8,8 @@ metadata:
    bar: foo
 spec:
   agentVersion: "{{ .scyllaDBManagerVersion }}"
-  {{- if .bootstrapPolicy }}
-  bootstrapPolicy: {{ .bootstrapPolicy }}
+  {{- if .enableParallelNodeOperations }}
+  enableParallelNodeOperations: {{ .enableParallelNodeOperations }}
   {{- end }}
   repository: "{{ .scyllaDBRepository }}"
   version: "{{ .scyllaDBVersion }}"

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -216,15 +216,15 @@ func scyllaDBTargetRepositoryVersion() (string, string) {
 func (f *Framework) GetDefaultScyllaCluster() *scyllav1.ScyllaCluster {
 	scyllaDBRepository, scyllaDBVersion := scyllaDBTargetRepositoryVersion()
 	renderArgs := map[string]any{
-		"scyllaDBRepository":          scyllaDBRepository,
-		"scyllaDBVersion":             scyllaDBVersion,
-		"scyllaDBManagerVersion":      TestContext.ScyllaDBManagerAgentVersion,
-		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
-		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
-		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
-		"storageClassName":            TestContext.ScyllaClusterOptions.StorageClassName,
-		"scyllaArgs":                  TestContext.ScyllaClusterOptions.ScyllaArgs(),
-		"bootstrapPolicy":             TestContext.ScyllaClusterOptions.BootstrapPolicy,
+		"scyllaDBRepository":           scyllaDBRepository,
+		"scyllaDBVersion":              scyllaDBVersion,
+		"scyllaDBManagerVersion":       TestContext.ScyllaDBManagerAgentVersion,
+		"nodeServiceType":              TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
+		"nodesBroadcastAddressType":    TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
+		"clientsBroadcastAddressType":  TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
+		"storageClassName":             TestContext.ScyllaClusterOptions.StorageClassName,
+		"scyllaArgs":                   TestContext.ScyllaClusterOptions.ScyllaArgs(),
+		"enableParallelNodeOperations": TestContext.ScyllaClusterOptions.EnableParallelNodeOperations,
 	}
 
 	sc, _, err := scyllafixture.ScyllaClusterTemplate.RenderObject(renderArgs)
@@ -246,16 +246,16 @@ func (f *Framework) GetNonDevModeScyllaCluster() *scyllav1.ScyllaCluster {
 func (f *Framework) GetDefaultZonalScyllaClusterWithThreeRacks() *scyllav1.ScyllaCluster {
 	scyllaDBRepository, scyllaDBVersion := scyllaDBTargetRepositoryVersion()
 	renderArgs := map[string]any{
-		"scyllaDBRepository":          scyllaDBRepository,
-		"scyllaDBVersion":             scyllaDBVersion,
-		"scyllaDBManagerVersion":      TestContext.ScyllaDBManagerAgentVersion,
-		"nodeServiceType":             TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
-		"nodesBroadcastAddressType":   TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
-		"clientsBroadcastAddressType": TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
-		"storageClassName":            TestContext.ScyllaClusterOptions.StorageClassName,
-		"scyllaArgs":                  TestContext.ScyllaClusterOptions.ScyllaArgs(),
-		"rackNames":                   []string{"a", "b", "c"},
-		"bootstrapPolicy":             TestContext.ScyllaClusterOptions.BootstrapPolicy,
+		"scyllaDBRepository":           scyllaDBRepository,
+		"scyllaDBVersion":              scyllaDBVersion,
+		"scyllaDBManagerVersion":       TestContext.ScyllaDBManagerAgentVersion,
+		"nodeServiceType":              TestContext.ScyllaClusterOptions.ExposeOptions.NodeServiceType,
+		"nodesBroadcastAddressType":    TestContext.ScyllaClusterOptions.ExposeOptions.NodesBroadcastAddressType,
+		"clientsBroadcastAddressType":  TestContext.ScyllaClusterOptions.ExposeOptions.ClientsBroadcastAddressType,
+		"storageClassName":             TestContext.ScyllaClusterOptions.StorageClassName,
+		"scyllaArgs":                   TestContext.ScyllaClusterOptions.ScyllaArgs(),
+		"rackNames":                    []string{"a", "b", "c"},
+		"enableParallelNodeOperations": TestContext.ScyllaClusterOptions.EnableParallelNodeOperations,
 	}
 
 	sc, _, err := scyllafixture.ZonalScyllaClusterTemplate.RenderObject(renderArgs)
@@ -274,7 +274,7 @@ func (f *Framework) GetDefaultScyllaDBDatacenter() *scyllav1alpha1.ScyllaDBDatac
 		"storageClassName":               TestContext.ScyllaClusterOptions.StorageClassName,
 		"scyllaArgs":                     TestContext.ScyllaClusterOptions.ScyllaArgs(),
 		"scyllaDBManagerAgentRepository": configassets.ScyllaDBManagerAgentImageRepository,
-		"bootstrapPolicy":                TestContext.ScyllaClusterOptions.BootstrapPolicy,
+		"enableParallelNodeOperations":   TestContext.ScyllaClusterOptions.EnableParallelNodeOperations,
 	}
 
 	sdc, _, err := scyllafixture.ScyllaDBDatacenterTemplate.RenderObject(renderArgs)

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -24,10 +24,10 @@ type IngressController struct {
 }
 
 type ScyllaClusterOptions struct {
-	ExposeOptions    ExposeOptions
-	StorageClassName string
-	ReactorBackend   string
-	BootstrapPolicy  string
+	ExposeOptions                ExposeOptions
+	StorageClassName             string
+	ReactorBackend               string
+	EnableParallelNodeOperations string
 }
 
 func (o *ScyllaClusterOptions) ScyllaArgs() []string {

--- a/test/e2e/set/scyllacluster/scyllacluster_defaulting.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_defaulting.go
@@ -7,7 +7,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/semver"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,34 +19,33 @@ var _ = g.Describe("ScyllaCluster's mutating admission webhook", framework.Suite
 		f = framework.NewFramework(ctx, "scyllacluster")
 	})
 
-	g.It("should default bootstrapPolicy on creation", func(ctx g.SpecContext) {
+	g.It("should default enableParallelNodeOperations on creation", func(ctx g.SpecContext) {
 		sc := f.GetDefaultScyllaCluster()
-		// The fixture carries an explicit bootstrapPolicy when the suite is invoked with one.
-		sc.Spec.BootstrapPolicy = nil
+		// The fixture carries an explicit enableParallelNodeOperations when the suite is invoked with one.
+		sc.Spec.EnableParallelNodeOperations = nil
 
-		// Parallel is only stamped for ScyllaDB versions known to support bootstrapping nodes in parallel, and
-		// Sequential is never stamped, so the expected value depends on the version under test. It's deliberately
-		// not hardcoded: the version can carry a digest, which makes it unparseable and hence not supporting
-		// parallel bootstrap.
-		var expectedBootstrapPolicy *scyllav1.BootstrapPolicy
+		// true is only stamped for ScyllaDB versions known to support bootstrapping nodes in parallel, and false is
+		// never stamped, so the expected value depends on the version under test. It's deliberately not hardcoded:
+		// the version can carry a digest, which makes it unparseable and hence not supporting parallel bootstrap.
+		var expectedEnableParallelNodeOperations *bool
 		if semver.SupportsParallelBootstrap(sc.Spec.Version) {
-			expectedBootstrapPolicy = new(scyllav1.BootstrapPolicyParallel)
+			expectedEnableParallelNodeOperations = new(true)
 		}
 
-		framework.By("Creating a ScyllaCluster without a bootstrapPolicy")
+		framework.By("Creating a ScyllaCluster without enableParallelNodeOperations")
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Spec.BootstrapPolicy).To(o.Equal(expectedBootstrapPolicy))
+		o.Expect(sc.Spec.EnableParallelNodeOperations).To(o.Equal(expectedEnableParallelNodeOperations))
 	})
 
-	g.It("should preserve an explicitly set bootstrapPolicy on creation", func(ctx g.SpecContext) {
+	g.It("should preserve an explicitly set enableParallelNodeOperations on creation", func(ctx g.SpecContext) {
 		sc := f.GetDefaultScyllaCluster()
-		// Sequential is valid for every ScyllaDB version, so this holds regardless of the version under test.
-		sc.Spec.BootstrapPolicy = new(scyllav1.BootstrapPolicySequential)
+		// false is valid for every ScyllaDB version, so this holds regardless of the version under test.
+		sc.Spec.EnableParallelNodeOperations = new(false)
 
-		framework.By("Creating a ScyllaCluster with an explicit bootstrapPolicy")
+		framework.By("Creating a ScyllaCluster with an explicit enableParallelNodeOperations")
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sc.Spec.BootstrapPolicy).To(o.Equal(new(scyllav1.BootstrapPolicySequential)))
+		o.Expect(sc.Spec.EnableParallelNodeOperations).To(o.Equal(new(false)))
 	})
 })

--- a/test/e2e/set/scylladbdatacenter/scylladbdatacenter_defaulting.go
+++ b/test/e2e/set/scylladbdatacenter/scylladbdatacenter_defaulting.go
@@ -7,7 +7,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/semver"
 	"github.com/scylladb/scylla-operator/test/e2e/framework"
@@ -21,36 +20,36 @@ var _ = g.Describe("ScyllaDBDatacenter's mutating admission webhook", framework.
 		f = framework.NewFramework(ctx, "scylladbdatacenter")
 	})
 
-	g.It("should default bootstrapPolicy on creation", func(ctx g.SpecContext) {
+	g.It("should default enableParallelNodeOperations on creation", func(ctx g.SpecContext) {
 		sdc := f.GetDefaultScyllaDBDatacenter()
-		// The fixture carries an explicit bootstrapPolicy when the suite is invoked with one.
-		sdc.Spec.BootstrapPolicy = nil
+		// The fixture carries an explicit enableParallelNodeOperations when the suite is invoked with one.
+		sdc.Spec.EnableParallelNodeOperations = nil
 
-		// Parallel is only stamped for ScyllaDB versions known to support bootstrapping nodes in parallel, and
-		// Sequential is never stamped, so the expected value depends on the image under test. It's deliberately not
-		// hardcoded: the tag the tests run against doesn't have to be a semver-parseable version.
+		// true is only stamped for ScyllaDB versions known to support bootstrapping nodes in parallel, and false is
+		// never stamped, so the expected value depends on the image under test. It's deliberately not hardcoded: the
+		// tag the tests run against doesn't have to be a semver-parseable version.
 		scyllaDBVersion, err := naming.ImageToVersion(sdc.Spec.ScyllaDB.Image)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		var expectedBootstrapPolicy *scyllav1alpha1.BootstrapPolicy
+		var expectedEnableParallelNodeOperations *bool
 		if semver.SupportsParallelBootstrap(scyllaDBVersion) {
-			expectedBootstrapPolicy = new(scyllav1alpha1.BootstrapPolicyParallel)
+			expectedEnableParallelNodeOperations = new(true)
 		}
 
-		framework.By("Creating a ScyllaDBDatacenter without a bootstrapPolicy")
+		framework.By("Creating a ScyllaDBDatacenter without enableParallelNodeOperations")
 		sdc, err = f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBDatacenters(f.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sdc.Spec.BootstrapPolicy).To(o.Equal(expectedBootstrapPolicy))
+		o.Expect(sdc.Spec.EnableParallelNodeOperations).To(o.Equal(expectedEnableParallelNodeOperations))
 	})
 
-	g.It("should preserve an explicitly set bootstrapPolicy on creation", func(ctx g.SpecContext) {
+	g.It("should preserve an explicitly set enableParallelNodeOperations on creation", func(ctx g.SpecContext) {
 		sdc := f.GetDefaultScyllaDBDatacenter()
-		// Sequential is valid for every ScyllaDB version, so this holds regardless of the image under test.
-		sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicySequential)
+		// false is valid for every ScyllaDB version, so this holds regardless of the image under test.
+		sdc.Spec.EnableParallelNodeOperations = new(false)
 
-		framework.By("Creating a ScyllaDBDatacenter with an explicit bootstrapPolicy")
+		framework.By("Creating a ScyllaDBDatacenter with an explicit enableParallelNodeOperations")
 		sdc, err := f.ScyllaAdminClient().ScyllaV1alpha1().ScyllaDBDatacenters(f.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sdc.Spec.BootstrapPolicy).To(o.Equal(new(scyllav1alpha1.BootstrapPolicySequential)))
+		o.Expect(sdc.Spec.EnableParallelNodeOperations).To(o.Equal(new(false)))
 	})
 })

--- a/test/e2e/set/scylladbdatacenter/scylladbdatacenter_parallelnodeoperations.go
+++ b/test/e2e/set/scylladbdatacenter/scylladbdatacenter_parallelnodeoperations.go
@@ -50,31 +50,31 @@ var _ = g.Describe("ScyllaDBDatacenter", framework.SuiteParallel, framework.Suit
 	}
 
 	type entry struct {
-		initialBootstrapPolicy scyllav1alpha1.BootstrapPolicy
-		targetBootstrapPolicy  scyllav1alpha1.BootstrapPolicy
+		initialEnableParallelNodeOperations bool
+		targetEnableParallelNodeOperations  bool
 	}
 
 	describeEntry := func(e *entry) string {
-		return fmt.Sprintf("from %s to %s", e.initialBootstrapPolicy, e.targetBootstrapPolicy)
+		return fmt.Sprintf("from %t to %t", e.initialEnableParallelNodeOperations, e.targetEnableParallelNodeOperations)
 	}
 
-	podManagementPolicyForBootstrapPolicy := func(bootstrapPolicy scyllav1alpha1.BootstrapPolicy) appsv1.PodManagementPolicyType {
-		if bootstrapPolicy == scyllav1alpha1.BootstrapPolicyParallel {
+	podManagementPolicyForEnableParallelNodeOperations := func(enableParallelNodeOperations bool) appsv1.PodManagementPolicyType {
+		if enableParallelNodeOperations {
 			return appsv1.ParallelPodManagement
 		}
 
 		return appsv1.OrderedReadyPodManagement
 	}
 
-	g.DescribeTable("should recreate StatefulSets without disrupting nodes when the bootstrap policy is changed",
+	g.DescribeTable("should recreate StatefulSets without disrupting nodes when parallel node operations are toggled",
 		func(ctx g.SpecContext, e *entry) {
 			ns, nsClient, ok := f.DefaultNamespaceIfAny()
 			o.Expect(ok).To(o.BeTrue())
 
 			sdc := f.GetDefaultScyllaDBDatacenter()
-			sdc.Spec.BootstrapPolicy = &e.initialBootstrapPolicy
+			sdc.Spec.EnableParallelNodeOperations = &e.initialEnableParallelNodeOperations
 
-			framework.By("Creating a ScyllaDBDatacenter with the %s bootstrap policy", e.initialBootstrapPolicy)
+			framework.By("Creating a ScyllaDBDatacenter with parallel node operations enabled=%t", e.initialEnableParallelNodeOperations)
 			sdc, err := nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(ns.Name).Create(ctx, sdc, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -86,12 +86,12 @@ var _ = g.Describe("ScyllaDBDatacenter", framework.SuiteParallel, framework.Suit
 			scylladbdatacenterverification.Verify(ctx, nsClient.KubeClient(), nsClient.ScyllaClient(), sdc)
 			scylladbdatacenterverification.WaitForFullQuorum(ctx, nsClient.KubeClient().CoreV1(), sdc)
 
-			framework.By("Verifying the rack StatefulSets are created with the %s pod management policy", podManagementPolicyForBootstrapPolicy(e.initialBootstrapPolicy))
+			framework.By("Verifying the rack StatefulSets are created with the %s pod management policy", podManagementPolicyForEnableParallelNodeOperations(e.initialEnableParallelNodeOperations))
 			statefulSets, err := utilsv1alpha1.GetStatefulSetsForScyllaDBDatacenter(ctx, nsClient.KubeClient().AppsV1(), sdc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(statefulSets).To(o.HaveLen(len(sdc.Spec.Racks)))
 			for _, sts := range statefulSets {
-				o.Expect(sts.Spec.PodManagementPolicy).To(o.Equal(podManagementPolicyForBootstrapPolicy(e.initialBootstrapPolicy)))
+				o.Expect(sts.Spec.PodManagementPolicy).To(o.Equal(podManagementPolicyForEnableParallelNodeOperations(e.initialEnableParallelNodeOperations)))
 			}
 
 			initialPodUIDs := getRackPodUIDs(ctx, nsClient, statefulSets)
@@ -102,17 +102,17 @@ var _ = g.Describe("ScyllaDBDatacenter", framework.SuiteParallel, framework.Suit
 			err = podObserver.Start(ctx)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			framework.By("Changing the bootstrap policy to %s", e.targetBootstrapPolicy)
+			framework.By("Setting parallel node operations enabled=%t", e.targetEnableParallelNodeOperations)
 			sdc, err = nsClient.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(ns.Name).Patch(
 				ctx,
 				sdc.Name,
 				types.MergePatchType,
-				[]byte(fmt.Sprintf(`{"spec":{"bootstrapPolicy":%q}}`, e.targetBootstrapPolicy)),
+				[]byte(fmt.Sprintf(`{"spec":{"enableParallelNodeOperations":%t}}`, e.targetEnableParallelNodeOperations)),
 				metav1.PatchOptions{},
 			)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(sdc.Spec.BootstrapPolicy).NotTo(o.BeNil())
-			o.Expect(*sdc.Spec.BootstrapPolicy).To(o.Equal(e.targetBootstrapPolicy))
+			o.Expect(sdc.Spec.EnableParallelNodeOperations).NotTo(o.BeNil())
+			o.Expect(*sdc.Spec.EnableParallelNodeOperations).To(o.Equal(e.targetEnableParallelNodeOperations))
 
 			framework.By("Waiting for the ScyllaDBDatacenter to roll out (RV=%s)", sdc.ResourceVersion)
 			patchRolloutCtx, patchRolloutCtxCancel := utilsv1alpha1.ContextForRollout(ctx, sdc)
@@ -122,18 +122,18 @@ var _ = g.Describe("ScyllaDBDatacenter", framework.SuiteParallel, framework.Suit
 			scylladbdatacenterverification.Verify(ctx, nsClient.KubeClient(), nsClient.ScyllaClient(), sdc)
 			scylladbdatacenterverification.WaitForFullQuorum(ctx, nsClient.KubeClient().CoreV1(), sdc)
 
-			framework.By("Verifying the rack StatefulSets are recreated with the %s pod management policy", podManagementPolicyForBootstrapPolicy(e.targetBootstrapPolicy))
+			framework.By("Verifying the rack StatefulSets are recreated with the %s pod management policy", podManagementPolicyForEnableParallelNodeOperations(e.targetEnableParallelNodeOperations))
 			statefulSets, err = utilsv1alpha1.GetStatefulSetsForScyllaDBDatacenter(ctx, nsClient.KubeClient().AppsV1(), sdc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(statefulSets).To(o.HaveLen(len(sdc.Spec.Racks)))
 			for _, sts := range statefulSets {
-				o.Expect(sts.Spec.PodManagementPolicy).To(o.Equal(podManagementPolicyForBootstrapPolicy(e.targetBootstrapPolicy)))
+				o.Expect(sts.Spec.PodManagementPolicy).To(o.Equal(podManagementPolicyForEnableParallelNodeOperations(e.targetEnableParallelNodeOperations)))
 			}
 
 			framework.By("Verifying the nodes were not disrupted")
 			observedPodEvents, err := podObserver.Stop()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			framework.Infof("Observed %d Pod events during the bootstrap policy change.", len(observedPodEvents))
+			framework.Infof("Observed %d Pod events during the parallel node operations change.", len(observedPodEvents))
 
 			// The StatefulSets are deleted with an orphan propagation policy, so their Pods survive the recreation and
 			// are adopted back. Any Pod being deleted or replaced at any point during the change means the running nodes were disrupted.
@@ -144,17 +144,17 @@ var _ = g.Describe("ScyllaDBDatacenter", framework.SuiteParallel, framework.Suit
 				o.Expect(observedPodEvent.Obj.DeletionTimestamp).To(o.BeNil(), fmt.Sprintf("Pod %q should not have been marked for deletion", observedPodEvent.Obj.Name))
 
 				initialPodUID, ok := initialPodUIDs[observedPodEvent.Obj.Name]
-				o.Expect(ok).To(o.BeTrue(), fmt.Sprintf("Pod %q should have existed before the bootstrap policy change", observedPodEvent.Obj.Name))
+				o.Expect(ok).To(o.BeTrue(), fmt.Sprintf("Pod %q should have existed before the parallel node operations change", observedPodEvent.Obj.Name))
 				o.Expect(observedPodEvent.Obj.UID).To(o.Equal(initialPodUID), fmt.Sprintf("Pod %q should not have been recreated", observedPodEvent.Obj.Name))
 			}
 		},
 		g.Entry(describeEntry, &entry{
-			initialBootstrapPolicy: scyllav1alpha1.BootstrapPolicySequential,
-			targetBootstrapPolicy:  scyllav1alpha1.BootstrapPolicyParallel,
+			initialEnableParallelNodeOperations: false,
+			targetEnableParallelNodeOperations:  true,
 		}),
 		g.Entry(describeEntry, &entry{
-			initialBootstrapPolicy: scyllav1alpha1.BootstrapPolicyParallel,
-			targetBootstrapPolicy:  scyllav1alpha1.BootstrapPolicySequential,
+			initialEnableParallelNodeOperations: true,
+			targetEnableParallelNodeOperations:  false,
 		}),
 	)
 })

--- a/test/envtest/controllers/mutating_webhook_test.go
+++ b/test/envtest/controllers/mutating_webhook_test.go
@@ -11,7 +11,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	operatorcmd "github.com/scylladb/scylla-operator/pkg/cmd/operator"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
@@ -112,8 +111,8 @@ var _ = g.Describe("Mutating admission webhook", func() {
 			o.Expect(updatedBaselineSpec).NotTo(o.HaveKey(field), "the defaulters must never stamp %q on an already existing object", field)
 		}
 	},
-		// Sequential is never stamped: an unset bootstrapPolicy is left unset, so that objects whose owners never
-		// made a choice keep resolving it rather than being pinned to today's resolution.
+		// false is never stamped: an unset enableParallelNodeOperations is left unset, so that objects whose owners
+		// never made a choice keep resolving it rather than being pinned to today's resolution.
 		g.Entry("admits a ScyllaCluster with a version not supporting parallel bootstrap unchanged", &entry{
 			resource:            "scyllaclusters",
 			expectedIntercepted: true,
@@ -124,7 +123,7 @@ var _ = g.Describe("Mutating admission webhook", func() {
 			},
 			expectedDefaultedSpecFields: nil,
 		}),
-		g.Entry("stamps a Parallel bootstrapPolicy on a ScyllaCluster with a version supporting parallel bootstrap", &entry{
+		g.Entry("stamps enableParallelNodeOperations on a ScyllaCluster with a version supporting parallel bootstrap", &entry{
 			resource:            "scyllaclusters",
 			expectedIntercepted: true,
 			newObject: func(name, namespace string) client.Object {
@@ -133,16 +132,16 @@ var _ = g.Describe("Mutating admission webhook", func() {
 				return sc
 			},
 			expectedDefaultedSpecFields: map[string]any{
-				"bootstrapPolicy": string(scyllav1.BootstrapPolicyParallel),
+				"enableParallelNodeOperations": true,
 			},
 		}),
-		g.Entry("admits a ScyllaCluster with an explicit bootstrapPolicy unchanged", &entry{
+		g.Entry("admits a ScyllaCluster with an explicit enableParallelNodeOperations unchanged", &entry{
 			resource:            "scyllaclusters",
 			expectedIntercepted: true,
 			newObject: func(name, namespace string) client.Object {
 				sc := newBasicScyllaCluster(name, namespace)
 				sc.Spec.Version = unit.ScyllaDBImageAtParallelBootstrapThresholdTag
-				sc.Spec.BootstrapPolicy = new(scyllav1.BootstrapPolicySequential)
+				sc.Spec.EnableParallelNodeOperations = new(false)
 				return sc
 			},
 			expectedDefaultedSpecFields: nil,
@@ -158,7 +157,7 @@ var _ = g.Describe("Mutating admission webhook", func() {
 			},
 			expectedDefaultedSpecFields: nil,
 		}),
-		g.Entry("stamps a Parallel bootstrapPolicy on a ScyllaDBDatacenter with an image supporting parallel bootstrap", &entry{
+		g.Entry("stamps enableParallelNodeOperations on a ScyllaDBDatacenter with an image supporting parallel bootstrap", &entry{
 			resource:            "scylladbdatacenters",
 			expectedIntercepted: true,
 			newObject: func(name, namespace string) client.Object {
@@ -168,17 +167,17 @@ var _ = g.Describe("Mutating admission webhook", func() {
 				return sdc
 			},
 			expectedDefaultedSpecFields: map[string]any{
-				"bootstrapPolicy": string(scyllav1alpha1.BootstrapPolicyParallel),
+				"enableParallelNodeOperations": true,
 			},
 		}),
-		g.Entry("admits a ScyllaDBDatacenter with an explicit bootstrapPolicy unchanged", &entry{
+		g.Entry("admits a ScyllaDBDatacenter with an explicit enableParallelNodeOperations unchanged", &entry{
 			resource:            "scylladbdatacenters",
 			expectedIntercepted: true,
 			newObject: func(name, namespace string) client.Object {
 				sdc := makeEnvtestScyllaDBDatacenter(namespace, []string{"rack1"})
 				sdc.Name = name
 				sdc.Spec.ScyllaDB.Image = unit.ScyllaDBImageAtParallelBootstrapThreshold
-				sdc.Spec.BootstrapPolicy = new(scyllav1alpha1.BootstrapPolicySequential)
+				sdc.Spec.EnableParallelNodeOperations = new(false)
 				return sdc
 			},
 			expectedDefaultedSpecFields: nil,

--- a/test/envtest/controllers/scylladbdatacenter_controller_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_test.go
@@ -57,7 +57,7 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 		env = envtest.Setup(ctx)
 	})
 
-	g.It("should create rack StatefulSets sequentially with Sequential bootstrap policy", func(ctx g.SpecContext) {
+	g.It("should create rack StatefulSets sequentially with parallel node operations disabled", func(ctx g.SpecContext) {
 		g.By("Running ScyllaDBDatacenter controller")
 		runScyllaDBDatacenterController(ctx, env)
 
@@ -65,7 +65,7 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 		createScyllaOperatorConfig(ctx, env)
 
 		g.By("Creating a ScyllaDBDatacenter with two racks")
-		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a", "rack-b"}, withBootstrapPolicy(scyllav1alpha1.BootstrapPolicySequential))
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a", "rack-b"}, withEnableParallelNodeOperations(false))
 		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -87,15 +87,15 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 		waitForStatefulSet(ctx, env, secondRackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
 	})
 
-	g.It("should create rack StatefulSets in parallel with Parallel bootstrap policy", func(ctx g.SpecContext) {
+	g.It("should create rack StatefulSets in parallel with parallel node operations enabled", func(ctx g.SpecContext) {
 		g.By("Running ScyllaDBDatacenter controller")
 		runScyllaDBDatacenterController(ctx, env)
 
 		g.By("Creating ScyllaOperatorConfig singleton")
 		createScyllaOperatorConfig(ctx, env)
 
-		g.By("Creating a ScyllaDBDatacenter with three racks and the Parallel bootstrap policy")
-		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a", "rack-b", "rack-c"}, withBootstrapPolicy(scyllav1alpha1.BootstrapPolicyParallel))
+		g.By("Creating a ScyllaDBDatacenter with three racks and parallel node operations enabled")
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a", "rack-b", "rack-c"}, withEnableParallelNodeOperations(true))
 		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -106,8 +106,8 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 		}
 	})
 
-	g.DescribeTableSubtree("with bootstrap policy",
-		func(bootstrapPolicy scyllav1alpha1.BootstrapPolicy) {
+	g.DescribeTableSubtree("with parallel node operations",
+		func(enableParallelNodeOperations bool) {
 			g.DescribeTable("should not create a StatefulSet for a new rack while an existing rack is not rolled out",
 				func(ctx g.SpecContext, initialRacks, updatedRacks []string, existingRack, newRack string) {
 					g.By("Running ScyllaDBDatacenter controller")
@@ -117,7 +117,7 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 					createScyllaOperatorConfig(ctx, env)
 
 					g.By("Creating a ScyllaDBDatacenter")
-					sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), initialRacks, withBootstrapPolicy(bootstrapPolicy))
+					sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), initialRacks, withEnableParallelNodeOperations(enableParallelNodeOperations))
 					sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
 					o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -156,11 +156,11 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 				g.Entry("when new rack is appended", []string{"rack-a"}, []string{"rack-a", "rack-b"}, "rack-a", "rack-b"),
 			)
 		},
-		g.Entry("Sequential", scyllav1alpha1.BootstrapPolicySequential),
-		// The Parallel bootstrap policy only relaxes the initial creation of missing StatefulSets. Adding a rack to an
-		// existing datacenter still waits for the existing racks to roll out, so that racks aren't added while another one
-		// is scaling or updating, regardless of the bootstrap policy.
-		g.Entry("Parallel", scyllav1alpha1.BootstrapPolicyParallel),
+		g.Entry("disabled", false),
+		// Parallel node operations only relax the initial creation of missing StatefulSets. Adding a rack to an existing
+		// datacenter still waits for the existing racks to roll out, so that racks aren't added while another one is
+		// scaling or updating, regardless of whether parallel node operations are enabled.
+		g.Entry("enabled", true),
 	)
 })
 
@@ -210,9 +210,9 @@ func makeEnvtestScyllaDBDatacenter(namespace string, racks []string, mutators ..
 	return sdc
 }
 
-func withBootstrapPolicy(bootstrapPolicy scyllav1alpha1.BootstrapPolicy) func(*scyllav1alpha1.ScyllaDBDatacenter) {
+func withEnableParallelNodeOperations(enableParallelNodeOperations bool) func(*scyllav1alpha1.ScyllaDBDatacenter) {
 	return func(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
-		sdc.Spec.BootstrapPolicy = new(bootstrapPolicy)
+		sdc.Spec.EnableParallelNodeOperations = new(enableParallelNodeOperations)
 	}
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Replaces the unreleased `bootstrapPolicy` enum with an `enableParallelNodeOperations` boolean in `ScyllaCluster.spec` and `ScyllaDBDatacenter.spec`, because the field governs more than bootstrap ordering: it's projected into the rack StatefulSets' `podManagementPolicy` and gates whether missing rack StatefulSets are created one per sync or all at once.

An unset field and `false` resolve exactly as unset and `Sequential` did, so behavior is unchanged. `true` still requires ScyllaDB 2026.2 or later, and the mutating webhook still stamps it on creation for supported versions only.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-322
