### PR TITLE
test(e2e): let ScyllaDB default the test keyspace replication

### DIFF
--- a/test/e2e/set/scyllacluster/multidatacenter/scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/multidatacenter/scyllacluster_external_seeds.go
@@ -103,7 +103,7 @@ var _ = g.Describe("MultiDC cluster", framework.SuiteMultiDatacenterParallel, fu
 
 		hostIDs1 := hostIDsByDC[sc1.Spec.Datacenter.Name]
 
-		di1 := verification.InsertAndVerifyCQLDataByDC(ctx, hostsByDC)
+		di1 := verification.InsertAndVerifyCQLData(ctx, slices.Concat(slices.Collect(maps.Values(hostsByDC))...))
 		defer di1.Close()
 
 		framework.By("Verifying data of datacenter %q", sc0.Spec.Datacenter.Name)
@@ -163,7 +163,7 @@ var _ = g.Describe("MultiDC cluster", framework.SuiteMultiDatacenterParallel, fu
 		o.Expect(hostIDsByDC[sc1.Spec.Datacenter.Name]).To(o.ConsistOf(hostIDs1))
 		o.Expect(hostIDsByDC[sc2.Spec.Datacenter.Name]).To(o.HaveLen(int(utils.GetMemberCount(sc2))))
 
-		di2 := verification.InsertAndVerifyCQLDataByDC(ctx, hostsByDC)
+		di2 := verification.InsertAndVerifyCQLData(ctx, slices.Concat(slices.Collect(maps.Values(hostsByDC))...))
 		defer di2.Close()
 
 		framework.By("Verifying data of datacenter %q", sc0.Spec.Datacenter.Name)

--- a/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_external_seeds.go
@@ -4,6 +4,8 @@ package scyllacluster
 
 import (
 	"context"
+	"maps"
+	"slices"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
@@ -96,7 +98,7 @@ var _ = g.Describe("MultiDC cluster", framework.SuiteParallel, framework.SuitePa
 		o.Expect(hostIDsByDC[sc1.Spec.Datacenter.Name]).To(o.ConsistOf(hostIDs1))
 		o.Expect(hostIDsByDC[sc2.Spec.Datacenter.Name]).To(o.HaveLen(int(utils.GetMemberCount(sc2))))
 
-		di2 := verification.InsertAndVerifyCQLDataByDC(ctx, hostsByDC)
+		di2 := verification.InsertAndVerifyCQLData(ctx, slices.Concat(slices.Collect(maps.Values(hostsByDC))...))
 		defer di2.Close()
 
 		framework.By("Verifying data of datacenter %q", sc1.Spec.Datacenter.Name)

--- a/test/e2e/set/scyllacluster/scyllacluster_pv.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_pv.go
@@ -44,9 +44,10 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteKindFa
 	})
 
 	g.It("should replace a node with orphaned PV", func(ctx g.SpecContext) {
-		sc := f.GetDefaultScyllaCluster()
+		// Use 3 racks of 1 member each instead of a single rack of 3 members, so that the default keyspace
+		// replication of a replica per rack replicates the test data across 3 nodes.
+		sc := f.GetDefaultZonalScyllaClusterWithThreeRacks()
 		sc.Spec.AutomaticOrphanedNodeCleanup = true
-		sc.Spec.Datacenter.Racks[0].Members = 3
 
 		framework.By("Creating a ScyllaCluster")
 		sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
@@ -64,6 +65,8 @@ var _ = g.Describe("ScyllaCluster Orphaned PV controller", framework.SuiteKindFa
 		hosts, _, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(3))
+		// The node's storage is discarded and the replacement streams from the other replicas, so the data only
+		// survives if it is replicated. The default replication puts a replica on each of the 3 racks.
 		di := verification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -179,5 +179,8 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		o.Expect(postReplacementHostIDs).To(o.HaveLen(int(utils.GetMemberCount(sc))))
 		o.Expect(postReplacementHostIDs).NotTo(o.ContainElement(preReplacementHostID))
 		o.Expect(postReplacementHostIDs).To(o.ContainElement(postReplacementHostID))
+
+		framework.By("Verifying the data survived the replacement")
+		verification.VerifyCQLData(ctx, di)
 	})
 })

