### PR TITLE
fix: report the Services waiting for a hostID in a deterministic order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Bug fixes
 
+- Fixed the `ScyllaDBDatacenter` controller updating the status in a loop while any member Service was missing its
+  hostID annotation, e.g. during bootstrap. The `CertControllerProgressing` condition listed the waiting Services in a
+  random order, so every sync produced a different status, and every status update triggered another sync.
+  [#3626](https://github.com/scylladb/scylla-operator/pull/3626)
 - Fixed `ScyllaDBDatacenter` rollouts getting stuck when a new rack was inserted before existing racks while an existing 
   rack was still progressing. The controller now waits for all existing `StatefulSets` to roll out before a new
   `StatefulSet` is created.

--- a/pkg/controller/scylladbdatacenter/sync_certs.go
+++ b/pkg/controller/scylladbdatacenter/sync_certs.go
@@ -122,6 +122,40 @@ func makeScyllaConnectionConfig(
 	return secret, nil
 }
 
+// getMemberServiceHostIDs returns the hostIDs of the member Services in serviceMap and a progressing message for
+// every member Service that doesn't have one yet.
+// Both are sorted, so that the certificates and the conditions built from them can be reconciled in a declarative way.
+// Otherwise the map iteration order would make the status differ on every sync, and every status update would
+// trigger another sync.
+func getMemberServiceHostIDs(serviceMap map[string]*corev1.Service) ([]string, []string) {
+	var hostIDs []string
+	var progressingMessages []string
+	for _, svc := range serviceMap {
+		if svc.Labels[naming.ScyllaServiceTypeLabel] != string(naming.ScyllaServiceTypeMember) {
+			continue
+		}
+
+		hostID, hasHostID := svc.Annotations[naming.HostIDAnnotation]
+		if len(hostID) == 0 {
+			if hasHostID {
+				klog.Warningf("service %q has empty hostID", klog.KObj(svc))
+			}
+
+			message := fmt.Sprintf("waiting for service %q to have a hostID set", naming.ObjRef(svc))
+			progressingMessages = append(progressingMessages, message)
+
+			continue
+		}
+
+		hostIDs = append(hostIDs, hostID)
+	}
+
+	slices.Sort(hostIDs)
+	slices.Sort(progressingMessages)
+
+	return hostIDs, progressingMessages
+}
+
 func (sdcc *Controller) syncCerts(
 	ctx context.Context,
 	sdc *scyllav1alpha1.ScyllaDBDatacenter,
@@ -294,27 +328,7 @@ func (sdcc *Controller) syncCerts(
 			return cmp.Compare(a.String(), b.String())
 		})
 
-		var hostIDs []string
-		var progressingMessages []string
-		for _, svc := range serviceMap {
-			if svc.Labels[naming.ScyllaServiceTypeLabel] != string(naming.ScyllaServiceTypeMember) {
-				continue
-			}
-
-			hostID, hasHostID := svc.Annotations[naming.HostIDAnnotation]
-			if len(hostID) == 0 {
-				if hasHostID {
-					klog.Warningf("service %q has empty hostID", klog.KObj(svc))
-				}
-
-				message := fmt.Sprintf("waiting for service %q to have a hostID set", naming.ObjRef(svc))
-				progressingMessages = append(progressingMessages, message)
-
-				continue
-			}
-
-			hostIDs = append(hostIDs, hostID)
-		}
+		hostIDs, progressingMessages := getMemberServiceHostIDs(serviceMap)
 
 		// For every cluster domain we'll create "cql" subdomain and "UUID.cql" subdomains for every node.
 		for _, domain := range sdc.Spec.DNSDomains {

--- a/pkg/controller/scylladbdatacenter/sync_certs_test.go
+++ b/pkg/controller/scylladbdatacenter/sync_certs_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -216,6 +217,82 @@ parameters:
 
 			if !reflect.DeepEqual(got, tc.expected) {
 				t.Errorf("expected and actual connection configs differ: %s", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}
+
+func Test_getMemberServiceHostIDs(t *testing.T) {
+	t.Parallel()
+
+	newService := func(name, serviceType string, annotations map[string]string) *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo-ns",
+				Name:      name,
+				Labels: map[string]string{
+					naming.ScyllaServiceTypeLabel: serviceType,
+				},
+				Annotations: annotations,
+			},
+		}
+	}
+
+	tt := []struct {
+		name                        string
+		serviceMap                  map[string]*corev1.Service
+		expectedHostIDs             []string
+		expectedProgressingMessages []string
+	}{
+		{
+			name:                        "no services",
+			serviceMap:                  map[string]*corev1.Service{},
+			expectedHostIDs:             nil,
+			expectedProgressingMessages: nil,
+		},
+		{
+			name: "non-member services are ignored",
+			serviceMap: map[string]*corev1.Service{
+				"identity": newService("identity", string(naming.ScyllaServiceTypeIdentity), nil),
+			},
+			expectedHostIDs:             nil,
+			expectedProgressingMessages: nil,
+		},
+		{
+			name: "hostIDs and messages are sorted regardless of the map order",
+			serviceMap: map[string]*corev1.Service{
+				"member-2": newService("member-2", string(naming.ScyllaServiceTypeMember), map[string]string{
+					naming.HostIDAnnotation: "b-host-id",
+				}),
+				"member-0": newService("member-0", string(naming.ScyllaServiceTypeMember), map[string]string{
+					naming.HostIDAnnotation: "a-host-id",
+				}),
+				"member-3": newService("member-3", string(naming.ScyllaServiceTypeMember), nil),
+				"member-1": newService("member-1", string(naming.ScyllaServiceTypeMember), map[string]string{
+					naming.HostIDAnnotation: "",
+				}),
+			},
+			expectedHostIDs: []string{"a-host-id", "b-host-id"},
+			expectedProgressingMessages: []string{
+				`waiting for service "foo-ns/member-1" to have a hostID set`,
+				`waiting for service "foo-ns/member-3" to have a hostID set`,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Run it multiple times so that the map iteration order gets a chance to differ.
+			for range 10 {
+				hostIDs, progressingMessages := getMemberServiceHostIDs(tc.serviceMap)
+				if !reflect.DeepEqual(hostIDs, tc.expectedHostIDs) {
+					t.Errorf("expected hostIDs %v, got %v", tc.expectedHostIDs, hostIDs)
+				}
+				if !reflect.DeepEqual(progressingMessages, tc.expectedProgressingMessages) {
+					t.Errorf("expected progressing messages %v, got %v", tc.expectedProgressingMessages, progressingMessages)
+				}
 			}
 		})
 	}


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

The cert sync built the progressing messages and the hostIDs by iterating a map, so the CertControllerProgressing condition listed the waiting Services in a random order. Every sync produced a different status, every status update triggered another sync, and the controller spun in a hot loop for as long as any member Service lacked a hostID.

Spotted when writing envtests for https://scylladb.atlassian.net/browse/OPERATOR-343.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-366
