### PR TITLE
feat: reject and warn on node count changes conflicting with an ongoing decommission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
   reported as successful and the key was forgotten rather than requeued, losing the retry with backoff. The degraded
   condition was reported correctly, so this was not visible in the resource status.
   [#3587](https://github.com/scylladb/scylla-operator/pull/3587)
+- Removing a rack of a `ScyllaDBDatacenter` or a `ScyllaCluster` that still has nodes leaving the cluster is now
+  rejected on admission. Previously the removal was only blocked while the rack's `StatefulSet` had replicas, so a rack
+  could be removed after the last node's `StatefulSet` was scaled down but before its member `Service` and `PVC` were
+  removed, after which the operator could no longer resolve their rack and never cleaned them up.
+  [#3633](https://github.com/scylladb/scylla-operator/pull/3633)
 
 - Fixed a rack getting stuck forever when its node count was changed while one of its nodes was being decommissioned.
   A node whose decommission has started must now finish leaving, together with its Service and PVC, before the rack
@@ -50,6 +55,10 @@
 - Added `status.racks[].decommissioningNodes` to `ScyllaDBDatacenter` and `status.racks[].decommissioningMembers` to
   `ScyllaCluster`, listing the nodes that are leaving the cluster.
   [#3623](https://github.com/scylladb/scylla-operator/pull/3623)
+- Changing the number of nodes of a `ScyllaDBDatacenter` rack, or of members of a `ScyllaCluster` rack, that has nodes
+  leaving the cluster now produces an admission warning. The change is accepted, but it isn't applied until the leaving
+  nodes have finished decommissioning and been removed.
+  [#3633](https://github.com/scylladb/scylla-operator/pull/3633)
 - Added an optional `enableParallelNodeOperations` boolean field to `ScyllaCluster.spec` and
   `ScyllaDBDatacenter.spec`. Enabling it requires ScyllaDB 2026.2 or later, declared with a semver-parseable image tag.
   In this release it only controls how nodes are started. Its scope is expected to widen in a future release, where it

--- a/docs/source/operate/scale-add-remove-racks.md
+++ b/docs/source/operate/scale-add-remove-racks.md
@@ -165,11 +165,13 @@ You must scale the rack to zero members first, wait for decommissioning to finis
 Update the ScyllaCluster spec to set `members: 0` for the rack being removed:
 
 ```bash
-kubectl -n scylla patch scyllacluster scylla --type=json \
-  -p='[{"op":"replace","path":"/spec/datacenter/racks/<index>/members","value":0}]'
-```
+# Zero-based index of the rack being removed in spec.datacenter.racks. Change it for your cluster.
+RACK_INDEX=0
 
-Replace `<index>` with the zero-based index of the rack in the `racks` array.
+kubectl -n scylla patch scyllacluster scylla --type=json --patch-file=/dev/stdin <<EOF
+[{"op": "replace", "path": "/spec/datacenter/racks/${RACK_INDEX}/members", "value": 0}]
+EOF
+```
 
 Wait for the Operator to decommission all nodes in the rack:
 
@@ -186,15 +188,66 @@ kubectl -n scylla get pods -l scylla/rack=<rack-name>
 
 Expected output: no pods listed.
 
+Verify no member of the rack is still leaving the cluster:
+
+```bash
+kubectl -n scylla describe scyllacluster scylla
+```
+
+Under `Status` → `Racks`, the entry of the rack being removed has to look like this:
+
+```console
+  Racks:
+    us-east-1a:
+      Available Members:  0
+      Members:            0
+      Ready Members:      0
+      Stale:              false
+      Updated Members:    0
+      Version:            2026.2.5
+```
+
+A rack that still has a member leaving lists it under `Decommissioning Members`:
+
+```console
+  Racks:
+    us-east-1a:
+      Available Members:  0
+      Conditions:
+        Status:  True
+        Type:    MemberLeaving
+      Decommissioning Members:
+        Name:           scylla-us-east-1-us-east-1a-0
+      Members:          0
+      Ready Members:    0
+      Stale:            false
+      Updated Members:  0
+      Version:          2026.2.5
+```
+
+A member is listed there from the moment its decommission is requested until it has been decommissioned and its Service and PVC have been removed.
+
 #### Step 2: Remove the rack definition from the spec
 
 Remove the rack entry from `spec.datacenter.racks`:
 
 ```bash
-kubectl -n scylla edit scyllacluster scylla
+# The same rack index as in step 1.
+RACK_INDEX=0
+
+kubectl -n scylla patch scyllacluster scylla --type=json --patch-file=/dev/stdin <<EOF
+[{"op": "remove", "path": "/spec/datacenter/racks/${RACK_INDEX}"}]
+EOF
 ```
 
-Delete the entire rack entry. Save and apply.
+The Operator's admission webhook rejects the removal while the rack still has members leaving the cluster, and names the members that hold it up.
+The command then fails with:
+
+```console
+The ScyllaCluster "scylla" is invalid: spec.datacenter.racks[0]: Forbidden: rack "us-east-1a" can't be removed because it still has members leaving the cluster: scylla-us-east-1-us-east-1a-0; they have to finish decommissioning and be removed first, please retry later
+```
+
+Wait for the named members to be removed and retry.
 
 :::{warning}
 Removing a rack is irreversible — any data that was stored on the rack's nodes is streamed away during decommission.

--- a/pkg/api/scylla/validation/cluster_validation.go
+++ b/pkg/api/scylla/validation/cluster_validation.go
@@ -460,6 +460,14 @@ func ValidateScyllaClusterSpecUpdate(new, old *scyllav1.ScyllaCluster, fldPath *
 				continue
 			}
 
+			// The member count above mirrors the StatefulSet replicas, which reach zero before the leaving members are
+			// pruned. Removing the rack while any of them are still around leaves the controller unable to resolve
+			// their rack, so their member Services and PVCs are never pruned.
+			if decommissioningMembers := old.Status.Racks[rack.Name].DecommissioningMembers; len(decommissioningMembers) != 0 {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("datacenter", "racks").Index(i), fmt.Sprintf("rack %q can't be removed because it still has members leaving the cluster: %s; they have to finish decommissioning and be removed first, please retry later", rackName, strings.Join(getDecommissioningMemberNames(decommissioningMembers), ", "))))
+				continue
+			}
+
 			if !isRackStatusUpToDate(old, rack.Name) {
 				allErrs = append(allErrs, field.InternalError(fldPath.Child("datacenter", "racks").Index(i), fmt.Errorf("rack %q can't be removed because its status, that's used to determine members count, is not yet up to date with the generation of this resource; please retry later", rackName)))
 			}
@@ -513,6 +521,12 @@ func ValidateScyllaClusterSpecUpdate(new, old *scyllav1.ScyllaCluster, fldPath *
 	return allErrs
 }
 
+func getDecommissioningMemberNames(decommissioningMembers []scyllav1.DecommissioningMemberStatus) []string {
+	return oslices.ConvertSlice(decommissioningMembers, func(decommissioningMember scyllav1.DecommissioningMemberStatus) string {
+		return decommissioningMember.Name
+	})
+}
+
 func isRackStatusUpToDate(sc *scyllav1.ScyllaCluster, rack string) bool {
 	return sc.Status.ObservedGeneration != nil &&
 		*sc.Status.ObservedGeneration >= sc.Generation &&
@@ -549,6 +563,40 @@ func GetWarningsOnScyllaClusterUpdate(new, old *scyllav1.ScyllaCluster) []string
 	var warnings []string
 
 	warnings = append(warnings, getWarningsForScyllaClusterSpec(&new.Spec, field.NewPath("spec"))...)
+	warnings = append(warnings, getWarningsForScyllaClusterRackMemberCountUpdate(new, old, field.NewPath("spec"))...)
+
+	return warnings
+}
+
+// getWarningsForScyllaClusterRackMemberCountUpdate warns about changes to the number of members of a rack that has
+// members leaving the cluster. Such a change is accepted, but it isn't applied until the leaving members are gone.
+func getWarningsForScyllaClusterRackMemberCountUpdate(new, old *scyllav1.ScyllaCluster, fldPath *field.Path) []string {
+	var warnings []string
+
+	for i, newRack := range new.Spec.Datacenter.Racks {
+		oldRack, _, ok := oslices.Find(old.Spec.Datacenter.Racks, func(rackSpec scyllav1.RackSpec) bool {
+			return rackSpec.Name == newRack.Name
+		})
+		if !ok {
+			continue
+		}
+
+		if newRack.Members == oldRack.Members {
+			continue
+		}
+
+		decommissioningMembers := old.Status.Racks[newRack.Name].DecommissioningMembers
+		if len(decommissioningMembers) == 0 {
+			continue
+		}
+
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: rack %q has members leaving the cluster: %s. The requested number of members is accepted, but it won't be applied until they have finished decommissioning and been removed.",
+			fldPath.Child("datacenter", "racks").Index(i),
+			newRack.Name,
+			strings.Join(getDecommissioningMemberNames(decommissioningMembers), ", "),
+		))
+	}
 
 	return warnings
 }

--- a/pkg/api/scylla/validation/cluster_validation_test.go
+++ b/pkg/api/scylla/validation/cluster_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	corev1 "k8s.io/api/core/v1"
@@ -1311,6 +1312,35 @@ func TestValidateScyllaClusterUpdate(t *testing.T) {
 			expectedErrorString: `spec.datacenter.racks[0]: Forbidden: rack "test-rack" can't be removed because the members are being scaled down`,
 		},
 		{
+			name: "empty rack with members leaving the cluster removed",
+			old: withStatus(unit.NewSingleRackCluster(0), scyllav1.ScyllaClusterStatus{Racks: map[string]scyllav1.RackStatus{"test-rack": {
+				Members:                0,
+				DecommissioningMembers: []scyllav1.DecommissioningMemberStatus{{Name: "basic-us-east-1-test-rack-0"}},
+				Stale:                  pointer.Ptr(false),
+			}}}),
+			new: racksDeleted(unit.NewSingleRackCluster(0)),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeForbidden, Field: "spec.datacenter.racks[0]", BadValue: "", Detail: `rack "test-rack" can't be removed because it still has members leaving the cluster: basic-us-east-1-test-rack-0; they have to finish decommissioning and be removed first, please retry later`},
+			},
+			expectedErrorString: `spec.datacenter.racks[0]: Forbidden: rack "test-rack" can't be removed because it still has members leaving the cluster: basic-us-east-1-test-rack-0; they have to finish decommissioning and be removed first, please retry later`,
+		},
+		{
+			name: "empty rack with members leaving the cluster and stale status removed",
+			old: withStatus(unit.NewSingleRackCluster(0), scyllav1.ScyllaClusterStatus{Racks: map[string]scyllav1.RackStatus{"test-rack": {
+				Members: 0,
+				DecommissioningMembers: []scyllav1.DecommissioningMemberStatus{
+					{Name: "basic-us-east-1-test-rack-0"},
+					{Name: "basic-us-east-1-test-rack-1"},
+				},
+				Stale: pointer.Ptr(true),
+			}}}),
+			new: racksDeleted(unit.NewSingleRackCluster(0)),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeForbidden, Field: "spec.datacenter.racks[0]", BadValue: "", Detail: `rack "test-rack" can't be removed because it still has members leaving the cluster: basic-us-east-1-test-rack-0, basic-us-east-1-test-rack-1; they have to finish decommissioning and be removed first, please retry later`},
+			},
+			expectedErrorString: `spec.datacenter.racks[0]: Forbidden: rack "test-rack" can't be removed because it still has members leaving the cluster: basic-us-east-1-test-rack-0, basic-us-east-1-test-rack-1; they have to finish decommissioning and be removed first, please retry later`,
+		},
+		{
 			name: "empty rack with stale status",
 			old:  withStatus(unit.NewSingleRackCluster(0), scyllav1.ScyllaClusterStatus{Racks: map[string]scyllav1.RackStatus{"test-rack": {Stale: pointer.Ptr(true), Members: 0}}}),
 			new:  racksDeleted(unit.NewSingleRackCluster(0)),
@@ -1583,6 +1613,22 @@ func storageChanged(c *scyllav1.ScyllaCluster) *scyllav1.ScyllaCluster {
 	return c
 }
 
+// newScyllaClusterWithDecommissioningMembersForWarnings returns a two-member rack whose status lists the named members
+// as leaving the cluster.
+func newScyllaClusterWithDecommissioningMembersForWarnings(decommissioningMemberNames ...string) *scyllav1.ScyllaCluster {
+	sc := unit.NewSingleRackCluster(2)
+	sc.Status.Racks = map[string]scyllav1.RackStatus{
+		sc.Spec.Datacenter.Racks[0].Name: {
+			Members: 2,
+			DecommissioningMembers: oslices.ConvertSlice(decommissioningMemberNames, func(name string) scyllav1.DecommissioningMemberStatus {
+				return scyllav1.DecommissioningMemberStatus{Name: name}
+			}),
+		},
+	}
+
+	return sc
+}
+
 func TestGetWarningsOnScyllaClusterCreate(t *testing.T) {
 	t.Parallel()
 
@@ -1678,6 +1724,34 @@ func TestGetWarningsOnScyllaClusterUpdate(t *testing.T) {
 			expectedWarnings: []string{
 				"`spec.exposeOptions.cql` field is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
 			},
+		},
+		{
+			name:  "rack member count changed while the rack has members leaving the cluster",
+			oldSC: newScyllaClusterWithDecommissioningMembersForWarnings("basic-us-east-1-test-rack-1", "basic-us-east-1-test-rack-2"),
+			newSC: func() *scyllav1.ScyllaCluster {
+				sc := newScyllaClusterWithDecommissioningMembersForWarnings("basic-us-east-1-test-rack-1", "basic-us-east-1-test-rack-2")
+				sc.Spec.Datacenter.Racks[0].Members = 3
+				return sc
+			}(),
+			expectedWarnings: []string{
+				`spec.datacenter.racks[0]: rack "test-rack" has members leaving the cluster: basic-us-east-1-test-rack-1, basic-us-east-1-test-rack-2. The requested number of members is accepted, but it won't be applied until they have finished decommissioning and been removed.`,
+			},
+		},
+		{
+			name:             "rack member count unchanged while the rack has members leaving the cluster",
+			oldSC:            newScyllaClusterWithDecommissioningMembersForWarnings("basic-us-east-1-test-rack-1"),
+			newSC:            newScyllaClusterWithDecommissioningMembersForWarnings("basic-us-east-1-test-rack-1"),
+			expectedWarnings: nil,
+		},
+		{
+			name:  "rack member count changed while no member is leaving the cluster",
+			oldSC: newScyllaClusterWithDecommissioningMembersForWarnings(),
+			newSC: func() *scyllav1.ScyllaCluster {
+				sc := newScyllaClusterWithDecommissioningMembersForWarnings()
+				sc.Spec.Datacenter.Racks[0].Members = 3
+				return sc
+			}(),
+			expectedWarnings: nil,
 		},
 	}
 

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation.go
@@ -476,15 +476,7 @@ func ValidateScyllaDBDatacenterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBDatac
 				continue
 			}
 
