### PR TITLE
fix: complete an ongoing decommission when the rack node count is raised back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 ## Unreleased
 
+### Upgrade requirements
+
+- Before upgrading, check your `ScyllaCluster` and `ScyllaDBDatacenter` member services for leftover
+  `scylla/decommissioned=true` labels and remove the stale ones. The label is stale if the node it belongs to is
+  healthy - for example, because it was recovered manually after its decommission had completed. Starting with this
+  release, the Operator treats every labeled node as a node that has to leave the cluster, so it decommissions such a
+  node, deletes its `PersistentVolumeClaim` and removes it from its rack, without any user action.
+  ```
+  kubectl get svc -A -l scylla/decommissioned=true
+  ```
+  [#3603](https://github.com/scylladb/scylla-operator/pull/3603)
+
 ### Bug fixes
 
 - Fixed `ScyllaDBDatacenter` rollouts getting stuck when a new rack was inserted before existing racks while an existing 
@@ -26,6 +38,14 @@
   Every node is now cleaned up once the ring changes. Note that this increases the number of cleanup jobs created at once,
   from N-1 to N for an N node cluster.
   [#3574](https://github.com/scylladb/scylla-operator/pull/3574)
+- Fixed a rack getting stuck forever when its node count was changed while one of its nodes was still being
+  decommissioned. A node's decommission can't be revoked, so the nodes that a scale down of a rack removes are now
+  recorded in `status.racks[].decommissioningNodes` before any of them is asked to decommission. Until they have left
+  and been removed, the rack keeps reconciling towards the node count that excludes them, and node count changes made
+  in the meantime only take effect afterwards, with the capacity given back added as new, empty nodes. The admission
+  webhook warns about such a deferred change, rejects removing a rack whose nodes are still leaving, and the rack
+  reports the deferral as progressing.
+  [#3603](https://github.com/scylladb/scylla-operator/pull/3603)
 - Fixed the `ScyllaDBDatacenter` controller discarding failures to sync `ScyllaDBDatacenterNodesStatusReport` objects.
   The error was dropped instead of being aggregated into the error returned by the reconciliation, so a failed sync was
   reported as successful and the key was forgotten rather than requeued, losing the retry with backoff. The degraded

--- a/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -10813,6 +10813,19 @@ spec:
                       description: version specifies the current version of ScyllaDB
                         in use.
                       type: string
+                    decommissioningNodes:
+                      description: |-
+                        decommissioningNodes specify the names of the rack's nodes that are leaving the cluster. A node's
+                        decommission can't be revoked, so once it has been initiated the node has to finish leaving and be
+                        removed together with its resources before its name can be used again.
+                        decommissioningNodes is only present while a scale down of the rack is in progress. While it's present,
+                        the rack reconciles as if its node count excluded these nodes, so any node count change made in the
+                        meantime only takes effect once they are removed, and the capacity they give back is added as new,
+                        empty nodes.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     name:
                       description: name specifies the name of datacenter this status
                         describes.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -45775,6 +45775,19 @@ spec:
                       currentVersion:
                         description: version specifies the current version of ScyllaDB in use.
                         type: string
+                      decommissioningNodes:
+                        description: |-
+                          decommissioningNodes specify the names of the rack's nodes that are leaving the cluster. A node's
+                          decommission can't be revoked, so once it has been initiated the node has to finish leaving and be
+                          removed together with its resources before its name can be used again.
+                          decommissioningNodes is only present while a scale down of the rack is in progress. While it's present,
+                          the rack reconciles as if its node count excluded these nodes, so any node count change made in the
+                          meantime only takes effect once they are removed, and the capacity they give back is added as new,
+                          empty nodes.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
                       name:
                         description: name specifies the name of datacenter this status describes.
                         type: string

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
@@ -13508,6 +13508,9 @@ object
    * - currentVersion
      - string
      - version specifies the current version of ScyllaDB in use.
+   * - decommissioningNodes
+     - array (string)
+     - decommissioningNodes specify the names of the rack's nodes that are leaving the cluster. A node's decommission can't be revoked, so once it has been initiated the node has to finish leaving and be removed together with its resources before its name can be used again. decommissioningNodes is only present while a scale down of the rack is in progress. While it's present, the rack reconciles as if its node count excluded these nodes, so any node count change made in the meantime only takes effect once they are removed, and the capacity they give back is added as new, empty nodes.
    * - name
      - string
      - name specifies the name of datacenter this status describes.

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -10212,6 +10212,19 @@ spec:
                       currentVersion:
                         description: version specifies the current version of ScyllaDB in use.
                         type: string
+                      decommissioningNodes:
+                        description: |-
+                          decommissioningNodes specify the names of the rack's nodes that are leaving the cluster. A node's
+                          decommission can't be revoked, so once it has been initiated the node has to finish leaving and be
+                          removed together with its resources before its name can be used again.
+                          decommissioningNodes is only present while a scale down of the rack is in progress. While it's present,
+                          the rack reconciles as if its node count excluded these nodes, so any node count change made in the
+                          meantime only takes effect once they are removed, and the capacity they give back is added as new,
+                          empty nodes.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
                       name:
                         description: name specifies the name of datacenter this status describes.
                         type: string

--- a/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
+++ b/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
@@ -496,6 +496,17 @@ type RackStatus struct {
 	// stale should eventually become false when the appropriate controller writes a fresh status.
 	// +optional
 	Stale *bool `json:"stale,omitempty"`
+
+	// decommissioningNodes specify the names of the rack's nodes that are leaving the cluster. A node's
+	// decommission can't be revoked, so once it has been initiated the node has to finish leaving and be
+	// removed together with its resources before its name can be used again.
+	// decommissioningNodes is only present while a scale down of the rack is in progress. While it's present,
+	// the rack reconciles as if its node count excluded these nodes, so any node count change made in the
+	// meantime only takes effect once they are removed, and the capacity they give back is added as new,
+	// empty nodes.
+	// +optional
+	// +listType=atomic
+	DecommissioningNodes []string `json:"decommissioningNodes,omitempty"`
 }
 
 // ScyllaDBDatacenterStatus defines the observed state of ScyllaDBDatacenter.

--- a/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/scylla/v1alpha1/zz_generated.deepcopy.go
@@ -1244,6 +1244,11 @@ func (in *RackStatus) DeepCopyInto(out *RackStatus) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DecommissioningNodes != nil {
+		in, out := &in.DecommissioningNodes, &out.DecommissioningNodes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation.go
@@ -476,15 +476,7 @@ func ValidateScyllaDBDatacenterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBDatac
 				continue
 			}
 
-			oldRackNodeCount := int32(0)
-			if old.Spec.RackTemplate != nil && old.Spec.RackTemplate.Nodes != nil {
-				oldRackNodeCount = *old.Spec.RackTemplate.Nodes
-			}
-			if oldRack.Nodes != nil {
-				oldRackNodeCount = *oldRack.Nodes
-			}
-
-			if oldRackNodeCount != 0 {
+			if getScyllaDBDatacenterRackNodeCount(old, oldRack) != 0 {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("racks").Index(i), fmt.Sprintf("rack %q can't be removed because it still has members that have to be scaled down to zero first", removedRackName)))
 				continue
 			}
@@ -498,6 +490,13 @@ func ValidateScyllaDBDatacenterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBDatac
 
 			if oldRackStatus.Nodes != nil && *oldRackStatus.Nodes != 0 {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("racks").Index(i), fmt.Sprintf("rack %q can't be removed because the members are being scaled down", removedRackName)))
+				continue
+			}
+
+			// The record of the nodes that are leaving lives in the rack status, and removing the rack from the spec
+			// would drop it before their resources are cleaned up.
+			if len(oldRackStatus.DecommissioningNodes) != 0 {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("racks").Index(i), fmt.Sprintf("rack %q can't be removed because its node(s) %s are still leaving the cluster", removedRackName, strings.Join(oldRackStatus.DecommissioningNodes, ", "))))
 				continue
 			}
 
