### PR TITLE
fix: introduce decommissioning scaling barrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@
   condition was reported correctly, so this was not visible in the resource status.
   [#3587](https://github.com/scylladb/scylla-operator/pull/3587)
 
+- Fixed a rack getting stuck forever when its node count was changed while one of its nodes was being decommissioned.
+  A node whose decommission has started must now finish leaving, together with its Service and PVC, before the rack
+  applies any further node count change. The deferred change is reported with the `DeferringRackNodeCountChange`
+  reason in the `Progressing` condition. Capacity that comes back is bootstrapped as new, empty nodes.
+  **Warning: after the upgrade, the operator removes any node whose member Service carries a leftover
+  `scylla/decommissioned=true` label, together with its PVC. If such a node is healthy, its data is lost. Before
+  upgrading, check for these labels with `kubectl get svc -A -l scylla/decommissioned=true` and remove the label from
+  the Services of healthy nodes.**
+  [#3629](https://github.com/scylladb/scylla-operator/pull/3629)
+
 ### Features & Enhancements
 - Added `status.racks[].decommissioningNodes` to `ScyllaDBDatacenter` and `status.racks[].decommissioningMembers` to
   `ScyllaCluster`, listing the nodes that are leaving the cluster.

--- a/pkg/controller/scylladbdatacenter/sync_services.go
+++ b/pkg/controller/scylladbdatacenter/sync_services.go
@@ -76,7 +76,11 @@ func (sdcc *Controller) pruneServices(
 				isRequired = true
 			}
 		}
-		if isRequired {
+		// A Service of a node that finished its decommission can be in the required set again when the node count was
+		// raised back mid-decommission and the spec calls for its ordinal. It must still be pruned, together with its
+		// PVC, or the decommissioned label would keep the rack held forever (see syncRackDecommission). It is
+		// recreated fresh below, and a new, empty node reuses the ordinal once the StatefulSet grows back.
+		if isRequired && svc.Labels[naming.DecommissionedLabel] != naming.LabelValueTrue {
 			continue
 		}
 

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -548,6 +548,18 @@ func getDecommissioningNodeNames(decommissioningNodes []scyllav1alpha1.Decommiss
 	return names
 }
 
+// makeDeferredNodeCountChangeCondition makes the progressing condition reporting that a change of the rack's spec node
+// count waits for the decommissioning nodes.
+func makeDeferredNodeCountChangeCondition(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, specNodeCount int32, decommissioningNodes []scyllav1alpha1.DecommissioningNodeStatus) metav1.Condition {
+	return metav1.Condition{
+		Type:               statefulSetControllerProgressingCondition,
+		Status:             metav1.ConditionTrue,
+		Reason:             "DeferringRackNodeCountChange",
+		Message:            fmt.Sprintf("Deferring node count change of rack %q to %d until the Services of its decommissioning nodes %q are pruned.", rackName, specNodeCount, getDecommissioningNodeNames(decommissioningNodes)),
+		ObservedGeneration: sdc.Generation,
+	}
+}
+
 // makeWaitingForRackServicePruningCondition makes the progressing condition reporting that the rack's decommissioned
 // nodes wait for their Services to be pruned.
 func makeWaitingForRackServicePruningCondition(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, decommissioningNodes []scyllav1alpha1.DecommissioningNodeStatus) metav1.Condition {
@@ -570,7 +582,8 @@ func makeWaitingForRackServicePruningCondition(sdc *scyllav1alpha1.ScyllaDBDatac
 //  4. Prune: pruneServices removes the node's Service and PVC (syncServices).
 //
 // The branches below are dispatched by the rack's current state, so they appear in guard order, not lifecycle order.
-// While any node is leaving, changes to the spec node count, up or down, are deferred.
+// While any node is leaving, changes to the spec node count, up or down, are deferred and reported with a progressing
+// condition.
 // It returns the progressing conditions to report: the rack still has leaving nodes and is held for as long as there
 // are any.
 func (sdcc *Controller) syncRackDecommission(ctx context.Context, sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, sts *appsv1.StatefulSet, rackServices map[string]*corev1.Service) ([]metav1.Condition, error) {
@@ -593,6 +606,12 @@ func (sdcc *Controller) syncRackDecommission(ctx context.Context, sdc *scyllav1a
 			return progressingConditions, fmt.Errorf("can't get decommission target node count of rack %q of ScyllaDBDatacenter %q: %w", rackName, naming.ObjRef(sdc), err)
 		}
 
+		// A plain scale-down has the spec already at the target count, so a difference means the spec changed since
+		// and the change is deferred until the leaving nodes' Services are pruned.
+		if *specNodeCount != targetNodeCount {
+			klog.V(4).InfoS("Deferring rack node count change until the Services of the decommissioning nodes are pruned", "ScyllaDBDatacenter", klog.KObj(sdc), "Rack", rackName, "NodeCount", *specNodeCount, "TargetNodeCount", targetNodeCount, "DecommissioningNodes", getDecommissioningNodeNames(decommissioningNodes))
+			progressingConditions = append(progressingConditions, makeDeferredNodeCountChangeCondition(sdc, rackName, *specNodeCount, decommissioningNodes))
+		}
 	}
 
 	// Wait if any decommissioning is in progress: a node with the label set to false was requested to decommission

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -518,6 +518,163 @@ func ensureRackNamesInRackStatuses(
 	return apimachineryutilerrors.NewAggregate(errs)
 }
 
+// getRackDecommissionTargetNodeCount returns the node count the rack reconciles to while nodes are leaving:
+// the leaving nodes are at the top of the StatefulSet, which can only remove its highest ordinals, so the count is the
+// lowest leaving ordinal, capped at the StatefulSet replicas.
+func getRackDecommissionTargetNodeCount(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, sts *appsv1.StatefulSet, decommissioningNodes []scyllav1alpha1.DecommissioningNodeStatus) (int32, error) {
+	if len(decommissioningNodes) == 0 {
+		return 0, fmt.Errorf("rack %q of ScyllaDBDatacenter %q has no decommissioning nodes", rackName, naming.ObjRef(sdc))
+	}
+
+	nodeCount := *sts.Spec.Replicas
+	for _, node := range decommissioningNodes {
+		ordinal, err := naming.IndexFromName(node.Name)
+		if err != nil {
+			return 0, fmt.Errorf("can't get ordinal of decommissioning node %q of rack %q of ScyllaDBDatacenter %q: %w", node.Name, rackName, naming.ObjRef(sdc), err)
+		}
+
+		nodeCount = min(nodeCount, ordinal)
+	}
+
+	return nodeCount, nil
+}
+
+// getDecommissioningNodeNames returns the names of the given decommissioning nodes.
+func getDecommissioningNodeNames(decommissioningNodes []scyllav1alpha1.DecommissioningNodeStatus) []string {
+	names := make([]string, 0, len(decommissioningNodes))
+	for _, node := range decommissioningNodes {
+		names = append(names, node.Name)
+	}
+	return names
+}
+
+// makeWaitingForRackServicePruningCondition makes the progressing condition reporting that the rack's decommissioned
+// nodes wait for their Services to be pruned.
+func makeWaitingForRackServicePruningCondition(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, decommissioningNodes []scyllav1alpha1.DecommissioningNodeStatus) metav1.Condition {
+	return metav1.Condition{
+		Type:               statefulSetControllerProgressingCondition,
+		Status:             metav1.ConditionTrue,
+		Reason:             "WaitingForRackServicePruning",
+		Message:            fmt.Sprintf("Waiting for decommissioned service(s) %q of rack %q to be pruned.", getDecommissioningNodeNames(decommissioningNodes), rackName),
+		ObservedGeneration: sdc.Generation,
+	}
+}
+
+// syncRackDecommission drives the decommission of the rack's leaving nodes and holds the rack while any is leaving.
+// A node is leaving from the moment its member Service carries the scylla/decommissioned label until the Service is
+// pruned, and a scale-down begins here by labelling the highest node. One node at a time, from the highest ordinal,
+// every leaving node goes through the following lifecycle:
+//  1. Request: the highest node is stamped with the scylla/decommissioned=false label.
+//  2. Wait: the node's sidecar runs the decommission and flips the label to true.
+//  3. Conclude: the StatefulSet is scaled below the node.
+//  4. Prune: pruneServices removes the node's Service and PVC (syncServices).
+//
+// The branches below are dispatched by the rack's current state, so they appear in guard order, not lifecycle order.
+// While any node is leaving, changes to the spec node count, up or down, are deferred.
+// It returns the progressing conditions to report: the rack still has leaving nodes and is held for as long as there
+// are any.
+func (sdcc *Controller) syncRackDecommission(ctx context.Context, sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string, sts *appsv1.StatefulSet, rackServices map[string]*corev1.Service) ([]metav1.Condition, error) {
+	var progressingConditions []metav1.Condition
+
+	specNodeCount, err := controllerhelpers.GetRackNodeCount(sdc, rackName)
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't get rack %q node count of ScyllaDBDatacenter %q: %w", rackName, naming.ObjRef(sdc), err)
+	}
+
+	decommissioningNodes := calculateDecommissioningNodes(rackName, rackServices)
+	if len(decommissioningNodes) == 0 && *specNodeCount >= *sts.Spec.Replicas {
+		return progressingConditions, nil
+	}
+
+	targetNodeCount := *specNodeCount
+	if len(decommissioningNodes) != 0 {
+		targetNodeCount, err = getRackDecommissionTargetNodeCount(sdc, rackName, sts, decommissioningNodes)
+		if err != nil {
+			return progressingConditions, fmt.Errorf("can't get decommission target node count of rack %q of ScyllaDBDatacenter %q: %w", rackName, naming.ObjRef(sdc), err)
+		}
+
+	}
+
+	// Wait if any decommissioning is in progress: a node with the label set to false was requested to decommission
+	// and hasn't finished. It is not necessarily the highest ordinal, e.g. a label that outlived its scale-down, so
+	// this can't be folded into the scale-down below, and nothing may be stamped or scaled while it is in flight.
+	for _, svc := range rackServices {
+		if svc.Labels[naming.DecommissionedLabel] == naming.LabelValueFalse {
+			klog.V(4).InfoS("Waiting for the node to finish decommissioning, signalled by its Service being labelled decommissioned=true", "ScyllaDBDatacenter", klog.KObj(sdc), "Service", klog.KObj(svc))
+			progressingConditions = append(progressingConditions, metav1.Condition{
+				Type:               statefulSetControllerProgressingCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             "WaitingForRackServiceDecommission",
+				Message:            fmt.Sprintf("Waiting for rack service %q to decommission.", naming.ObjRef(svc)),
+				ObservedGeneration: sdc.Generation,
+			})
+
+			return progressingConditions, nil
+		}
+	}
+
+	// The target node count is never above the StatefulSet replicas, so equality means there is nothing left to scale.
+	if *sts.Spec.Replicas == targetNodeCount {
+		// The remaining leaving nodes are already scaled away from the StatefulSet, but their Services and PVCs
+		// still exist. The pruning itself happens in syncServices; hold the rack until it is done, so that a raised
+		// node count can't recreate a leaving node on its old PVC before its identity is fully removed.
+		progressingConditions = append(progressingConditions, makeWaitingForRackServicePruningCondition(sdc, rackName, decommissioningNodes))
+		return progressingConditions, nil
+	}
+
+	// Make sure we always scale down by 1 member.
+	newReplicas := *sts.Spec.Replicas - 1
+
+	lastSvcName := fmt.Sprintf("%s-%d", sts.Name, *sts.Spec.Replicas-1)
+	lastSvc, ok := rackServices[lastSvcName]
+	if !ok {
+		klog.V(4).InfoS("Missing service", "ScyllaDBDatacenter", klog.KObj(sdc), "ServiceName", lastSvcName)
+		progressingConditions = append(progressingConditions, metav1.Condition{
+			Type:               statefulSetControllerProgressingCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             "WaitingForMissingService",
+			Message:            fmt.Sprintf("Statusfulset %q is waiting for service %q to be created", naming.ObjRef(sts), lastSvcName),
+			ObservedGeneration: sdc.Generation,
+		})
+		// Services are managed in the other loop.
+		// When informers see the new service, will get re-queued.
+		return progressingConditions, nil
+	}
+
+	if len(lastSvc.Labels[naming.DecommissionedLabel]) == 0 {
+		lastSvcCopy := lastSvc.DeepCopy()
+		// Record the intent to decommission the member. This is level triggered: the leaving nodes are re-derived
+		// from the spec node count, the decommissioned labels and the StatefulSet replicas on every sync, so a
+		// failed or interrupted request ends up here again until the label is set.
+		lastSvcCopy.Labels[naming.DecommissionedLabel] = naming.LabelValueFalse
+		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, statefulSetControllerProgressingCondition, lastSvcCopy, "update", sdc.Generation)
+		_, err = sdcc.kubeClient.CoreV1().Services(lastSvcCopy.Namespace).Update(ctx, lastSvcCopy, metav1.UpdateOptions{})
+		if err != nil {
+			return progressingConditions, fmt.Errorf("can't update service %q: %w", naming.ObjRef(lastSvcCopy), err)
+		}
+		return progressingConditions, nil
+	}
+
+	// The node has been decommissioned, conclude by scaling the StatefulSet below it.
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            sts.Name,
+			Namespace:       sts.Namespace,
+			ResourceVersion: sts.ResourceVersion,
+		},
+		Spec: autoscalingv1.ScaleSpec{
+			Replicas: newReplicas,
+		},
+	}
+	klog.V(2).InfoS("Scaling StatefulSet", "ScyllaDBDatacenter", klog.KObj(sdc), "StatefulSet", klog.KObj(sts), "CurrentReplicas", *sts.Spec.Replicas, "UpdatedReplicas", scale.Spec.Replicas)
+	controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, statefulSetControllerProgressingCondition, scale, "updateScale", sdc.Generation)
+	_, err = sdcc.kubeClient.AppsV1().StatefulSets(sts.Namespace).UpdateScale(ctx, sts.Name, scale, metav1.UpdateOptions{})
+	if err != nil {
+		return progressingConditions, fmt.Errorf("can't update scale: %w", err)
+	}
+	return progressingConditions, nil
+}
+
 func (sdcc *Controller) syncStatefulSets(
 	ctx context.Context,
 	key string,
@@ -652,6 +809,35 @@ func (sdcc *Controller) syncStatefulSets(
 	for _, req := range requiredStatefulSets {
 		sts := statefulSets[req.Name]
 
+		rackName, ok := sts.Labels[naming.RackNameLabel]
+		if !ok || len(rackName) == 0 {
+			return progressingConditions, fmt.Errorf("can't determine rack name: statefulset %q is missing label %q", naming.ObjRef(sts), naming.RackNameLabel)
+		}
+
+		rackServices := map[string]*corev1.Service{}
+		for _, svc := range services {
+			svcRackName, ok := svc.Labels[naming.RackNameLabel]
+			if ok && svcRackName == rackName {
+				rackServices[svc.Name] = svc
+			}
+		}
+
+		// The decommission flow: while any node of the rack is leaving, it owns the StatefulSet scale and holds the
+		// rack, and any scale-down starts there.
+		decommissionProgressingConditions, err := sdcc.syncRackDecommission(ctx, sdc, rackName, sts, rackServices)
+		progressingConditions = append(progressingConditions, decommissionProgressingConditions...)
+		if err != nil {
+			return progressingConditions, fmt.Errorf("can't sync decommission of rack %q of ScyllaDBDatacenter %q: %w", rackName, naming.ObjRef(sdc), err)
+		}
+		if len(decommissionProgressingConditions) != 0 {
+			// The rack is held; only one node operation may be in flight in the datacenter.
+			return progressingConditions, nil
+		}
+
+		if *req.Spec.Replicas <= *sts.Spec.Replicas {
+			continue
+		}
+
 		scale := &autoscalingv1.Scale{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            sts.Name,
@@ -661,69 +847,6 @@ func (sdcc *Controller) syncStatefulSets(
 			Spec: autoscalingv1.ScaleSpec{
 				Replicas: *req.Spec.Replicas,
 			},
-		}
-
-		rackServices := map[string]*corev1.Service{}
-		for _, svc := range services {
-			svcRackName, ok := svc.Labels[naming.RackNameLabel]
-			if ok && svcRackName == sts.Labels[naming.RackNameLabel] {
-				rackServices[svc.Name] = svc
-			}
-		}
-
-		// Wait if any decommissioning is in progress.
-		for _, svc := range rackServices {
-			if svc.Labels[naming.DecommissionedLabel] == naming.LabelValueFalse {
-				klog.V(4).InfoS("Waiting for service to be decommissioned")
-				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               statefulSetControllerProgressingCondition,
-					Status:             metav1.ConditionTrue,
-					Reason:             "WaitingForRackServiceDecommission",
-					Message:            fmt.Sprintf("Waiting for rack service %q to decommission.", naming.ObjRef(svc)),
-					ObservedGeneration: sdc.Generation,
-				})
-
-				return progressingConditions, nil
-			}
-		}
-
-		if scale.Spec.Replicas == *sts.Spec.Replicas {
-			continue
-		}
-
-		if scale.Spec.Replicas < *sts.Spec.Replicas {
-			// Make sure we always scale down by 1 member.
-			scale.Spec.Replicas = *sts.Spec.Replicas - 1
-
-			lastSvcName := fmt.Sprintf("%s-%d", sts.Name, *sts.Spec.Replicas-1)
-			lastSvc, ok := rackServices[lastSvcName]
-			if !ok {
-				klog.V(4).InfoS("Missing service", "ScyllaDBDatacenter", klog.KObj(sdc), "ServiceName", lastSvcName)
-				progressingConditions = append(progressingConditions, metav1.Condition{
-					Type:               statefulSetControllerProgressingCondition,
-					Status:             metav1.ConditionTrue,
-					Reason:             "WaitingForMissingService",
-					Message:            fmt.Sprintf("Statusfulset %q is waiting for service %q to be created", naming.ObjRef(req), lastSvcName),
-					ObservedGeneration: sdc.Generation,
-				})
-				// Services are managed in the other loop.
-				// When informers see the new service, will get re-queued.
-				return progressingConditions, nil
-			}
-
-			if len(lastSvc.Labels[naming.DecommissionedLabel]) == 0 {
-				lastSvcCopy := lastSvc.DeepCopy()
-				// Record the intent to decommission the member.
-				// TODO: Move this into syncServices so it reconciles properly. This is edge triggered
-				//  and nothing will reconcile the label if something goes wrong or the flow changes.
-				lastSvcCopy.Labels[naming.DecommissionedLabel] = naming.LabelValueFalse
-				controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, statefulSetControllerProgressingCondition, lastSvcCopy, "update", sdc.Generation)
-				_, err := sdcc.kubeClient.CoreV1().Services(lastSvcCopy.Namespace).Update(ctx, lastSvcCopy, metav1.UpdateOptions{})
-				if err != nil {
-					return progressingConditions, err
-				}
-				return progressingConditions, nil
-			}
 		}
 
 		klog.V(2).InfoS("Scaling StatefulSet", "ScyllaDBDatacenter", klog.KObj(sdc), "StatefulSet", klog.KObj(sts), "CurrentReplicas", *sts.Spec.Replicas, "UpdatedReplicas", scale.Spec.Replicas)

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
@@ -757,6 +757,13 @@ func Test_syncRackDecommission(t *testing.T) {
 				{
 					Type:               statefulSetControllerProgressingCondition,
 					Status:             metav1.ConditionTrue,
+					Reason:             "DeferringRackNodeCountChange",
+					Message:            fmt.Sprintf(`Deferring node count change of rack %q to 3 until the Services of its decommissioning nodes ["%s-1"] are pruned.`, rackName, stsName),
+					ObservedGeneration: sdc.Generation,
+				},
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
 					Reason:             "WaitingForRackServiceDecommission",
 					Message:            fmt.Sprintf(`Waiting for rack service "%s/%s-1" to decommission.`, testNamespace, stsName),
 					ObservedGeneration: sdc.Generation,
@@ -770,6 +777,13 @@ func Test_syncRackDecommission(t *testing.T) {
 			sts:          newSts(1),
 			rackServices: newRackServices(newMemberService(0, nil), newMemberService(1, new(naming.LabelValueTrue))),
 			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "DeferringRackNodeCountChange",
+					Message:            fmt.Sprintf(`Deferring node count change of rack %q to 2 until the Services of its decommissioning nodes ["%s-1"] are pruned.`, rackName, stsName),
+					ObservedGeneration: sdc.Generation,
+				},
 				{
 					Type:               statefulSetControllerProgressingCondition,
 					Status:             metav1.ConditionTrue,

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets_test.go
@@ -3,18 +3,25 @@ package scylladbdatacenter
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -514,5 +521,357 @@ func newStatefulSet(name string) *appsv1.StatefulSet {
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: new(int32(1)),
 		},
+	}
+}
+
+func Test_getRackDecommissionTargetNodeCount(t *testing.T) {
+	t.Parallel()
+
+	sdc := newScyllaDBDatacenter()
+	sdc.Spec.Racks = []scyllav1alpha1.RackSpec{
+		{Name: "a"},
+	}
+	stsName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+	newRackStatefulSet := func(replicas int32) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: stsName,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: new(replicas),
+			},
+		}
+	}
+	newDecommissioningNodes := func(names ...string) []scyllav1alpha1.DecommissioningNodeStatus {
+		var nodes []scyllav1alpha1.DecommissioningNodeStatus
+		for _, name := range names {
+			nodes = append(nodes, scyllav1alpha1.DecommissioningNodeStatus{Name: name})
+		}
+		return nodes
+	}
+
+	tt := []struct {
+		name                 string
+		sts                  *appsv1.StatefulSet
+		decommissioningNodes []scyllav1alpha1.DecommissioningNodeStatus
+		expectedNodeCount    int32
+		expectedErr          error
+	}{
+		{
+			name:                 "lowest leaving ordinal",
+			sts:                  newRackStatefulSet(3),
+			decommissioningNodes: newDecommissioningNodes(stsName+"-1", stsName+"-2"),
+			expectedNodeCount:    1,
+		},
+		{
+			name:                 "capped at the StatefulSet replicas when the leaving nodes are already scaled down",
+			sts:                  newRackStatefulSet(2),
+			decommissioningNodes: newDecommissioningNodes(stsName + "-2"),
+			expectedNodeCount:    2,
+		},
+		{
+			name:                 "no decommissioning nodes error out",
+			sts:                  newRackStatefulSet(3),
+			decommissioningNodes: nil,
+			expectedErr:          fmt.Errorf(`rack "a" of ScyllaDBDatacenter %q has no decommissioning nodes`, naming.ObjRef(sdc)),
+		},
+		{
+			name:                 "unparsable leaving node name errors out",
+			sts:                  newRackStatefulSet(3),
+			decommissioningNodes: newDecommissioningNodes("foo"),
+			expectedErr:          fmt.Errorf(`can't get ordinal of decommissioning node "foo" of rack "a" of ScyllaDBDatacenter %q: %w`, naming.ObjRef(sdc), fmt.Errorf(`didn't find '-' delimiter in string foo`)),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := getRackDecommissionTargetNodeCount(sdc, "a", tc.sts, tc.decommissioningNodes)
+			if !reflect.DeepEqual(err, tc.expectedErr) {
+				t.Fatalf("expected error %v, got %v", tc.expectedErr, err)
+			}
+			if got != tc.expectedNodeCount {
+				t.Errorf("expected node count %d, got %d", tc.expectedNodeCount, got)
+			}
+		})
+	}
+}
+
+func Test_syncRackDecommission(t *testing.T) {
+	t.Parallel()
+
+	const rackName = "a"
+
+	newSDCWithNodes := func(nodes int32) *scyllav1alpha1.ScyllaDBDatacenter {
+		sdc := newScyllaDBDatacenter()
+		sdc.Spec.Racks = []scyllav1alpha1.RackSpec{
+			{
+				Name: rackName,
+				RackTemplate: scyllav1alpha1.RackTemplate{
+					Nodes: new(nodes),
+				},
+			},
+		}
+		return sdc
+	}
+
+	sdc := newSDCWithNodes(1)
+	stsName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+
+	newSts := func(replicas int32) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      stsName,
+				Labels: map[string]string{
+					naming.RackNameLabel: rackName,
+				},
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: new(replicas),
+			},
+		}
+	}
+	newMemberService := func(ordinal int32, decommissionedLabelValue *string) *corev1.Service {
+		labels := map[string]string{
+			naming.RackNameLabel: rackName,
+		}
+		if decommissionedLabelValue != nil {
+			labels[naming.DecommissionedLabel] = *decommissionedLabelValue
+		}
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      fmt.Sprintf("%s-%d", stsName, ordinal),
+				Labels:    labels,
+			},
+		}
+	}
+	newRackServices := func(services ...*corev1.Service) map[string]*corev1.Service {
+		rackServices := map[string]*corev1.Service{}
+		for _, svc := range services {
+			rackServices[svc.Name] = svc
+		}
+		return rackServices
+	}
+	makeStampCondition := func(svc *corev1.Service) metav1.Condition {
+		svcCopy := svc.DeepCopy()
+		svcCopy.Labels[naming.DecommissionedLabel] = naming.LabelValueFalse
+		var conditions []metav1.Condition
+		controllerhelpers.AddGenericProgressingStatusCondition(&conditions, statefulSetControllerProgressingCondition, svcCopy, "update", sdc.Generation)
+		return conditions[0]
+	}
+	makeScaleCondition := func(sts *appsv1.StatefulSet, replicas int32) metav1.Condition {
+		scale := &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            sts.Name,
+				Namespace:       sts.Namespace,
+				ResourceVersion: sts.ResourceVersion,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: replicas,
+			},
+		}
+		var conditions []metav1.Condition
+		controllerhelpers.AddGenericProgressingStatusCondition(&conditions, statefulSetControllerProgressingCondition, scale, "updateScale", sdc.Generation)
+		return conditions[0]
+	}
+
+	tt := []struct {
+		name                                     string
+		sdc                                      *scyllav1alpha1.ScyllaDBDatacenter
+		rackName                                 string
+		sts                                      *appsv1.StatefulSet
+		rackServices                             map[string]*corev1.Service
+		expectedConditions                       []metav1.Condition
+		expectedErrorString                      string
+		expectedDecommissionRequestedServiceName string
+		expectedScaledReplicas                   *int32
+	}{
+		{
+			name:               "idle rack yields no conditions and no actions",
+			sdc:                newSDCWithNodes(1),
+			rackName:           rackName,
+			sts:                newSts(1),
+			rackServices:       newRackServices(newMemberService(0, nil)),
+			expectedConditions: nil,
+		},
+		{
+			name:                                     "a fresh scale-down stamps the highest node",
+			sdc:                                      newSDCWithNodes(1),
+			rackName:                                 rackName,
+			sts:                                      newSts(2),
+			rackServices:                             newRackServices(newMemberService(0, nil), newMemberService(1, nil)),
+			expectedConditions:                       []metav1.Condition{makeStampCondition(newMemberService(1, nil))},
+			expectedDecommissionRequestedServiceName: stsName + "-1",
+		},
+		{
+			name:         "an in-flight decommission of the highest node is waited for",
+			sdc:          newSDCWithNodes(1),
+			rackName:     rackName,
+			sts:          newSts(2),
+			rackServices: newRackServices(newMemberService(0, nil), newMemberService(1, new(naming.LabelValueFalse))),
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "WaitingForRackServiceDecommission",
+					Message:            fmt.Sprintf(`Waiting for rack service "%s/%s-1" to decommission.`, testNamespace, stsName),
+					ObservedGeneration: sdc.Generation,
+				},
+			},
+		},
+		{
+			name:         "an in-flight decommission below the highest node is waited for and the highest node is not stamped",
+			sdc:          newSDCWithNodes(1),
+			rackName:     rackName,
+			sts:          newSts(3),
+			rackServices: newRackServices(newMemberService(0, nil), newMemberService(1, new(naming.LabelValueFalse)), newMemberService(2, nil)),
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "WaitingForRackServiceDecommission",
+					Message:            fmt.Sprintf(`Waiting for rack service "%s/%s-1" to decommission.`, testNamespace, stsName),
+					ObservedGeneration: sdc.Generation,
+				},
+			},
+		},
+		{
+			name:                   "a decommissioned highest node concludes by scaling the StatefulSet below it",
+			sdc:                    newSDCWithNodes(1),
+			rackName:               rackName,
+			sts:                    newSts(2),
+			rackServices:           newRackServices(newMemberService(0, nil), newMemberService(1, new(naming.LabelValueTrue))),
+			expectedConditions:     []metav1.Condition{makeScaleCondition(newSts(2), 1)},
+			expectedScaledReplicas: new(int32(1)),
+		},
+		{
+			name:         "a node count raised mid-decommission is deferred",
+			sdc:          newSDCWithNodes(3),
+			rackName:     rackName,
+			sts:          newSts(2),
+			rackServices: newRackServices(newMemberService(0, nil), newMemberService(1, new(naming.LabelValueFalse))),
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "WaitingForRackServiceDecommission",
+					Message:            fmt.Sprintf(`Waiting for rack service "%s/%s-1" to decommission.`, testNamespace, stsName),
+					ObservedGeneration: sdc.Generation,
+				},
+			},
+		},
+		{
+			name:         "decommissioned nodes scaled away already are held until their Services are pruned",
+			sdc:          newSDCWithNodes(2),
+			rackName:     rackName,
+			sts:          newSts(1),
+			rackServices: newRackServices(newMemberService(0, nil), newMemberService(1, new(naming.LabelValueTrue))),
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "WaitingForRackServicePruning",
+					Message:            fmt.Sprintf(`Waiting for decommissioned service(s) ["%s-1"] of rack %q to be pruned.`, stsName, rackName),
+					ObservedGeneration: sdc.Generation,
+				},
+			},
+		},
+		{
+			name:         "a scale-down with the highest node's Service missing waits for it",
+			sdc:          newSDCWithNodes(1),
+			rackName:     rackName,
+			sts:          newSts(2),
+			rackServices: newRackServices(newMemberService(0, nil)),
+			expectedConditions: []metav1.Condition{
+				{
+					Type:               statefulSetControllerProgressingCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "WaitingForMissingService",
+					Message:            fmt.Sprintf(`Statusfulset "%s/%s" is waiting for service %q to be created`, testNamespace, stsName, stsName+"-1"),
+					ObservedGeneration: sdc.Generation,
+				},
+			},
+		},
+		{
+			name:                "a rack missing from the spec errors out",
+			sdc:                 newSDCWithNodes(1),
+			rackName:            "missing",
+			sts:                 newSts(1),
+			rackServices:        newRackServices(),
+			expectedErrorString: fmt.Sprintf(`can't get rack "missing" node count of ScyllaDBDatacenter "%[1]s/": can't find rack "missing" in rack spec of ScyllaDBDatacenter "%[1]s/"`, testNamespace),
+		},
+		{
+			name:                "an unparsable leaving node name errors out",
+			sdc:                 newSDCWithNodes(1),
+			rackName:            rackName,
+			sts:                 newSts(1),
+			rackServices:        newRackServices(&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "foo", Labels: map[string]string{naming.RackNameLabel: rackName, naming.DecommissionedLabel: naming.LabelValueTrue}}}),
+			expectedErrorString: fmt.Sprintf(`can't get decommission target node count of rack %[1]q of ScyllaDBDatacenter "%[2]s/": can't get ordinal of decommissioning node "foo" of rack %[1]q of ScyllaDBDatacenter "%[2]s/": didn't find '-' delimiter in string foo`, rackName, testNamespace),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			objects := []runtime.Object{tc.sts}
+			for _, svc := range tc.rackServices {
+				objects = append(objects, svc)
+			}
+			client := fake.NewSimpleClientset(objects...)
+
+			var scaledReplicas *int32
+			client.PrependReactor("update", "statefulsets", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				updateAction := action.(clienttesting.UpdateAction)
+				if updateAction.GetSubresource() != "scale" {
+					return false, nil, nil
+				}
+				scaledReplicas = new(updateAction.GetObject().(*autoscalingv1.Scale).Spec.Replicas)
+				return true, updateAction.GetObject(), nil
+			})
+
+			sdcc := &Controller{
+				kubeClient: client,
+			}
+
+			gotConditions, err := sdcc.syncRackDecommission(t.Context(), tc.sdc, tc.rackName, tc.sts, tc.rackServices)
+
+			var errString string
+			if err != nil {
+				errString = err.Error()
+			}
+			if errString != tc.expectedErrorString {
+				t.Fatalf("expected error %q, got %q", tc.expectedErrorString, errString)
+			}
+			if !reflect.DeepEqual(gotConditions, tc.expectedConditions) {
+				t.Errorf("expected and actual conditions differ: %s", cmp.Diff(tc.expectedConditions, gotConditions))
+			}
+
+			// A Service whose decommissioned label value changed is one whose decommission was requested: the flow
+			// only ever sets the label to false.
+			var decommissionRequestedServiceName string
+			for name := range tc.rackServices {
+				svc, err := client.CoreV1().Services(testNamespace).Get(t.Context(), name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if svc.Labels[naming.DecommissionedLabel] == tc.rackServices[name].Labels[naming.DecommissionedLabel] {
+					continue
+				}
+				if svc.Labels[naming.DecommissionedLabel] != naming.LabelValueFalse {
+					t.Errorf("service %q has unexpected decommissioned label value %q", name, svc.Labels[naming.DecommissionedLabel])
+				}
+				decommissionRequestedServiceName = name
+			}
+			if decommissionRequestedServiceName != tc.expectedDecommissionRequestedServiceName {
+				t.Errorf("expected the decommission of service %q to be requested, got %q", tc.expectedDecommissionRequestedServiceName, decommissionRequestedServiceName)
+			}
+			if !reflect.DeepEqual(scaledReplicas, tc.expectedScaledReplicas) {
+				t.Errorf("expected scaled replicas %v, got %v", tc.expectedScaledReplicas, scaledReplicas)
+			}
+		})
 	}
 }