-			oldRackNodeCount := int32(0)
-			if old.Spec.RackTemplate != nil && old.Spec.RackTemplate.Nodes != nil {
-				oldRackNodeCount = *old.Spec.RackTemplate.Nodes
-			}
-			if oldRack.Nodes != nil {
-				oldRackNodeCount = *oldRack.Nodes
-			}
-
-			if oldRackNodeCount != 0 {
+			if getScyllaDBDatacenterRackNodeCount(&old.Spec, oldRack) != 0 {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("racks").Index(i), fmt.Sprintf("rack %q can't be removed because it still has members that have to be scaled down to zero first", removedRackName)))
 				continue
 			}
@@ -498,6 +490,14 @@ func ValidateScyllaDBDatacenterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBDatac
 
 			if oldRackStatus.Nodes != nil && *oldRackStatus.Nodes != 0 {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("racks").Index(i), fmt.Sprintf("rack %q can't be removed because the members are being scaled down", removedRackName)))
+				continue
+			}
+
+			// The node count above mirrors the StatefulSet replicas, which reach zero before the leaving nodes are
+			// pruned. Removing the rack while any of them are still around leaves the controller unable to resolve
+			// their rack, so their member Services and PVCs are never pruned.
+			if len(oldRackStatus.DecommissioningNodes) != 0 {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("racks").Index(i), fmt.Sprintf("rack %q can't be removed because it still has nodes leaving the cluster: %s; they have to finish decommissioning and be removed first, please retry later", removedRackName, strings.Join(getDecommissioningNodeNames(oldRackStatus.DecommissioningNodes), ", "))))
 				continue
 			}
 