--- a/test/e2e/set/scyllacluster/scyllacluster_replace.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_replace.go
@@ -32,8 +32,9 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		ns, nsClient, ok := f.DefaultNamespaceIfAny()
 		o.Expect(ok).To(o.BeTrue(), "Can't get default namespace")
 
-		sc := f.GetDefaultScyllaCluster()
-		sc.Spec.Datacenter.Racks[0].Members = 3
+		// Use 3 racks of 1 member each instead of a single rack of 3 members, so that the default keyspace
+		// replication of a replica per rack replicates the test data across 3 nodes.
+		sc := f.GetDefaultZonalScyllaClusterWithThreeRacks()
 
 		framework.By("Creating a ScyllaCluster")
 		sc, err := nsClient.ScyllaClient().ScyllaV1().ScyllaClusters(ns.Name).Create(ctx, sc, metav1.CreateOptions{})
@@ -51,6 +52,8 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		hosts, err := utils.GetBroadcastRPCAddresses(ctx, nsClient.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(int(utils.GetMemberCount(sc))))
+		// The node's storage is discarded and the replacement streams from the other replicas, so the data only
+		// survives if it is replicated. The default replication puts a replica on each of the 3 racks.
 		di := verification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
 

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -53,8 +53,8 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts).To(o.HaveLen(3))
 		o.Expect(hostIDs).To(o.HaveLen(3))
-		diRF3 := verification.InsertAndVerifyCQLData(ctx, hosts)
-		defer diRF3.Close()
+		di := verification.InsertAndVerifyCQLData(ctx, hosts)
+		defer di.Close()
 
 		framework.By("Scaling the ScyllaCluster to 5 replicas")
 		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
@@ -87,7 +87,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		o.Expect(hostIDs).To(o.HaveLen(5))
 		o.Expect(hostIDs).To(o.ContainElements(oldHostIDs))
 
-		verification.VerifyCQLData(ctx, diRF3)
+		verification.VerifyCQLData(ctx, di)
 
 		podName := naming.StatefulSetNameForRackForScyllaCluster(sc.Spec.Datacenter.Racks[0], sc) + "-4"
 		svcName := podName
@@ -158,7 +158,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		o.Expect(hostIDs).To(o.HaveLen(4))
 		o.Expect(oldHostIDs).To(o.ContainElements(hostIDs))
 
-		verification.VerifyCQLData(ctx, diRF3)
+		verification.VerifyCQLData(ctx, di)
 
 		framework.By("Scaling the ScyllaCluster down to 3 replicas")
 		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
@@ -190,7 +190,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		o.Expect(hostIDs).To(o.HaveLen(3))
 		o.Expect(oldHostIDs).To(o.ContainElements(hostIDs))
 
-		verification.VerifyCQLData(ctx, diRF3)
+		verification.VerifyCQLData(ctx, di)
 
 		framework.By("Scaling the ScyllaCluster back to 5 replicas to make sure there isn't an old (decommissioned) storage in place")
 		sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
@@ -222,7 +222,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		o.Expect(hostIDs).To(o.HaveLen(5))
 		o.Expect(hostIDs).To(o.ContainElements(oldHostIDs))
 
-		verification.VerifyCQLData(ctx, diRF3)
+		verification.VerifyCQLData(ctx, di)
 	})
 })
 