@@ -676,8 +675,56 @@ func GetWarningsOnScyllaDBDatacenterUpdate(new, old *scyllav1alpha1.ScyllaDBData
 	var warnings []string
 
 	warnings = append(warnings, getWarningsForScyllaDBDatacenterSpec(&new.Spec, field.NewPath("spec"))...)
+	warnings = append(warnings, getWarningsForScyllaDBDatacenterRackNodeCountUpdate(new, old)...)
 
 	return warnings
+}
+
+// getWarningsForScyllaDBDatacenterRackNodeCountUpdate warns about a node count change of a rack that still has nodes
+// leaving the cluster. A node's decommission can't be revoked, so the change is deferred until they are removed.
+func getWarningsForScyllaDBDatacenterRackNodeCountUpdate(new, old *scyllav1alpha1.ScyllaDBDatacenter) []string {
+	var warnings []string
+
+	for _, newRack := range new.Spec.Racks {
+		oldRackStatus, _, ok := oslices.Find(old.Status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
+			return rackStatus.Name == newRack.Name
+		})
+		if !ok || len(oldRackStatus.DecommissioningNodes) == 0 {
+			continue
+		}
+
+		oldRack, _, ok := oslices.Find(old.Spec.Racks, func(rack scyllav1alpha1.RackSpec) bool {
+			return rack.Name == newRack.Name
+		})
+		if !ok {
+			continue
+		}
+
+		if getScyllaDBDatacenterRackNodeCount(new, newRack) == getScyllaDBDatacenterRackNodeCount(old, oldRack) {
+			continue
+		}
+
+		warnings = append(warnings, fmt.Sprintf(
+			"node count change of rack %q won't take effect until the ongoing decommission of node(s) %s finishes; the capacity they give back is added as new, empty nodes",
+			newRack.Name,
+			strings.Join(oldRackStatus.DecommissioningNodes, ", "),
+		))
+	}
+
+	return warnings
+}
+
+// getScyllaDBDatacenterRackNodeCount mirrors how the controller resolves the node count of a rack.
+func getScyllaDBDatacenterRackNodeCount(sdc *scyllav1alpha1.ScyllaDBDatacenter, rack scyllav1alpha1.RackSpec) int32 {
+	if rack.Nodes != nil {
+		return *rack.Nodes
+	}
+
+	if sdc.Spec.RackTemplate != nil && sdc.Spec.RackTemplate.Nodes != nil {
+		return *sdc.Spec.RackTemplate.Nodes
+	}
+
+	return 0
 }
 
 func getWarningsForScyllaDBDatacenterSpec(spec *scyllav1alpha1.ScyllaDBDatacenterSpec, fldPath *field.Path) []string {

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
@@ -1116,6 +1116,31 @@ func TestValidateScyllaDBDatacenterUpdate(t *testing.T) {
 			expectedErrorString: `spec.racks[0]: Forbidden: rack "rack" can't be removed because the members are being scaled down`,
 		},
 		{
+			name: "empty rack with nodes still leaving the cluster",
+			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.Racks[0].Nodes = pointer.Ptr[int32](0)
+				sdc.Status.Racks = []scyllav1alpha1.RackStatus{
+					{
+						Name:                 sdc.Spec.Racks[0].Name,
+						Nodes:                pointer.Ptr[int32](0),
+						Stale:                pointer.Ptr(false),
+						DecommissioningNodes: []string{"basic-dc-rack-0"},
+					},
+				}
+				return sdc
+			}(),
+			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.Racks = []scyllav1alpha1.RackSpec{}
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeForbidden, Field: "spec.racks[0]", BadValue: "", Detail: `rack "rack" can't be removed because its node(s) basic-dc-rack-0 are still leaving the cluster`},
+			},
+			expectedErrorString: `spec.racks[0]: Forbidden: rack "rack" can't be removed because its node(s) basic-dc-rack-0 are still leaving the cluster`,
+		},
+		{
 			name: "empty rack with stale status",
 			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
@@ -1787,6 +1812,88 @@ func TestGetWarningsOnScyllaDBDatacenterUpdate(t *testing.T) {
 			}(),
 			expectedWarnings: []string{
 				"`spec.exposeOptions.cql` field is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
+			},
+		},
+		{
+			name: "no warning when the node count of a rack that isn't decommissioning nodes changes",
+			oldSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.Racks[0].Nodes = pointer.Ptr[int32](3)
+				return sdc
+			}(),
+			newSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.Racks[0].Nodes = pointer.Ptr[int32](1)
+				return sdc
+			}(),
+			expectedWarnings: nil,
+		},
+		{
+			name: "no warning when the node count of a rack that is decommissioning nodes doesn't change",
+			oldSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.Racks[0].Nodes = pointer.Ptr[int32](1)
+				sdc.Status.Racks = []scyllav1alpha1.RackStatus{
+					{
+						Name:                 "rack",
+						DecommissioningNodes: []string{"basic-dc-rack-1", "basic-dc-rack-2"},
+					},
+				}
+				return sdc
+			}(),
+			newSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.Racks[0].Nodes = pointer.Ptr[int32](1)
+				return sdc
+			}(),
+			expectedWarnings: nil,
+		},
+		{
+			name: "deferred node count change warning for a rack that is decommissioning nodes",
+			oldSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.Racks[0].Nodes = pointer.Ptr[int32](1)
+				sdc.Status.Racks = []scyllav1alpha1.RackStatus{
+					{
+						Name:                 "rack",
+						DecommissioningNodes: []string{"basic-dc-rack-1", "basic-dc-rack-2"},
+					},
+				}
+				return sdc
+			}(),
+			newSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.Racks[0].Nodes = pointer.Ptr[int32](3)
+				return sdc
+			}(),
+			expectedWarnings: []string{
+				`node count change of rack "rack" won't take effect until the ongoing decommission of node(s) basic-dc-rack-1, basic-dc-rack-2 finishes; the capacity they give back is added as new, empty nodes`,
+			},
+		},
+		{
+			name: "deferred node count change warning for a rack whose node count comes from the rack template",
+			oldSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.RackTemplate = &scyllav1alpha1.RackTemplate{
+					Nodes: pointer.Ptr[int32](1),
+				}
+				sdc.Status.Racks = []scyllav1alpha1.RackStatus{
+					{
+						Name:                 "rack",
+						DecommissioningNodes: []string{"basic-dc-rack-1"},
+					},
+				}
+				return sdc
+			}(),
+			newSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenterForWarnings()
+				sdc.Spec.RackTemplate = &scyllav1alpha1.RackTemplate{
+					Nodes: pointer.Ptr[int32](2),
+				}
+				return sdc
+			}(),
+			expectedWarnings: []string{
+				`node count change of rack "rack" won't take effect until the ongoing decommission of node(s) basic-dc-rack-1 finishes; the capacity they give back is added as new, empty nodes`,
 			},
 		},
 	}

