### PR TITLE
test(e2e): scale by multiple nodes and across racks

### DIFF
--- a/test/e2e/set/scyllacluster/helpers.go
+++ b/test/e2e/set/scyllacluster/helpers.go
@@ -16,18 +16,29 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// createClusterAndWaitForRollout creates a ScyllaCluster with the specified number of members and waits for rollout.
+// rackLayout is the number of racks of a ScyllaCluster and the number of members in each of them.
+type rackLayout struct {
+	rackCount      int32
+	membersPerRack int32
+}
+
+func (rl rackLayout) String() string {
+	return fmt.Sprintf("%d rack(s) of %d member(s)", rl.rackCount, rl.membersPerRack)
+}
+
+// createClusterAndWaitForRollout creates a ScyllaCluster with the given rack layout and waits for rollout.
 func createClusterAndWaitForRollout(
 	ctx context.Context,
 	f *framework.Framework,
-	members int32,
+	rl rackLayout,
 ) *scyllav1.ScyllaCluster {
 	sc := f.GetDefaultScyllaCluster()
-	sc.Spec.Datacenter.Racks[0].Members = members
+	sc.Spec.Datacenter.Racks = replicateRackSpecs(sc, rl)
 
-	framework.By("Creating a %d node ScyllaCluster", members)
+	framework.By("Creating a ScyllaCluster with %s", rl)
 	sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Create(ctx, sc, metav1.CreateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
+	expectRackLayout(sc, rl)
 
 	framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
 	waitCtx, waitCtxCancel := utils.ContextForRollout(ctx, sc)
@@ -40,26 +51,24 @@ func createClusterAndWaitForRollout(
 	return sc
 }
 
-// scaleClusterAndWaitForRollout scales the cluster to the given number of members and waits for rollout.
+// scaleClusterAndWaitForRollout scales the cluster to the given rack layout and waits for rollout. The entire rack
+// array is replaced, so a single scaling operation can both add racks and change the member count of every rack at
+// once.
 func scaleClusterAndWaitForRollout(
 	ctx context.Context,
 	f *framework.Framework,
 	sc *scyllav1.ScyllaCluster,
-	members int32,
+	rl rackLayout,
 ) *scyllav1.ScyllaCluster {
-	patchData := []byte(fmt.Sprintf(`[{"op": "replace", "path": "/spec/datacenter/racks/0/members", "value": %d}]`, members))
-
-	framework.By("Scaling the ScyllaCluster to %d members", members)
-	sc, err := f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(
-		ctx,
-		sc.Name,
-		types.JSONPatchType,
-		patchData,
-		metav1.PatchOptions{},
-	)
+	scCopy := sc.DeepCopy()
+	scCopy.Spec.Datacenter.Racks = replicateRackSpecs(sc, rl)
+	patch, err := controllerhelpers.GenerateMergePatch(sc, scCopy)
 	o.Expect(err).NotTo(o.HaveOccurred())
-	o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(1))
-	o.Expect(sc.Spec.Datacenter.Racks[0].Members).To(o.BeEquivalentTo(members))
+
+	framework.By("Scaling the ScyllaCluster to %s", rl)
+	sc, err = f.ScyllaClient().ScyllaV1().ScyllaClusters(f.Namespace()).Patch(ctx, sc.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	expectRackLayout(sc, rl)
 
 	framework.By("Waiting for the ScyllaCluster to roll out (RV=%s)", sc.ResourceVersion)
 	waitCtx, waitCtxCancel := utils.ContextForRollout(ctx, sc)
@@ -70,4 +79,28 @@ func scaleClusterAndWaitForRollout(
 	scyllaclusterverification.Verify(ctx, f.KubeClient(), f.ScyllaClient(), sc)
 
 	return sc
+}
+
+// replicateRackSpecs fans the ScyllaCluster's first rack out into the given rack layout.
+func replicateRackSpecs(sc *scyllav1.ScyllaCluster, rl rackLayout) []scyllav1.RackSpec {
+	o.Expect(sc.Spec.Datacenter.Racks).NotTo(o.BeEmpty())
+	o.Expect(rl.rackCount).NotTo(o.BeZero())
+
+	rackSpecs := make([]scyllav1.RackSpec, 0, rl.rackCount)
+	for i := range rl.rackCount {
+		rackSpec := sc.Spec.Datacenter.Racks[0].DeepCopy()
+		rackSpec.Name = fmt.Sprintf("rack-%d", i)
+		rackSpec.Members = rl.membersPerRack
+		rackSpecs = append(rackSpecs, *rackSpec)
+	}
+
+	return rackSpecs
+}
+
+// expectRackLayout asserts that the ScyllaCluster has the given rack layout.
+func expectRackLayout(sc *scyllav1.ScyllaCluster, rl rackLayout) {
+	o.Expect(sc.Spec.Datacenter.Racks).To(o.HaveLen(int(rl.rackCount)))
+	for _, rackSpec := range sc.Spec.Datacenter.Racks {
+		o.Expect(rackSpec.Members).To(o.BeEquivalentTo(rl.membersPerRack))
+	}
 }

--- a/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_cleanup.go
@@ -28,8 +28,8 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 	})
 
 	type horizontalScalingEntry struct {
-		initialMembers int32
-		targetMembers  int32
+		initialRackLayout rackLayout
+		targetRackLayout  rackLayout
 	}
 	g.DescribeTable("nodes are cleaned up", framework.SuiteKindClusterTopology, func(ctx g.SpecContext, e *horizontalScalingEntry) {
 		jobListWatcher := createJobListWatcher(ctx, f)
@@ -37,7 +37,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		err := jobObserver.Start(ctx)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc := createClusterAndWaitForRollout(ctx, f, e.initialMembers)
+		sc := createClusterAndWaitForRollout(ctx, f, e.initialRackLayout)
 
 		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
 
@@ -48,7 +48,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		err = jobObserver.Start(ctx)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc = scaleClusterAndWaitForRollout(ctx, f, sc, e.targetMembers)
+		sc = scaleClusterAndWaitForRollout(ctx, f, sc, e.targetRackLayout)
 
 		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
 
@@ -56,12 +56,12 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		o.Expect(err).NotTo(o.HaveOccurred())
 	},
 		g.Entry("after scaling the cluster out", &horizontalScalingEntry{
-			initialMembers: 1,
-			targetMembers:  3,
+			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 1},
+			targetRackLayout:  rackLayout{rackCount: 1, membersPerRack: 3},
 		}),
 		g.Entry("after scaling the cluster in", &horizontalScalingEntry{
-			initialMembers: 3,
-			targetMembers:  1,
+			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 3},
+			targetRackLayout:  rackLayout{rackCount: 1, membersPerRack: 1},
 		}),
 	)
 
