### PR TITLE
fix(test/crypto): strip RawSignatureAlgorithm in cert comparison

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scylladb/scylla-operator
 
-go 1.26.3
+go 1.27.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/pkg/crypto/certcreators_test.go
+++ b/pkg/crypto/certcreators_test.go
@@ -242,6 +242,7 @@ func TestX509CertCreator_MakeCertificate(t *testing.T) {
 			cert.RawIssuer = nil
 			cert.RawSubject = nil
 			cert.RawSubjectPublicKeyInfo = nil
+			cert.RawSignatureAlgorithm = nil
 			cert.Subject.Names = nil
 			cert.Issuer.Names = nil
 			cert.Extensions = nil


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Go 1.27 added Certificate.RawSignatureAlgorithm to crypto/x509 and ParseCertificate now populates it. TestX509CertCreator_MakeCertificate zeroes the non-deterministic/raw fields before comparing against a hand-built expected cert, and that list predated the new field, so all four subtests failed on it alone once the CI runner image moved to go 1.27.

Zero the field alongside the other raw ones. This requires bumping the go directive to 1.27.0, since the directive gates stdlib struct fields.

**Which issue is resolved by this Pull Request:**
Resolves #