--- a/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_upgrade.go
+++ b/test/e2e/set/scylladbcluster/multidatacenter/scylladbcluster_upgrade.go
@@ -69,7 +69,7 @@ var _ = g.Describe("ScyllaDBCluster", framework.SuiteMultiDatacenterParallel, fu
 		o.Expect(err).NotTo(o.HaveOccurred())
 		allInitialHosts := slices.Concat(slices.Collect(maps.Values(initialHostsByDC))...)
 		o.Expect(allInitialHosts).To(o.HaveLen(int(controllerhelpers.GetScyllaDBClusterNodeCount(sc))))
-		di := verification.InsertAndVerifyCQLDataByDC(ctx, initialHostsByDC)
+		di := verification.InsertAndVerifyCQLData(ctx, slices.Concat(slices.Collect(maps.Values(initialHostsByDC))...))
 		defer di.Close()
 
 		var initialScyllaClientReportedVersions []string

--- a/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
+++ b/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager.go
@@ -83,7 +83,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 		allHosts := slices.Concat(slices.Collect(maps.Values(hostsByDC))...)
 		o.Expect(allHosts).To(o.HaveLen(int(controllerhelpers.GetScyllaDBClusterNodeCount(sc))))
 
-		di := verification.InsertAndVerifyCQLDataByDC(ctx, hostsByDC)
+		di := verification.InsertAndVerifyCQLData(ctx, slices.Concat(slices.Collect(maps.Values(hostsByDC))...))
 		g.DeferCleanup(di.Close)
 
 		smt = &scyllav1alpha1.ScyllaDBManagerTask{

--- a/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager_object_storage.go
+++ b/test/e2e/set/scylladbmanagertask/multidatacenter/scylladbmanagertask_scylladbcluster_globalmanager_object_storage.go
@@ -71,7 +71,7 @@ var _ = g.Describe("ScyllaDBManagerTask and ScyllaDBCluster integration with glo
 		o.Expect(err).NotTo(o.HaveOccurred())
 		allSourceHosts := slices.Concat(slices.Collect(maps.Values(sourceHostsByDC))...)
 		o.Expect(allSourceHosts).To(o.HaveLen(int(controllerhelpers.GetScyllaDBClusterNodeCount(sourceSC))))
-		di := verification.InsertAndVerifyCQLDataByDC(ctx, sourceHostsByDC)
+		di := verification.InsertAndVerifyCQLData(ctx, slices.Concat(slices.Collect(maps.Values(sourceHostsByDC))...))
 		defer di.Close()
 
 		var backupLocations []string

--- a/test/e2e/utils/datainserter.go
+++ b/test/e2e/utils/datainserter.go
@@ -5,7 +5,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -26,11 +25,10 @@ const (
 )
 
 type DataInserter struct {
-	session           *gocqlx.Session
-	keyspace          string
-	table             *table.Table
-	data              []*TestData
-	replicationFactor map[string]int
+	session  *gocqlx.Session
+	keyspace string
+	table    *table.Table
+	data     []*TestData
 }
 
 type TestData struct {
@@ -47,11 +45,6 @@ func WithSession(session *gocqlx.Session) func(*DataInserter) {
 }
 
 func NewDataInserter(hosts []string, options ...DataInserterOption) (*DataInserter, error) {
-	// Instead of specifying hosts for the provided datacenter, use 'replication_factor' as a single key to specify a default RF.
-	return NewMultiDCDataInserter(map[string][]string{"replication_factor": hosts}, options...)
-}
-
-func NewMultiDCDataInserter(dcHosts map[string][]string, options ...DataInserterOption) (*DataInserter, error) {
 	keyspace := apimachineryutilrand.String(8)
 	table := table.New(table.Metadata{
 		Name:    fmt.Sprintf(`"%s"."test"`, keyspace),
@@ -63,16 +56,10 @@ func NewMultiDCDataInserter(dcHosts map[string][]string, options ...DataInserter
 		data = append(data, &TestData{Id: i, Data: apimachineryutilrand.String(32)})
 	}
 
-	replicationFactor := make(map[string]int, len(dcHosts))
-	for dc, hosts := range dcHosts {
-		replicationFactor[dc] = len(hosts)
-	}
-
 	di := &DataInserter{
-		keyspace:          keyspace,
-		table:             table,
-		data:              data,
-		replicationFactor: replicationFactor,
+		keyspace: keyspace,
+		table:    table,
+		data:     data,
 	}
 
 	for _, option := range options {
@@ -80,7 +67,7 @@ func NewMultiDCDataInserter(dcHosts map[string][]string, options ...DataInserter
 	}
 
 	if di.session == nil {
-		err := di.SetClientEndpoints(slices.Concat(slices.Collect(maps.Values(dcHosts))...))
+		err := di.SetClientEndpoints(hosts)
 		if err != nil {
 			return nil, fmt.Errorf("can't set client endpoints: %w", err)
 		}
@@ -124,17 +111,13 @@ func (di *DataInserter) SetClientEndpoints(hosts []string) error {
 }
 
 func (di *DataInserter) Insert(ctx context.Context) error {
-	ss := make([]string, 0, len(di.replicationFactor))
-	for dc, rf := range di.replicationFactor {
-		ss = append(ss, fmt.Sprintf("'%s': %d", dc, rf))
-	}
-	replicationFactor := strings.Join(ss, ",")
-
-	framework.Infof("Creating keyspace %q with RF %q", di.keyspace, replicationFactor)
+	// The replication factor is deliberately left unset. With neither datacenters nor a replication factor
+	// specified, ScyllaDB places a replica on every rack of every datacenter, which is RF-rack-valid by
+	// construction.
+	framework.Infof("Creating keyspace %q", di.keyspace)
 	err := di.session.ExecStmt(fmt.Sprintf(
-		`CREATE KEYSPACE %q WITH replication = {'class': 'NetworkTopologyStrategy', %s}`,
+		`CREATE KEYSPACE %q WITH replication = {'class': 'NetworkTopologyStrategy'}`,
 		di.keyspace,
-		replicationFactor,
 	))
 	if err != nil {
 		return fmt.Errorf("can't create keyspace: %w", err)

--- a/test/e2e/utils/verification/cql.go
+++ b/test/e2e/utils/verification/cql.go
@@ -19,14 +19,6 @@ func InsertAndVerifyCQLData(ctx context.Context, hosts []string, options ...util
 	return di
 }
 
-func InsertAndVerifyCQLDataByDC(ctx context.Context, hosts map[string][]string) *utils.DataInserter {
-	di, err := utils.NewMultiDCDataInserter(hosts)
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	InsertAndVerifyCQLDataUsingDataInserter(ctx, di)
-	return di
-}
-
 func InsertAndVerifyCQLDataUsingDataInserter(ctx context.Context, di *utils.DataInserter) *utils.DataInserter {
 	framework.By("Inserting data")
 	err := di.Insert(ctx)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
The e2e `DataInserter` couples two unrelated things: the hosts it gets are both the driver's contact points and the source of the keyspace's replication factor. Tests that need a specific RF have to contort the host list to get it - e.g. in https://github.com/scylladb/scylla-operator/pull/3629#discussion_r3893900930 a test would have to pass only the nodes remaining after a scale-down operation to keep RF below the scaled-down node count, which as a side effect limited the client's contact points to those nodes and stopped reproducing reality (although this could be further simplified and improved by passing just the identity service address as an endpoint).
The derived RF is also RF-rack-invalid on our single-rack fixtures - RF=3 on a 1-rack DC.

This decouples the two by dropping RF derivation entirely: the keyspace now omits the replication factor, and with optionless `NetworkTopologyStrategy` ScyllaDB places a replica on every rack of every datacenter, which is RF-rack-valid by construction and independent of the host list. The tests whose data must survive a node's storage loss (`scyllacluster_pv.go`, `scyllacluster_replace.go`) get their replication from topology instead - the zonal fixture with 3 racks of 1 member.

Risks and mitigations:

* Optionless `NetworkTopologyStrategy` requires ScyllaDB 2026.1+. All versions covered by the suites, including the upgrade path from 2026.1.10, support it.
* Tests on single-rack fixtures silently drop from RF = node count to RF=1. For `scyllacluster_rebootstrap.go` this is irrelevant - the PVCs survive, so the data never depends on replication. For `scyllacluster_scaling.go` it's a stricter check: at RF=1, `CL=ALL` reads verify that decommission actually streamed every range.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-372

/cc