--- a/pkg/controller/scylladbdatacenter/decommission.go
+++ b/pkg/controller/scylladbdatacenter/decommission.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 ScyllaDB.
+
+package scylladbdatacenter
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+func getRackDecommissioningNodes(status *scyllav1alpha1.ScyllaDBDatacenterStatus, rackName string) []string {
+	rackStatus, _, ok := oslices.Find(status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
+		return rackStatus.Name == rackName
+	})
+	if !ok {
+		return nil
+	}
+
+	return rackStatus.DecommissioningNodes
+}
+
+func setRackDecommissioningNodes(status *scyllav1alpha1.ScyllaDBDatacenterStatus, rackName string, decommissioningNodes []string) {
+	_, i, ok := oslices.Find(status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
+		return rackStatus.Name == rackName
+	})
+	if !ok {
+		return
+	}
+
+	status.Racks[i].DecommissioningNodes = decommissioningNodes
+}
+
+// getEffectiveRackNodeCount returns the node count the rack reconciles towards.
+// While any of the rack's nodes are recorded as decommissioning, the rack reconciles as if its node count excluded
+// them. Because members are identified by their StatefulSet ordinal, and a StatefulSet can only remove its highest
+// ordinal, the leaving members have to hold the top of the ordinal range until they are removed. The node count is
+// therefore pinned to the lowest recorded ordinal, and the node count from the spec only takes effect once the record
+// is empty.
+func getEffectiveRackNodeCount(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, decommissioningNodes []string) (*int32, error) {
+	if len(decommissioningNodes) > 0 {
+		lowestOrdinal, err := getMemberServiceOrdinal(decommissioningNodes[0])
+		if err != nil {
+			return nil, fmt.Errorf("can't get ordinal of decommissioning node %q: %w", decommissioningNodes[0], err)
+		}
+
+		for _, name := range decommissioningNodes[1:] {
+			ordinal, err := getMemberServiceOrdinal(name)
+			if err != nil {
+				return nil, fmt.Errorf("can't get ordinal of decommissioning node %q: %w", name, err)
+			}
+
+			lowestOrdinal = min(lowestOrdinal, ordinal)
+		}
+
+		return new(lowestOrdinal), nil
+	}
+
+	nodeCount, err := controllerhelpers.GetRackNodeCount(sdc, rackName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get rack %q node count of ScyllaDBDatacenter %q: %w", rackName, naming.ObjRef(sdc), err)
+	}
+
+	return nodeCount, nil
+}
+
+// reconcileRackDecommissioningNodes maintains the record of the nodes that are leaving their racks.
+//
+// A node's decommission can't be revoked, so before any decommission is initiated the operator records which nodes are
+// going to leave. The record is what holds the barrier: while it's non-empty, the rack reconciles towards the node count
+// that excludes the recorded nodes, so a node count change made in the meantime only takes effect once they are fully
+// removed, and the capacity they give back bootstraps as new, empty nodes.
+//
+// The decommission labels on the member services stay the ground truth underneath the record: every labeled member is
+// taken into the record, so a record lost to a restored backup or a manual edit is rebuilt from the labels.
+//
+// It reports whether the record has changed, in which case the caller must not act on it before it's persisted.
+func (sdcc *Controller) reconcileRackDecommissioningNodes(
+	sdc *scyllav1alpha1.ScyllaDBDatacenter,
+	status *scyllav1alpha1.ScyllaDBDatacenterStatus,
+	statefulSets map[string]*appsv1.StatefulSet,
+	services map[string]*corev1.Service,
+) ([]metav1.Condition, bool, error) {
+	var progressingConditions []metav1.Condition
+	changed := false
+
+	for _, rack := range sdc.Spec.Racks {
+		sts, ok := statefulSets[naming.StatefulSetNameForRack(rack, sdc)]
+		if !ok || sts.Spec.Replicas == nil {
+			// Nothing can be leaving a rack that hasn't been created yet.
+			continue
+		}
+
+		rackServices := map[string]*corev1.Service{}
+		for _, svc := range services {
+			if svc.Labels[naming.RackNameLabel] == rack.Name {
+				rackServices[svc.Name] = svc
+			}
+		}
+
+		existing := getRackDecommissioningNodes(status, rack.Name)
+		required, err := makeRackDecommissioningNodes(sdc, rack, existing, sts, rackServices)
+		if err != nil {
+			return progressingConditions, changed, fmt.Errorf("can't make decommissioning nodes of rack %q: %w", rack.Name, err)
+		}
+
+		if slices.Equal(existing, required) {
+			continue
+		}
+
+		klog.V(2).InfoS("Updating the record of decommissioning nodes", "ScyllaDBDatacenter", klog.KObj(sdc), "Rack", rack.Name, "Existing", existing, "Required", required)
+		setRackDecommissioningNodes(status, rack.Name, required)
+		changed = true
+
+		switch {
+		case len(existing) == 0:
+			sdcc.eventRecorder.Eventf(sdc, corev1.EventTypeNormal, "DecommissioningRackNodes", "Node(s) %s of rack %q are being decommissioned. Node count changes of the rack will only take effect once they are removed.", strings.Join(required, ", "), rack.Name)
+		case len(required) == 0:
+			sdcc.eventRecorder.Eventf(sdc, corev1.EventTypeNormal, "DecommissionedRackNodes", "Node(s) %s of rack %q have been decommissioned and removed. Reconciliation of the rack node count is resuming.", strings.Join(existing, ", "), rack.Name)
+		}
+
+		progressingConditions = append(progressingConditions, metav1.Condition{
+			Type:               statefulSetControllerProgressingCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "RecordingRackDecommissioningNodes",
+			Message:            fmt.Sprintf("Recording the decommissioning nodes of rack %q in the status.", rack.Name),
+			ObservedGeneration: sdc.Generation,
+		})
+	}
+
+	return progressingConditions, changed, nil
+}
+
+// makeRackDecommissioningNodes returns the names of the rack's nodes that are leaving, ordered by their ordinal.
+// It keeps the recorded nodes that haven't been fully removed yet, adds any member already carrying the decommission
+// label, and, if nothing is leaving, commits the nodes a scale down of the rack is about to remove.
+func makeRackDecommissioningNodes(
+	sdc *scyllav1alpha1.ScyllaDBDatacenter,
+	rack scyllav1alpha1.RackSpec,
+	decommissioningNodes []string,
+	sts *appsv1.StatefulSet,
+	rackServices map[string]*corev1.Service,
+) ([]string, error) {
+	var required []string
+
+	for _, name := range decommissioningNodes {
+		removed, err := isMemberRemoved(name, sts, rackServices)
+		if err != nil {
+			return nil, err
+		}
+
+		if !removed {
+			required = append(required, name)
+		}
+	}
+
+	// A labeled member is irrevocably leaving, no matter what the record says.
+	for _, svc := range rackServices {
+		if _, ok := svc.Labels[naming.DecommissionedLabel]; !ok {
+			continue
+		}
+
+		_, err := getMemberServiceOrdinal(svc.Name)
+		if err != nil {
+			return nil, fmt.Errorf("can't get ordinal of decommissioned member service %q: %w", naming.ObjRef(svc), err)
+		}
+
+		if !slices.Contains(required, svc.Name) {
+			required = append(required, svc.Name)
+		}
+	}
+
+	if len(required) == 0 {
+		// Commit the nodes of a scale down in a single write, before any of them is asked to decommission, so that the
+		// operation is fully defined no matter what happens to the spec later. A scale down requested while another one
+		// is still in progress is only committed once that one concludes.
+		nodeCount, err := controllerhelpers.GetRackNodeCount(sdc, rack.Name)
+		if err != nil {
+			return nil, fmt.Errorf("can't get rack %q node count of ScyllaDBDatacenter %q: %w", rack.Name, naming.ObjRef(sdc), err)
+		}
+
+		for ordinal := *nodeCount; ordinal < *sts.Spec.Replicas; ordinal++ {
+			required = append(required, naming.MemberServiceName(rack, sdc, int(ordinal)))
+		}
+	}
+
+	slices.SortFunc(required, func(lhs, rhs string) int {
+		// Every name has already been parsed above, so an error here is impossible.
+		lhsOrdinal, _ := getMemberServiceOrdinal(lhs)
+		rhsOrdinal, _ := getMemberServiceOrdinal(rhs)
+		return cmp.Compare(lhsOrdinal, rhsOrdinal)
+	})
+
+	return required, nil
+}
+
+// isMemberRemoved reports whether a member that was leaving is gone: the StatefulSet no longer accounts for its
+// ordinal, and its service either has been pruned or no longer carries the decommission label, meaning it has been
+// recreated for a fresh bootstrap.
+func isMemberRemoved(name string, sts *appsv1.StatefulSet, rackServices map[string]*corev1.Service) (bool, error) {
+	ordinal, err := getMemberServiceOrdinal(name)
+	if err != nil {
+		return false, fmt.Errorf("can't get ordinal of decommissioning node %q: %w", name, err)
+	}
+
+	if ordinal < *sts.Spec.Replicas {
+		return false, nil
+	}
+
+	svc, ok := rackServices[name]
+	if !ok {
+		return true, nil
+	}
+
+	_, ok = svc.Labels[naming.DecommissionedLabel]
+
+	return !ok, nil
+}