--- a/test/envtest/controllers/scylladbdatacenter_controller_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	scyllainformers "github.com/scylladb/scylla-operator/pkg/client/scylla/informers/externalversions"
 	"github.com/scylladb/scylla-operator/pkg/controller/scylladbdatacenter"
 	"github.com/scylladb/scylla-operator/pkg/crypto"
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/scylla"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
@@ -26,7 +28,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"k8s.io/client-go/util/retry"
@@ -106,16 +110,14 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 		}
 	})
 
-	g.Describe("decommissioning nodes record", func() {
+	g.Describe("decommissioning", func() {
 		const (
 			rackName     = "rack-a"
 			initialNodes = int32(2)
 		)
 
-		// setup runs the controller and brings up a rolled-out two-node rack. It returns the ScyllaDBDatacenter, the
-		// name of the rack StatefulSet and the name of the member Service of the highest ordinal, which is the node
-		// that a scale-down by one removes.
-		setup := func(ctx g.SpecContext) (*scyllav1alpha1.ScyllaDBDatacenter, string, string) {
+		// setupRacks runs the controller and brings up rolled-out racks with the given number of nodes each.
+		setupRacks := func(ctx g.SpecContext, rackNames []string, nodes int32) *scyllav1alpha1.ScyllaDBDatacenter {
 			g.GinkgoHelper()
 
 			g.By("Running ScyllaDBDatacenter controller")
@@ -124,24 +126,41 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 			g.By("Creating ScyllaOperatorConfig singleton")
 			createScyllaOperatorConfig(ctx, env)
 
-			g.By("Creating a ScyllaDBDatacenter with a two-node rack")
-			sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{rackName}, withRackTemplateNodes(initialNodes))
+			g.By(fmt.Sprintf("Creating a ScyllaDBDatacenter with %d rack(s) of %d node(s)", len(rackNames), nodes))
+			sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), rackNames, withRackTemplateNodes(nodes))
 			sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Waiting for the rack StatefulSet and member Services to be created")
-			rackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
-			waitForStatefulSet(ctx, env, rackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
-			leavingServiceName := fmt.Sprintf("%s-%d", rackStatefulSetName, initialNodes-1)
-			waitForService(ctx, env, leavingServiceName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+			// Racks are created one by one, so every rack has to roll out before the next one shows up.
+			for _, rack := range sdc.Spec.Racks {
+				g.By(fmt.Sprintf("Waiting for the %q rack StatefulSet and member Services to be created", rack.Name))
+				rackStatefulSetName := naming.StatefulSetNameForRack(rack, sdc)
+				waitForStatefulSet(ctx, env, rackStatefulSetName, scyllaDBDatacenterControllerDefaultEventuallyTimeout)
+				waitForService(ctx, env, naming.MemberServiceName(rack, sdc, int(nodes-1)), scyllaDBDatacenterControllerDefaultEventuallyTimeout)
 
-			g.By("Marking the rack StatefulSet as rolled out")
-			markStatefulSetAsRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), rackStatefulSetName)
+				g.By(fmt.Sprintf("Marking the %q rack StatefulSet as rolled out", rack.Name))
+				markStatefulSetAsRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), rackStatefulSetName)
+			}
 
 			g.By("Verifying no node is recorded as decommissioning")
 			o.Consistently(func(co o.Gomega, ctx context.Context) {
-				co.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rackName)).To(o.BeEmpty())
+				for _, rack := range sdc.Spec.Racks {
+					co.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rack.Name)).To(o.BeEmpty())
+				}
 			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			return sdc