@@ -564,6 +564,26 @@ func ValidateScyllaDBDatacenterSpecUpdate(new, old *scyllav1alpha1.ScyllaDBDatac
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(newNodeServiceType, oldNodeServiceType, fldPath.Child("exposeOptions", "nodeService", "type"))...)
 
 	return allErrs
+}
+
+// getScyllaDBDatacenterRackNodeCount returns the number of nodes requested in the given rack of spec, resolving the
+// rack template default.
+func getScyllaDBDatacenterRackNodeCount(spec *scyllav1alpha1.ScyllaDBDatacenterSpec, rack scyllav1alpha1.RackSpec) int32 {
+	if rack.Nodes != nil {
+		return *rack.Nodes
+	}
+
+	if spec.RackTemplate != nil && spec.RackTemplate.Nodes != nil {
+		return *spec.RackTemplate.Nodes
+	}
+
+	return 0
+}
+
+func getDecommissioningNodeNames(decommissioningNodes []scyllav1alpha1.DecommissioningNodeStatus) []string {
+	return oslices.ConvertSlice(decommissioningNodes, func(decommissioningNode scyllav1alpha1.DecommissioningNodeStatus) string {
+		return decommissioningNode.Name
+	})
 }
 
 func validateStructSliceFieldUniqueness[E any, F comparable](s []E, mapFunc func(E) F, fieldSubPath string, structPath *field.Path) field.ErrorList {
@@ -676,6 +696,42 @@ func GetWarningsOnScyllaDBDatacenterUpdate(new, old *scyllav1alpha1.ScyllaDBData
 	var warnings []string
 
 	warnings = append(warnings, getWarningsForScyllaDBDatacenterSpec(&new.Spec, field.NewPath("spec"))...)
+	warnings = append(warnings, getWarningsForScyllaDBDatacenterRackNodeCountUpdate(new, old, field.NewPath("spec"))...)
+
+	return warnings
+}
+
+// getWarningsForScyllaDBDatacenterRackNodeCountUpdate warns about changes to the number of nodes of a rack that has
+// nodes leaving the cluster. Such a change is accepted, but it isn't applied until the leaving nodes are gone.
+func getWarningsForScyllaDBDatacenterRackNodeCountUpdate(new, old *scyllav1alpha1.ScyllaDBDatacenter, fldPath *field.Path) []string {
+	var warnings []string
+
+	for i, newRack := range new.Spec.Racks {
+		oldRack, _, ok := oslices.Find(old.Spec.Racks, func(rackSpec scyllav1alpha1.RackSpec) bool {
+			return rackSpec.Name == newRack.Name
+		})
+		if !ok {
+			continue
+		}
+
+		if getScyllaDBDatacenterRackNodeCount(&new.Spec, newRack) == getScyllaDBDatacenterRackNodeCount(&old.Spec, oldRack) {
+			continue
+		}
+
+		oldRackStatus, _, ok := oslices.Find(old.Status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
+			return rackStatus.Name == newRack.Name
+		})
+		if !ok || len(oldRackStatus.DecommissioningNodes) == 0 {
+			continue
+		}
+
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: rack %q has nodes leaving the cluster: %s. The requested number of nodes is accepted, but it won't be applied until they have finished decommissioning and been removed.",
+			fldPath.Child("racks").Index(i),
+			newRack.Name,
+			strings.Join(getDecommissioningNodeNames(oldRackStatus.DecommissioningNodes), ", "),
+		))
+	}
 
 	return warnings
 }

