### PR TITLE
Revert "chore: switch BootstrapSynchronisation feature gate to opt-out"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,6 @@
   Previously every node expected to exist in the Kubernetes state was required to be reported and UP, including nodes
   that hadn't joined yet and couldn't report their status.
   [#3530](https://github.com/scylladb/scylla-operator/pull/3530)
-- The `BootstrapSynchronisation` feature gate is now enabled by default, making the bootstrap barrier opt-out. It
-  remains a no-op below ScyllaDB 2025.2.0, where the operator does not inject the `scylladb-bootstrap-barrier` init
-  container regardless of the gate.
-  [#3590](https://github.com/scylladb/scylla-operator/pull/3590)
 - Restored the multi-datacenter documentation, which was dropped by the docs restructuring in 1.21. The guide for
   deploying a multi-datacenter ScyllaDB cluster, and the guides for preparing interconnected EKS and GKE clusters to
   run it on, are available again under Deploy ScyllaDB and Provision infrastructure respectively.

--- a/docs/source/reference/feature-gates.md
+++ b/docs/source/reference/feature-gates.md
@@ -64,8 +64,8 @@ additionalArgs:
   - `true`
   - v1.11
 * - `BootstrapSynchronisation`
-  - `true`
-  - v1.22
+  - `false`
+  - v1.19
 :::
 
 - **Default** — whether the feature is enabled when you don't set it explicitly.

--- a/docs/source/understand/bootstrap-sync.md
+++ b/docs/source/understand/bootstrap-sync.md
@@ -71,7 +71,7 @@ If any node is missing a host ID, has not yet reported, does not list another no
 * - Requirement
   - Value
 * - Feature gate
-  - `BootstrapSynchronisation` (default on since v1.22)
+  - `BootstrapSynchronisation` (default off since v1.19)
 * - Minimum ScyllaDB version
   - 2025.2
 ```

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -21,7 +21,6 @@ const (
 
 	// BootstrapSynchronisation enables a barrier which ensures bootstrap preconditions are met before starting a ScyllaDB node attempting to join the cluster.
 	// alpha: v1.19
-	// beta: v1.22
 	BootstrapSynchronisation featuregate.Feature = "BootstrapSynchronisation"
 )
 
@@ -37,8 +36,8 @@ func init() {
 			PreRelease: featuregate.Beta,
 		},
 		BootstrapSynchronisation: {
-			Default:    true,
-			PreRelease: featuregate.Beta,
+			Default:    false,
+			PreRelease: featuregate.Alpha,
 		},
 	}))
 }


### PR DESCRIPTION
Reverts scylladb/scylla-operator#3590 due to https://scylladb.atlassian.net/browse/OPERATOR-353. We don't want to send a last-minute fix and would rather be on the safe side. I'll send a separate PR adding a note to the docs about the known issue.

/cc @mflendrich 