--- a/pkg/controller/scylladbdatacenter/decommission_test.go
+++ b/pkg/controller/scylladbdatacenter/decommission_test.go
@@ -1,0 +1,272 @@
+package scylladbdatacenter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newDecommissionTestScyllaDBDatacenter(nodes int32) *scyllav1alpha1.ScyllaDBDatacenter {
+	return &scyllav1alpha1.ScyllaDBDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "basic",
+			Namespace: testNamespace,
+		},
+		Spec: scyllav1alpha1.ScyllaDBDatacenterSpec{
+			DatacenterName: new("dc"),
+			Racks: []scyllav1alpha1.RackSpec{
+				{
+					Name: "a",
+					RackTemplate: scyllav1alpha1.RackTemplate{
+						Nodes: new(nodes),
+					},
+				},
+			},
+		},
+	}
+}
+
+func newDecommissionTestStatefulSet(replicas int32) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "basic-dc-a",
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: new(replicas),
+		},
+	}
+}
+
+func newDecommissionTestMemberService(name string, decommissionedLabelValue *string) *corev1.Service {
+	labels := map[string]string{
+		naming.RackNameLabel: "a",
+	}
+	if decommissionedLabelValue != nil {
+		labels[naming.DecommissionedLabel] = *decommissionedLabelValue
+	}
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Labels:    labels,
+		},
+	}
+}
+
+func Test_getEffectiveRackNodeCount(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name                 string
+		nodes                int32
+		decommissioningNodes []string
+		expectedNodeCount    int32
+		expectedErrorString  string
+	}{
+		{
+			name:                 "node count from the spec when nothing is leaving",
+			nodes:                3,
+			decommissioningNodes: nil,
+			expectedNodeCount:    3,
+		},
+		{
+			name:                 "node count pinned to the lowest recorded ordinal",
+			nodes:                3,
+			decommissioningNodes: []string{"basic-dc-a-1", "basic-dc-a-2"},
+			expectedNodeCount:    1,
+		},
+		{
+			name:                 "node count pinned below a node count raised in the meantime",
+			nodes:                5,
+			decommissioningNodes: []string{"basic-dc-a-2"},
+			expectedNodeCount:    2,
+		},
+		{
+			name:                 "node count pinned above a node count lowered in the meantime",
+			nodes:                0,
+			decommissioningNodes: []string{"basic-dc-a-2"},
+			expectedNodeCount:    2,
+		},
+		{
+			name:                 "error for an unparsable node name",
+			nodes:                3,
+			decommissioningNodes: []string{"basic-dc-a"},
+			expectedErrorString:  `can't get ordinal of decommissioning node "basic-dc-a": can't parse ordinal from member service name "basic-dc-a"`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			nodeCount, err := getEffectiveRackNodeCount(newDecommissionTestScyllaDBDatacenter(tc.nodes), "a", tc.decommissioningNodes)
+
+			gotErrorString := ""
+			if err != nil {
+				gotErrorString = err.Error()
+			}
+			if gotErrorString != tc.expectedErrorString {
+				t.Fatalf("expected error %q, got %q", tc.expectedErrorString, gotErrorString)
+			}
+			if err != nil {
+				return
+			}
+
+			if *nodeCount != tc.expectedNodeCount {
+				t.Errorf("expected node count %d, got %d", tc.expectedNodeCount, *nodeCount)
+			}
+		})
+	}
+}
+
+func Test_makeRackDecommissioningNodes(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name                 string
+		nodes                int32
+		replicas             int32
+		decommissioningNodes []string
+		services             []*corev1.Service
+		expectedNodes        []string
+		expectedErrorString  string
+	}{
+		{
+			name:          "nothing is leaving a rack that isn't being scaled down",
+			nodes:         2,
+			replicas:      2,
+			expectedNodes: nil,
+		},
+		{
+			name:          "a scale down commits all the nodes it removes",
+			nodes:         1,
+			replicas:      3,
+			expectedNodes: []string{"basic-dc-a-1", "basic-dc-a-2"},
+		},
+		{
+			name:          "a scale down to zero commits all the nodes of the rack",
+			nodes:         0,
+			replicas:      2,
+			expectedNodes: []string{"basic-dc-a-0", "basic-dc-a-1"},
+		},
+		{
+			name:                 "a scale down requested while nodes are still leaving isn't committed",
+			nodes:                0,
+			replicas:             3,
+			decommissioningNodes: []string{"basic-dc-a-2"},
+			services: []*corev1.Service{
+				newDecommissionTestMemberService("basic-dc-a-2", new(naming.LabelValueFalse)),
+			},
+			expectedNodes: []string{"basic-dc-a-2"},
+		},
+		{
+			name:                 "a node count raised back doesn't release a node that is still leaving",
+			nodes:                3,
+			replicas:             3,
+			decommissioningNodes: []string{"basic-dc-a-2"},
+			services: []*corev1.Service{
+				newDecommissionTestMemberService("basic-dc-a-2", new(naming.LabelValueFalse)),
+			},
+			expectedNodes: []string{"basic-dc-a-2"},
+		},
+		{
+			name:                 "a decommissioned node is kept until its service is pruned",
+			nodes:                1,
+			replicas:             1,
+			decommissioningNodes: []string{"basic-dc-a-1"},
+			services: []*corev1.Service{
+				newDecommissionTestMemberService("basic-dc-a-1", new(naming.LabelValueTrue)),
+			},
+			expectedNodes: []string{"basic-dc-a-1"},
+		},
+		{
+			name:                 "a removed node is dropped from the record",
+			nodes:                1,
+			replicas:             1,
+			decommissioningNodes: []string{"basic-dc-a-1"},
+			expectedNodes:        nil,
+		},
+		{
+			name:                 "a node whose service was recreated afresh is dropped from the record",
+			nodes:                2,
+			replicas:             1,
+			decommissioningNodes: []string{"basic-dc-a-1"},
+			services: []*corev1.Service{
+				newDecommissionTestMemberService("basic-dc-a-1", nil),
+			},
+			expectedNodes: nil,
+		},
+		{
+			name:                 "a node still accounted for by the StatefulSet is kept in the record",
+			nodes:                2,
+			replicas:             2,
+			decommissioningNodes: []string{"basic-dc-a-1"},
+			expectedNodes:        []string{"basic-dc-a-1"},
+		},
+		{
+			name:     "a labeled node absent from the record is taken into it",
+			nodes:    2,
+			replicas: 2,
+			services: []*corev1.Service{
+				newDecommissionTestMemberService("basic-dc-a-0", new(naming.LabelValueTrue)),
+				newDecommissionTestMemberService("basic-dc-a-1", new(naming.LabelValueFalse)),
+			},
+			expectedNodes: []string{"basic-dc-a-0", "basic-dc-a-1"},
+		},
+		{
+			name:                 "the record is ordered by ordinal",
+			nodes:                0,
+			replicas:             11,
+			decommissioningNodes: []string{"basic-dc-a-10", "basic-dc-a-2"},
+			services: []*corev1.Service{
+				newDecommissionTestMemberService("basic-dc-a-10", new(naming.LabelValueFalse)),
+				newDecommissionTestMemberService("basic-dc-a-2", new(naming.LabelValueFalse)),
+				newDecommissionTestMemberService("basic-dc-a-9", new(naming.LabelValueFalse)),
+			},
+			expectedNodes: []string{"basic-dc-a-2", "basic-dc-a-9", "basic-dc-a-10"},
+		},
+		{
+			name:                 "error for an unparsable recorded node name",
+			nodes:                1,
+			replicas:             1,
+			decommissioningNodes: []string{"basic-dc-a"},
+			expectedErrorString:  `can't get ordinal of decommissioning node "basic-dc-a": can't parse ordinal from member service name "basic-dc-a"`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sdc := newDecommissionTestScyllaDBDatacenter(tc.nodes)
+			rackServices := map[string]*corev1.Service{}
+			for _, svc := range tc.services {
+				rackServices[svc.Name] = svc
+			}
+
+			got, err := makeRackDecommissioningNodes(sdc, sdc.Spec.Racks[0], tc.decommissioningNodes, newDecommissionTestStatefulSet(tc.replicas), rackServices)
+
+			gotErrorString := ""
+			if err != nil {
+				gotErrorString = err.Error()
+			}
+			if gotErrorString != tc.expectedErrorString {
+				t.Fatalf("expected error %q, got %q", tc.expectedErrorString, gotErrorString)
+			}
+			if err != nil {
+				return
+			}
+
+			if !cmp.Equal(got, tc.expectedNodes) {
+				t.Errorf("expected and actual decommissioning nodes differ: %s", cmp.Diff(tc.expectedNodes, got))
+			}
+		})
+	}
+}

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -382,7 +382,7 @@ func effectiveParallelNodeOperationsEnabled(sdc *scyllav1alpha1.ScyllaDBDatacent
 
 // StatefulSetForRack make a StatefulSet for the rack.
 // existingSts may be nil if it doesn't exist yet.
-func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.ScyllaDBDatacenter, existingSts *appsv1.StatefulSet, sidecarImage string, nodeExporterImage string, rackOrdinal int, inputsHash string) (*appsv1.StatefulSet, error) {
+func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.ScyllaDBDatacenter, existingSts *appsv1.StatefulSet, decommissioningNodes []string, sidecarImage string, nodeExporterImage string, rackOrdinal int, inputsHash string) (*appsv1.StatefulSet, error) {
 	selectorLabels, err := naming.RackSelectorLabels(rack, sdc)
 	if err != nil {
 		return nil, fmt.Errorf("can't get selector labels: %w", err)
@@ -523,9 +523,11 @@ func StatefulSetForRack(rack scyllav1alpha1.RackSpec, sdc *scyllav1alpha1.Scylla
 		return nil, fmt.Errorf("can't get scylla container ports: %w", err)
 	}
 
-	rackNodeCount, err := controllerhelpers.GetRackNodeCount(sdc, rack.Name)
+	// Members that are leaving hold the top of the ordinal range until they are removed, so a node count change made
+	// in the meantime can only take effect after that.
+	rackNodeCount, err := getEffectiveRackNodeCount(sdc, rack.Name, decommissioningNodes)
 	if err != nil {
-		return nil, fmt.Errorf("can't get rack %q node count of ScyllaDBDatacenter %q: %w", rack.Name, naming.ObjRef(sdc), err)
+		return nil, fmt.Errorf("can't get effective rack %q node count of ScyllaDBDatacenter %q: %w", rack.Name, naming.ObjRef(sdc), err)
 	}
 
 	initContainers, err := makeInitContainers(sdc, sidecarImage)

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -1502,12 +1502,13 @@ exec scylla-manager-agent \
 	const runBootstrapBarrierInitContainerIndex = 1
 
 	tt := []struct {
-		name                string
-		rack                scyllav1alpha1.RackSpec
-		scyllaDBDatacenter  *scyllav1alpha1.ScyllaDBDatacenter
-		existingStatefulSet *appsv1.StatefulSet
-		expectedStatefulSet *appsv1.StatefulSet
-		expectedError       error
+		name                 string
+		rack                 scyllav1alpha1.RackSpec
+		scyllaDBDatacenter   *scyllav1alpha1.ScyllaDBDatacenter
+		existingStatefulSet  *appsv1.StatefulSet
+		decommissioningNodes []string
+		expectedStatefulSet  *appsv1.StatefulSet
+		expectedError        error
 	}{
 		{
 			name:                "new StatefulSet",
@@ -1516,6 +1517,23 @@ exec scylla-manager-agent \
 			existingStatefulSet: nil,
 			expectedStatefulSet: newBasicStatefulSet(),
 			expectedError:       nil,
+		},
+		{
+			name: "replicas pinned to the lowest ordinal of a decommissioning node",
+			rack: newBasicRack(),
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newBasicScyllaDBDatacenter()
+				sdc.Spec.Racks[0].Nodes = new(int32(3))
+				return sdc
+			}(),
+			existingStatefulSet:  nil,
+			decommissioningNodes: []string{"basic-dc-rack-1", "basic-dc-rack-2"},
+			expectedStatefulSet: func() *appsv1.StatefulSet {
+				sts := newBasicStatefulSet()
+				sts.Spec.Replicas = new(int32(1))
+				return sts
+			}(),
+			expectedError: nil,
 		},
 		{
 			name: "error for invalid Rack storage",
@@ -2257,7 +2275,7 @@ exec scylla-manager-agent \
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := StatefulSetForRack(tc.rack, tc.scyllaDBDatacenter, tc.existingStatefulSet, unit.ScyllaDBOperatorImage, unit.ScyllaDBNodeExporterImage, 0, "")
+			got, err := StatefulSetForRack(tc.rack, tc.scyllaDBDatacenter, tc.existingStatefulSet, tc.decommissioningNodes, unit.ScyllaDBOperatorImage, unit.ScyllaDBNodeExporterImage, 0, "")
 
 			if !reflect.DeepEqual(err, tc.expectedError) {
 				t.Fatalf("expected and actual errors differ: %s",

--- a/pkg/controller/scylladbdatacenter/status.go
+++ b/pkg/controller/scylladbdatacenter/status.go
@@ -131,7 +131,11 @@ func (sdcc *Controller) calculateStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, 
 	// Calculate the status for racks.
 	for _, rack := range sdc.Spec.Racks {
 		stsName := naming.StatefulSetNameForRack(rack, sdc)
-		status.Racks = append(status.Racks, *calculateRackStatus(sdcc.podLister, sdc, rack.Name, statefulSetMap[stsName]))
+		rackStatus := calculateRackStatus(sdcc.podLister, sdc, rack.Name, statefulSetMap[stsName])
+		// The record of decommissioning nodes isn't derived from the observed state, it's maintained explicitly by the
+		// StatefulSet sync, so carry it over.
+		rackStatus.DecommissioningNodes = getRackDecommissioningNodes(&sdc.Status, rack.Name)
+		status.Racks = append(status.Racks, *rackStatus)
 	}
 
 	updateAggregatedStatusFields(status)

--- a/pkg/controller/scylladbdatacenter/sync_services.go
+++ b/pkg/controller/scylladbdatacenter/sync_services.go
@@ -25,7 +25,23 @@ import (
 
 var serviceOrdinalRegex = regexp.MustCompile("^.*-([0-9]+)$")
 
-func (sdcc *Controller) makeServices(sdc *scyllav1alpha1.ScyllaDBDatacenter, oldServices map[string]*corev1.Service, jobs map[string]*batchv1.Job) ([]*corev1.Service, error) {
+// getMemberServiceOrdinal returns the ordinal of the member the service with the given name belongs to.
+// TODO: Label services with the ordinal instead of parsing.
+func getMemberServiceOrdinal(name string) (int32, error) {
+	ordinalStrings := serviceOrdinalRegex.FindStringSubmatch(name)
+	if len(ordinalStrings) != 2 {
+		return 0, fmt.Errorf("can't parse ordinal from member service name %q", name)
+	}
+
+	ordinal, err := strconv.ParseInt(ordinalStrings[1], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("can't parse ordinal from member service name %q: %w", name, err)
+	}
+
+	return int32(ordinal), nil
+}
+
+func (sdcc *Controller) makeServices(sdc *scyllav1alpha1.ScyllaDBDatacenter, status *scyllav1alpha1.ScyllaDBDatacenterStatus, oldServices map[string]*corev1.Service, jobs map[string]*batchv1.Job) ([]*corev1.Service, error) {
 	identityService, err := IdentityService(sdc)
 	if err != nil {
 		return nil, fmt.Errorf("can't create identity service: %w", err)
@@ -37,9 +53,9 @@ func (sdcc *Controller) makeServices(sdc *scyllav1alpha1.ScyllaDBDatacenter, old
 
 	for _, rack := range sdc.Spec.Racks {
 		stsName := naming.StatefulSetNameForRack(rack, sdc)
-		rackNodes, err := controllerhelpers.GetRackNodeCount(sdc, rack.Name)
+		rackNodes, err := getEffectiveRackNodeCount(sdc, rack.Name, getRackDecommissioningNodes(status, rack.Name))
 		if err != nil {
-			return nil, fmt.Errorf("can't get rack %q node count of ScyllaDBDatacenter %q: %w", rack.Name, naming.ObjRef(sdc), err)
+			return nil, fmt.Errorf("can't get effective rack %q node count of ScyllaDBDatacenter %q: %w", rack.Name, naming.ObjRef(sdc), err)
 		}
 
 		for ord := int32(0); ord < *rackNodes; ord++ {
@@ -100,19 +116,12 @@ func (sdcc *Controller) pruneServices(
 			errs = append(errs, fmt.Errorf("statefulset %s/%s is missing", sdc.Namespace, stsName))
 			continue
 		}
-		// TODO: Label services with the ordinal instead of parsing.
-		// TODO: Move it to a function and unit test it.
-		svcOrdinalStrings := serviceOrdinalRegex.FindStringSubmatch(svc.Name)
-		if len(svcOrdinalStrings) != 2 {
-			errs = append(errs, fmt.Errorf("can't parse ordinal from service %s/%s", svc.Namespace, svc.Name))
-			continue
-		}
-		svcOrdinal, err := strconv.Atoi(svcOrdinalStrings[1])
+		svcOrdinal, err := getMemberServiceOrdinal(svc.Name)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		if int32(svcOrdinal) < *sts.Spec.Replicas {
+		if svcOrdinal < *sts.Spec.Replicas {
 			progressingConditions = append(progressingConditions, metav1.Condition{
 				Type:               serviceControllerProgressingCondition,
 				Status:             metav1.ConditionTrue,
@@ -206,7 +215,7 @@ func (sdcc *Controller) syncServices(
 	statefulSets map[string]*appsv1.StatefulSet,
 	jobs map[string]*batchv1.Job,
 ) ([]metav1.Condition, error) {
-	requiredServices, err := sdcc.makeServices(sdc, services, jobs)
+	requiredServices, err := sdcc.makeServices(sdc, status, services, jobs)
 	if err != nil {
 		return nil, fmt.Errorf("can't make services: %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/sync_services_test.go
+++ b/pkg/controller/scylladbdatacenter/sync_services_test.go
@@ -1,0 +1,52 @@
+package scylladbdatacenter
+
+import (
+	"testing"
+)
+
+func Test_getMemberServiceOrdinal(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name                string
+		memberServiceName   string
+		expectedOrdinal     int32
+		expectedErrorString string
+	}{
+		{
+			name:              "single digit ordinal",
+			memberServiceName: "basic-dc-a-1",
+			expectedOrdinal:   1,
+		},
+		{
+			name:              "multi digit ordinal",
+			memberServiceName: "basic-dc-a-42",
+			expectedOrdinal:   42,
+		},
+		{
+			name:                "name without an ordinal",
+			memberServiceName:   "basic-dc-a",
+			expectedErrorString: `can't parse ordinal from member service name "basic-dc-a"`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ordinal, err := getMemberServiceOrdinal(tc.memberServiceName)
+
+			gotErrorString := ""
+			if err != nil {
+				gotErrorString = err.Error()
+			}
+			if gotErrorString != tc.expectedErrorString {
+				t.Fatalf("expected error %q, got %q", tc.expectedErrorString, gotErrorString)
+			}
+
+			if ordinal != tc.expectedOrdinal {
+				t.Errorf("expected ordinal %d, got %d", tc.expectedOrdinal, ordinal)
+			}
+		})
+	}
+}

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -39,11 +39,11 @@ func snapshotTag(prefix string, t time.Time) string {
 	return fmt.Sprintf("so_%s_%sUTC", prefix, t.UTC().Format(time.RFC3339))
 }
 
-func (sdcc *Controller) makeRacks(sdc *scyllav1alpha1.ScyllaDBDatacenter, statefulSets map[string]*appsv1.StatefulSet, nodeExporterImage string, inputsHash string) ([]*appsv1.StatefulSet, error) {
+func (sdcc *Controller) makeRacks(sdc *scyllav1alpha1.ScyllaDBDatacenter, status *scyllav1alpha1.ScyllaDBDatacenterStatus, statefulSets map[string]*appsv1.StatefulSet, nodeExporterImage string, inputsHash string) ([]*appsv1.StatefulSet, error) {
 	sets := make([]*appsv1.StatefulSet, 0, len(sdc.Spec.Racks))
 	for i, rack := range sdc.Spec.Racks {
 		oldSts := statefulSets[naming.StatefulSetNameForRack(rack, sdc)]
-		sts, err := StatefulSetForRack(rack, sdc, oldSts, sdcc.operatorImage, nodeExporterImage, i, inputsHash)
+		sts, err := StatefulSetForRack(rack, sdc, oldSts, getRackDecommissioningNodes(status, rack.Name), sdcc.operatorImage, nodeExporterImage, i, inputsHash)
 		if err != nil {
 			return nil, err
 		}
@@ -557,12 +557,23 @@ func (sdcc *Controller) syncStatefulSets(
 		return progressingConditions, nil
 	}
 
+	decommissioningNodesProgressingConditions, decommissioningNodesChanged, err := sdcc.reconcileRackDecommissioningNodes(sdc, status, statefulSets, services)
+	progressingConditions = append(progressingConditions, decommissioningNodesProgressingConditions...)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't reconcile decommissioning nodes: %w", err)
+	}
+	// The record of decommissioning nodes is a write-ahead log of the decommission intent, so it has to be persisted
+	// before anything acts on it. Let the status update at the end of the sync commit it, and act on the next resync.
+	if decommissioningNodesChanged {
+		return progressingConditions, nil
+	}
+
 	inputsHash, err := hash.HashObjects(managedScyllaDBConfigCM.Data)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't hash inputs: %w", err)
 	}
 
-	requiredStatefulSets, err := sdcc.makeRacks(sdc, statefulSets, nodeExporterImage, inputsHash)
+	requiredStatefulSets, err := sdcc.makeRacks(sdc, status, statefulSets, nodeExporterImage, inputsHash)
 	if err != nil {
 		sdcc.eventRecorder.Eventf(
 			sdc,

--- a/test/envtest/controllers/scylladbdatacenter_decommission_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_decommission_test.go
@@ -1,0 +1,325 @@
+//go:build envtest
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/test/envtest"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+var _ = g.Describe("ScyllaDBDatacenter controller scale down", func() {
+	var env *envtest.Environment
+	g.BeforeEach(func(ctx g.SpecContext) {
+		env = envtest.Setup(ctx)
+	})
+
+	g.It("should decommission the last member of a rack on scale down", func(ctx g.SpecContext) {
+		g.By("Running ScyllaDBDatacenter controller")
+		runScyllaDBDatacenterController(ctx, env)
+
+		g.By("Running a fake StatefulSet rollout syncer")
+		runFakeStatefulSetRolloutSyncer(ctx, env)
+
+		g.By("Creating ScyllaOperatorConfig singleton")
+		createScyllaOperatorConfig(ctx, env)
+
+		g.By("Creating a ScyllaDBDatacenter with a two-node rack")
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a"}, withEnableParallelNodeOperations(false), withRackTemplateNodes(2))
+		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for the rack StatefulSet and the last member service to be created")
+		statefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+		waitForStatefulSet(ctx, env, statefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+		lastMemberServiceName := naming.MemberServiceName(sdc.Spec.Racks[0], sdc, 1)
+		waitForService(ctx, env, lastMemberServiceName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+
+		g.By("Scaling the rack down to one node")
+		sdc = updateRackTemplateNodes(ctx, env, sdc.Name, 1)
+
+		g.By("Waiting for the last member service to be marked with the decommission intent")
+		waitForServiceDecommissionIntent(ctx, env, lastMemberServiceName)
+
+		g.By("Marking the member as decommissioned in place of the sidecar")
+		markMemberServiceAsDecommissioned(ctx, env, lastMemberServiceName)
+
+		g.By("Waiting for the StatefulSet to scale down and the member service to be pruned")
+		o.Eventually(func(eo o.Gomega, ctx context.Context) {
+			statefulSet, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, statefulSetName, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			eo.Expect(*statefulSet.Spec.Replicas).To(o.Equal(int32(1)))
+
+			_, err = env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, lastMemberServiceName, metav1.GetOptions{})
+			eo.Expect(apierrors.IsNotFound(err)).To(o.BeTrue())
+		}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+	})
+
+	g.It("should complete an ongoing decommission and re-bootstrap the member when the rack is scaled back up mid-decommission", func(ctx g.SpecContext) {
+		g.By("Running ScyllaDBDatacenter controller")
+		runScyllaDBDatacenterController(ctx, env)
+
+		g.By("Running a fake StatefulSet rollout syncer")
+		runFakeStatefulSetRolloutSyncer(ctx, env)
+
+		g.By("Creating ScyllaOperatorConfig singleton")
+		createScyllaOperatorConfig(ctx, env)
+
+		g.By("Creating a ScyllaDBDatacenter with a two-node rack")
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a"}, withEnableParallelNodeOperations(false), withRackTemplateNodes(2))
+		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for the rack StatefulSet and the last member service to be created")
+		statefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+		waitForStatefulSet(ctx, env, statefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+		lastMemberServiceName := naming.MemberServiceName(sdc.Spec.Racks[0], sdc, 1)
+		waitForService(ctx, env, lastMemberServiceName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+
+		g.By("Scaling the rack down to one node")
+		sdc = updateRackTemplateNodes(ctx, env, sdc.Name, 1)
+
+		g.By("Waiting for the last member service to be marked with the decommission intent")
+		decommissioningService := waitForServiceDecommissionIntent(ctx, env, lastMemberServiceName)
+
+		g.By("Scaling the rack back up to two nodes while the decommission is still in progress")
+		sdc = updateRackTemplateNodes(ctx, env, sdc.Name, 2)
+
+		g.By("Waiting for the controller to observe the scale up")
+		o.Eventually(func(eo o.Gomega, ctx context.Context) {
+			freshSDC, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			eo.Expect(freshSDC.Status.ObservedGeneration).NotTo(o.BeNil())
+			eo.Expect(*freshSDC.Status.ObservedGeneration).To(o.BeNumerically(">=", sdc.Generation))
+		}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+		g.By("Marking the member as decommissioned in place of the sidecar")
+		markMemberServiceAsDecommissioned(ctx, env, lastMemberServiceName)
+
+		g.By("Waiting for the decommissioned member to be removed and re-bootstrapped afresh")
+		o.Eventually(func(eo o.Gomega, ctx context.Context) {
+			svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, lastMemberServiceName, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			eo.Expect(svc.UID).NotTo(o.Equal(decommissioningService.UID), "the decommissioned member's service should have been pruned and recreated for a fresh bootstrap")
+			eo.Expect(svc.Labels).NotTo(o.HaveKey(naming.DecommissionedLabel))
+
+			statefulSet, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, statefulSetName, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			eo.Expect(*statefulSet.Spec.Replicas).To(o.Equal(int32(2)))
+		}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+	})
+
+	g.It("should complete a scale down that the user reverted mid-decommission and bootstrap the regained capacity afresh", func(ctx g.SpecContext) {
+		g.By("Running ScyllaDBDatacenter controller")
+		runScyllaDBDatacenterController(ctx, env)
+
+		g.By("Running a fake StatefulSet rollout syncer")
+		runFakeStatefulSetRolloutSyncer(ctx, env)
+
+		g.By("Creating ScyllaOperatorConfig singleton")
+		createScyllaOperatorConfig(ctx, env)
+
+		g.By("Creating a ScyllaDBDatacenter with a three-node rack")
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{"rack-a"}, withEnableParallelNodeOperations(false), withRackTemplateNodes(3))
+		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for the rack StatefulSet and all member services to be created")
+		statefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+		waitForStatefulSet(ctx, env, statefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+		memberServiceNames := []string{
+			naming.MemberServiceName(sdc.Spec.Racks[0], sdc, 1),
+			naming.MemberServiceName(sdc.Spec.Racks[0], sdc, 2),
+		}
+		decommissioningServices := map[string]*corev1.Service{}
+		for _, name := range memberServiceNames {
+			decommissioningServices[name] = waitForService(ctx, env, name, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+		}
+
+		g.By("Scaling the rack down to one node")
+		sdc = updateRackTemplateNodes(ctx, env, sdc.Name, 1)
+
+		g.By("Waiting for both leaving nodes to be recorded in the rack status")
+		waitForRackDecommissioningNodes(ctx, env, sdc.Name, sdc.Spec.Racks[0].Name, memberServiceNames)
+
+		g.By("Waiting for the last member service to be marked with the decommission intent")
+		waitForServiceDecommissionIntent(ctx, env, memberServiceNames[1])
+
+		g.By("Scaling the rack back up to three nodes while the decommission is still in progress")
+		sdc = updateRackTemplateNodes(ctx, env, sdc.Name, 3)
+
+		g.By("Marking the last member as decommissioned in place of the sidecar")
+		markMemberServiceAsDecommissioned(ctx, env, memberServiceNames[1])
+
+		g.By("Waiting for the second leaving node to be marked with the decommission intent despite the reverted node count")
+		waitForServiceDecommissionIntent(ctx, env, memberServiceNames[0])
+
+		g.By("Marking the second member as decommissioned in place of the sidecar")
+		markMemberServiceAsDecommissioned(ctx, env, memberServiceNames[0])
+
+		g.By("Waiting for both nodes to be removed and bootstrapped afresh")
+		o.Eventually(func(eo o.Gomega, ctx context.Context) {
+			for _, name := range memberServiceNames {
+				svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, name, metav1.GetOptions{})
+				eo.Expect(err).NotTo(o.HaveOccurred())
+				eo.Expect(svc.UID).NotTo(o.Equal(decommissioningServices[name].UID), "the decommissioned member's service should have been pruned and recreated for a fresh bootstrap")
+				eo.Expect(svc.Labels).NotTo(o.HaveKey(naming.DecommissionedLabel))
+			}
+
+			statefulSet, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, statefulSetName, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			eo.Expect(*statefulSet.Spec.Replicas).To(o.Equal(int32(3)))
+
+			freshSDC, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			eo.Expect(freshSDC.Status.Racks).To(o.HaveLen(1))
+			eo.Expect(freshSDC.Status.Racks[0].DecommissioningNodes).To(o.BeEmpty())
+		}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+	})
+})
+
+func withRackTemplateNodes(nodes int32) func(*scyllav1alpha1.ScyllaDBDatacenter) {
+	return func(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
+		sdc.Spec.RackTemplate.Nodes = new(nodes)
+	}
+}
+
+// updateRackTemplateNodes retries the update until it lands: the controller keeps writing the status of the object
+// while it reconciles, so a conflict is expected rather than exceptional.
+func updateRackTemplateNodes(ctx context.Context, e *envtest.Environment, name string, nodes int32) *scyllav1alpha1.ScyllaDBDatacenter {
+	g.GinkgoHelper()
+
+	var sdc *scyllav1alpha1.ScyllaDBDatacenter
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		freshSDC, err := e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+
+		freshSDC.Spec.RackTemplate.Nodes = new(nodes)
+		sdc, err = e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Update(ctx, freshSDC, metav1.UpdateOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+	}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+	return sdc
+}
+
+func waitForService(ctx context.Context, e *envtest.Environment, name string, timeout time.Duration) *corev1.Service {
+	g.GinkgoHelper()
+
+	var svc *corev1.Service
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		var err error
+		svc, err = e.TypedKubeClient().CoreV1().Services(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+	}).WithContext(ctx).WithTimeout(timeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+	return svc
+}
+
+func waitForServiceDecommissionIntent(ctx context.Context, e *envtest.Environment, name string) *corev1.Service {
+	g.GinkgoHelper()
+
+	var svc *corev1.Service
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		var err error
+		svc, err = e.TypedKubeClient().CoreV1().Services(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+		eo.Expect(svc.Labels).To(o.HaveKeyWithValue(naming.DecommissionedLabel, naming.LabelValueFalse))
+	}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+	return svc
+}
+
+func waitForRackDecommissioningNodes(ctx context.Context, e *envtest.Environment, name string, rackName string, decommissioningNodes []string) {
+	g.GinkgoHelper()
+
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		sdc, err := e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+
+		rackStatus, _, ok := oslices.Find(sdc.Status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
+			return rackStatus.Name == rackName
+		})
+		eo.Expect(ok).To(o.BeTrue())
+		eo.Expect(rackStatus.DecommissioningNodes).To(o.Equal(decommissioningNodes))
+	}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+}
+
+// markMemberServiceAsDecommissioned stands in for the sidecar, which doesn't run in envtest: it reports
+// the completion of the member's decommission by flipping the decommission label to true.
+func markMemberServiceAsDecommissioned(ctx context.Context, e *envtest.Environment, name string) {
+	g.GinkgoHelper()
+
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		svc, err := e.TypedKubeClient().CoreV1().Services(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+
+		svc.Labels[naming.DecommissionedLabel] = naming.LabelValueTrue
+		_, err = e.TypedKubeClient().CoreV1().Services(e.Namespace()).Update(ctx, svc, metav1.UpdateOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+	}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+}
+
+// runFakeStatefulSetRolloutSyncer stands in for the StatefulSet controller and kubelet, which don't run in envtest:
+// it keeps every StatefulSet's status in sync with its spec so that rollouts always converge.
+func runFakeStatefulSetRolloutSyncer(ctx context.Context, e *envtest.Environment) {
+	client := e.TypedKubeClient().AppsV1().StatefulSets(e.Namespace())
+
+	go func() {
+		defer g.GinkgoRecover()
+
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			statefulSetList, err := client.List(ctx, metav1.ListOptions{})
+			if err != nil {
+				continue
+			}
+
+			for i := range statefulSetList.Items {
+				statefulSet := &statefulSetList.Items[i]
+				if statefulSet.Spec.Replicas == nil || isFakeRolledOut(statefulSet) {
+					continue
+				}
+
+				replicas := *statefulSet.Spec.Replicas
+				statefulSet.Status.ObservedGeneration = statefulSet.Generation
+				statefulSet.Status.Replicas = replicas
+				statefulSet.Status.ReadyReplicas = replicas
+				statefulSet.Status.AvailableReplicas = replicas
+				statefulSet.Status.UpdatedReplicas = replicas
+				statefulSet.Status.CurrentRevision = "envtest-revision"
+				statefulSet.Status.UpdateRevision = statefulSet.Status.CurrentRevision
+				// Conflicts and transient errors are retried on the next tick.
+				if _, err := client.UpdateStatus(ctx, statefulSet, metav1.UpdateOptions{}); err != nil {
+					klog.Warningf("can't update status of StatefulSet %q: %s", naming.ObjRef(statefulSet), err)
+				}
+			}
+		}
+	}()
+}
+
+func isFakeRolledOut(statefulSet *appsv1.StatefulSet) bool {
+	replicas := *statefulSet.Spec.Replicas
+	return statefulSet.Status.ObservedGeneration == statefulSet.Generation &&
+		statefulSet.Status.Replicas == replicas &&
+		statefulSet.Status.ReadyReplicas == replicas &&
+		statefulSet.Status.AvailableReplicas == replicas &&
+		statefulSet.Status.UpdatedReplicas == replicas
+}


### PR DESCRIPTION
**Description of your changes:**

Implements https://github.com/scylladb/scylla-operator/pull/3611.

**Which issue is resolved by this Pull Request:**
Closes https://scylladb.atlassian.net/browse/OPERATOR-343