### PR TITLE
fix: stop blocking bootstrapping new nodes for the duration of the decommission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@
   could be removed after the last node's `StatefulSet` was scaled down but before its member `Service` and `PVC` were
   removed, after which the operator could no longer resolve their rack and never cleaned them up.
   [#3633](https://github.com/scylladb/scylla-operator/pull/3633)
+- Fixed nodes being decommissioned dropping out of `ScyllaDBDatacenterNodesStatusReport` and blocking bootstrapping new nodes for the duration of the decommission.
+  The report enumerated a rack's nodes from the desired node count, so a decommissioning node
+  disappeared from it as soon as the count shrank, while its peers kept reporting it until the decommission
+  completed. The bootstrap barrier requires every observed host ID to have a report entry of its own, so a node joining
+  during a scale down waited for the decommission to finish.
+  This could additionally prevent unblocking decommissioning by adding new nodes.
+  The report is now built from the existing member Services, and a node which has finished decommissioning is dropped
+  from it as soon as it has left the ring, rather than when its Service is removed, since it can no longer report a
+  status of its own.
+  [#3615](https://github.com/scylladb/scylla-operator/pull/3615)
+- Fixed decommissioning a node which hasn't finished bootstrapping failing with an unexpected operation mode error
+  instead of waiting for the node to reach the normal mode.
+  [#3615](https://github.com/scylladb/scylla-operator/pull/3615)
 
 - Fixed a rack getting stuck forever when its node count was changed while one of its nodes was being decommissioned.
   A node whose decommission has started must now finish leaving, together with its Service and PVC, before the rack

--- a/pkg/controller/scylladbdatacenter/resource.go
+++ b/pkg/controller/scylladbdatacenter/resource.go
@@ -2423,15 +2423,21 @@ func cloneMapExcludingKeysOrEmpty[M ~map[K]V, S ~[]K, K comparable, V any](m M, 
 	return r
 }
 
+// makeScyllaDBDatacenterNodesStatusReport creates a ScyllaDBDatacenterNodesStatusReport for a ScyllaDBDatacenter.
+// The caller must ensure all the provided Services are controlled by the given ScyllaDBDatacenter.
 func makeScyllaDBDatacenterNodesStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, services map[string]*corev1.Service, podLister corev1listers.PodLister) (*scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport, error) {
-	var err error
-
 	var errs []error
+
+	rackMemberServices, err := groupMemberServicesByRack(services)
+	if err != nil {
+		return nil, fmt.Errorf("can't group member Services by rack for ScyllaDBDatacenter %q: %w", naming.ObjRef(sdc), err)
+	}
+
 	var rackStatusReports []scyllav1alpha1.RackNodesStatusReport
 	for _, rack := range sdc.Spec.Racks {
-		rackNodesStatusReport, err := makeRackNodesStatusReport(sdc, &rack, services, podLister)
+		rackNodesStatusReport, err := makeRackNodesStatusReport(sdc, &rack, rackMemberServices[rack.Name], podLister)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("can't make rack status report for rack %q of ScyllaDBDatacenter %q: %w", rack.Name, naming.ObjRef(sdc), err))
+			errs = append(errs, fmt.Errorf("can't make rack nodes status report for rack %q of ScyllaDBDatacenter %q: %w", rack.Name, naming.ObjRef(sdc), err))
 			continue
 		}
 
@@ -2469,19 +2475,49 @@ func makeScyllaDBDatacenterNodesStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacen
 	return ssr, nil
 }
 
-func makeRackNodesStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec *scyllav1alpha1.RackSpec, services map[string]*corev1.Service, podLister corev1listers.PodLister) (*scyllav1alpha1.RackNodesStatusReport, error) {
+// groupMemberServicesByRack filters member Services and groups them by the name of the rack they belong to.
+// The caller must ensure all the provided Services are controlled by a single ScyllaDBDatacenter.
+func groupMemberServicesByRack(services map[string]*corev1.Service) (map[string][]*corev1.Service, error) {
 	var errs []error
 
-	desiredRackNodeCount, err := controllerhelpers.GetRackNodeCount(sdc, rackSpec.Name)
+	rackMemberServices := map[string][]*corev1.Service{}
+	for _, svc := range services {
+		if svc.Labels[naming.ScyllaServiceTypeLabel] != string(naming.ScyllaServiceTypeMember) {
+			continue
+		}
+
+		rackName, ok := svc.Labels[naming.RackNameLabel]
+		if !ok {
+			// Fail closed: a member Service that can't be attributed to a rack may belong to a live node, and dropping it
+			// would let new nodes bootstrap against an incomplete report.
+			klog.Warningf("Member Service %q is missing %q label, the nodes status report can't be built", naming.ObjRef(svc), naming.RackNameLabel)
+			errs = append(errs, fmt.Errorf("member Service %q is missing %q label", naming.ObjRef(svc), naming.RackNameLabel))
+			continue
+		}
+
+		rackMemberServices[rackName] = append(rackMemberServices[rackName], svc)
+	}
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
-		return nil, fmt.Errorf("can't get rack %q node count of ScyllaDBDatacenter %q: %w", rackSpec.Name, naming.ObjRef(sdc), err)
+		return nil, err
 	}
 
+	return rackMemberServices, nil
+}
+
+// makeRackNodesStatusReport creates a RackNodesStatusReport for a rack.
+// Nodes are enumerated from the rack's existing member Services rather than from the desired node count, because a node
+// being decommissioned during a scale down outlives the desired count: it stays a member of the ScyllaDB cluster, observed
+// by its peers, until it finishes decommissioning. Its sidecar then annotates it as no longer joined, and it drops out
+// of the report, while its member Service is only pruned later.
+func makeRackNodesStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec *scyllav1alpha1.RackSpec, rackMemberServices []*corev1.Service, podLister corev1listers.PodLister) (*scyllav1alpha1.RackNodesStatusReport, error) {
+	var errs []error
+
 	var nodeStatusReports []scyllav1alpha1.NodeStatusReport
-	for ord := int32(0); ord < *desiredRackNodeCount; ord++ {
-		nodeStatusReport, ok, err := makeNodeStatusReport(sdc, rackSpec, int(ord), services, podLister)
+	for _, svc := range rackMemberServices {
+		nodeStatusReport, ok, err := makeNodeStatusReport(sdc, svc, podLister)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("can't make node status report for node %d of rack %q of ScyllaDBDatacenter %q: %w", ord, rackSpec.Name, naming.ObjRef(sdc), err))
+			errs = append(errs, fmt.Errorf("can't make node status report for member Service %q of rack %q of ScyllaDBDatacenter %q: %w", naming.ObjRef(svc), rackSpec.Name, naming.ObjRef(sdc), err))
 			continue
 		}
 		if !ok {
@@ -2490,10 +2526,15 @@ func makeRackNodesStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec 
 
 		nodeStatusReports = append(nodeStatusReports, *nodeStatusReport)
 	}
-	err = apimachineryutilerrors.NewAggregate(errs)
+	err := apimachineryutilerrors.NewAggregate(errs)
 	if err != nil {
 		return nil, err
 	}
+
+	// Ordering by ordinal guarantees stability of the entries and prevents unnecessary state changes that would result only from reshuffling.
+	slices.SortFunc(nodeStatusReports, func(a, b scyllav1alpha1.NodeStatusReport) int {
+		return cmp.Compare(a.Ordinal, b.Ordinal)
+	})
 
 	rackStatusReport := &scyllav1alpha1.RackNodesStatusReport{
 		Name:  rackSpec.Name,
@@ -2506,21 +2547,20 @@ func makeRackNodesStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec 
 // It returns an optional NodeStatusReport, a boolean indicating whether the NodeStatusReport is non-nil, and an error.
 // A node is included in the report only while its Service is annotated with naming.NodeJoinedScyllaDBClusterAnnotation
 // set to true, signaling it is a member of the ScyllaDB cluster.
-func makeNodeStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackSpec *scyllav1alpha1.RackSpec, ordinal int, services map[string]*corev1.Service, podLister corev1listers.PodLister) (*scyllav1alpha1.NodeStatusReport, bool, error) {
-	svcName := naming.MemberServiceName(*rackSpec, sdc, ordinal)
-	svc, ok := services[svcName]
-	if !ok {
-		klog.V(4).InfoS("Member Service is missing, skipping", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KRef(sdc.Namespace, svcName))
-		return nil, false, nil
-	}
-
+// The provided Service must be a member Service, named with an ordinal suffix.
+func makeNodeStatusReport(sdc *scyllav1alpha1.ScyllaDBDatacenter, svc *corev1.Service, podLister corev1listers.PodLister) (*scyllav1alpha1.NodeStatusReport, bool, error) {
 	if svc.Annotations[naming.NodeJoinedScyllaDBClusterAnnotation] != naming.LabelValueTrue {
 		klog.V(5).InfoS("Node has not yet been annotated as a member of the ScyllaDB cluster, skipping", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc), "AnnotationKey", naming.NodeJoinedScyllaDBClusterAnnotation)
 		return nil, false, nil
 	}
 
+	ordinal, err := naming.IndexFromName(svc.Name)
+	if err != nil {
+		return nil, false, fmt.Errorf("can't get ordinal from member Service %q: %w", naming.ObjRef(svc), err)
+	}
+
 	nodeStatusReport := &scyllav1alpha1.NodeStatusReport{
-		Ordinal: ordinal,
+		Ordinal: int(ordinal),
 	}
 
 	hostID := svc.Annotations[naming.HostIDAnnotation]

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -25,6 +25,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	apimachineryutilintstr "k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -7623,6 +7624,114 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				},
 			},
 			expectedErr: nil,
+		},
+		{
+			// Services of the datacenter which aren't member Services, like the identity Service, don't represent
+			// nodes and must not be reported.
+			name: "non-member service is not reported",
+			sdc:  basicScyllaDBDatacenter(),
+			services: map[string]*corev1.Service{
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-0"),
+				"basic-dc-client": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic-dc-client",
+						Namespace: "default",
+						Labels: map[string]string{
+							naming.ScyllaServiceTypeLabel: string(naming.ScyllaServiceTypeIdentity),
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				newPod(t, "basic-dc-a-0", &internalapi.NodeStatusReport{
+					ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+						{
+							HostID: "host-id-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+					},
+				}),
+			},
+			expected: &scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-12wmr",
+					Namespace: "default",
+					Labels: map[string]string{
+						"default-sc-label":              "foo",
+						"app":                           naming.AppName,
+						naming.KubernetesManagedByLabel: naming.OperatorAppName,
+						naming.KubernetesNameLabel:      naming.AppName,
+						naming.ScyllaDBDatacenterNodesStatusReportSelectorLabel: "basic",
+						naming.ClusterNameLabel:                                 "basic",
+					},
+					Annotations: map[string]string{
+						"default-sc-annotation": "bar",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scylla.scylladb.com/v1alpha1",
+							Kind:               "ScyllaDBDatacenter",
+							Name:               "basic",
+							UID:                "uid",
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
+						},
+					},
+				},
+				DatacenterName: "dc",
+				Racks: []scyllav1alpha1.RackNodesStatusReport{
+					{
+						Name: "a",
+						Nodes: []scyllav1alpha1.NodeStatusReport{
+							{
+								Ordinal: 0,
+								HostID:  pointer.Ptr("host-id-0"),
+								ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+									{
+										HostID: "host-id-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			// A member Service can't be attributed to a rack without the rack name label, so it's an error rather
+			// than a silently dropped node.
+			name: "member service missing the rack label is an error",
+			sdc:  basicScyllaDBDatacenter(),
+			services: map[string]*corev1.Service{
+				"basic-dc-a-0": func() *corev1.Service {
+					svc := newMemberService("basic-dc-a-0", "a", "host-id-0")
+					delete(svc.Labels, naming.RackNameLabel)
+					return svc
+				}(),
+			},
+			pods:     []*corev1.Pod{},
+			expected: nil,
+			expectedErr: fmt.Errorf(`can't group member Services by rack for ScyllaDBDatacenter "default/basic": %w`, apimachineryutilerrors.NewAggregate([]error{
+				fmt.Errorf("member Service %q is missing %q label", "default/basic-dc-a-0", naming.RackNameLabel),
+			})),
+		},
+		{
+			// A member Service without an ordinal suffix can't be attributed to a node, so it's an error rather than
+			// a silently dropped node.
+			name: "member service without an ordinal suffix is an error",
+			sdc:  basicScyllaDBDatacenter(),
+			services: map[string]*corev1.Service{
+				"basic-dc-a-foo": newMemberService("basic-dc-a-foo", "a", "host-id-0"),
+			},
+			pods:     []*corev1.Pod{},
+			expected: nil,
+			expectedErr: apimachineryutilerrors.NewAggregate([]error{
+				fmt.Errorf(`can't make rack nodes status report for rack %q of ScyllaDBDatacenter %q: %w`, "a", "default/basic", apimachineryutilerrors.NewAggregate([]error{
+					fmt.Errorf(`can't make node status report for member Service %q of rack %q of ScyllaDBDatacenter %q: %w`, "default/basic-dc-a-foo", "a", "default/basic", fmt.Errorf(`can't get ordinal from member Service %q: %w`, "default/basic-dc-a-foo", fmt.Errorf("couldn't convert '%s' to a number", "foo"))),
+				})),
+			}),
 		},
 	}
 

--- a/pkg/controller/scylladbdatacenter/resource_test.go
+++ b/pkg/controller/scylladbdatacenter/resource_test.go
@@ -5790,19 +5790,20 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 		}
 	}
 
-	newMemberService := func(name, hostID string) *corev1.Service {
+	newMemberService := func(name, rackName, hostID string) *corev1.Service {
 		return &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "default",
 				Annotations: map[string]string{
-					"default-sc-annotation":                                              "bar",
-					"internal.scylla-operator.scylladb.com/host-id":                      hostID,
-					"internal.scylla-operator.scylladb.com/node-joined-scylladb-cluster": "true",
+					"default-sc-annotation":                    "bar",
+					naming.HostIDAnnotation:                    hostID,
+					naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
 				},
 				Labels: map[string]string{
-					"default-sc-label": "foo",
-					"scylla-operator.scylladb.com/scylla-service-type": "member",
+					"default-sc-label":            "foo",
+					naming.ScyllaServiceTypeLabel: string(naming.ScyllaServiceTypeMember),
+					naming.RackNameLabel:          rackName,
 				},
 			},
 		}
@@ -6090,7 +6091,7 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				return sdc
 			}(),
 			services: map[string]*corev1.Service{
-				"basic-dc-a-0": newMemberService("basic-dc-a-0", "host-id-0"),
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-0"),
 			},
 			pods: []*corev1.Pod{},
 			expected: &scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport{
@@ -6150,7 +6151,7 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				return sdc
 			}(),
 			services: map[string]*corev1.Service{
-				"basic-dc-a-0": newMemberService("basic-dc-a-0", "host-id-0"),
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-0"),
 			},
 			pods: []*corev1.Pod{
 				{
@@ -6217,7 +6218,7 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				return sdc
 			}(),
 			services: map[string]*corev1.Service{
-				"basic-dc-a-0": newMemberService("basic-dc-a-0", "host-id-0"),
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-0"),
 			},
 			pods: []*corev1.Pod{
 				newPod(t, "basic-dc-a-0", &internalapi.NodeStatusReport{
@@ -6281,7 +6282,7 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				return sdc
 			}(),
 			services: map[string]*corev1.Service{
-				"basic-dc-a-0": newMemberService("basic-dc-a-0", "host-id-0"),
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-0"),
 			},
 			pods: []*corev1.Pod{
 				newPod(t, "basic-dc-a-0", &internalapi.NodeStatusReport{
@@ -6356,7 +6357,7 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				return sdc
 			}(),
 			services: map[string]*corev1.Service{
-				"basic-dc-a-0": newMemberService("basic-dc-a-0", "host-id-0"),
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-0"),
 			},
 			pods: []*corev1.Pod{},
 			expected: &scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport{
@@ -6421,12 +6422,13 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 						Name:      "basic-dc-a-0",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"default-sc-annotation": "bar",
-							"internal.scylla-operator.scylladb.com/node-joined-scylladb-cluster": "true",
+							"default-sc-annotation":                    "bar",
+							naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
 						},
 						Labels: map[string]string{
-							"default-sc-label": "foo",
-							"scylla-operator.scylladb.com/scylla-service-type": "member",
+							"default-sc-label":            "foo",
+							naming.ScyllaServiceTypeLabel: string(naming.ScyllaServiceTypeMember),
+							naming.RackNameLabel:          "a",
 						},
 					},
 				},
@@ -6497,7 +6499,7 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				return sdc
 			}(),
 			services: map[string]*corev1.Service{
-				"basic-dc-a-0": newMemberService("basic-dc-a-0", "host-id-0"),
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-0"),
 			},
 			pods: []*corev1.Pod{
 				newPod(t, "basic-dc-a-0", &internalapi.NodeStatusReport{
@@ -6572,9 +6574,9 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				return sdc
 			}(),
 			services: map[string]*corev1.Service{
-				"basic-dc-a-0": newMemberService("basic-dc-a-0", "host-id-0"),
-				"basic-dc-a-1": newMemberService("basic-dc-a-1", "host-id-1"),
-				"basic-dc-a-2": newMemberService("basic-dc-a-2", "host-id-2"),
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-0"),
+				"basic-dc-a-1": newMemberService("basic-dc-a-1", "a", "host-id-1"),
+				"basic-dc-a-2": newMemberService("basic-dc-a-2", "a", "host-id-2"),
 			},
 			pods: []*corev1.Pod{
 				newPod(t, "basic-dc-a-0", &internalapi.NodeStatusReport{
@@ -6753,10 +6755,10 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				return sdc
 			}(),
 			services: map[string]*corev1.Service{
-				"basic-dc-a-0": newMemberService("basic-dc-a-0", "host-id-a-0"),
-				"basic-dc-a-1": newMemberService("basic-dc-a-1", "host-id-a-1"),
-				"basic-dc-b-0": newMemberService("basic-dc-b-0", "host-id-b-0"),
-				"basic-dc-b-1": newMemberService("basic-dc-b-1", "host-id-b-1"),
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-a-0"),
+				"basic-dc-a-1": newMemberService("basic-dc-a-1", "a", "host-id-a-1"),
+				"basic-dc-b-0": newMemberService("basic-dc-b-0", "b", "host-id-b-0"),
+				"basic-dc-b-1": newMemberService("basic-dc-b-1", "b", "host-id-b-1"),
 			},
 			pods: []*corev1.Pod{
 				newPod(t, "basic-dc-a-0", &internalapi.NodeStatusReport{
@@ -7006,10 +7008,10 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 				return sdc
 			}(),
 			services: map[string]*corev1.Service{
-				"basic-dc-a-0": newMemberService("basic-dc-a-0", "host-id-a-0"),
-				"basic-dc-a-1": newMemberService("basic-dc-a-1", "host-id-a-1"),
-				"basic-dc-b-0": newMemberService("basic-dc-b-0", "host-id-b-0"),
-				"basic-dc-b-1": newMemberService("basic-dc-b-1", "host-id-b-1"),
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-a-0"),
+				"basic-dc-a-1": newMemberService("basic-dc-a-1", "a", "host-id-a-1"),
+				"basic-dc-b-0": newMemberService("basic-dc-b-0", "b", "host-id-b-0"),
+				"basic-dc-b-1": newMemberService("basic-dc-b-1", "b", "host-id-b-1"),
 			},
 			pods: []*corev1.Pod{
 				// Each pod's ObservedNodes are intentionally in reverse (unsorted) order to verify sorting.
@@ -7215,6 +7217,403 @@ func Test_makeScyllaDBDatacenterNodesStatusReport(t *testing.T) {
 									},
 									{
 										HostID: "host-id-b-1",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "rack scaled down by one, decommissioning node still has a service and a pod and is reported",
+			sdc: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := basicScyllaDBDatacenter()
+
+				sdc.Spec.Racks[0].RackTemplate.Nodes = pointer.Ptr[int32](2)
+
+				return sdc
+			}(),
+			services: map[string]*corev1.Service{
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-0"),
+				"basic-dc-a-1": newMemberService("basic-dc-a-1", "a", "host-id-1"),
+				"basic-dc-a-2": newMemberService("basic-dc-a-2", "a", "host-id-2"),
+			},
+			pods: []*corev1.Pod{
+				newPod(t, "basic-dc-a-0", &internalapi.NodeStatusReport{
+					ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+						{
+							HostID: "host-id-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-1",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-2",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+					},
+				}),
+				newPod(t, "basic-dc-a-1", &internalapi.NodeStatusReport{
+					ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+						{
+							HostID: "host-id-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-1",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-2",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+					},
+				}),
+				newPod(t, "basic-dc-a-2", &internalapi.NodeStatusReport{
+					ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+						{
+							HostID: "host-id-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-1",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-2",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+					},
+				}),
+			},
+			expected: &scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-12wmr",
+					Namespace: "default",
+					Labels: map[string]string{
+						"default-sc-label":             "foo",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla-operator.scylladb.com/scylladb-datacenter-nodes-status-report-selector": "basic",
+						"scylla/cluster": "basic",
+					},
+					Annotations: map[string]string{
+						"default-sc-annotation": "bar",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scylla.scylladb.com/v1alpha1",
+							Kind:               "ScyllaDBDatacenter",
+							Name:               "basic",
+							UID:                "uid",
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
+						},
+					},
+				},
+				DatacenterName: "dc",
+				Racks: []scyllav1alpha1.RackNodesStatusReport{
+					{
+						Name: "a",
+						Nodes: []scyllav1alpha1.NodeStatusReport{
+							{
+								Ordinal: 0,
+								HostID:  pointer.Ptr("host-id-0"),
+								ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+									{
+										HostID: "host-id-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-1",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-2",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+								},
+							},
+							{
+								Ordinal: 1,
+								HostID:  pointer.Ptr("host-id-1"),
+								ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+									{
+										HostID: "host-id-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-1",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-2",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+								},
+							},
+							{
+								Ordinal: 2,
+								HostID:  pointer.Ptr("host-id-2"),
+								ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+									{
+										HostID: "host-id-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-1",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-2",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			// One rack is scaling out while another is scaling in, in a single patch. The new node of rack a is created
+			// first and rack b's scale down is deferred until it's rolled out, so all of rack b's nodes have to be reported
+			// for the new node to get past the bootstrap barrier.
+			name: "one rack scaled up while another is scaled down, the nodes of the scaled down rack are all reported",
+			sdc: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := basicScyllaDBDatacenter()
+
+				sdc.Spec.Racks = []scyllav1alpha1.RackSpec{
+					{
+						Name: "a",
+						RackTemplate: scyllav1alpha1.RackTemplate{
+							Nodes: pointer.Ptr[int32](2),
+						},
+					},
+					{
+						Name: "b",
+						RackTemplate: scyllav1alpha1.RackTemplate{
+							Nodes: pointer.Ptr[int32](1),
+						},
+					},
+				}
+				return sdc
+			}(),
+			services: map[string]*corev1.Service{
+				"basic-dc-a-0": newMemberService("basic-dc-a-0", "a", "host-id-a-0"),
+				"basic-dc-b-0": newMemberService("basic-dc-b-0", "b", "host-id-b-0"),
+				"basic-dc-b-1": newMemberService("basic-dc-b-1", "b", "host-id-b-1"),
+				"basic-dc-b-2": newMemberService("basic-dc-b-2", "b", "host-id-b-2"),
+			},
+			pods: []*corev1.Pod{
+				newPod(t, "basic-dc-a-0", &internalapi.NodeStatusReport{
+					ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+						{
+							HostID: "host-id-a-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-1",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-2",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+					},
+				}),
+				newPod(t, "basic-dc-b-0", &internalapi.NodeStatusReport{
+					ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+						{
+							HostID: "host-id-a-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-1",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-2",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+					},
+				}),
+				newPod(t, "basic-dc-b-1", &internalapi.NodeStatusReport{
+					ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+						{
+							HostID: "host-id-a-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-1",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-2",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+					},
+				}),
+				newPod(t, "basic-dc-b-2", &internalapi.NodeStatusReport{
+					ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+						{
+							HostID: "host-id-a-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-0",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-1",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+						{
+							HostID: "host-id-b-2",
+							Status: scyllav1alpha1.NodeStatusUp,
+						},
+					},
+				}),
+			},
+			expected: &scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic-12wmr",
+					Namespace: "default",
+					Labels: map[string]string{
+						"default-sc-label":             "foo",
+						"app":                          "scylla",
+						"app.kubernetes.io/managed-by": "scylla-operator",
+						"app.kubernetes.io/name":       "scylla",
+						"scylla-operator.scylladb.com/scylladb-datacenter-nodes-status-report-selector": "basic",
+						"scylla/cluster": "basic",
+					},
+					Annotations: map[string]string{
+						"default-sc-annotation": "bar",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scylla.scylladb.com/v1alpha1",
+							Kind:               "ScyllaDBDatacenter",
+							Name:               "basic",
+							UID:                "uid",
+							Controller:         pointer.Ptr(true),
+							BlockOwnerDeletion: pointer.Ptr(true),
+						},
+					},
+				},
+				DatacenterName: "dc",
+				Racks: []scyllav1alpha1.RackNodesStatusReport{
+					{
+						Name: "a",
+						Nodes: []scyllav1alpha1.NodeStatusReport{
+							{
+								Ordinal: 0,
+								HostID:  pointer.Ptr("host-id-a-0"),
+								ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+									{
+										HostID: "host-id-a-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-1",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-2",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "b",
+						Nodes: []scyllav1alpha1.NodeStatusReport{
+							{
+								Ordinal: 0,
+								HostID:  pointer.Ptr("host-id-b-0"),
+								ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+									{
+										HostID: "host-id-a-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-1",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-2",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+								},
+							},
+							{
+								Ordinal: 1,
+								HostID:  pointer.Ptr("host-id-b-1"),
+								ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+									{
+										HostID: "host-id-a-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-1",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-2",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+								},
+							},
+							{
+								Ordinal: 2,
+								HostID:  pointer.Ptr("host-id-b-2"),
+								ObservedNodes: []scyllav1alpha1.ObservedNodeStatus{
+									{
+										HostID: "host-id-a-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-0",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-1",
+										Status: scyllav1alpha1.NodeStatusUp,
+									},
+									{
+										HostID: "host-id-b-2",
 										Status: scyllav1alpha1.NodeStatusUp,
 									},
 								},

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -246,12 +246,12 @@ func (sdcc *Controller) beforeNodeUpgrade(ctx context.Context, sdc *scyllav1alph
 		return true, err
 	}
 
-	if om.IsDraining() {
+	if om == scyllaclient.OperationalModeDraining {
 		klog.V(4).InfoS("Waiting for scylla node to finish draining", "ScyllaDBDatacenter", klog.KObj(sdc), "Host", host)
 		return false, nil
 	}
 
-	if !om.IsDrained() {
+	if om != scyllaclient.OperationalModeDrained {
 		klog.V(4).InfoS("Draining scylla node", "ScyllaDBDatacenter", klog.KObj(sdc), "Host", host)
 		err = scyllaClient.Drain(ctx, host)
 		if err != nil {

--- a/pkg/controller/sidecar/sync.go
+++ b/pkg/controller/sidecar/sync.go
@@ -39,8 +39,8 @@ func (c *Controller) decommissionNode(ctx context.Context, svc *corev1.Service) 
 
 	klog.V(4).InfoS("Scylla operation mode", "Mode", opMode)
 	switch opMode {
-	case scyllaclient.OperationalModeLeaving, scyllaclient.OperationalModeDecommissioning, scyllaclient.OperationalModeDraining:
-		// If node is leaving/draining/decommissioning, keep retrying.
+	case scyllaclient.OperationalModeLeaving, scyllaclient.OperationalModeDraining:
+		// If node is leaving/draining, keep retrying.
 		klog.V(2).InfoS("Waiting for scylla to finish the operation, requeuing", "Mode", opMode)
 		c.queue.AddAfter(c.key, requeueWaitDuration)
 		return nil
@@ -77,7 +77,7 @@ func (c *Controller) decommissionNode(ctx context.Context, svc *corev1.Service) 
 			// Decommission is long running task, so request fails due to the timeout in most cases.
 			// To not raise an error, when it is in progress, we check opMode.
 			opMode, err := scyllaClient.OperationMode(ctx, c.localhostAddress)
-			if err == nil && (opMode.IsDecommissioned() || opMode.IsLeaving() || opMode.IsDecommissioning()) {
+			if err == nil && (opMode == scyllaclient.OperationalModeDecommissioned || opMode == scyllaclient.OperationalModeLeaving) {
 				klog.V(2).InfoS("Decommissioning is in progress. Waiting a bit.", "Mode", opMode)
 				c.queue.AddAfter(c.key, requeueWaitDuration)
 				return nil
@@ -86,9 +86,9 @@ func (c *Controller) decommissionNode(ctx context.Context, svc *corev1.Service) 
 			return fmt.Errorf("can't decommission the node: %w", decommissionErr)
 		}
 
-	case scyllaclient.OperationalModeJoining:
-		// If node is joining we need to wait till it reaches Normal state and then decommission it
-		klog.V(2).InfoS("Can't decommission a joining node. Waiting a bit.")
+	case scyllaclient.OperationalModeStarting, scyllaclient.OperationalModeJoining, scyllaclient.OperationalModeBootstrap:
+		// The node has to reach the NORMAL mode before it can be decommissioned.
+		klog.V(2).InfoS("Can't decommission a node which hasn't reached the NORMAL mode yet. Requeuing.", "Mode", opMode)
 		c.queue.AddAfter(c.key, requeueWaitDuration)
 		return nil
 

--- a/pkg/controller/sidecar/sync.go
+++ b/pkg/controller/sidecar/sync.go
@@ -156,43 +156,81 @@ func (c *Controller) getRequiredServiceAnnotations(ctx context.Context, scyllaCl
 
 	annotations[naming.HostIDAnnotation] = hostID
 
-	isMember, isKnown, err := nodeIsScyllaDBClusterMember(ctx, scyllaClient, c.localhostAddress, hostID)
+	membership, err := getScyllaDBClusterMembership(ctx, scyllaClient, c.localhostAddress, hostID)
 	if err != nil {
-		return annotations, false, fmt.Errorf("can't determine ScyllaDB cluster membership: %w", err)
+		return annotations, false, fmt.Errorf("can't get ScyllaDB cluster membership: %w", err)
 	}
 
-	if !isKnown {
-		klog.V(4).InfoS("Node hasn't joined the ScyllaDB cluster yet", "HostID", hostID)
+	switch membership {
+	case scyllaDBClusterMembershipUnknown:
+		// Retain the last observed membership status in the annotation.
+		klog.V(4).InfoS("Node's ScyllaDB cluster membership can't be determined", "HostID", hostID)
 		return annotations, true, nil
-	}
 
-	if !isMember {
-		klog.V(4).InfoS("Node doesn't own any tokens yet", "HostID", hostID)
+	case scyllaDBClusterMembershipNotMember:
+		// Requeue to pick up the node joining. A decommissioned node never does, so its sidecar keeps polling until
+		// its Pod is deleted, but its member Service is pruned shortly after the decommission anyway.
+		klog.V(4).InfoS("Node doesn't own any tokens in the ScyllaDB cluster", "HostID", hostID)
 		annotations[naming.NodeJoinedScyllaDBClusterAnnotation] = naming.LabelValueFalse
 		return annotations, true, nil
-	}
 
-	annotations[naming.NodeJoinedScyllaDBClusterAnnotation] = naming.LabelValueTrue
+	case scyllaDBClusterMembershipMember:
+		annotations[naming.NodeJoinedScyllaDBClusterAnnotation] = naming.LabelValueTrue
+
+	default:
+		return annotations, false, fmt.Errorf("unexpected ScyllaDB cluster membership: %d", membership)
+	}
 
 	currentTokenRingHash, err := getTokenRingHash(ctx, scyllaClient, c.localhostAddress)
 	if err != nil {
 		return annotations, false, fmt.Errorf("can't get current token ring hash: %w", err)
 	}
+
 	annotations[naming.CurrentTokenRingHashAnnotation] = currentTokenRingHash
 
 	return annotations, false, nil
 }
 
-// nodeIsScyllaDBClusterMember reports whether the node is a member of the ScyllaDB cluster, i.e. whether it owns normal
+type scyllaDBClusterMembership int
+
+const (
+	// scyllaDBClusterMembershipUnknown means the membership can't be determined: the node is absent from the cluster's
+	// token metadata, or its gossiper is down (starting, drained, in maintenance mode) so the token metadata can't be queried.
+	scyllaDBClusterMembershipUnknown scyllaDBClusterMembership = iota
+	// scyllaDBClusterMembershipNotMember means the node owns no normal tokens: it is bootstrapping, has lost its state,
+	// or has been decommissioned and left the ring for good.
+	scyllaDBClusterMembershipNotMember
+	// scyllaDBClusterMembershipMember means the node owns normal tokens.
+	scyllaDBClusterMembershipMember
+)
+
+// getScyllaDBClusterMembership reports whether the node is a member of the ScyllaDB cluster, i.e. whether it owns normal
 // tokens in the cluster's token metadata. Unlike the node's operation mode, this survives a restart: a bootstrapped node
 // has its token metadata restored from disk before gossip starts, so it never stops owning normal tokens while it boots.
 // A node that is bootstrapping holds only pending tokens and is not a member until the operation completes.
-// The second return value reports whether membership could be determined at all. When it is false, the caller must not act
-// on the first one.
-func nodeIsScyllaDBClusterMember(ctx context.Context, scyllaClient *scyllaclient.Client, localhostAddr string, hostID string) (bool, bool, error) {
+// The operation mode is consulted first, because the host ID map can only be served while the gossiper is up: it is
+// stopped for good once a node is decommissioned, and it is down while a node is starting, drained or in maintenance mode.
+func getScyllaDBClusterMembership(ctx context.Context, scyllaClient *scyllaclient.Client, localhostAddr string, hostID string) (scyllaDBClusterMembership, error) {
+	opMode, err := scyllaClient.OperationMode(ctx, localhostAddr)
+	if err != nil {
+		return scyllaDBClusterMembershipUnknown, fmt.Errorf("can't get operation mode: %w", err)
+	}
+
+	switch opMode {
+	case scyllaclient.OperationalModeDecommissioned:
+		// The node has left the ring for good. Its gossiper is stopped, so the token metadata can't be asked.
+		klog.V(4).InfoS("Node has been decommissioned")
+		return scyllaDBClusterMembershipNotMember, nil
+
+	case scyllaclient.OperationalModeStarting, scyllaclient.OperationalModeDraining, scyllaclient.OperationalModeDrained, scyllaclient.OperationalModeMaintenance:
+		// The node may still own tokens, but its gossiper is down (not started yet, or stopped) so the token metadata
+		// can't be queried.
+		return scyllaDBClusterMembershipUnknown, nil
+	}
+
 	ipToHostIDMap, err := scyllaClient.GetIPToHostIDMap(ctx, localhostAddr)
 	if err != nil {
-		return false, false, fmt.Errorf("can't get host id to ip mapping: %w", err)
+		return scyllaDBClusterMembershipUnknown, fmt.Errorf("can't get host id to ip mapping: %w", err)
 	}
 	klog.V(4).InfoS("Got IP to HostID mapping", "IPToHostIDMap", ipToHostIDMap)
 
@@ -206,16 +244,20 @@ func nodeIsScyllaDBClusterMember(ctx context.Context, scyllaClient *scyllaclient
 
 	if len(localIP) == 0 {
 		// The node is not present in the cluster's token metadata, so its membership can't be determined.
-		return false, false, nil
+		return scyllaDBClusterMembershipUnknown, nil
 	}
 
 	// Only normal tokens are reported for the endpoint, pending tokens of a bootstrapping or replacing node are not.
 	nodeTokens, err := scyllaClient.GetNodeTokens(ctx, localhostAddr, localIP)
 	if err != nil {
-		return false, false, fmt.Errorf("can't get node tokens: %w", err)
+		return scyllaDBClusterMembershipUnknown, fmt.Errorf("can't get node tokens: %w", err)
 	}
 
-	return len(nodeTokens) != 0, true, nil
+	if len(nodeTokens) == 0 {
+		return scyllaDBClusterMembershipNotMember, nil
+	}
+
+	return scyllaDBClusterMembershipMember, nil
 }
 
 func getTokenRingHash(ctx context.Context, scyllaClient *scyllaclient.Client, localhostAddr string) (string, error) {

--- a/pkg/controller/sidecar/sync_test.go
+++ b/pkg/controller/sidecar/sync_test.go
@@ -4,96 +4,135 @@ package sidecar
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/scylladb/scylla-operator/pkg/scyllaclient"
 )
 
-func TestNodeIsScyllaDBClusterMember(t *testing.T) {
+func TestGetScyllaDBClusterMembership(t *testing.T) {
 	t.Parallel()
 
-	const hostID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	const (
+		localIP = "10.0.0.1"
+		hostID  = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	)
 
 	tt := []struct {
-		name           string
-		handler        http.HandlerFunc
-		expectedMember bool
-		expectedKnown  bool
-		expectedErr    bool
+		name               string
+		fake               fakeScyllaDBTokenMetadata
+		expectedMembership scyllaDBClusterMembership
+		expectedErr        bool
 	}{
 		{
 			name: "node owning normal tokens is a member",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/storage_service/host_id":
-					w.Write([]byte(`[{"key":"10.0.0.1","value":"` + hostID + `"}]`))
-				case "/storage_service/tokens/10.0.0.1":
-					w.Write([]byte(`["-1","0","1"]`))
-				default:
-					t.Errorf("unexpected request to %q", r.URL.Path)
-				}
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
+				ipToHostIDMap: map[string]string{localIP: hostID},
+				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
 			},
-			expectedMember: true,
-			expectedKnown:  true,
-			expectedErr:    false,
+			expectedMembership: scyllaDBClusterMembershipMember,
 		},
 		{
-			name: "node without normal tokens is known but not a member",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/storage_service/host_id":
-					w.Write([]byte(`[{"key":"10.0.0.1","value":"` + hostID + `"}]`))
-				case "/storage_service/tokens/10.0.0.1":
-					w.Write([]byte(`[]`))
-				default:
-					t.Errorf("unexpected request to %q", r.URL.Path)
-				}
+			// A vnode decommission streams while in LEAVING. The node still owns its tokens and its peers still observe it.
+			name: "leaving node owning normal tokens is a member",
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeLeaving,
+				ipToHostIDMap: map[string]string{localIP: hostID},
+				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
 			},
-			expectedMember: false,
-			expectedKnown:  true,
-			expectedErr:    false,
+			expectedMembership: scyllaDBClusterMembershipMember,
 		},
 		{
+			// BOOTSTRAP is a mode without special handling, which falls through to the token metadata.
+			name: "node in a mode without special handling is looked up in the token metadata",
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeBootstrap,
+				ipToHostIDMap: map[string]string{localIP: hostID},
+				nodeTokens:    map[string][]string{localIP: {}},
+			},
+			expectedMembership: scyllaDBClusterMembershipNotMember,
+		},
+		{
+			name: "node without normal tokens is not a member",
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
+				ipToHostIDMap: map[string]string{localIP: hostID},
+				nodeTokens:    map[string][]string{localIP: {}},
+			},
+			expectedMembership: scyllaDBClusterMembershipNotMember,
+		},
+		{
+			// The node tokens endpoint must not be reached, it reports an empty token list for an address the cluster
+			// doesn't know, which is indistinguishable from a bootstrapping node. Reaching it fails the request instead.
 			name: "node absent from the host ID map is undeterminable",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/storage_service/host_id":
-					w.Write([]byte(`[{"key":"10.0.0.2","value":"ffffffff-ffff-ffff-ffff-ffffffffffff"}]`))
-				default:
-					// The node tokens endpoint must not be reached, it reports an empty token list for an
-					// address the cluster doesn't know, which is indistinguishable from a bootstrapping node.
-					t.Errorf("unexpected request to %q", r.URL.Path)
-				}
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode:  scyllaclient.OperationalModeNormal,
+				ipToHostIDMap:  map[string]string{"10.0.0.2": "ffffffff-ffff-ffff-ffff-ffffffffffff"},
+				failNodeTokens: true,
 			},
-			expectedMember: false,
-			expectedKnown:  false,
-			expectedErr:    false,
+			expectedMembership: scyllaDBClusterMembershipUnknown,
+		},
+		{
+			// The token metadata endpoints must not be reached: the gossiper is stopped and the host ID map fails.
+			name: "decommissioned node is not a member without consulting the token metadata",
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode:     scyllaclient.OperationalModeDecommissioned,
+				failIPToHostIDMap: true,
+				failNodeTokens:    true,
+			},
+			expectedMembership: scyllaDBClusterMembershipNotMember,
+		},
+		{
+			// Ditto, but the node still owns its tokens and is restarted eventually, so the last observation stands.
+			name: "drained node is undeterminable without consulting the token metadata",
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode:     scyllaclient.OperationalModeDrained,
+				failIPToHostIDMap: true,
+				failNodeTokens:    true,
+			},
+			expectedMembership: scyllaDBClusterMembershipUnknown,
+		},
+		{
+			// Ditto, the gossiper hasn't started yet.
+			name: "starting node is undeterminable without consulting the token metadata",
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode:     scyllaclient.OperationalModeStarting,
+				failIPToHostIDMap: true,
+				failNodeTokens:    true,
+			},
+			expectedMembership: scyllaDBClusterMembershipUnknown,
+		},
+		{
+			name: "operation mode error is propagated",
+			fake: fakeScyllaDBTokenMetadata{
+				failOperationMode: true,
+			},
+			expectedMembership: scyllaDBClusterMembershipUnknown,
+			expectedErr:        true,
 		},
 		{
 			name: "host ID map error is propagated",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusInternalServerError)
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode:     scyllaclient.OperationalModeNormal,
+				failIPToHostIDMap: true,
 			},
-			expectedMember: false,
-			expectedKnown:  false,
-			expectedErr:    true,
+			expectedMembership: scyllaDBClusterMembershipUnknown,
+			expectedErr:        true,
 		},
 		{
 			name: "node tokens error is propagated",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/storage_service/host_id":
-					w.Write([]byte(`[{"key":"10.0.0.1","value":"` + hostID + `"}]`))
-				default:
-					w.WriteHeader(http.StatusInternalServerError)
-				}
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode:  scyllaclient.OperationalModeNormal,
+				ipToHostIDMap:  map[string]string{localIP: hostID},
+				failNodeTokens: true,
 			},
-			expectedMember: false,
-			expectedKnown:  false,
-			expectedErr:    true,
+			expectedMembership: scyllaDBClusterMembershipUnknown,
+			expectedErr:        true,
 		},
 	}
 
@@ -101,7 +140,7 @@ func TestNodeIsScyllaDBClusterMember(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			server := httptest.NewServer(tc.handler)
+			server := httptest.NewServer(newFakeScyllaDBTokenMetadataHandler(t, tc.fake))
 			t.Cleanup(server.Close)
 
 			u, err := url.Parse(server.URL)
@@ -118,16 +157,78 @@ func TestNodeIsScyllaDBClusterMember(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			isMember, isKnown, err := nodeIsScyllaDBClusterMember(context.Background(), client, u.Hostname(), hostID)
+			membership, err := getScyllaDBClusterMembership(context.Background(), client, u.Hostname(), hostID)
 			if (err != nil) != tc.expectedErr {
 				t.Fatalf("expected error %v, got %v", tc.expectedErr, err)
 			}
-			if isMember != tc.expectedMember {
-				t.Errorf("expected isMember %v, got %v", tc.expectedMember, isMember)
-			}
-			if isKnown != tc.expectedKnown {
-				t.Errorf("expected isKnown %v, got %v", tc.expectedKnown, isKnown)
+			if membership != tc.expectedMembership {
+				t.Errorf("expected membership %v, got %v", tc.expectedMembership, membership)
 			}
 		})
+	}
+}
+
+// fakeScyllaDBTokenMetadata describes the ScyllaDB API responses served by newFakeScyllaDBTokenMetadataHandler.
+type fakeScyllaDBTokenMetadata struct {
+	// operationMode is the node's operational mode.
+	operationMode scyllaclient.OperationalMode
+	// failOperationMode makes the operation mode request fail.
+	failOperationMode bool
+	// ipToHostIDMap is the cluster's IP to host ID mapping.
+	ipToHostIDMap map[string]string
+	// failIPToHostIDMap makes the host ID mapping request fail.
+	failIPToHostIDMap bool
+	// nodeTokens maps an endpoint to the normal tokens it owns. An endpoint absent from the map is served as 404.
+	nodeTokens map[string][]string
+	// failNodeTokens makes the per-endpoint tokens request fail.
+	failNodeTokens bool
+}
+
+// newFakeScyllaDBTokenMetadataHandler returns a handler serving the given fake ScyllaDB API responses, failing the test
+// on any other request.
+func newFakeScyllaDBTokenMetadataHandler(t *testing.T, fake fakeScyllaDBTokenMetadata) http.HandlerFunc {
+	encode := func(w http.ResponseWriter, v any) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(v); err != nil {
+			t.Errorf("can't encode response: %v", err)
+		}
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/storage_service/operation_mode":
+			if fake.failOperationMode {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			encode(w, string(fake.operationMode))
+
+		case r.URL.Path == "/storage_service/host_id":
+			if fake.failIPToHostIDMap {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			var mapping []map[string]string
+			for ip, hostID := range fake.ipToHostIDMap {
+				mapping = append(mapping, map[string]string{"key": ip, "value": hostID})
+			}
+			encode(w, mapping)
+
+		case strings.HasPrefix(r.URL.Path, "/storage_service/tokens/"):
+			if fake.failNodeTokens {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			tokens, ok := fake.nodeTokens[strings.TrimPrefix(r.URL.Path, "/storage_service/tokens/")]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			encode(w, tokens)
+
+		default:
+			t.Errorf("unexpected request to %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
 	}
 }

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -61,12 +61,14 @@ const (
 	// (the actual ScyllaDB cluster, not the Kubernetes abstraction). Membership is determined by whether the node
 	// owns normal tokens in the cluster's token metadata, so it is unaffected by the node restarting - a bootstrapped
 	// node has its token metadata restored from disk before gossip starts and never stops owning normal tokens while
-	// it boots. It is set to "false" when the node owns no normal tokens, which covers a node that is bootstrapping
-	// for the first time, a node that has lost its state, and a node undergoing a replacement procedure.
+	// it boots. It is set to "false" when the node owns no normal tokens, which covers a node that has not completed its
+	// bootstrap yet, a node that has lost its state, and a node undergoing a replacement procedure. It is also set
+	// to "false" once the node has been decommissioned: it has left the token ring and its gossiper is stopped, so it
+	// can neither answer the membership queries nor report a status of its own.
 	// The value is only ever written from a successful observation and is left untouched when membership can't be
-	// determined. Since the ScyllaDB API is unreachable for as long as the node is down, the annotation retains the
-	// last observed value throughout - a node that has lost its state keeps "true" from before the loss until its
-	// sidecar can query the API again.
+	// determined. Since the ScyllaDB API is unreachable for as long as the node is down, and its token metadata can't
+	// be queried while it is drained, the annotation retains the last observed value throughout - a node that has lost
+	// its state keeps "true" from before the loss until its sidecar can query the API again.
 	NodeJoinedScyllaDBClusterAnnotation = "internal.scylla-operator.scylladb.com/node-joined-scylladb-cluster"
 )
 

--- a/pkg/scyllaclient/model.go
+++ b/pkg/scyllaclient/model.go
@@ -48,66 +48,42 @@ func (s NodeState) String() string {
 
 type OperationalMode string
 
+// The modes ScyllaDB's storage service reports.
+// NONE is reported as STARTING.
 const (
-	OperationalModeClient          OperationalMode = "CLIENT"
-	OperationalModeDecommissioned  OperationalMode = "DECOMMISSIONED"
-	OperationalModeDecommissioning OperationalMode = "DECOMMISSIONING"
-	OperationalModeJoining         OperationalMode = "JOINING"
-	OperationalModeLeaving         OperationalMode = "LEAVING"
-	OperationalModeNormal          OperationalMode = "NORMAL"
-	OperationalModeDrained         OperationalMode = "DRAINED"
-	OperationalModeDraining        OperationalMode = "DRAINING"
-	OperationalModeUnknown         OperationalMode = "UNKNOWN"
+	OperationalModeStarting       OperationalMode = "STARTING"
+	OperationalModeJoining        OperationalMode = "JOINING"
+	OperationalModeBootstrap      OperationalMode = "BOOTSTRAP"
+	OperationalModeNormal         OperationalMode = "NORMAL"
+	OperationalModeLeaving        OperationalMode = "LEAVING"
+	OperationalModeDecommissioned OperationalMode = "DECOMMISSIONED"
+	OperationalModeMoving         OperationalMode = "MOVING"
+	OperationalModeDraining       OperationalMode = "DRAINING"
+	OperationalModeDrained        OperationalMode = "DRAINED"
+	OperationalModeMaintenance    OperationalMode = "MAINTENANCE"
+	OperationalModeUnknown        OperationalMode = "UNKNOWN"
 )
 
 var (
 	operationalModeMap = map[string]OperationalMode{
-		"CLIENT":          OperationalModeClient,
-		"DECOMMISSIONED":  OperationalModeDecommissioned,
-		"DECOMMISSIONING": OperationalModeDecommissioning,
-		"JOINING":         OperationalModeJoining,
-		"LEAVING":         OperationalModeLeaving,
-		"DRAINED":         OperationalModeDrained,
-		"DRAINING":        OperationalModeDraining,
-		"NORMAL":          OperationalModeNormal,
+		"STARTING":       OperationalModeStarting,
+		"JOINING":        OperationalModeJoining,
+		"BOOTSTRAP":      OperationalModeBootstrap,
+		"NORMAL":         OperationalModeNormal,
+		"LEAVING":        OperationalModeLeaving,
+		"DECOMMISSIONED": OperationalModeDecommissioned,
+		"MOVING":         OperationalModeMoving,
+		"DRAINING":       OperationalModeDraining,
+		"DRAINED":        OperationalModeDrained,
+		"MAINTENANCE":    OperationalModeMaintenance,
 	}
 )
 
 func (o OperationalMode) String() string {
-	switch o {
-	case "CLIENT", "DECOMMISSIONED", "DECOMMISSIONING", "JOINING", "LEAVING", "NORMAL", "DRAINED", "DRAINING":
+	if _, ok := operationalModeMap[string(o)]; ok {
 		return string(o)
-	default:
-		return "UNKNOWN"
 	}
-}
-
-func (o OperationalMode) IsDecommissioned() bool {
-	return o == OperationalModeDecommissioned
-}
-
-func (o OperationalMode) IsDecommissioning() bool {
-	return o == OperationalModeDecommissioning
-}
-
-func (o OperationalMode) IsLeaving() bool {
-	return o == OperationalModeLeaving
-}
-
-func (o OperationalMode) IsNormal() bool {
-	return o == OperationalModeNormal
-}
-
-func (o OperationalMode) IsJoining() bool {
-	return o == OperationalModeJoining
-}
-
-func (o OperationalMode) IsDrained() bool {
-	return o == OperationalModeDrained
-}
-
-func (o OperationalMode) IsDraining() bool {
-	return o == OperationalModeDraining
+	return "UNKNOWN"
 }
 
 func operationalModeFromString(str string) OperationalMode {

--- a/pkg/scyllaclient/model_test.go
+++ b/pkg/scyllaclient/model_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 ScyllaDB.
+
+package scyllaclient
+
+import (
+	"testing"
+)
+
+func TestOperationalModeFromString(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		str      string
+		expected OperationalMode
+	}{
+		// NONE is reported as STARTING.
+		{str: "STARTING", expected: OperationalModeStarting},
+		{str: "JOINING", expected: OperationalModeJoining},
+		{str: "BOOTSTRAP", expected: OperationalModeBootstrap},
+		{str: "NORMAL", expected: OperationalModeNormal},
+		{str: "LEAVING", expected: OperationalModeLeaving},
+		{str: "DECOMMISSIONED", expected: OperationalModeDecommissioned},
+		{str: "MOVING", expected: OperationalModeMoving},
+		{str: "DRAINING", expected: OperationalModeDraining},
+		{str: "DRAINED", expected: OperationalModeDrained},
+		{str: "MAINTENANCE", expected: OperationalModeMaintenance},
+		{str: "", expected: OperationalModeUnknown},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.str, func(t *testing.T) {
+			t.Parallel()
+
+			got := operationalModeFromString(tc.str)
+			if got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+			if got.String() != string(tc.expected) {
+				t.Errorf("expected String() %q, got %q", tc.expected, got.String())
+			}
+		})
+	}
+}

--- a/test/e2e/set/scyllacluster/helpers.go
+++ b/test/e2e/set/scyllacluster/helpers.go
@@ -16,14 +16,31 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// rackLayout is the number of racks of a ScyllaCluster and the number of members in each of them.
+// rackLayout is the racks of a ScyllaCluster, named explicitly, and the number of members in each of them,
+// mirroring how ScyllaDBDatacenter itself layers a per-rack override (RackSpec.Nodes) under a datacenter-wide
+// default (RackTemplate.Nodes): every named rack has defaultMemberCount members, unless memberCounts overrides it for
+// that rack specifically.
 type rackLayout struct {
-	rackCount      int32
-	membersPerRack int32
+	racks              []string
+	defaultMemberCount int32
+	// memberCounts overrides defaultMemberCount for the named racks. A key not present in racks is an error.
+	memberCounts map[string]int32
 }
 
 func (rl rackLayout) String() string {
-	return fmt.Sprintf("%d rack(s) of %d member(s)", rl.rackCount, rl.membersPerRack)
+	if len(rl.memberCounts) != 0 {
+		return fmt.Sprintf("racks %v, %d member(s) each except %v", rl.racks, rl.defaultMemberCount, rl.memberCounts)
+	}
+	return fmt.Sprintf("racks %v, %d member(s) each", rl.racks, rl.defaultMemberCount)
+}
+
+// membersOfRack returns the member count of the named rack: its override from memberCounts if it has one, else
+// defaultMemberCount.
+func (rl rackLayout) membersOfRack(name string) int32 {
+	if members, ok := rl.memberCounts[name]; ok {
+		return members
+	}
+	return rl.defaultMemberCount
 }
 
 // createClusterAndWaitForRollout creates a ScyllaCluster with the given rack layout and waits for rollout.
@@ -47,6 +64,7 @@ func createClusterAndWaitForRollout(
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+	scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 	return sc
 }
@@ -77,6 +95,7 @@ func scaleClusterAndWaitForRollout(
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
+	scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 	return sc
 }
@@ -84,14 +103,18 @@ func scaleClusterAndWaitForRollout(
 // replicateRackSpecs fans the ScyllaCluster's first rack out into the given rack layout.
 func replicateRackSpecs(sc *scyllav1.ScyllaCluster, rl rackLayout) []scyllav1.RackSpec {
 	o.Expect(sc.Spec.Datacenter.Racks).NotTo(o.BeEmpty())
-	o.Expect(rl.rackCount).NotTo(o.BeZero())
+	o.Expect(rl.racks).NotTo(o.BeEmpty())
 
-	rackSpecs := make([]scyllav1.RackSpec, 0, rl.rackCount)
-	for i := range rl.rackCount {
+	rackSpecs := make([]scyllav1.RackSpec, 0, len(rl.racks))
+	for _, name := range rl.racks {
 		rackSpec := sc.Spec.Datacenter.Racks[0].DeepCopy()
-		rackSpec.Name = fmt.Sprintf("rack-%d", i)
-		rackSpec.Members = rl.membersPerRack
+		rackSpec.Name = name
+		rackSpec.Members = rl.membersOfRack(name)
 		rackSpecs = append(rackSpecs, *rackSpec)
+	}
+
+	for name := range rl.memberCounts {
+		o.Expect(rl.racks).To(o.ContainElement(name), "memberCounts names rack %q, which isn't among the layout's rack names %v", name, rl.racks)
 	}
 
 	return rackSpecs
@@ -99,8 +122,8 @@ func replicateRackSpecs(sc *scyllav1.ScyllaCluster, rl rackLayout) []scyllav1.Ra
 
 // expectRackLayout asserts that the ScyllaCluster has the given rack layout.
 func expectRackLayout(sc *scyllav1.ScyllaCluster, rl rackLayout) {
-	o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(int(rl.rackCount)))
+	o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(len(rl.racks)))
 	for _, rackSpec := range sc.Spec.Datacenter.Racks {
-		o.Expect(rackSpec.Members).To(o.BeEquivalentTo(rl.membersPerRack))
+		o.Expect(rackSpec.Members).To(o.BeEquivalentTo(rl.membersOfRack(rackSpec.Name)))
 	}
 }

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -56,12 +56,12 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		o.Expect(err).NotTo(o.HaveOccurred())
 	},
 		g.Entry("after scaling the cluster out", &horizontalScalingEntry{
-			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 1},
-			targetRackLayout:  rackLayout{rackCount: 1, membersPerRack: 3},
+			initialRackLayout: rackLayout{racks: []string{"a"}, defaultMemberCount: 1},
+			targetRackLayout:  rackLayout{racks: []string{"a"}, defaultMemberCount: 3},
 		}),
 		g.Entry("after scaling the cluster in", &horizontalScalingEntry{
-			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 3},
-			targetRackLayout:  rackLayout{rackCount: 1, membersPerRack: 1},
+			initialRackLayout: rackLayout{racks: []string{"a"}, defaultMemberCount: 3},
+			targetRackLayout:  rackLayout{racks: []string{"a"}, defaultMemberCount: 1},
 		}),
 	)
 
@@ -71,7 +71,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		err := jobObserver.Start(ctx)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc := createClusterAndWaitForRollout(ctx, f, rackLayout{rackCount: 1, membersPerRack: 3})
+		sc := createClusterAndWaitForRollout(ctx, f, rackLayout{racks: []string{"a"}, defaultMemberCount: 3})
 
 		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
 

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -41,19 +41,24 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 
 	type horizontalScalingEntry struct {
 		initialRackLayout rackLayout
-		steps             []scalingStep
+		// replication, when set, overrides the keyspace's default replication strategy.
+		replication *utils.Replication
+		steps       []scalingStep
 	}
 
 	g.DescribeTable("should support horizontal scaling", func(ctx g.SpecContext, e *horizontalScalingEntry) {
 		sc := createClusterAndWaitForRollout(ctx, f, e.initialRackLayout)
-		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, hostIDs, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(int(utils.GetMemberCount(sc))))
 		o.Expect(hostIDs).To(o.HaveLen(int(utils.GetMemberCount(sc))))
 
-		di := verification.InsertAndVerifyCQLData(ctx, hosts)
+		var dataInserterOptions []utils.DataInserterOption
+		if e.replication != nil {
+			dataInserterOptions = append(dataInserterOptions, utils.WithReplication(*e.replication))
+		}
+		di := verification.InsertAndVerifyCQLData(ctx, hosts, dataInserterOptions...)
 		defer di.Close()
 
 		// Host IDs of nodes that have left the cluster. None of them may be resurrected - a node scaled back up has to
@@ -68,7 +73,6 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 			previousHostIDs := hostIDs
 
 			sc = scaleClusterAndWaitForRollout(ctx, f, sc, step.rackLayout)
-			scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 			hosts, hostIDs, err = utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -89,33 +93,33 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		// Scaling by more than a single node at a time is what distinguishes parallel node operations from sequential
 		// ones - a step moving a single node is indistinguishable between the two.
 		g.Entry("out", &horizontalScalingEntry{
-			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 1},
+			initialRackLayout: rackLayout{racks: []string{"a"}, defaultMemberCount: 1},
 			steps: []scalingStep{
-				{rackCount: 1, membersPerRack: 3, verifyFunc: verifyScaledOut},
+				{racks: []string{"a"}, defaultMemberCount: 3, verifyFunc: verifyScaledOut},
 			},
 		}),
 		g.Entry("out, into new racks", &horizontalScalingEntry{
-			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 1},
+			initialRackLayout: rackLayout{racks: []string{"a"}, defaultMemberCount: 1},
 			steps: []scalingStep{
-				{rackCount: 3, membersPerRack: 1, verifyFunc: verifyScaledOut},
+				{racks: []string{"a", "b", "c"}, defaultMemberCount: 1, verifyFunc: verifyScaledOut},
 			},
 		}),
 		g.Entry("out, across multiple racks", &horizontalScalingEntry{
-			initialRackLayout: rackLayout{rackCount: 3, membersPerRack: 1},
+			initialRackLayout: rackLayout{racks: []string{"a", "b", "c"}, defaultMemberCount: 1},
 			steps: []scalingStep{
-				{rackCount: 3, membersPerRack: 2, verifyFunc: verifyScaledOut},
+				{racks: []string{"a", "b", "c"}, defaultMemberCount: 2, verifyFunc: verifyScaledOut},
 			},
 		}),
 		g.Entry("in", &horizontalScalingEntry{
-			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 3},
+			initialRackLayout: rackLayout{racks: []string{"a"}, defaultMemberCount: 3},
 			steps: []scalingStep{
-				{rackCount: 1, membersPerRack: 1, verifyFunc: verifyScaledIn},
+				{racks: []string{"a"}, defaultMemberCount: 1, verifyFunc: verifyScaledIn},
 			},
 		}),
 		g.Entry("in, across multiple racks", &horizontalScalingEntry{
-			initialRackLayout: rackLayout{rackCount: 3, membersPerRack: 2},
+			initialRackLayout: rackLayout{racks: []string{"a", "b", "c"}, defaultMemberCount: 2},
 			steps: []scalingStep{
-				{rackCount: 3, membersPerRack: 1, verifyFunc: verifyScaledIn},
+				{racks: []string{"a", "b", "c"}, defaultMemberCount: 1, verifyFunc: verifyScaledIn},
 			},
 		}),
 		// Draining a node leaves it in ScyllaDB's DRAINED operational mode, which no longer accepts writes and cannot be
@@ -126,17 +130,32 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		// Scaling in from here therefore exercises a different code path than an ordinary decommission. The drain targets
 		// the highest ordinal node, so this entry deliberately scales in by a single node.
 		g.Entry("in, when the node has been drained in maintenance mode", &horizontalScalingEntry{
-			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 3},
+			initialRackLayout: rackLayout{racks: []string{"a"}, defaultMemberCount: 3},
 			steps: []scalingStep{
-				{rackCount: 1, membersPerRack: 2, beforeFunc: markHighestOrdinalForMaintenanceAndDrain, verifyFunc: verifyScaledIn},
+				{racks: []string{"a"}, defaultMemberCount: 2, beforeFunc: markHighestOrdinalForMaintenanceAndDrain, verifyFunc: verifyScaledIn},
 			},
 		}),
 		// Scaling back out verifies that a decommissioned node's storage isn't left in place and reused.
 		g.Entry("out, with new storage after decommissioning", &horizontalScalingEntry{
-			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 3},
+			initialRackLayout: rackLayout{racks: []string{"a"}, defaultMemberCount: 3},
 			steps: []scalingStep{
-				{rackCount: 1, membersPerRack: 1, verifyFunc: verifyScaledIn},
-				{rackCount: 1, membersPerRack: 3, verifyFunc: verifyScaledOutWithNewNodes},
+				{racks: []string{"a"}, defaultMemberCount: 1, verifyFunc: verifyScaledIn},
+				{racks: []string{"a"}, defaultMemberCount: 3, verifyFunc: verifyScaledOutWithNewNodes},
+			},
+		}),
+		// Regression test verifying that decommission can be unblocked by a scale-out.
+		// With RF=4 on a 2x3 cluster, decommissioning rack "a" down to 0 while adding rack "c" lets the first two
+		// decommissions complete normally, but the third blocks until rack "c" has enough nodes to hold a valid
+		// replica placement for RF=4.
+		// Rack "c" needs at least 2 nodes to hold its share - with only 1, the last node of rack "a" could never find
+		// a legal replica placement and decommission would stall forever.
+		// The balancer refuses to raise a rack's replica count above the maximum any other rack already holds,
+		// so it won't place a tablet's 4th replica back in rack "b" (already at 2).
+		g.Entry("in and out simultaneously, with replication blocking decommissioning until the new node joins", &horizontalScalingEntry{
+			initialRackLayout: rackLayout{racks: []string{"a", "b"}, defaultMemberCount: 3},
+			replication:       new(utils.NetworkTopologyStrategyReplication(map[string]int{"replication_factor": 4})),
+			steps: []scalingStep{
+				{racks: []string{"a", "b", "c"}, defaultMemberCount: 3, memberCounts: map[string]int32{"a": 0, "c": 2}, verifyFunc: verifyScaledSimultaneouslyInAndOut},
 			},
 		}),
 	)
@@ -156,14 +175,11 @@ func verifyScaledIn(previousHostIDs, hostIDs, _ []string) {
 	o.Expect(previousHostIDs).To(o.ContainElements(hostIDs))
 }
 
-// verifyScaledOutWithNewNodes asserts that scaling out preserved the existing nodes and bootstrapped genuinely new
-// ones, instead of resurrecting a node which has left the cluster from storage left behind after it.
-func verifyScaledOutWithNewNodes(previousHostIDs, hostIDs, leftHostIDs []string) {
+// verifyNoneResurrected asserts that none of the given left host IDs have reappeared among the current ones.
+func verifyNoneResurrected(hostIDs, leftHostIDs []string) {
 	g.GinkgoHelper()
 
-	verifyScaledOut(previousHostIDs, hostIDs, leftHostIDs)
-
-	// Guard against the assertion below passing vacuously before any node has left the cluster.
+	// Guard against the loop below passing vacuously before any node has left the cluster.
 	o.Expect(leftHostIDs).NotTo(o.BeEmpty())
 	for _, leftHostID := range leftHostIDs {
 		o.Expect(hostIDs).NotTo(
@@ -171,6 +187,33 @@ func verifyScaledOutWithNewNodes(previousHostIDs, hostIDs, leftHostIDs []string)
 			"host ID %q of a node which has left the cluster must not be resurrected", leftHostID,
 		)
 	}
+}
+
+// verifyScaledSimultaneouslyInAndOut asserts that no departed node was resurrected, and that at least one current
+// node is genuinely new - unlike verifyScaledOut/verifyScaledIn, it makes no assumption about whether every previous
+// node survived or every current node already existed, since a step where nodes leave and join at once satisfies
+// neither.
+func verifyScaledSimultaneouslyInAndOut(previousHostIDs, hostIDs, leftHostIDs []string) {
+	g.GinkgoHelper()
+
+	verifyNoneResurrected(hostIDs, leftHostIDs)
+
+	var newHostIDs []string
+	for _, hostID := range hostIDs {
+		if !slices.Contains(previousHostIDs, hostID) {
+			newHostIDs = append(newHostIDs, hostID)
+		}
+	}
+	o.Expect(newHostIDs).NotTo(o.BeEmpty(), "scaling out should have bootstrapped at least one genuinely new node")
+}
+
+// verifyScaledOutWithNewNodes asserts that scaling out preserved the existing nodes and bootstrapped genuinely new
+// ones, instead of resurrecting a node which has left the cluster from storage left behind after it.
+func verifyScaledOutWithNewNodes(previousHostIDs, hostIDs, leftHostIDs []string) {
+	g.GinkgoHelper()
+
+	verifyScaledOut(previousHostIDs, hostIDs, leftHostIDs)
+	verifyNoneResurrected(hostIDs, leftHostIDs)
 }
 
 // markHighestOrdinalForMaintenanceAndDrain puts the highest ordinal node of the first rack into maintenance mode and drains it.

--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -5,6 +5,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -25,10 +26,34 @@ const (
 )
 
 type DataInserter struct {
-	session  *gocqlx.Session
-	keyspace string
-	table    *table.Table
-	data     []*TestData
+	session     *gocqlx.Session
+	keyspace    string
+	table       *table.Table
+	data        []*TestData
+	replication Replication
+}
+
+// Replication describes a keyspace's replication strategy as a CQL 'replication' map value, e.g.
+// "{'class': 'NetworkTopologyStrategy', 'us-east-1': 4}". Build one with NetworkTopologyStrategyReplication - the
+// only class this repo's keyspaces use - which only accepts the options that class actually supports, rather than
+// an arbitrary class/options pair that could describe an invalid combination.
+// See https://docs.scylladb.com/manual/stable/cql/ddl.html.
+type Replication struct {
+	cql string
+}
+
+// NetworkTopologyStrategyReplication describes a NetworkTopologyStrategy keyspace, replicating to the given number
+// of nodes in each named datacenter. The special key "replication_factor" sets the default for every datacenter not
+// given its own entry. A nil or empty map is ScyllaDB's own default of one replica per rack of every datacenter, which is
+// RF-rack-valid by construction.
+// See https://docs.scylladb.com/manual/stable/cql/ddl.html#networktopologystrategy.
+func NetworkTopologyStrategyReplication(datacenterReplicationFactors map[string]int) Replication {
+	parts := []string{`'class': 'NetworkTopologyStrategy'`}
+	for _, dc := range slices.Sorted(maps.Keys(datacenterReplicationFactors)) {
+		parts = append(parts, fmt.Sprintf(`'%s': %d`, dc, datacenterReplicationFactors[dc]))
+	}
+
+	return Replication{cql: "{" + strings.Join(parts, ", ") + "}"}
 }
 
 type TestData struct {
@@ -41,6 +66,13 @@ type DataInserterOption func(*DataInserter)
 func WithSession(session *gocqlx.Session) func(*DataInserter) {
 	return func(di *DataInserter) {
 		di.session = session
+	}
+}
+
+// WithReplication overrides the keyspace's default replication strategy.
+func WithReplication(replication Replication) DataInserterOption {
+	return func(di *DataInserter) {
+		di.replication = replication
 	}
 }
 
@@ -57,9 +89,10 @@ func NewDataInserter(hosts []string, options ...DataInserterOption) (*DataInsert
 	}
 
 	di := &DataInserter{
-		keyspace: keyspace,
-		table:    table,
-		data:     data,
+		keyspace:    keyspace,
+		table:       table,
+		data:        data,
+		replication: NetworkTopologyStrategyReplication(nil),
 	}
 
 	for _, option := range options {
@@ -111,14 +144,8 @@ func (di *DataInserter) SetClientEndpoints(hosts []string) error {
 }
 
 func (di *DataInserter) Insert(ctx context.Context) error {
-	// The replication factor is deliberately left unset. With neither datacenters nor a replication factor
-	// specified, ScyllaDB places a replica on every rack of every datacenter, which is RF-rack-valid by
-	// construction.
-	framework.Infof("Creating keyspace %q", di.keyspace)
-	err := di.session.ExecStmt(fmt.Sprintf(
-		`CREATE KEYSPACE %q WITH replication = {'class': 'NetworkTopologyStrategy'}`,
-		di.keyspace,
-	))
+	framework.Infof("Creating keyspace %q with replication %s", di.keyspace, di.replication.cql)
+	err := di.session.ExecStmt(fmt.Sprintf(`CREATE KEYSPACE %q WITH replication = %s`, di.keyspace, di.replication.cql))
 	if err != nil {
 		return fmt.Errorf("can't create keyspace: %w", err)
 	}

--- a/test/envtest/controllers/sidecar_controller_test.go
+++ b/test/envtest/controllers/sidecar_controller_test.go
@@ -121,6 +121,7 @@ var _ = g.Describe("SidecarController", func() {
 	g.DescribeTable("annotates the node's membership in the ScyllaDB cluster", syncsAnnotations,
 		g.Entry("when the node owns normal tokens", annotationTestCase{
 			fake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
 				localHostID:   hostID,
 				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
@@ -134,6 +135,7 @@ var _ = g.Describe("SidecarController", func() {
 		}),
 		g.Entry("when the node owns no normal tokens", annotationTestCase{
 			fake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
 				localHostID:   hostID,
 				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				// A bootstrapping node holds only pending tokens, which the endpoint doesn't report.
@@ -149,6 +151,7 @@ var _ = g.Describe("SidecarController", func() {
 		}),
 		g.Entry("when the token ring hash can't be fetched", annotationTestCase{
 			fake: fakeScyllaDBTokenMetadata{
+				operationMode:  scyllaclient.OperationalModeNormal,
 				localHostID:    hostID,
 				ipToHostIDMap:  []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				nodeTokens:     map[string][]string{localIP: {"-1", "0", "1"}},
@@ -159,11 +162,47 @@ var _ = g.Describe("SidecarController", func() {
 			},
 			absentAnnotations: []string{naming.CurrentTokenRingHashAnnotation},
 		}),
+		// A decommissioned node has left the token ring and its gossiper is stopped, so the token metadata API no longer answers.
+		g.Entry("when the node has been decommissioned and its token metadata can't be fetched", annotationTestCase{
+			existingAnnotations: map[string]string{
+				naming.HostIDAnnotation:                    hostID,
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
+			},
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:       hostID,
+				operationMode:     scyllaclient.OperationalModeDecommissioned,
+				failIPToHostIDMap: true,
+				failRingTokens:    true,
+			},
+			expectedAnnotations: map[string]string{
+				naming.HostIDAnnotation:                    hostID,
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueFalse,
+				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
+			},
+		}),
+		// A leaving node still owns its tokens and is still observed by its peers, so it stays a member until the
+		// decommission completes.
+		g.Entry("when the node is leaving", annotationTestCase{
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:   hostID,
+				operationMode: scyllaclient.OperationalModeLeaving,
+				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
+				ringTokens:    []string{"-1", "0", "1"},
+			},
+			expectedAnnotations: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+				naming.HostIDAnnotation:                    hostID,
+			},
+			expectedTokenRingHashOf: []string{"-1", "0", "1"},
+		}),
 	)
 
 	g.DescribeTable("annotates the HostID", syncsAnnotations,
 		g.Entry("when the host ID mapping can't be fetched", annotationTestCase{
 			fake: fakeScyllaDBTokenMetadata{
+				operationMode:     scyllaclient.OperationalModeNormal,
 				localHostID:       hostID,
 				failIPToHostIDMap: true,
 				ringTokens:        []string{"-1", "0", "1"},
@@ -175,7 +214,8 @@ var _ = g.Describe("SidecarController", func() {
 		}),
 		g.Entry("when the node's tokens can't be fetched", annotationTestCase{
 			fake: fakeScyllaDBTokenMetadata{
-				localHostID: hostID,
+				operationMode: scyllaclient.OperationalModeNormal,
+				localHostID:   hostID,
 				// The node is present in the cluster's token metadata, but its tokens can't be read.
 				ipToHostIDMap:  []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				failNodeTokens: true,
@@ -191,7 +231,8 @@ var _ = g.Describe("SidecarController", func() {
 	g.DescribeTable("leaves the annotations untouched", syncsAnnotations,
 		g.Entry("when the node is absent from the cluster's token metadata", annotationTestCase{
 			fake: fakeScyllaDBTokenMetadata{
-				localHostID: hostID,
+				operationMode: scyllaclient.OperationalModeNormal,
+				localHostID:   hostID,
 				// The node's own host ID is absent from the mapping, so its membership can't be determined.
 				ipToHostIDMap: []scyllaNodeResponse{{Key: "10.0.0.2", Value: "ffffffff-ffff-ffff-ffff-ffffffffffff"}},
 				ringTokens:    []string{"-1", "0", "1"},
@@ -208,6 +249,7 @@ var _ = g.Describe("SidecarController", func() {
 				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
 			},
 			fake: fakeScyllaDBTokenMetadata{
+				operationMode:     scyllaclient.OperationalModeNormal,
 				localHostID:       hostID,
 				failIPToHostIDMap: true,
 				ringTokens:        []string{"-1", "0", "1"},
@@ -217,8 +259,46 @@ var _ = g.Describe("SidecarController", func() {
 				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
 			},
 		}),
+		// A drained node's gossiper is down too, but it still owns its tokens and is restarted eventually.
+		g.Entry("when the node is drained and its token metadata can't be fetched", annotationTestCase{
+			existingAnnotations: map[string]string{
+				naming.HostIDAnnotation:                    hostID,
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
+			},
+			fake: fakeScyllaDBTokenMetadata{
+				localHostID:       hostID,
+				operationMode:     scyllaclient.OperationalModeDrained,
+				failIPToHostIDMap: true,
+				failRingTokens:    true,
+			},
+			expectedAnnotations: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
+			},
+		}),
+		g.Entry("when the operation mode can't be fetched and a membership was already observed", annotationTestCase{
+			existingAnnotations: map[string]string{
+				naming.HostIDAnnotation:                    hostID,
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
+			},
+			fake: fakeScyllaDBTokenMetadata{
+				operationMode:     scyllaclient.OperationalModeNormal,
+				localHostID:       hostID,
+				failOperationMode: true,
+				ipToHostIDMap:     []scyllaNodeResponse{{Key: localIP, Value: hostID}},
+				nodeTokens:        map[string][]string{localIP: {"-1", "0", "1"}},
+				ringTokens:        []string{"-1", "0", "1"},
+			},
+			expectedAnnotations: map[string]string{
+				naming.NodeJoinedScyllaDBClusterAnnotation: naming.LabelValueTrue,
+				naming.CurrentTokenRingHashAnnotation:      "previous-hash",
+			},
+		}),
 		g.Entry("when the local HostID can't be fetched", annotationTestCase{
 			fake: fakeScyllaDBTokenMetadata{
+				operationMode:   scyllaclient.OperationalModeNormal,
 				failLocalHostID: true,
 				ipToHostIDMap:   []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				nodeTokens:      map[string][]string{localIP: {"-1", "0", "1"}},
@@ -231,6 +311,7 @@ var _ = g.Describe("SidecarController", func() {
 	g.DescribeTable("annotates the token ring hash", syncsAnnotations,
 		g.Entry("when the cluster has a token ring", annotationTestCase{
 			fake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
 				localHostID:   hostID,
 				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
@@ -242,6 +323,7 @@ var _ = g.Describe("SidecarController", func() {
 		// Expecting the hash of the reordered ring asserts exactly that: the in-order hash would not match.
 		g.Entry("when the same tokens are returned in a different order", annotationTestCase{
 			fake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
 				localHostID:   hostID,
 				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
@@ -259,6 +341,7 @@ var _ = g.Describe("SidecarController", func() {
 
 		g.By("Running the SidecarController against a ScyllaDB owning normal tokens")
 		newScyllaClient := newFakeScyllaDBClientFactory(newFakeScyllaDBTokenMetadataHandler(fakeScyllaDBTokenMetadata{
+			operationMode: scyllaclient.OperationalModeNormal,
 			localHostID:   hostID,
 			ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 			nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
@@ -332,6 +415,7 @@ var _ = g.Describe("SidecarController", func() {
 	},
 		g.Entry("when the node finishes bootstrapping", transitionTestCase{
 			firstFake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
 				localHostID:   hostID,
 				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				// A bootstrapping node holds only pending tokens, which the endpoint doesn't report.
@@ -339,6 +423,7 @@ var _ = g.Describe("SidecarController", func() {
 				ringTokens: []string{},
 			},
 			secondFake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
 				localHostID:   hostID,
 				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
@@ -354,12 +439,14 @@ var _ = g.Describe("SidecarController", func() {
 		}),
 		g.Entry("when the node shows up in the cluster's token metadata", transitionTestCase{
 			firstFake: fakeScyllaDBTokenMetadata{
-				localHostID: hostID,
+				operationMode: scyllaclient.OperationalModeNormal,
+				localHostID:   hostID,
 				// The node's own host ID is absent from the mapping, so its membership can't be determined.
 				ipToHostIDMap: []scyllaNodeResponse{{Key: "10.0.0.2", Value: "ffffffff-ffff-ffff-ffff-ffffffffffff"}},
 				ringTokens:    []string{"-1", "0", "1"},
 			},
 			secondFake: fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
 				localHostID:   hostID,
 				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
@@ -385,12 +472,14 @@ var _ = g.Describe("SidecarController", func() {
 		g.By("Running the SidecarController against a ScyllaDB owning normal tokens")
 		switcher, newScyllaClient := newSwitchableFakeScyllaDBClientFactory(
 			newFakeScyllaDBTokenMetadataHandler(fakeScyllaDBTokenMetadata{
+				operationMode: scyllaclient.OperationalModeNormal,
 				localHostID:   hostID,
 				ipToHostIDMap: []scyllaNodeResponse{{Key: localIP, Value: hostID}},
 				nodeTokens:    map[string][]string{localIP: {"-1", "0", "1"}},
 				ringTokens:    ringTokens,
 			}),
 			newFakeScyllaDBTokenMetadataHandler(fakeScyllaDBTokenMetadata{
+				operationMode:     scyllaclient.OperationalModeNormal,
 				localHostID:       hostID,
 				failIPToHostIDMap: true,
 				ringTokens:        ringTokens,
@@ -445,8 +534,8 @@ func createNodeService(ctx context.Context, env *envtest.Environment, name strin
 	return svc
 }
 
-// fakeScyllaDBTokenMetadata describes the fake ScyllaDB API responses for the token metadata surface the sidecar
-// controller reads.
+// fakeScyllaDBTokenMetadata describes the fake ScyllaDB API responses for the token metadata and operation mode surface
+// the sidecar controller reads.
 type fakeScyllaDBTokenMetadata struct {
 	// localHostID is returned for the local host ID request.
 	localHostID string
@@ -464,6 +553,10 @@ type fakeScyllaDBTokenMetadata struct {
 	failNodeTokens bool
 	// failRingTokens makes the token ring request fail.
 	failRingTokens bool
+	// operationMode is the node's operational mode. It must be set.
+	operationMode scyllaclient.OperationalMode
+	// failOperationMode makes the operation mode request fail.
+	failOperationMode bool
 }
 
 // newFakeScyllaDBTokenMetadataHandler returns a handler serving the given fake ScyllaDB API responses.
@@ -485,6 +578,17 @@ func newFakeScyllaDBTokenMetadataHandler(fake fakeScyllaDBTokenMetadata) http.Ha
 				return
 			}
 			encodeJSON(w, r, fake.localHostID)
+
+		case r.URL.Path == "/storage_service/operation_mode":
+			if fake.failOperationMode {
+				failWith("operation mode is unavailable")
+				return
+			}
+			if len(fake.operationMode) == 0 {
+				failWith("operation mode is not set in the fake, the test case is incomplete")
+				return
+			}
+			encodeJSON(w, r, string(fake.operationMode))
 
 		case r.URL.Path == "/storage_service/host_id":
 			if fake.failIPToHostIDMap {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
Currently, bootstrapping a new node is blocked by the bootstrap barrier while another node is decommissioning, which in the worst case scenario can block unstucking a decommission by adding new nodes.

The bootstrap barrier requires every host ID observed by the peers to have an entry with a status of its own in the nodes status report. A decommissioning node stays a token owning member the whole time, so its peers keep observing it, but makeRackNodesStatusReport enumerated the rack's nodes from the desired node count and dropped it as soon as the count shrank. Once the decommission completes the node flips to DECOMMISSIONED and its gossiper stops, so its sidecar can no longer answer the host ID map request it determines the membership with, nor report a status. The membership annotation is only written from a successful observation, so it kept "true", and the node was still entitled to an entry, now one without a status. Either way the barrier rejected the report and the joining node waited for the decommission, or the decommissioned node's Service, to go away. That Service is pruned only after the StatefulSet is scaled down, and the scaling loop isn't reached while any rack has a pending rollout, which is exactly the state a node stuck in the barrier leaves its rack in. Adding nodes to unstick a decommission was blocked by the same mechanism.

The report is now enumerated from the rack's member Services. The sidecar consults the operation mode before the token metadata: a DECOMMISSIONED node has left the ring for good and is annotated as not joined, dropping out of the report right away, while a STARTING, DRAINED or MAINTENANCE node, whose gossiper is down as well but which still owns its tokens, keeps its last observed membership instead of erroring on every sync. To do that the OperationalMode set is aligned with ScyllaDB's storage service mode enum, identical on every release we support: it carried CLIENT and DECOMMISSIONING, which ScyllaDB never reports, and lacked STARTING, BOOTSTRAP, MOVING and MAINTENANCE. As a side effect, decommissioning a node which hasn't finished bootstrapping now waits instead of failing on an UNKNOWN mode.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-353

/cc