### PR TITLE
docs: add a note about EnableParallelNodeOperations gating future enablement of parallel decommission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@
 - Added an optional `enableParallelNodeOperations` boolean field to `ScyllaCluster.spec` and
   `ScyllaDBDatacenter.spec`. Enabling it requires ScyllaDB 2026.2 or later, declared with a semver-parseable image tag.
   In this release it only controls how nodes are started. Its scope is expected to widen in a future release, where it
-  will most likely also allow decommissioning nodes in parallel, so setting it to `true` now may take effect for more
-  operations after an upgrade.
+  will also allow decommissioning nodes in parallel, so setting it to `true` now takes effect for those operations after
+  an upgrade, without another change to the spec.
   [#3568](https://github.com/scylladb/scylla-operator/pull/3568)
 - The webhook server now serves a mutating admission webhook that applies API defaults to `ScyllaClusters` and
   `ScyllaDBDatacenters` on creation. Matching `MutatingWebhookConfiguration` is added to the operator's manifests.

--- a/docs/source/operate/scale-add-remove-racks.md
+++ b/docs/source/operate/scale-add-remove-racks.md
@@ -55,6 +55,11 @@ The minimum ScyllaDB version required by Operator for parallel node operations i
 The Operator determines the ScyllaDB version from the ScyllaDB container image tag and rejects `true` when the version doesn't satisfy the requirement. An image whose version cannot be determined, such as one pinned by digest, is treated as not supporting parallel bootstrap.
 :::
 
+:::{warning}
+The field currently only controls how nodes are started. Its scope is expected to widen in a future release, where it will also allow decommissioning nodes in parallel.
+Setting it to `true` now takes effect for those operations after you upgrade the Operator, without another change to the spec.
+:::
+
 If you don't specify the field, the Operator defaults it to `true` on creation, provided the ScyllaDB version is higher or equal to 2026.2.
 
 Operator keeps bootstrapping the nodes of clusters that already existed before the addition of this feature sequentially. 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
This PR adds a docs note about EnableParallelNodeOperations gating future enablement of parallel decommission.
It also strengthens the wording in the changelog. 

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-365
