### PR TITLE
fix(hack/kind): export KUBECONFIG before applying the registry ConfigMap

### DIFF
--- a/hack/kind/cluster-setup.sh
+++ b/hack/kind/cluster-setup.sh
@@ -77,10 +77,14 @@ if [ "$(podman inspect -f='{{json .NetworkSettings.Networks.kind}}' "${KIND_REGI
   podman network connect "kind" "${KIND_REGISTRY_NAME}"
 fi
 
+# Set up KUBECONFIG for kubectl commands during deployment.
+KUBECONFIG="$(mktemp --suffix ".kubeconfig")"
+kind get kubeconfig --name="${CLUSTER_NAME}" > "${KUBECONFIG}"
+export KUBECONFIG
+trap 'rm -f "${KUBECONFIG}"' EXIT
+
 # Inform KinD cluster about the local registry.
-temp_kubeconfig="$(mktemp)"
-kind get kubeconfig --name="${CLUSTER_NAME}" > "${temp_kubeconfig}"
-KUBECONFIG="${temp_kubeconfig}" cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -91,16 +95,9 @@ data:
     host: "${KIND_REGISTRY_HOST}:${KIND_REGISTRY_PORT}"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
-rm "${temp_kubeconfig}"
 
 REENTRANT="${REENTRANT:-true}"
 export REENTRANT
-
-# Set up KUBECONFIG for kubectl commands during deployment.
-KUBECONFIG="$(mktemp --suffix ".kubeconfig")"
-kind get kubeconfig --name="${CLUSTER_NAME}" > "${KUBECONFIG}"
-export KUBECONFIG
-trap 'rm -f "${KUBECONFIG}"' EXIT
 
 # Use 'standard' storage class that comes with KinD by default.
 # This must be set before sourcing run-e2e-shared.env.sh, which would otherwise default to 'scylladb-local-xfs'.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**
cluster-setup.sh set KUBECONFIG as a command prefix on cat (KUBECONFIG=... cat <<EOF | kubectl apply -f -), which scopes the assignment to cat and never reaches kubectl on the other side of the pipe. kubectl then fell back to the default localhost:8080 and `make kind-setup` failed with
`dial tcp [::1]:8080: connect: connection refused` on any host without a pre-existing ~/.kube/config pointing at the kind cluster.

The script already wrote and exported a KUBECONFIG for the deployment step further down, so this moves that block above the ConfigMap apply and drops the duplicated mktemp/`kind get kubeconfig` pair. The EXIT trap now covers the temporary kubeconfig for the whole run.

**Which issue is resolved by this Pull Request:**
Resolves https://scylladb.atlassian.net/browse/OPERATOR-373