--- a/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
+++ b/pkg/api/scylla/validation/scylladbdatacenter_validation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/api/scylla/validation"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/pointer"
 	"github.com/scylladb/scylla-operator/pkg/test/unit"
 	corev1 "k8s.io/api/core/v1"
@@ -1116,6 +1117,59 @@ func TestValidateScyllaDBDatacenterUpdate(t *testing.T) {
 			expectedErrorString: `spec.racks[0]: Forbidden: rack "rack" can't be removed because the members are being scaled down`,
 		},
 		{
+			name: "empty rack with nodes leaving the cluster removed",
+			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Status.Racks = []scyllav1alpha1.RackStatus{
+					{
+						Name:  sdc.Spec.Racks[0].Name,
+						Nodes: pointer.Ptr[int32](0),
+						DecommissioningNodes: []scyllav1alpha1.DecommissioningNodeStatus{
+							{Name: "basic-dc-rack-0"},
+						},
+						Stale: pointer.Ptr(false),
+					},
+				}
+				return sdc
+			}(),
+			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.Racks = []scyllav1alpha1.RackSpec{}
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeForbidden, Field: "spec.racks[0]", BadValue: "", Detail: `rack "rack" can't be removed because it still has nodes leaving the cluster: basic-dc-rack-0; they have to finish decommissioning and be removed first, please retry later`},
+			},
+			expectedErrorString: `spec.racks[0]: Forbidden: rack "rack" can't be removed because it still has nodes leaving the cluster: basic-dc-rack-0; they have to finish decommissioning and be removed first, please retry later`,
+		},
+		{
+			name: "empty rack with nodes leaving the cluster and stale status removed",
+			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Status.Racks = []scyllav1alpha1.RackStatus{
+					{
+						Name:  sdc.Spec.Racks[0].Name,
+						Nodes: pointer.Ptr[int32](0),
+						DecommissioningNodes: []scyllav1alpha1.DecommissioningNodeStatus{
+							{Name: "basic-dc-rack-0"},
+							{Name: "basic-dc-rack-1"},
+						},
+						Stale: pointer.Ptr(true),
+					},
+				}
+				return sdc
+			}(),
+			new: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newValidScyllaDBDatacenter()
+				sdc.Spec.Racks = []scyllav1alpha1.RackSpec{}
+				return sdc
+			}(),
+			expectedErrorList: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeForbidden, Field: "spec.racks[0]", BadValue: "", Detail: `rack "rack" can't be removed because it still has nodes leaving the cluster: basic-dc-rack-0, basic-dc-rack-1; they have to finish decommissioning and be removed first, please retry later`},
+			},
+			expectedErrorString: `spec.racks[0]: Forbidden: rack "rack" can't be removed because it still has nodes leaving the cluster: basic-dc-rack-0, basic-dc-rack-1; they have to finish decommissioning and be removed first, please retry later`,
+		},
+		{
 			name: "empty rack with stale status",
 			old: func() *scyllav1alpha1.ScyllaDBDatacenter {
 				sdc := newValidScyllaDBDatacenter()
@@ -1720,6 +1774,26 @@ func newValidScyllaDBDatacenterForWarnings() *scyllav1alpha1.ScyllaDBDatacenter 
 	}
 }
 