+		}
+
+		// setup brings up a rolled-out two-node rack. It returns the ScyllaDBDatacenter, the name of the rack
+		// StatefulSet and the name of the member Service of the highest ordinal, which is the node that a scale-down
+		// by one removes.
+		setup := func(ctx g.SpecContext) (*scyllav1alpha1.ScyllaDBDatacenter, string, string) {
+			g.GinkgoHelper()
+
+			sdc := setupRacks(ctx, []string{rackName}, initialNodes)
+			rackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+			leavingServiceName := naming.MemberServiceName(sdc.Spec.Racks[0], sdc, int(initialNodes-1))
 
 			return sdc, rackStatefulSetName, leavingServiceName
 		}
@@ -172,14 +191,59 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 			waitForServiceToBePrunedAndRecordToDrain(ctx, env, sdc.Name, rackName, leavingServiceName)
 		})
 
-		// This is a reproducer of OPERATOR-343: raising the node count while a node is being decommissioned wedges the
-		// rack, because both the StatefulSet scale and the Service pruning are driven by the spec node count, which no
-		// longer calls for a scale-in. The leaving node keeps its decommissioned label throughout, so it stays listed in
-		// the status. The barrier implemented under OPERATOR-343 will source the leaving nodes from the same labels to
-		// finish the decommission first and only then apply the raised count. Once that lands, the trailing assertions
-		// flip: the StatefulSet has to scale down, the Service has to be pruned and the list has to drain before the
-		// rack grows back.
-		g.It("should keep listing a decommissioning node when the node count is raised back mid-decommission", func(ctx g.SpecContext) {
+		g.It("should decommission a multi-node scale-down one node at a time from the highest ordinal", func(ctx g.SpecContext) {
+			const nodes = int32(3)
+
+			sdc := setupRacks(ctx, []string{rackName}, nodes)
+			rackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+			firstLeavingServiceName := naming.MemberServiceName(sdc.Spec.Racks[0], sdc, 2)
+			secondLeavingServiceName := naming.MemberServiceName(sdc.Spec.Racks[0], sdc, 1)
+
+			g.By("Scaling the rack down to one node")
+			scaleRackTemplate(ctx, env, sdc.Name, 1)
+
+			g.By("Waiting for the decommission of the highest node to be requested and listed")
+			waitForServiceDecommissionedLabel(ctx, env, firstLeavingServiceName, naming.LabelValueFalse)
+			o.Eventually(func(eo o.Gomega, ctx context.Context) {
+				eo.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rackName)).To(o.Equal([]scyllav1alpha1.DecommissioningNodeStatus{
+					{Name: firstLeavingServiceName},
+				}))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By("Verifying the decommission of the lower node is not requested until the highest node is removed")
+			o.Consistently(func(co o.Gomega, ctx context.Context) {
+				svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, secondLeavingServiceName, metav1.GetOptions{})
+				co.Expect(err).NotTo(o.HaveOccurred())
+				co.Expect(svc.Labels).NotTo(o.HaveKey(naming.DecommissionedLabel))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By("Marking the highest node as decommissioned in place of the sidecar")
+			setServiceDecommissionedLabel(ctx, env, firstLeavingServiceName, naming.LabelValueTrue)
+
+			g.By("Waiting for the rack StatefulSet to be scaled down by one and the highest node to be pruned")
+			waitForStatefulSetReplicas(ctx, env, rackStatefulSetName, nodes-1)
+			o.Eventually(func(eo o.Gomega, ctx context.Context) {
+				_, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, firstLeavingServiceName, metav1.GetOptions{})
+				eo.Expect(apierrors.IsNotFound(err)).To(o.BeTrue())
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By("Waiting for the decommission of the remaining leaving node to be requested and listed")
+			waitForServiceDecommissionedLabel(ctx, env, secondLeavingServiceName, naming.LabelValueFalse)
+			o.Eventually(func(eo o.Gomega, ctx context.Context) {
+				eo.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rackName)).To(o.Equal([]scyllav1alpha1.DecommissioningNodeStatus{
+					{Name: secondLeavingServiceName},
+				}))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By("Marking the remaining node as decommissioned in place of the sidecar")
+			setServiceDecommissionedLabel(ctx, env, secondLeavingServiceName, naming.LabelValueTrue)
+
+			g.By("Waiting for the rack StatefulSet to be scaled down to one node and the list to drain")
+			waitForStatefulSetReplicas(ctx, env, rackStatefulSetName, 1)
+			waitForServiceToBePrunedAndRecordToDrain(ctx, env, sdc.Name, rackName, secondLeavingServiceName)
+		})
+
+		g.It("should finish an ongoing decommission before scaling up", func(ctx g.SpecContext) {
 			sdc, rackStatefulSetName, leavingServiceName := setup(ctx)
 
 			g.By("Scaling the rack down to one node")
@@ -188,13 +252,25 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 			g.By("Waiting for the decommission of the leaving node to be requested")
 			waitForServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueFalse)
 
+			leavingService, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, leavingServiceName, metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			leavingServiceUID := leavingService.UID
+
 			g.By("Raising the node count back while the node is still decommissioning")
 			scaleRackTemplate(ctx, env, sdc.Name, initialNodes)
 
-			g.By("Marking the node as decommissioned in place of the sidecar")
-			setServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueTrue)
+			g.By("Waiting for the deferred node count change to be reported as progressing")
+			o.Eventually(func(eo o.Gomega, ctx context.Context) {
+				sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+				eo.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Verifying the rack is wedged with the decommissioned node still recorded")
+				progressingCondition := apimeta.FindStatusCondition(sdc.Status.Conditions, internalapi.MakeKindControllerCondition("StatefulSet", scyllav1alpha1.ProgressingCondition))
+				eo.Expect(progressingCondition).NotTo(o.BeNil())
+				eo.Expect(progressingCondition.Status).To(o.Equal(metav1.ConditionTrue))
+				eo.Expect(progressingCondition.Reason).To(o.ContainSubstring("DeferringRackNodeCountChange"))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By("Verifying the raised node count is not applied while the node is still decommissioning")
 			o.Consistently(func(co o.Gomega, ctx context.Context) {
 				sts, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, rackStatefulSetName, metav1.GetOptions{})
 				co.Expect(err).NotTo(o.HaveOccurred())
@@ -202,12 +278,109 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 
 				svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, leavingServiceName, metav1.GetOptions{})
 				co.Expect(err).NotTo(o.HaveOccurred())
-				co.Expect(svc.Labels).To(o.HaveKeyWithValue(naming.DecommissionedLabel, naming.LabelValueTrue))
+				co.Expect(svc.Labels).To(o.HaveKeyWithValue(naming.DecommissionedLabel, naming.LabelValueFalse))
 
 				co.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rackName)).To(o.Equal([]scyllav1alpha1.DecommissioningNodeStatus{
 					{Name: leavingServiceName},
 				}))
 			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By("Marking the node as decommissioned in place of the sidecar")
+			setServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueTrue)
+
+			// The scale-down, the pruning and the scale-up back can all happen within milliseconds, so instead of
+			// sampling the intermediate states, verify the end state: the node can only have been pruned once the
+			// StatefulSet was scaled below it, and a pruned node comes back as a fresh Service.
+			g.By("Waiting for the leaving node to be removed and the rack to grow back to the raised node count with a fresh node")
+			o.Eventually(func(eo o.Gomega, ctx context.Context) {
+				sts, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, rackStatefulSetName, metav1.GetOptions{})
+				eo.Expect(err).NotTo(o.HaveOccurred())
+				eo.Expect(*sts.Spec.Replicas).To(o.Equal(initialNodes))
+
+				svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, leavingServiceName, metav1.GetOptions{})
+				eo.Expect(err).NotTo(o.HaveOccurred())
+				eo.Expect(svc.UID).NotTo(o.Equal(leavingServiceUID))
+				eo.Expect(svc.Labels).NotTo(o.HaveKey(naming.DecommissionedLabel))
+
+				eo.Expect(getDecommissioningNodes(ctx, env, sdc.Name, rackName)).To(o.BeEmpty())
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+		})
+
+		g.It("should wait for a rack's decommissioning node before scaling another rack", func(ctx g.SpecContext) {
+			const otherRackName = "rack-b"
+
+			sdc := setupRacks(ctx, []string{rackName, otherRackName}, initialNodes)
+			rackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+			leavingServiceName := naming.MemberServiceName(sdc.Spec.Racks[0], sdc, int(initialNodes-1))
+			otherRackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[1], sdc)
+
+			g.By(fmt.Sprintf("Scaling the %q rack down to one node", rackName))
+			scaleRack(ctx, env, sdc.Name, rackName, initialNodes-1)
+
+			g.By("Waiting for the decommission of the leaving node to be requested")
+			waitForServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueFalse)
+
+			g.By(fmt.Sprintf("Scaling the %q rack up while the %q rack is still decommissioning", otherRackName, rackName))
+			scaleRack(ctx, env, sdc.Name, otherRackName, initialNodes+1)
+
+			g.By(fmt.Sprintf("Verifying the %q rack StatefulSet is not scaled up while the %q rack is decommissioning", otherRackName, rackName))
+			o.Consistently(func(co o.Gomega, ctx context.Context) {
+				sts, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, otherRackStatefulSetName, metav1.GetOptions{})
+				co.Expect(err).NotTo(o.HaveOccurred())
+				co.Expect(*sts.Spec.Replicas).To(o.Equal(initialNodes))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By("Marking the node as decommissioned in place of the sidecar")
+			setServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueTrue)
+
+			g.By(fmt.Sprintf("Waiting for the %q rack StatefulSet to be scaled down and marking it as rolled out", rackName))
+			waitForStatefulSetReplicas(ctx, env, rackStatefulSetName, initialNodes-1)
+			markStatefulSetAsRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), rackStatefulSetName)
+
+			g.By(fmt.Sprintf("Waiting for the %q rack StatefulSet to be scaled up once the decommission is finished", otherRackName))
+			waitForStatefulSetReplicas(ctx, env, otherRackStatefulSetName, initialNodes+1)
+		})
+
+		g.It("should decommission racks one node at a time across racks", func(ctx g.SpecContext) {
+			const otherRackName = "rack-b"
+
+			sdc := setupRacks(ctx, []string{rackName, otherRackName}, initialNodes)
+			rackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+			leavingServiceName := naming.MemberServiceName(sdc.Spec.Racks[0], sdc, int(initialNodes-1))
+			otherRackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[1], sdc)
+			otherLeavingServiceName := naming.MemberServiceName(sdc.Spec.Racks[1], sdc, int(initialNodes-1))
+
+			g.By("Scaling both racks down to one node")
+			scaleRack(ctx, env, sdc.Name, rackName, initialNodes-1)
+			scaleRack(ctx, env, sdc.Name, otherRackName, initialNodes-1)
+
+			g.By(fmt.Sprintf("Waiting for the decommission of the %q rack's leaving node to be requested", rackName))
+			waitForServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueFalse)
+
+			g.By(fmt.Sprintf("Verifying the decommission of the %q rack's leaving node is not requested until the %q rack is done", otherRackName, rackName))
+			o.Consistently(func(co o.Gomega, ctx context.Context) {
+				svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, otherLeavingServiceName, metav1.GetOptions{})
+				co.Expect(err).NotTo(o.HaveOccurred())
+				co.Expect(svc.Labels).NotTo(o.HaveKey(naming.DecommissionedLabel))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultConsistentlyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By(fmt.Sprintf("Marking the %q rack's node as decommissioned in place of the sidecar", rackName))
+			setServiceDecommissionedLabel(ctx, env, leavingServiceName, naming.LabelValueTrue)
+
+			g.By(fmt.Sprintf("Waiting for the %q rack's leaving node to be removed and marking the StatefulSet as rolled out", rackName))
+			waitForStatefulSetReplicas(ctx, env, rackStatefulSetName, initialNodes-1)
+			waitForServiceToBePrunedAndRecordToDrain(ctx, env, sdc.Name, rackName, leavingServiceName)
+			markStatefulSetAsRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), rackStatefulSetName)
+
+			g.By(fmt.Sprintf("Waiting for the decommission of the %q rack's leaving node to be requested", otherRackName))
+			waitForServiceDecommissionedLabel(ctx, env, otherLeavingServiceName, naming.LabelValueFalse)
+
+			g.By(fmt.Sprintf("Marking the %q rack's node as decommissioned in place of the sidecar", otherRackName))
+			setServiceDecommissionedLabel(ctx, env, otherLeavingServiceName, naming.LabelValueTrue)
+
+			g.By(fmt.Sprintf("Waiting for the %q rack's leaving node to be removed", otherRackName))
+			waitForStatefulSetReplicas(ctx, env, otherRackStatefulSetName, initialNodes-1)
+			waitForServiceToBePrunedAndRecordToDrain(ctx, env, sdc.Name, otherRackName, otherLeavingServiceName)
 		})
 
 		g.It("should rebuild the list from the decommissioned labels when it is wiped from the status", func(ctx g.SpecContext) {
@@ -364,6 +537,30 @@ func scaleRackTemplate(ctx context.Context, e *envtest.Environment, sdcName stri
 
 		return nil
 	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+// scaleRack sets the node count of the named rack, overriding the rack template.
+func scaleRack(ctx context.Context, e *envtest.Environment, sdcName, rackName string, nodes int32) {
+	g.GinkgoHelper()
+
+	sdc, err := e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Get(ctx, sdcName, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	rackIdx := slices.IndexFunc(sdc.Spec.Racks, func(rack scyllav1alpha1.RackSpec) bool {
+		return rack.Name == rackName
+	})
+	o.Expect(rackIdx).NotTo(o.Equal(-1), "rack %q not found in ScyllaDBDatacenter %q", rackName, naming.ObjRef(sdc))
+
+	// Patch instead of update: the controller keeps writing the status of the same object, so an optimistic update
+	// issued while it is reconciling is prone to exhausting the conflict retries.
+	_, err = e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Patch(
+		ctx,
+		sdcName,
+		types.JSONPatchType,
+		[]byte(fmt.Sprintf(`[{"op": "add", "path": "/spec/racks/%d/nodes", "value": %d}]`, rackIdx, nodes)),
+		metav1.PatchOptions{},
+	)
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

Fixes a rack getting stuck forever when its node count is changed while one of its nodes is being decommissioned: while a rack has decommissioning nodes, it now reconciles to the lowest leaving ordinal instead of the spec count, so spec changes are deferred (reported as `DeferringRackNodeCountChange`) until the leaving nodes are fully removed, and returning capacity bootstraps as fresh nodes.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-343.
