### PR TITLE
chore: configure Renovate base branch patterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,11 @@
     "config:recommended",
     ":semanticCommitTypeAll(chore)"
   ],
+  "baseBranchPatterns": [
+    "master",
+    "v1.20",
+    "v1.21"
+  ],
   "enabledManagers": [
     "custom.regex",
     "gomod"


### PR DESCRIPTION
Please review in tandem with https://github.com/scylladb/scylla-operator-release/pull/660.
Part of: OPERATOR-338

## Description

By default Renovate only processes the repository's default branch, so dependency updates are never proposed against release branches. This configures `baseBranchPatterns` with `master` and the currently supported release branches `v1.20` and `v1.21`.

```json
"baseBranchPatterns": [
  "master",
  "v1.20",
  "v1.21"
]
```

Notes:

- (Claude claims that) Renovate reads its config from the default branch only, so this `renovate.json` will govern all three streams. The separate (and until now inert) `renovate.json` files on `v1.20`/`v1.21` remain ignored unless `useBaseBranchConfig: "merge"` is added.

## Verification

- `make verify-renovate-config` passes (the change is stable across the `jq` round-trip performed by `hack/sync-renovate-config-with-go-mod-replace.sh`).
- `baseBranchPatterns` validated as a top-level `array` of `string` against Renovate's published schema (v44.34.0).
- `master`, `v1.20` and `v1.21` all confirmed to exist on the remote.