+// newScyllaDBDatacenterWithDecommissioningNodesForWarnings returns a two-node rack, whose node count comes from the
+// rack template, and whose status lists the named nodes as leaving the cluster.
+func newScyllaDBDatacenterWithDecommissioningNodesForWarnings(decommissioningNodeNames ...string) *scyllav1alpha1.ScyllaDBDatacenter {
+	sdc := newValidScyllaDBDatacenterForWarnings()
+	sdc.Spec.RackTemplate = &scyllav1alpha1.RackTemplate{
+		Nodes: pointer.Ptr[int32](2),
+	}
+	sdc.Status.Racks = []scyllav1alpha1.RackStatus{
+		{
+			Name:  sdc.Spec.Racks[0].Name,
+			Nodes: pointer.Ptr[int32](2),
+			DecommissioningNodes: oslices.ConvertSlice(decommissioningNodeNames, func(name string) scyllav1alpha1.DecommissioningNodeStatus {
+				return scyllav1alpha1.DecommissioningNodeStatus{Name: name}
+			}),
+		},
+	}
+
+	return sdc
+}
+
 func TestGetWarningsOnScyllaDBDatacenterCreate(t *testing.T) {
 	t.Parallel()
 
@@ -1788,6 +1862,46 @@ func TestGetWarningsOnScyllaDBDatacenterUpdate(t *testing.T) {
 			expectedWarnings: []string{
 				"`spec.exposeOptions.cql` field is deprecated and will be removed in a future release, along with operator support for exposing CQL over an SNI proxy.",
 			},
+		},
+		{
+			name:   "rack node count changed while the rack has nodes leaving the cluster",
+			oldSDC: newScyllaDBDatacenterWithDecommissioningNodesForWarnings("basic-dc-rack-1", "basic-dc-rack-2"),
+			newSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newScyllaDBDatacenterWithDecommissioningNodesForWarnings("basic-dc-rack-1", "basic-dc-rack-2")
+				sdc.Spec.Racks[0].Nodes = pointer.Ptr[int32](3)
+				return sdc
+			}(),
+			expectedWarnings: []string{
+				`spec.racks[0]: rack "rack" has nodes leaving the cluster: basic-dc-rack-1, basic-dc-rack-2. The requested number of nodes is accepted, but it won't be applied until they have finished decommissioning and been removed.`,
+			},
+		},
+		{
+			name:   "rack node count changed through the rack template while the rack has nodes leaving the cluster",
+			oldSDC: newScyllaDBDatacenterWithDecommissioningNodesForWarnings("basic-dc-rack-1"),
+			newSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newScyllaDBDatacenterWithDecommissioningNodesForWarnings("basic-dc-rack-1")
+				sdc.Spec.RackTemplate.Nodes = pointer.Ptr[int32](3)
+				return sdc
+			}(),
+			expectedWarnings: []string{
+				`spec.racks[0]: rack "rack" has nodes leaving the cluster: basic-dc-rack-1. The requested number of nodes is accepted, but it won't be applied until they have finished decommissioning and been removed.`,
+			},
+		},
+		{
+			name:             "rack node count unchanged while the rack has nodes leaving the cluster",
+			oldSDC:           newScyllaDBDatacenterWithDecommissioningNodesForWarnings("basic-dc-rack-1"),
+			newSDC:           newScyllaDBDatacenterWithDecommissioningNodesForWarnings("basic-dc-rack-1"),
+			expectedWarnings: nil,
+		},
+		{
+			name:   "rack node count changed while no node is leaving the cluster",
+			oldSDC: newScyllaDBDatacenterWithDecommissioningNodesForWarnings(),
+			newSDC: func() *scyllav1alpha1.ScyllaDBDatacenter {
+				sdc := newScyllaDBDatacenterWithDecommissioningNodesForWarnings()
+				sdc.Spec.Racks[0].Nodes = pointer.Ptr[int32](3)
+				return sdc
+			}(),
+			expectedWarnings: nil,
 		},
 	}
 