@@ -71,7 +71,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		err := jobObserver.Start(ctx)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		sc := createClusterAndWaitForRollout(ctx, f, 3)
+		sc := createClusterAndWaitForRollout(ctx, f, rackLayout{rackCount: 1, membersPerRack: 3})
 
 		verifyCleanupJobsCreatedEventually(ctx, f, sc, &jobObserver)
 

--- a/test/e2e/set/scyllacluster/scyllacluster_scaling.go
+++ b/test/e2e/set/scyllacluster/scyllacluster_scaling.go
@@ -31,7 +31,7 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 	})
 
 	type scalingStep struct {
-		members int32
+		rackLayout
 		// beforeFunc, when set, runs against the cluster in the state preceding the scaling operation.
 		beforeFunc func(ctx context.Context, f *framework.Framework, sc *scyllav1.ScyllaCluster)
 		// verifyFunc asserts how the cluster's members changed over the scaling operation.
@@ -40,18 +40,18 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 	}
 
 	type horizontalScalingEntry struct {
-		initialMembers int32
-		steps          []scalingStep
+		initialRackLayout rackLayout
+		steps             []scalingStep
 	}
 
 	g.DescribeTable("should support horizontal scaling", func(ctx g.SpecContext, e *horizontalScalingEntry) {
-		sc := createClusterAndWaitForRollout(ctx, f, e.initialMembers)
+		sc := createClusterAndWaitForRollout(ctx, f, e.initialRackLayout)
 		scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 		hosts, hostIDs, err := utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(hosts).To(o.HaveLen(int(e.initialMembers)))
-		o.Expect(hostIDs).To(o.HaveLen(int(e.initialMembers)))
+		o.Expect(hosts).To(o.HaveLen(int(utils.GetMemberCount(sc))))
+		o.Expect(hostIDs).To(o.HaveLen(int(utils.GetMemberCount(sc))))
 
 		di := verification.InsertAndVerifyCQLData(ctx, hosts)
 		defer di.Close()
@@ -67,13 +67,13 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 
 			previousHostIDs := hostIDs
 
-			sc = scaleClusterAndWaitForRollout(ctx, f, sc, step.members)
+			sc = scaleClusterAndWaitForRollout(ctx, f, sc, step.rackLayout)
 			scyllaclusterverification.WaitForFullQuorum(ctx, f.KubeClient().CoreV1(), sc)
 
 			hosts, hostIDs, err = utils.GetBroadcastRPCAddressesAndUUIDs(ctx, f.KubeClient().CoreV1(), sc)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(hosts).To(o.HaveLen(int(step.members)))
-			o.Expect(hostIDs).To(o.HaveLen(int(step.members)))
+			o.Expect(hosts).To(o.HaveLen(int(utils.GetMemberCount(sc))))
+			o.Expect(hostIDs).To(o.HaveLen(int(utils.GetMemberCount(sc))))
 
 			for _, previousHostID := range previousHostIDs {
 				if !slices.Contains(hostIDs, previousHostID) {
@@ -86,16 +86,36 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 			verification.VerifyCQLData(ctx, di)
 		}
 	},
+		// Scaling by more than a single node at a time is what distinguishes parallel node operations from sequential
+		// ones - a step moving a single node is indistinguishable between the two.
 		g.Entry("out", &horizontalScalingEntry{
-			initialMembers: 2,
+			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 1},
 			steps: []scalingStep{
-				{members: 3, verifyFunc: verifyScaledOut},
+				{rackCount: 1, membersPerRack: 3, verifyFunc: verifyScaledOut},
+			},
+		}),
+		g.Entry("out, into new racks", &horizontalScalingEntry{
+			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 1},
+			steps: []scalingStep{
+				{rackCount: 3, membersPerRack: 1, verifyFunc: verifyScaledOut},
+			},
+		}),
+		g.Entry("out, across multiple racks", &horizontalScalingEntry{
+			initialRackLayout: rackLayout{rackCount: 3, membersPerRack: 1},
+			steps: []scalingStep{
+				{rackCount: 3, membersPerRack: 2, verifyFunc: verifyScaledOut},
 			},
 		}),
 		g.Entry("in", &horizontalScalingEntry{
-			initialMembers: 3,
+			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 3},
 			steps: []scalingStep{
-				{members: 2, verifyFunc: verifyScaledIn},
+				{rackCount: 1, membersPerRack: 1, verifyFunc: verifyScaledIn},
+			},
+		}),
+		g.Entry("in, across multiple racks", &horizontalScalingEntry{
+			initialRackLayout: rackLayout{rackCount: 3, membersPerRack: 2},
+			steps: []scalingStep{
+				{rackCount: 3, membersPerRack: 1, verifyFunc: verifyScaledIn},
 			},
 		}),
 		// Draining a node leaves it in ScyllaDB's DRAINED operational mode, which no longer accepts writes and cannot be
