### PR TITLE
feat: record and drain the set of decommissioning nodes in the rack status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
   [#3587](https://github.com/scylladb/scylla-operator/pull/3587)
 
 ### Features & Enhancements
+- Added `status.racks[].decommissioningNodes` to `ScyllaDBDatacenter` and `status.racks[].decommissioningMembers` to
+  `ScyllaCluster`, listing the nodes that are leaving the cluster.
+  [#3623](https://github.com/scylladb/scylla-operator/pull/3623)
 - Added an optional `enableParallelNodeOperations` boolean field to `ScyllaCluster.spec` and
   `ScyllaDBDatacenter.spec`. Enabling it requires ScyllaDB 2026.2 or later, declared with a semver-parseable image tag.
   In this release it only controls how nodes are started. Its scope is expected to widen in a future release, where it

--- a/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scyllaclusters.yaml
@@ -4076,8 +4076,7 @@ spec:
                     decommissioningMembers:
                       description: |-
                         decommissioningMembers holds the list of members in this rack that are leaving the cluster.
-                        An entry is recorded before the member's decommission is requested, and it is removed only after the member has
-                        been successfully decommissioned.
+                        A member is listed from the moment its decommission is requested until it has been decommissioned and removed.
                         Until the list is empty, changes to the number of members requested in this rack are accepted but not applied.
                       items:
                         description: DecommissioningMemberStatus is the status of

--- a/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/bundle/manifests/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -10816,8 +10816,7 @@ spec:
                     decommissioningNodes:
                       description: |-
                         decommissioningNodes holds the list of nodes in this rack that are leaving the cluster.
-                        An entry is recorded before the node's decommission is requested, and it is removed only after the node has been
-                        successfully decommissioned.
+                        A node is listed from the moment its decommission is requested until it has been decommissioned and removed.
                         Until the list is empty, changes to the number of nodes requested in this rack are accepted but not applied.
                       items:
                         description: DecommissioningNodeStatus is the status of a

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -5633,8 +5633,7 @@ spec:
                       decommissioningMembers:
                         description: |-
                           decommissioningMembers holds the list of members in this rack that are leaving the cluster.
-                          An entry is recorded before the member's decommission is requested, and it is removed only after the member has
-                          been successfully decommissioned.
+                          A member is listed from the moment its decommission is requested until it has been decommissioned and removed.
                           Until the list is empty, changes to the number of members requested in this rack are accepted but not applied.
                         items:
                           description: DecommissioningMemberStatus is the status of a member that is leaving a cluster.
@@ -45797,8 +45796,7 @@ spec:
                       decommissioningNodes:
                         description: |-
                           decommissioningNodes holds the list of nodes in this rack that are leaving the cluster.
-                          An entry is recorded before the node's decommission is requested, and it is removed only after the node has been
-                          successfully decommissioned.
+                          A node is listed from the moment its decommission is requested until it has been decommissioned and removed.
                           Until the list is empty, changes to the number of nodes requested in this rack are accepted but not applied.
                         items:
                           description: DecommissioningNodeStatus is the status of a node that is leaving a cluster.

--- a/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
+++ b/docs/source/reference/api/groups/scylla.scylladb.com/scylladbdatacenters.rst
@@ -13510,7 +13510,7 @@ object
      - version specifies the current version of ScyllaDB in use.
    * - :ref:`decommissioningNodes<api-scylla.scylladb.com-scylladbdatacenters-v1alpha1-.status.racks[].decommissioningNodes[]>`
      - array (object)
-     - decommissioningNodes holds the list of nodes in this rack that are leaving the cluster. An entry is recorded before the node's decommission is requested, and it is removed only after the node has been successfully decommissioned. Until the list is empty, changes to the number of nodes requested in this rack are accepted but not applied.
+     - decommissioningNodes holds the list of nodes in this rack that are leaving the cluster. A node is listed from the moment its decommission is requested until it has been decommissioned and removed. Until the list is empty, changes to the number of nodes requested in this rack are accepted but not applied.
    * - name
      - string
      - name specifies the name of datacenter this status describes.

--- a/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
+++ b/pkg/api/scylla/v1/scylla.scylladb.com_scyllaclusters.yaml
@@ -3839,8 +3839,7 @@ spec:
                       decommissioningMembers:
                         description: |-
                           decommissioningMembers holds the list of members in this rack that are leaving the cluster.
-                          An entry is recorded before the member's decommission is requested, and it is removed only after the member has
-                          been successfully decommissioned.
+                          A member is listed from the moment its decommission is requested until it has been decommissioned and removed.
                           Until the list is empty, changes to the number of members requested in this rack are accepted but not applied.
                         items:
                           description: DecommissioningMemberStatus is the status of a member that is leaving a cluster.

--- a/pkg/api/scylla/v1/types_cluster.go
+++ b/pkg/api/scylla/v1/types_cluster.go
@@ -868,8 +868,7 @@ type RackStatus struct {
 	UpdatedMembers *int32 `json:"updatedMembers,omitempty"`
 
 	// decommissioningMembers holds the list of members in this rack that are leaving the cluster.
-	// An entry is recorded before the member's decommission is requested, and it is removed only after the member has
-	// been successfully decommissioned.
+	// A member is listed from the moment its decommission is requested until it has been decommissioned and removed.
 	// Until the list is empty, changes to the number of members requested in this rack are accepted but not applied.
 	// +optional
 	// +listType=map

--- a/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
+++ b/pkg/api/scylla/v1alpha1/scylla.scylladb.com_scylladbdatacenters.yaml
@@ -10215,8 +10215,7 @@ spec:
                       decommissioningNodes:
                         description: |-
                           decommissioningNodes holds the list of nodes in this rack that are leaving the cluster.
-                          An entry is recorded before the node's decommission is requested, and it is removed only after the node has been
-                          successfully decommissioned.
+                          A node is listed from the moment its decommission is requested until it has been decommissioned and removed.
                           Until the list is empty, changes to the number of nodes requested in this rack are accepted but not applied.
                         items:
                           description: DecommissioningNodeStatus is the status of a node that is leaving a cluster.

--- a/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
+++ b/pkg/api/scylla/v1alpha1/types_scylladbdatacenter.go
@@ -493,8 +493,7 @@ type RackStatus struct {
 	AvailableNodes *int32 `json:"availableNodes,omitempty"`
 
 	// decommissioningNodes holds the list of nodes in this rack that are leaving the cluster.
-	// An entry is recorded before the node's decommission is requested, and it is removed only after the node has been
-	// successfully decommissioned.
+	// A node is listed from the moment its decommission is requested until it has been decommissioned and removed.
 	// Until the list is empty, changes to the number of nodes requested in this rack are accepted but not applied.
 	// +optional
 	// +listType=map

--- a/pkg/controller/scyllacluster/migrate.go
+++ b/pkg/controller/scyllacluster/migrate.go
@@ -385,6 +385,23 @@ func MigrateV1ScyllaClusterToV1Alpha1ScyllaDBDatacenter(sc *scyllav1.ScyllaClust
 	return sdc, upgradeContext, apimachineryutilerrors.NewAggregate(migrateErrs)
 }
 
+// migrateV1Alpha1DecommissioningNodesToV1DecommissioningMembers migrates v1alpha1 decommissioning nodes into
+// v1 decommissioning members. An empty record stays nil so that the migrated status round-trips unchanged.
+func migrateV1Alpha1DecommissioningNodesToV1DecommissioningMembers(nodes []scyllav1alpha1.DecommissioningNodeStatus) []scyllav1.DecommissioningMemberStatus {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	members := make([]scyllav1.DecommissioningMemberStatus, 0, len(nodes))
+	for _, node := range nodes {
+		members = append(members, scyllav1.DecommissioningMemberStatus{
+			Name: node.Name,
+		})
+	}
+
+	return members
+}
+
 // migrateV1Alpha1ScyllaDBDatacenterStatusToV1ScyllaClusterStatus migrates v1alpha1.ScyllaDBDatacenterStatus into v1.ScyllaClusterStatus.
 // ObservedGeneration is not migrated as there might be a generation skew between ScyllaCluster and ScyllaDBDatacenter.
 // Conditions are handled independently as they also need to take controller conditions into account.
@@ -411,10 +428,11 @@ func migrateV1Alpha1ScyllaDBDatacenterStatusToV1ScyllaClusterStatus(sdc *scyllav
 						}
 						return 0
 					}(),
-					AvailableMembers: rackStatus.AvailableNodes,
-					UpdatedMembers:   rackStatus.UpdatedNodes,
-					Stale:            rackStatus.Stale,
-					Conditions:       nil,
+					AvailableMembers:       rackStatus.AvailableNodes,
+					UpdatedMembers:         rackStatus.UpdatedNodes,
+					DecommissioningMembers: migrateV1Alpha1DecommissioningNodesToV1DecommissioningMembers(rackStatus.DecommissioningNodes),
+					Stale:                  rackStatus.Stale,
+					Conditions:             nil,
 				}
 
 				rackServices := oslices.Filter(services, func(svc *corev1.Service) bool {

--- a/pkg/controller/scyllacluster/migrate_test.go
+++ b/pkg/controller/scyllacluster/migrate_test.go
@@ -65,6 +65,29 @@ func TestMigrateV1Alpha1ScyllaDBDatacenterStatusToV1ScyllaClusterStatus(t *testi
 			expectedScyllaClusterStatus: newMigratedScyllaClusterStatus(),
 		},
 		{
+			name:       "decommissioning nodes are mirrored as decommissioning members",
+			configMaps: nil,
+			services:   nil,
+			scyllaDBDatacenter: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newBasicScyllaDBDatacenterWithStatus()
+				sdc.Status.Racks[0].DecommissioningNodes = []scyllav1alpha1.DecommissioningNodeStatus{
+					{Name: "basic-dc-a-1"},
+					{Name: "basic-dc-a-2"},
+				}
+				return sdc
+			}(),
+			expectedScyllaClusterStatus: func() scyllav1.ScyllaClusterStatus {
+				status := newMigratedScyllaClusterStatus()
+				rackStatus := status.Racks["a"]
+				rackStatus.DecommissioningMembers = []scyllav1.DecommissioningMemberStatus{
+					{Name: "basic-dc-a-1"},
+					{Name: "basic-dc-a-2"},
+				}
+				status.Racks["a"] = rackStatus
+				return status
+			}(),
+		},
+		{
 			name:       "decommissioning and leaving rack condition when one of the member services has special label",
 			configMaps: nil,
 			services: []*corev1.Service{

--- a/pkg/controller/scylladbdatacenter/status.go
+++ b/pkg/controller/scylladbdatacenter/status.go
@@ -3,6 +3,8 @@ package scylladbdatacenter
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/naming"
@@ -58,18 +60,20 @@ func getScyllaVersion(podLister corev1listers.PodLister, sts *appsv1.StatefulSet
 	return version, nil
 }
 
-// calculateRackStatus builds rack status from its StatefulSet.
+// calculateRackStatus builds rack status from its StatefulSet and member Services.
 // If sts is nil, it returns a stale zero status so the rack still appears in status.
 // Empty racks report the target image version; non-empty racks report the version from ordinal-0.
-func calculateRackStatus(podLister corev1listers.PodLister, sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, sts *appsv1.StatefulSet) *scyllav1alpha1.RackStatus {
+// The decommissioning nodes are derived from the decommissioned labels of the rack's member Services in services.
+func calculateRackStatus(podLister corev1listers.PodLister, sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, sts *appsv1.StatefulSet, services map[string]*corev1.Service) *scyllav1alpha1.RackStatus {
 	status := &scyllav1alpha1.RackStatus{
-		Name:           rackName,
-		Nodes:          new(int32(0)),
-		CurrentNodes:   new(int32(0)),
-		UpdatedNodes:   new(int32(0)),
-		ReadyNodes:     new(int32(0)),
-		AvailableNodes: new(int32(0)),
-		Stale:          new(true),
+		Name:                 rackName,
+		Nodes:                new(int32(0)),
+		CurrentNodes:         new(int32(0)),
+		UpdatedNodes:         new(int32(0)),
+		ReadyNodes:           new(int32(0)),
+		AvailableNodes:       new(int32(0)),
+		DecommissioningNodes: calculateDecommissioningNodes(rackName, services),
+		Stale:                new(true),
 	}
 
 	if sts == nil {
@@ -105,6 +109,33 @@ func calculateRackStatus(podLister corev1listers.PodLister, sdc *scyllav1alpha1.
 	return status
 }
 
+// calculateDecommissioningNodes returns the nodes of the rack whose member Service carries the decommissioned label,
+// with either value: a node is leaving from the moment its decommission is requested until its Service is pruned.
+// The labels are the ground truth, so the list is derived from them on every sync.
+// Entries are sorted by name so that the list is stable across syncs. It is nil when no node is leaving.
+func calculateDecommissioningNodes(rackName string, services map[string]*corev1.Service) []scyllav1alpha1.DecommissioningNodeStatus {
+	var nodes []scyllav1alpha1.DecommissioningNodeStatus
+	for _, svc := range services {
+		if svc.Labels[naming.RackNameLabel] != rackName {
+			continue
+		}
+
+		if _, ok := svc.Labels[naming.DecommissionedLabel]; !ok {
+			continue
+		}
+
+		nodes = append(nodes, scyllav1alpha1.DecommissioningNodeStatus{
+			Name: svc.Name,
+		})
+	}
+
+	slices.SortFunc(nodes, func(a, b scyllav1alpha1.DecommissioningNodeStatus) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	return nodes
+}
+
 func updateAggregatedStatusFields(status *scyllav1alpha1.ScyllaDBDatacenterStatus) {
 	status.Nodes = new(int32(0))
 	status.ReadyNodes = new(int32(0))
@@ -132,7 +163,7 @@ func (sdcc *Controller) calculateStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, 
 	// Calculate the status for racks.
 	for _, rack := range sdc.Spec.Racks {
 		stsName := naming.StatefulSetNameForRack(rack, sdc)
-		status.Racks = append(status.Racks, *calculateRackStatus(sdcc.podLister, sdc, rack.Name, statefulSetMap[stsName]))
+		status.Racks = append(status.Racks, *calculateRackStatus(sdcc.podLister, sdc, rack.Name, statefulSetMap[stsName], serviceMap))
 	}
 
 	updateAggregatedStatusFields(status)

--- a/pkg/controller/scylladbdatacenter/status.go
+++ b/pkg/controller/scylladbdatacenter/status.go
@@ -7,6 +7,7 @@ import (
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -121,7 +122,7 @@ func updateAggregatedStatusFields(status *scyllav1alpha1.ScyllaDBDatacenterStatu
 // calculateStatus calculates the ScyllaCluster status.
 // This function should always succeed. Do not return an error.
 // If a particular object can be missing, it should be reflected in the value itself, like "Unknown" or "".
-func (sdcc *Controller) calculateStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, statefulSetMap map[string]*appsv1.StatefulSet) *scyllav1alpha1.ScyllaDBDatacenterStatus {
+func (sdcc *Controller) calculateStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, statefulSetMap map[string]*appsv1.StatefulSet, serviceMap map[string]*corev1.Service) *scyllav1alpha1.ScyllaDBDatacenterStatus {
 	status := sdc.Status.DeepCopy()
 	status.ObservedGeneration = new(sdc.Generation)
 

--- a/pkg/controller/scylladbdatacenter/status_test.go
+++ b/pkg/controller/scylladbdatacenter/status_test.go
@@ -1,0 +1,95 @@
+package scylladbdatacenter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_calculateDecommissioningNodes(t *testing.T) {
+	t.Parallel()
+
+	newRackService := func(name, rackName string, labels map[string]string) *corev1.Service {
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[naming.RackNameLabel] = rackName
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      name,
+				Labels:    labels,
+			},
+		}
+	}
+
+	tt := []struct {
+		name     string
+		services map[string]*corev1.Service
+		expected []scyllav1alpha1.DecommissioningNodeStatus
+	}{
+		{
+			name:     "no Services yields nil",
+			services: nil,
+			expected: nil,
+		},
+		{
+			name: "no labelled Services yields nil",
+			services: map[string]*corev1.Service{
+				"basic-dc-a-0": newRackService("basic-dc-a-0", "a", nil),
+				"basic-dc-a-1": newRackService("basic-dc-a-1", "a", nil),
+			},
+			expected: nil,
+		},
+		{
+			name: "labels with either value are listed",
+			services: map[string]*corev1.Service{
+				"basic-dc-a-0": newRackService("basic-dc-a-0", "a", nil),
+				"basic-dc-a-1": newRackService("basic-dc-a-1", "a", map[string]string{naming.DecommissionedLabel: naming.LabelValueTrue}),
+				"basic-dc-a-2": newRackService("basic-dc-a-2", "a", map[string]string{naming.DecommissionedLabel: naming.LabelValueFalse}),
+			},
+			expected: []scyllav1alpha1.DecommissioningNodeStatus{
+				{Name: "basic-dc-a-1"},
+				{Name: "basic-dc-a-2"},
+			},
+		},
+		{
+			name: "only Services of this rack are listed",
+			services: map[string]*corev1.Service{
+				"basic-dc-a-1": newRackService("basic-dc-a-1", "a", map[string]string{naming.DecommissionedLabel: naming.LabelValueFalse}),
+				"basic-dc-b-1": newRackService("basic-dc-b-1", "b", map[string]string{naming.DecommissionedLabel: naming.LabelValueFalse}),
+			},
+			expected: []scyllav1alpha1.DecommissioningNodeStatus{
+				{Name: "basic-dc-a-1"},
+			},
+		},
+		{
+			name: "entries are sorted by name",
+			services: map[string]*corev1.Service{
+				"basic-dc-a-2":  newRackService("basic-dc-a-2", "a", map[string]string{naming.DecommissionedLabel: naming.LabelValueFalse}),
+				"basic-dc-a-10": newRackService("basic-dc-a-10", "a", map[string]string{naming.DecommissionedLabel: naming.LabelValueFalse}),
+				"basic-dc-a-1":  newRackService("basic-dc-a-1", "a", map[string]string{naming.DecommissionedLabel: naming.LabelValueFalse}),
+			},
+			expected: []scyllav1alpha1.DecommissioningNodeStatus{
+				{Name: "basic-dc-a-1"},
+				{Name: "basic-dc-a-10"},
+				{Name: "basic-dc-a-2"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := calculateDecommissioningNodes("a", tc.services)
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("expected and got decommissioning nodes differ (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/scylladbdatacenter/sync.go
+++ b/pkg/controller/scylladbdatacenter/sync.go
@@ -211,7 +211,7 @@ func (sdcc *Controller) sync(ctx context.Context, key string) error {
 		return objectErr
 	}
 
-	status := sdcc.calculateStatus(sdc, statefulSetMap)
+	status := sdcc.calculateStatus(sdc, statefulSetMap, serviceMap)
 
 	if sdc.DeletionTimestamp != nil {
 		return sdcc.updateStatus(ctx, sdc, status)

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -490,6 +490,7 @@ func ensureRackNamesInRackStatuses(
 	sdc *scyllav1alpha1.ScyllaDBDatacenter,
 	status *scyllav1alpha1.ScyllaDBDatacenterStatus,
 	statefulSets []*appsv1.StatefulSet,
+	services map[string]*corev1.Service,
 ) error {
 	var errs []error
 
@@ -504,14 +505,13 @@ func ensureRackNamesInRackStatuses(
 			continue
 		}
 
-		updatedRackStatus := *calculateRackStatus(podLister, sdc, rackName, sts)
 		_, idx, ok := oslices.Find(status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
 			return rackStatus.Name == rackName
 		})
 		if ok {
-			status.Racks[idx] = updatedRackStatus
+			status.Racks[idx] = *calculateRackStatus(podLister, sdc, rackName, sts, services)
 		} else {
-			status.Racks = append(status.Racks, updatedRackStatus)
+			status.Racks = append(status.Racks, *calculateRackStatus(podLister, sdc, rackName, sts, services))
 		}
 	}
 
@@ -634,7 +634,7 @@ func (sdcc *Controller) syncStatefulSets(
 	}
 
 	// Record the statuses of the StatefulSets that were created, even if creating another one failed.
-	err = ensureRackNamesInRackStatuses(sdcc.podLister, sdc, status, createdStatefulSets)
+	err = ensureRackNamesInRackStatuses(sdcc.podLister, sdc, status, createdStatefulSets, services)
 	if err != nil {
 		createErrs = append(createErrs, fmt.Errorf("can't update status with rack statuses: %w", err))
 	}
@@ -870,7 +870,7 @@ func (sdcc *Controller) syncStatefulSets(
 						continue
 					}
 
-					status.Racks[idx] = *calculateRackStatus(sdcc.podLister, sdc, rackName, updatedSts)
+					status.Racks[idx] = *calculateRackStatus(sdcc.podLister, sdc, rackName, updatedSts, services)
 				}
 			}
 			if anyStsChanged {
@@ -1138,7 +1138,7 @@ func (sdcc *Controller) syncStatefulSets(
 				return progressingConditions, fmt.Errorf("can't find rack %q status in %q ScyllaDBDatacenter", rackName, naming.ObjRef(sdc))
 			}
 
-			status.Racks[idx] = *calculateRackStatus(sdcc.podLister, sdc, rackName, updatedSts)
+			status.Racks[idx] = *calculateRackStatus(sdcc.podLister, sdc, rackName, updatedSts, services)
 		}
 
 		// Wait for the StatefulSet to roll out.

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
@@ -348,6 +348,7 @@ func Test_ensureRackNamesInRackStatuses(t *testing.T) {
 		scyllaDBDatacenter  *scyllav1alpha1.ScyllaDBDatacenter
 		status              *scyllav1alpha1.ScyllaDBDatacenterStatus
 		statefulSets        []*appsv1.StatefulSet
+		services            map[string]*corev1.Service
 		expectedRacks       []scyllav1alpha1.RackStatus
 		expectedErrorString string
 	}{
@@ -385,6 +386,35 @@ func Test_ensureRackNamesInRackStatuses(t *testing.T) {
 			},
 			expectedRacks: []scyllav1alpha1.RackStatus{
 				freshRackStatus("foo"),
+			},
+		},
+		{
+			name:               "lists nodes whose member Service carries the decommissioned label",
+			scyllaDBDatacenter: newScyllaDBDatacenter(),
+			status:             &scyllav1alpha1.ScyllaDBDatacenterStatus{},
+			statefulSets: []*appsv1.StatefulSet{
+				newRackStatefulSet("foo"),
+			},
+			services: map[string]*corev1.Service{
+				"foo-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      "foo-1",
+						Labels: map[string]string{
+							naming.RackNameLabel:       "foo",
+							naming.DecommissionedLabel: naming.LabelValueFalse,
+						},
+					},
+				},
+			},
+			expectedRacks: []scyllav1alpha1.RackStatus{
+				func() scyllav1alpha1.RackStatus {
+					rs := freshRackStatus("foo")
+					rs.DecommissioningNodes = []scyllav1alpha1.DecommissioningNodeStatus{
+						{Name: "foo-1"},
+					}
+					return rs
+				}(),
 			},
 		},
 		{
@@ -435,6 +465,7 @@ func Test_ensureRackNamesInRackStatuses(t *testing.T) {
 				tc.scyllaDBDatacenter,
 				tc.status,
 				tc.statefulSets,
+				tc.services,
 			)
 
 			var errStr string

--- a/test/envtest/controllers/scylladbdatacenter_controller_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_test.go
@@ -106,6 +106,147 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 		}
 	})
 
+	g.Describe("decommissioning nodes record", func() {
+		const (
+			rackName     = "rack-a"
+			initialNodes = int32(2)
+		)
+
+		// setup runs the controller and brings up a rolled-out two-node rack. It returns the ScyllaDBDatacenter, the
+		// name of the rack StatefulSet and the name of the member Service of the highest ordinal, which is the node
+		// that a scale-down by one removes.
+		setup := func(ctx g.SpecContext) (*scyllav1alpha1.ScyllaDBDatacenter, string, string) {
+			g.GinkgoHelper()
+
+			g.By("Running ScyllaDBDatacenter controller")
+			runScyllaDBDatacenterController(ctx, env)
+
+			g.By("Creating ScyllaOperatorConfig singleton")
+			createScyllaOperatorConfig(ctx, env)
+
+			g.By("Creating a ScyllaDBDatacenter with a two-node rack")
+			sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{rackName}, withRackTemplateNodes(initialNodes))
+			sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Waiting for the rack StatefulSet and member Services to be created")
+			rackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+			waitForStatefulSet(ctx, env, rackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+			leavingServiceName := fmt.Sprintf("%s-%d", rackStatefulSetName, initialNodes-1)
+			waitForService(ctx, env, leavingServiceName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+
+			g.By("Marking the rack StatefulSet as rolled out")
+			markStatefulSetAsRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), rackStatefulSetName)
+
+			g.By("Verifying no node is recorded as decommissioning")
+			o.Consistently(func(co o.Gomega, ctx context.Context) {
+				co.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rackName)).To(o.BeEmpty())
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			return sdc, rackStatefulSetName, leavingServiceName
+		}
+
+		g.It("should list a node whose decommission is requested and drop it once it is pruned", func(ctx g.SpecContext) {
+			sdc, rackStatefulSetName, leavingServiceName := setup(ctx)
+
+			g.By("Scaling the rack down to one node")
+			scaleRackTemplate(ctx, env, sdc.Name, initialNodes-1)
+
+			g.By("Waiting for the decommission of the leaving node to be requested")
+			waitForServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueFalse)
+
+			g.By("Waiting for the leaving node to be listed in the rack status")
+			o.Eventually(func(eo o.Gomega, ctx context.Context) {
+				eo.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rackName)).To(o.Equal([]scyllav1alpha1.DecommissioningNodeStatus{
+					{Name: leavingServiceName},
+				}))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By("Marking the node as decommissioned in place of the sidecar")
+			setServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueTrue)
+
+			g.By("Waiting for the rack StatefulSet to be scaled down")
+			waitForStatefulSetReplicas(ctx, env, rackStatefulSetName, initialNodes-1)
+
+			g.By("Waiting for the leaving node's Service to be pruned and the record to drain")
+			waitForServiceToBePrunedAndRecordToDrain(ctx, env, sdc.Name, rackName, leavingServiceName)
+		})
+
+		// This is a reproducer of OPERATOR-343: raising the node count while a node is being decommissioned wedges the
+		// rack, because both the StatefulSet scale and the Service pruning are driven by the spec node count, which no
+		// longer calls for a scale-in. The leaving node keeps its decommissioned label throughout, so it stays listed in
+		// the status. The barrier implemented under OPERATOR-343 will source the leaving nodes from the same labels to
+		// finish the decommission first and only then apply the raised count. Once that lands, the trailing assertions
+		// flip: the StatefulSet has to scale down, the Service has to be pruned and the list has to drain before the
+		// rack grows back.
+		g.It("should keep listing a decommissioning node when the node count is raised back mid-decommission", func(ctx g.SpecContext) {
+			sdc, rackStatefulSetName, leavingServiceName := setup(ctx)
+
+			g.By("Scaling the rack down to one node")
+			scaleRackTemplate(ctx, env, sdc.Name, initialNodes-1)
+
+			g.By("Waiting for the decommission of the leaving node to be requested")
+			waitForServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueFalse)
+
+			g.By("Raising the node count back while the node is still decommissioning")
+			scaleRackTemplate(ctx, env, sdc.Name, initialNodes)
+
+			g.By("Marking the node as decommissioned in place of the sidecar")
+			setServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueTrue)
+
+			g.By("Verifying the rack is wedged with the decommissioned node still recorded")
+			o.Consistently(func(co o.Gomega, ctx context.Context) {
+				sts, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, rackStatefulSetName, metav1.GetOptions{})
+				co.Expect(err).NotTo(o.HaveOccurred())
+				co.Expect(*sts.Spec.Replicas).To(o.Equal(initialNodes))
+
+				svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, leavingServiceName, metav1.GetOptions{})
+				co.Expect(err).NotTo(o.HaveOccurred())
+				co.Expect(svc.Labels).To(o.HaveKeyWithValue(naming.DecommissionedLabel, naming.LabelValueTrue))
+
+				co.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rackName)).To(o.Equal([]scyllav1alpha1.DecommissioningNodeStatus{
+					{Name: leavingServiceName},
+				}))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+		})
+
+		g.It("should rebuild the list from the decommissioned labels when it is wiped from the status", func(ctx g.SpecContext) {
+			sdc, _, leavingServiceName := setup(ctx)
+
+			g.By("Scaling the rack down to one node")
+			scaleRackTemplate(ctx, env, sdc.Name, initialNodes-1)
+
+			g.By("Waiting for the decommission of the leaving node to be requested")
+			waitForServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueFalse)
+
+			g.By("Wiping the list from the rack status")
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("can't get ScyllaDBDatacenter %q: %w", naming.ManualRef(env.Namespace(), sdc.Name), err)
+				}
+
+				for i := range sdc.Status.Racks {
+					sdc.Status.Racks[i].DecommissioningNodes = nil
+				}
+				_, err = env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).UpdateStatus(ctx, sdc, metav1.UpdateOptions{})
+				if err != nil {
+					return fmt.Errorf("can't update status of ScyllaDBDatacenter %q: %w", naming.ObjRef(sdc), err)
+				}
+
+				return nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Waiting for the list to be rebuilt from the label")
+			o.Eventually(func(eo o.Gomega, ctx context.Context) {
+				eo.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rackName)).To(o.Equal([]scyllav1alpha1.DecommissioningNodeStatus{
+					{Name: leavingServiceName},
+				}))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+		})
+	})
+
 	g.DescribeTableSubtree("with parallel node operations",
 		func(enableParallelNodeOperations bool) {
 			g.DescribeTable("should not create a StatefulSet for a new rack while an existing rack is not rolled out",
@@ -177,6 +318,106 @@ func waitForStatefulSet(ctx context.Context, e *envtest.Environment, name string
 	return statefulSet
 }
 
+func waitForService(ctx context.Context, e *envtest.Environment, name string, timeout time.Duration) *corev1.Service {
+	g.GinkgoHelper()
+
+	var service *corev1.Service
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		var err error
+		service, err = e.TypedKubeClient().CoreV1().Services(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+	}).WithContext(ctx).WithTimeout(timeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+	return service
+}
+
+// getDecommissioningNodes returns the decommissioning nodes recorded in the status of the named rack.
+func getDecommissioningNodes(ctx context.Context, e *envtest.Environment, sdcName, rackName string) []scyllav1alpha1.DecommissioningNodeStatus {
+	g.GinkgoHelper()
+
+	sdc, err := e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Get(ctx, sdcName, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	for _, rackStatus := range sdc.Status.Racks {
+		if rackStatus.Name == rackName {
+			return rackStatus.DecommissioningNodes
+		}
+	}
+
+	return nil
+}
+
+func scaleRackTemplate(ctx context.Context, e *envtest.Environment, sdcName string, nodes int32) {
+	g.GinkgoHelper()
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		sdc, err := e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Get(ctx, sdcName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("can't get ScyllaDBDatacenter %q: %w", naming.ManualRef(e.Namespace(), sdcName), err)
+		}
+
+		sdc.Spec.RackTemplate.Nodes = new(nodes)
+		_, err = e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Update(ctx, sdc, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("can't update ScyllaDBDatacenter %q: %w", naming.ObjRef(sdc), err)
+		}
+
+		return nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func setServiceDecommissionedLabel(ctx context.Context, e *envtest.Environment, name, value string) {
+	g.GinkgoHelper()
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		svc, err := e.TypedKubeClient().CoreV1().Services(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("can't get Service %q: %w", naming.ManualRef(e.Namespace(), name), err)
+		}
+
+		svc.Labels[naming.DecommissionedLabel] = value
+		_, err = e.TypedKubeClient().CoreV1().Services(e.Namespace()).Update(ctx, svc, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("can't update Service %q: %w", naming.ObjRef(svc), err)
+		}
+
+		return nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func waitForServiceDecommissionedLabel(ctx context.Context, e *envtest.Environment, name, value string) {
+	g.GinkgoHelper()
+
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		svc, err := e.TypedKubeClient().CoreV1().Services(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+		eo.Expect(svc.Labels).To(o.HaveKeyWithValue(naming.DecommissionedLabel, value))
+	}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+}
+
+func waitForStatefulSetReplicas(ctx context.Context, e *envtest.Environment, name string, replicas int32) {
+	g.GinkgoHelper()
+
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		sts, err := e.TypedKubeClient().AppsV1().StatefulSets(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		eo.Expect(err).NotTo(o.HaveOccurred())
+		eo.Expect(*sts.Spec.Replicas).To(o.Equal(replicas))
+	}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+}
+
+func waitForServiceToBePrunedAndRecordToDrain(ctx context.Context, e *envtest.Environment, sdcName, rackName, serviceName string) {
+	g.GinkgoHelper()
+
+	o.Eventually(func(eo o.Gomega, ctx context.Context) {
+		_, err := e.TypedKubeClient().CoreV1().Services(e.Namespace()).Get(ctx, serviceName, metav1.GetOptions{})
+		eo.Expect(apierrors.IsNotFound(err)).To(o.BeTrue())
+
+		eo.Expect(getDecommissioningNodes(ctx, e, sdcName, rackName)).To(o.BeEmpty())
+	}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+}
+
 func makeEnvtestScyllaDBDatacenter(namespace string, racks []string, mutators ...func(*scyllav1alpha1.ScyllaDBDatacenter)) *scyllav1alpha1.ScyllaDBDatacenter {
 	sdc := &scyllav1alpha1.ScyllaDBDatacenter{
 		ObjectMeta: metav1.ObjectMeta{
@@ -216,6 +457,12 @@ func makeEnvtestScyllaDBDatacenter(namespace string, racks []string, mutators ..
 func withEnableParallelNodeOperations(enableParallelNodeOperations bool) func(*scyllav1alpha1.ScyllaDBDatacenter) {
 	return func(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
 		sdc.Spec.EnableParallelNodeOperations = new(enableParallelNodeOperations)
+	}
+}
+
+func withRackTemplateNodes(nodes int32) func(*scyllav1alpha1.ScyllaDBDatacenter) {
+	return func(sdc *scyllav1alpha1.ScyllaDBDatacenter) {
+		sdc.Spec.RackTemplate.Nodes = new(nodes)
 	}
 }
 


### PR DESCRIPTION
Populates `status.racks[].decommissioningNodes` (`decommissioningMembers` on `ScyllaCluster`) with the nodes leaving a rack: a node is recorded before its decommission is requested and dropped once its PVC and Service have been pruned. This is a status-only change with no change to scale-down behaviour; the barrier that holds the rack node count while nodes are leaving is to be implemented separately under OPERATOR-343.

Closes https://scylladb.atlassian.net/browse/OPERATOR-363.