--- a/test/envtest/controllers/scylladbdatacenter_controller_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_test.go
@@ -20,6 +20,7 @@ import (
 	scyllainformers "github.com/scylladb/scylla-operator/pkg/client/scylla/informers/externalversions"
 	"github.com/scylladb/scylla-operator/pkg/controller/scylladbdatacenter"
 	"github.com/scylladb/scylla-operator/pkg/crypto"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
 	"github.com/scylladb/scylla-operator/pkg/internalapi"
 	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/scylla"
@@ -53,6 +54,10 @@ const (
 	// Pad accordingly when a test uses a non-zero cache-propagation delay, otherwise Consistently may pass while the
 	// controller is delayed instead of observing real steady state.
 	scyllaDBDatacenterControllerDefaultConsistentlyTimeout = 5 * time.Second
+
+	// envtestServiceFinalizer holds a member Service in a terminating state, so that specs can freeze the window
+	// between the controller deleting it and the object actually going away.
+	envtestServiceFinalizer = "scylla-operator.scylladb.com/envtest"
 )
 
 var _ = g.Describe("ScyllaDBDatacenter controller", func() {
@@ -383,6 +388,59 @@ var _ = g.Describe("ScyllaDBDatacenter controller", func() {
 			waitForServiceToBePrunedAndRecordToDrain(ctx, env, sdc.Name, otherRackName, otherLeavingServiceName)
 		})
 
+		// The rack node count in the status reaches zero as soon as the StatefulSet is scaled down, while the member
+		// Service of the last leaving node lives until it is pruned. The Service is held by a finalizer to freeze that
+		// window, in which the rack removal used to be admitted, leaving its member Service and PVC unprunable.
+		g.It("should reject removing a rack whose last leaving node is not pruned yet", func(ctx g.SpecContext) {
+			sdc, rackStatefulSetName, leavingServiceName := setup(ctx)
+
+			lastServiceName := fmt.Sprintf("%s-0", rackStatefulSetName)
+
+			g.By("Adding a finalizer to the member Service of the last node")
+			addServiceFinalizer(ctx, env, lastServiceName)
+
+			g.By("Scaling the rack down to zero nodes")
+			scaleRackTemplate(ctx, env, sdc.Name, 0)
+
+			g.By("Marking both nodes as decommissioned in place of the sidecar")
+			for _, serviceName := range []string{leavingServiceName, lastServiceName} {
+				waitForServiceDecommissionedLabel(ctx, env, serviceName, naming.LabelValueFalse)
+				setServiceDecommissionedLabel(ctx, env, serviceName, naming.LabelValueTrue)
+			}
+
+			g.By("Waiting for the rack StatefulSet to be scaled down to zero replicas")
+			waitForStatefulSetReplicas(ctx, env, rackStatefulSetName, 0)
+
+			g.By("Marking the rack StatefulSet as rolled out so that the rack status is not stale")
+			markStatefulSetAsRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), rackStatefulSetName)
+
+			g.By("Waiting for the rack status to report no nodes with the finalized node still listed as leaving")
+			o.Eventually(func(eo o.Gomega, ctx context.Context) {
+				rackStatus := getRackStatus(ctx, env, sdc.Name, rackName)
+				eo.Expect(rackStatus).NotTo(o.BeNil())
+				eo.Expect(rackStatus.Nodes).To(o.HaveValue(o.BeEquivalentTo(0)))
+				eo.Expect(rackStatus.Stale).To(o.HaveValue(o.BeFalse()))
+				eo.Expect(rackStatus.DecommissioningNodes).To(o.Equal([]scyllav1alpha1.DecommissioningNodeStatus{
+					{Name: lastServiceName},
+				}))
+			}).WithContext(ctx).WithTimeout(scyllaDBDatacenterControllerDefaultEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+			g.By("Verifying the rack can't be removed")
+			err := removeRacks(ctx, env, sdc.Name)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring(fmt.Sprintf("rack %q can't be removed because it still has nodes leaving the cluster: %s", rackName, lastServiceName)))
+
+			g.By("Removing the finalizer from the member Service of the last node")
+			removeServiceFinalizer(ctx, env, lastServiceName)
+
+			g.By("Waiting for the last node's Service to be pruned and the record to drain")
+			waitForServiceToBePrunedAndRecordToDrain(ctx, env, sdc.Name, rackName, lastServiceName)
+
+			g.By("Verifying the rack can be removed")
+			err = removeRacks(ctx, env, sdc.Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
 		g.It("should rebuild the list from the decommissioned labels when it is wiped from the status", func(ctx g.SpecContext) {
 			sdc, _, leavingServiceName := setup(ctx)
 
@@ -504,8 +562,8 @@ func waitForService(ctx context.Context, e *envtest.Environment, name string, ti
 	return service
 }
 
-// getDecommissioningNodes returns the decommissioning nodes recorded in the status of the named rack.
-func getDecommissioningNodes(ctx context.Context, e *envtest.Environment, sdcName, rackName string) []scyllav1alpha1.DecommissioningNodeStatus {
+// getRackStatus returns the status of the named rack, or nil if the rack has none.
+func getRackStatus(ctx context.Context, e *envtest.Environment, sdcName, rackName string) *scyllav1alpha1.RackStatus {
 	g.GinkgoHelper()
 
 	sdc, err := e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Get(ctx, sdcName, metav1.GetOptions{})
@@ -513,11 +571,80 @@ func getDecommissioningNodes(ctx context.Context, e *envtest.Environment, sdcNam
 
 	for _, rackStatus := range sdc.Status.Racks {
 		if rackStatus.Name == rackName {
-			return rackStatus.DecommissioningNodes
+			return &rackStatus
 		}
 	}
 
 	return nil
+}
+
+// getDecommissioningNodes returns the decommissioning nodes recorded in the status of the named rack.
+func getDecommissioningNodes(ctx context.Context, e *envtest.Environment, sdcName, rackName string) []scyllav1alpha1.DecommissioningNodeStatus {
+	g.GinkgoHelper()
+
+	rackStatus := getRackStatus(ctx, e, sdcName, rackName)
+	if rackStatus == nil {
+		return nil
+	}
+
+	return rackStatus.DecommissioningNodes
+}
+
+// removeRacks removes all racks from the spec, returning the error of the update so that admission can be asserted.
+// The controller keeps writing the status, so the update is retried on conflict to make sure the error that's returned
+// comes from admission and not from a resource version race.
+func removeRacks(ctx context.Context, e *envtest.Environment, sdcName string) error {
+	g.GinkgoHelper()
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		sdc, err := e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Get(ctx, sdcName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("can't get ScyllaDBDatacenter %q: %w", naming.ManualRef(e.Namespace(), sdcName), err)
+		}
+
+		sdc.Spec.Racks = nil
+		_, err = e.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(e.Namespace()).Update(ctx, sdc, metav1.UpdateOptions{})
+
+		return err
+	})
+}
+
+func addServiceFinalizer(ctx context.Context, e *envtest.Environment, name string) {
+	g.GinkgoHelper()
+
+	updateServiceFinalizers(ctx, e, name, func(finalizers []string) []string {
+		return append(finalizers, envtestServiceFinalizer)
+	})
+}
+
+func removeServiceFinalizer(ctx context.Context, e *envtest.Environment, name string) {
+	g.GinkgoHelper()
+
+	updateServiceFinalizers(ctx, e, name, func(finalizers []string) []string {
+		return oslices.Filter(finalizers, func(finalizer string) bool {
+			return finalizer != envtestServiceFinalizer
+		})
+	})
+}
+
+func updateServiceFinalizers(ctx context.Context, e *envtest.Environment, name string, mutateFunc func([]string) []string) {
+	g.GinkgoHelper()
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		svc, err := e.TypedKubeClient().CoreV1().Services(e.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("can't get Service %q: %w", naming.ManualRef(e.Namespace(), name), err)
+		}
+
+		svc.Finalizers = mutateFunc(svc.Finalizers)
+		_, err = e.TypedKubeClient().CoreV1().Services(e.Namespace()).Update(ctx, svc, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("can't update Service %q: %w", naming.ObjRef(svc), err)
+		}
+
+		return nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
 }
 
 func scaleRackTemplate(ctx context.Context, e *envtest.Environment, sdcName string, nodes int32) {


### PR DESCRIPTION
Guards a rack's node count against an ongoing decommission on admission, on both `ScyllaDBDatacenter` and `ScyllaCluster`, using the record added in OPERATOR-362 and OPERATOR-363.

**Removing a rack that still has nodes leaving is rejected**, naming the nodes that hold it up. The existing rule only blocked the removal while the rack's `StatefulSet` had replicas: the node count in the rack status mirrors those replicas and reaches zero before the leaving nodes are pruned, while the member `Service` and `PVC` live until `pruneServices` succeeds. Once the rack is gone from the spec, the controller can no longer resolve the rack of those objects, so it never prunes them and its sync stays degraded. The new check is placed before the staleness check, so a stale status doesn't mask it with a less actionable error. The error is retryable: the record is derived from a `Service` cache snapshot, so it can still list a node for about one reconcile after its `Service` is gone.

**Changing the number of nodes of a rack that has nodes leaving produces a warning.** The change is accepted, but the rack reconciles as if it hadn't been made until the leaving nodes have finished decommissioning and been removed, which is otherwise invisible to the user.

Covered by unit tests for both APIs and by an envtest that holds the last leaving node's `Service` with a finalizer to freeze the window in which the removal used to be admitted.

Closes https://scylladb.atlassian.net/browse/OPERATOR-364.