@@ -103,23 +123,20 @@ var _ = g.Describe("ScyllaCluster", framework.SuiteParallel, framework.SuitePara
 		// how that state is reachable in practice: it makes the readiness probe report the node as not ready, so the
 		// operator does not restart it while nodetool is driven against it by hand.
 		//
-		// Scaling in from here therefore exercises a different code path than an ordinary decommission.
+		// Scaling in from here therefore exercises a different code path than an ordinary decommission. The drain targets
+		// the highest ordinal node, so this entry deliberately scales in by a single node.
 		g.Entry("in, when the node has been drained in maintenance mode", &horizontalScalingEntry{
-			initialMembers: 3,
+			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 3},
 			steps: []scalingStep{
-				{
-					members:    2,
-					beforeFunc: markHighestOrdinalForMaintenanceAndDrain,
-					verifyFunc: verifyScaledIn,
-				},
+				{rackCount: 1, membersPerRack: 2, beforeFunc: markHighestOrdinalForMaintenanceAndDrain, verifyFunc: verifyScaledIn},
 			},
 		}),
 		// Scaling back out verifies that a decommissioned node's storage isn't left in place and reused.
 		g.Entry("out, with new storage after decommissioning", &horizontalScalingEntry{
-			initialMembers: 3,
+			initialRackLayout: rackLayout{rackCount: 1, membersPerRack: 3},
 			steps: []scalingStep{
-				{members: 2, verifyFunc: verifyScaledIn},
-				{members: 3, verifyFunc: verifyScaledOutWithNewNodes},
+				{rackCount: 1, membersPerRack: 1, verifyFunc: verifyScaledIn},
+				{rackCount: 1, membersPerRack: 3, verifyFunc: verifyScaledOutWithNewNodes},
 			},
 		}),
 	)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
The scaling entries each moved a single node, which is indistinguishable between parallel and sequential node operations, and never changed a node count on a multi-rack cluster.

This PR changes them to move multiple nodes and adds additional cases moving nodes across racks.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-331

/cc @czeslavo 