### PR TITLE
fix(webhook): set controller-runtime logger once per process

### DIFF
--- a/pkg/cmd/operator/webhooks.go
+++ b/pkg/cmd/operator/webhooks.go
@@ -282,6 +282,10 @@ func (o *WebhookOptions) Run(streams genericclioptions.IOStreams, cmd *cobra.Com
 	cmdutil.LogCommandStarting(cmd)
 	cliflag.PrintFlags(cmd.Flags())
 
+	// The mutating webhook is served by controller-runtime's admission webhook, which logs through
+	// controller-runtime's logger. Route it to klog, or it complains about never having been set up.
+	ctrllog.SetLogger(klog.Background())
+
 	stopCh := signals.StopChannel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -299,10 +303,6 @@ func (o *WebhookOptions) run(ctx context.Context, streams genericclioptions.IOSt
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-
-	// The mutating webhook is served by controller-runtime's admission webhook, which logs through
-	// controller-runtime's logger. Route it to klog, or it complains about never having been set up.
-	ctrllog.SetLogger(klog.Background())
 
 	handler := http.NewServeMux()
 	handler.HandleFunc("/readyz", func(w http.ResponseWriter, req *http.Request) {

--- a/pkg/cmd/operator/webhooks_test.go
+++ b/pkg/cmd/operator/webhooks_test.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/klog/v2"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -44,6 +46,8 @@ const (
 
 func TestMain(m *testing.M) {
 	dynamiccertificates.FileRefreshDuration = 1 * time.Second
+	// SetLogger isn't safe for concurrent calls, so route controller-runtime's logger to klog once here.
+	ctrllog.SetLogger(klog.Background())
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
`WebhookOptions.run` called controller-runtime's `SetLogger`, which isn't safe for concurrent calls, so `TestWebhookOptionsRun` raced when its parallel subtests ran it at once. The call moves to `Run`, which runs once per process, and the tests set it once in `TestMain`.

Closes https://scylladb.atlassian.net/browse/OPERATOR-375
