### PR TITLE
[PoC] feat: read your own writes in ScyllaDBDatacenter controller with client-go informers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -831,7 +831,7 @@ test-binary: build
 .PHONY: test-binary
 
 test-envtest:
-	ginkgo --tags=envtest -p './test/envtest/controllers/...'
+	ginkgo --tags=envtest -p './test/envtest/...'
 
 help:
 	$(info The following make targets are available:)

--- a/pkg/cacheconsistency/consistencyhandler.go
+++ b/pkg/cacheconsistency/consistencyhandler.go
@@ -1,0 +1,382 @@
+// Package cacheconsistency provides read-your-own-writes semantics on top of shared informers.
+//
+// Informer caches are eventually consistent: a write acknowledged by the API server is only reflected in the cache
+// once the informer has processed the corresponding watch event. A controller that decides from the cache right
+// after writing can therefore decide from state that predates its own write.
+//
+// A ConsistencyStore closes that gap: it records writes and waits until the informers have observed them. One
+// consistency handler per informer does the work. Writes are recorded with the resourceVersion returned by the API
+// server and deletes with the UID of the deleted object. Wait blocks until the informer has observed all of them,
+// relying on the resourceVersion being monotonically increasing for a resource type (see KEP-5505) and on watch
+// events being delivered in resourceVersion order: once the informer store has seen resourceVersion R, every change
+// with a lower resourceVersion is already in it.
+//
+// The resourceVersion the store has seen is taken from the store itself (Store.LastStoreSyncResourceVersion, added
+// in client-go 1.36 and advanced by events, bookmarks and relists alike) and, should that be unavailable, from the
+// events delivered to the handler itself.
+//
+// The approach is the one kube-controller-manager uses since Kubernetes 1.36 for its Pod-owning controllers and the
+// one controller-runtime's read-your-writes consistency (kubernetes-sigs/controller-runtime pull request 3472) uses,
+// adapted to client-go shared informers and listers.
+package cacheconsistency
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// storePollInterval bounds how long a waiter takes to notice the store advancing without an event being delivered,
+// which is how bookmarks and relists advance it.
+const storePollInterval = 100 * time.Millisecond
+
+// ConsistencyError is returned by WaitReady when the context is done before the caches have observed all the writes.
+type ConsistencyError struct {
+	PendingResourceVersions map[string]int64
+	PendingDeletes          map[string][]types.UID
+	Err                     error
+}
+
+func (e *ConsistencyError) Error() string {
+	return fmt.Sprintf(
+		"cache has not observed all writes yet (pending resourceVersions: %v, pending deletes: %v): %v",
+		e.PendingResourceVersions, e.PendingDeletes, e.Err,
+	)
+}
+
+func (e *ConsistencyError) Unwrap() error {
+	return e.Err
+}
+
+type objectKey struct {
+	namespace string
+	name      string
+}
+
+func (k objectKey) String() string {
+	if len(k.namespace) == 0 {
+		return k.name
+	}
+	return k.namespace + "/" + k.name
+}
+
+func objectKeyFor(obj metav1.Object) objectKey {
+	return objectKey{
+		namespace: obj.GetNamespace(),
+		name:      obj.GetName(),
+	}
+}
+
+// consistencyHandler records the writes made to a resource type and tells when the informer cache of that type has
+// observed them. It is registered as an event handler on the informer. It is safe for concurrent use.
+type consistencyHandler struct {
+	informer     cache.SharedIndexInformer
+	registration cache.ResourceEventHandlerRegistration
+
+	lock sync.Mutex
+	// observedRV is the highest resourceVersion seen in any event delivered by the informer. It backs up the
+	// informer store's own resourceVersion, which isn't available when the AtomicFIFO client-go feature gate is
+	// disabled.
+	observedRV int64
+	// pendingRVs holds, per object, the resourceVersion the informer has to observe before the object's writes
+	// are guaranteed to be in the cache. Entries not above observedRV are pruned.
+	pendingRVs map[objectKey]int64
+	// pendingDeletes holds, per object, the UIDs whose deletion the informer has to observe.
+	pendingDeletes map[objectKey]sets.Set[types.UID]
+	// changed is closed and replaced whenever the observed state advances, waking up the waiters.
+	changed chan struct{}
+}
+
+// newConsistencyHandler registers a handler on the informer. The informer has to observe every object the handler is
+// told about, so the informer's namespace and selector restrictions must include all the objects written through it.
+func newConsistencyHandler(informer cache.SharedIndexInformer) (*consistencyHandler, error) {
+	t := &consistencyHandler{
+		informer:       informer,
+		pendingRVs:     map[objectKey]int64{},
+		pendingDeletes: map[objectKey]sets.Set[types.UID]{},
+		changed:        make(chan struct{}),
+	}
+
+	registration, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    t.onAdd,
+		UpdateFunc: t.onUpdate,
+		DeleteFunc: t.onDelete,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't register event handler: %w", err)
+	}
+	t.registration = registration
+
+	return t, nil
+}
+
+// HasSynced returns true once the handler has been delivered the initial state of the informer.
+func (t *consistencyHandler) HasSynced() bool {
+	return t.registration.HasSynced()
+}
+
+// wroteAt records a write acknowledged by the API server: the object identified by namespace and name now exists at
+// resourceVersion.
+func (t *consistencyHandler) wroteAt(namespace, name, resourceVersion string) {
+	rv, err := parseResourceVersion(resourceVersion)
+	if err != nil {
+		klog.ErrorS(err, "Can't record write, its resourceVersion is not comparable", "Ref", klog.KRef(namespace, name))
+		return
+	}
+
+	key := objectKey{namespace: namespace, name: name}
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if rv <= t.observedResourceVersionLocked() {
+		return
+	}
+	if rv > t.pendingRVs[key] {
+		t.pendingRVs[key] = rv
+	}
+}
+
+// observedResourceVersionLocked returns the resourceVersion the informer store is known to have caught up with.
+func (t *consistencyHandler) observedResourceVersionLocked() int64 {
+	observedRV := t.observedRV
+
+	storeRV := t.informer.GetStore().LastStoreSyncResourceVersion()
+	if len(storeRV) != 0 {
+		rv, err := parseResourceVersion(storeRV)
+		if err != nil {
+			klog.ErrorS(err, "Can't parse the store resourceVersion")
+		} else if rv > observedRV {
+			observedRV = rv
+		}
+	}
+
+	return observedRV
+}
+
+// deleted records a delete acknowledged by the API server. obj is the object that was deleted, as read from the
+// cache; its UID identifies the deleted instance so that a recreated object with the same name is told apart.
+// Objects that already have a deletionTimestamp are not recorded, as the delete didn't change them.
+func (t *consistencyHandler) deleted(obj metav1.Object) {
+	if obj.GetDeletionTimestamp() != nil {
+		return
+	}
+
+	uid := obj.GetUID()
+	if len(uid) == 0 {
+		klog.ErrorS(nil, "Can't record delete of an object without UID", "Ref", klog.KObj(obj))
+		return
+	}
+
+	key := objectKeyFor(obj)
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if t.pendingDeletes[key] == nil {
+		t.pendingDeletes[key] = sets.New[types.UID]()
+	}
+	t.pendingDeletes[key].Insert(uid)
+}
+
+// deletedByName records a delete acknowledged by the API server for the object identified by namespace and name,
+// taking the deleted instance from the informer store. Nothing is recorded when the store doesn't hold the object,
+// as there is nothing left for the cache to observe.
+func (t *consistencyHandler) deletedByName(namespace, name string) {
+	key := objectKey{namespace: namespace, name: name}
+
+	untyped, exists, err := t.informer.GetIndexer().GetByKey(key.String())
+	if err != nil {
+		klog.ErrorS(err, "Can't get object from the informer store, its delete won't be recorded", "Ref", key.String())
+		return
+	}
+	if !exists {
+		return
+	}
+
+	obj, err := meta.Accessor(untyped)
+	if err != nil {
+		klog.ErrorS(err, "Can't access object metadata, its delete won't be recorded", "Ref", key.String())
+		return
+	}
+
+	t.deleted(obj)
+}
+
+// waitReady blocks until the informer cache reflects all the recorded writes and deletes, or the context is done.
+func (t *consistencyHandler) waitReady(ctx context.Context) error {
+	for {
+		// Grab the wait channel before checking, so that a change racing with the check is never missed.
+		changed := t.waitChan()
+
+		pendingRVs, pendingDeletes := t.settle()
+		if len(pendingRVs) == 0 && len(pendingDeletes) == 0 {
+			return nil
+		}
+
+		select {
+		case <-changed:
+		case <-time.After(storePollInterval):
+		case <-ctx.Done():
+			return &ConsistencyError{
+				PendingResourceVersions: pendingRVs,
+				PendingDeletes:          pendingDeletes,
+				Err:                     ctx.Err(),
+			}
+		}
+	}
+}
+
+func (t *consistencyHandler) waitChan() <-chan struct{} {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.changed
+}
+
+func (t *consistencyHandler) broadcastLocked() {
+	close(t.changed)
+	t.changed = make(chan struct{})
+}
+
+// settle drops the pending entries the cache has caught up with and returns the ones that remain.
+func (t *consistencyHandler) settle() (map[string]int64, map[string][]types.UID) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	observedRV := t.observedResourceVersionLocked()
+	for key, rv := range t.pendingRVs {
+		if rv <= observedRV {
+			delete(t.pendingRVs, key)
+		}
+	}
+
+	for key, uids := range t.pendingDeletes {
+		for uid := range uids {
+			if t.isDeletedInCacheLocked(key, uid) {
+				uids.Delete(uid)
+			}
+		}
+		if uids.Len() == 0 {
+			delete(t.pendingDeletes, key)
+		}
+	}
+
+	if len(t.pendingRVs) == 0 && len(t.pendingDeletes) == 0 {
+		return nil, nil
+	}
+
+	pendingRVs := make(map[string]int64, len(t.pendingRVs))
+	for key, rv := range t.pendingRVs {
+		pendingRVs[key.String()] = rv
+	}
+	pendingDeletes := make(map[string][]types.UID, len(t.pendingDeletes))
+	for key, uids := range t.pendingDeletes {
+		pendingDeletes[key.String()] = sets.List(uids)
+	}
+
+	return pendingRVs, pendingDeletes
+}
+
+// isDeletedInCacheLocked tells whether the cache no longer holds the given instance of an object: it is gone, it
+// was replaced by an instance with a different UID, or it is being deleted, which is what a delete of an object
+// with finalizers results in.
+func (t *consistencyHandler) isDeletedInCacheLocked(key objectKey, uid types.UID) bool {
+	untyped, exists, err := t.informer.GetIndexer().GetByKey(key.String())
+	if err != nil {
+		klog.ErrorS(err, "Can't get object from the informer store", "Ref", key.String())
+		return false
+	}
+	if !exists {
+		return true
+	}
+
+	obj, err := meta.Accessor(untyped)
+	if err != nil {
+		klog.ErrorS(err, "Can't access object metadata", "Ref", key.String())
+		return false
+	}
+
+	return obj.GetUID() != uid || obj.GetDeletionTimestamp() != nil
+}
+
+func (t *consistencyHandler) observe(obj metav1.Object, deleted bool) {
+	rv, err := parseResourceVersion(obj.GetResourceVersion())
+	if err != nil {
+		klog.ErrorS(err, "Can't observe event, the resourceVersion is not comparable", "Ref", klog.KObj(obj))
+		return
+	}
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	changed := false
+	if rv > t.observedRV {
+		t.observedRV = rv
+		changed = true
+	}
+
+	// Deletions are settled against the store on wait, but a delete event is a cheap and definite signal.
+	if deleted || obj.GetDeletionTimestamp() != nil {
+		key := objectKeyFor(obj)
+		if uids := t.pendingDeletes[key]; uids != nil && uids.Has(obj.GetUID()) {
+			changed = true
+		}
+	}
+
+	if changed {
+		t.broadcastLocked()
+	}
+}
+
+func (t *consistencyHandler) onAdd(untyped any) {
+	obj, err := meta.Accessor(untyped)
+	if err != nil {
+		klog.ErrorS(err, "Can't access object metadata", "Object", untyped)
+		return
+	}
+
+	t.observe(obj, false)
+}
+
+func (t *consistencyHandler) onUpdate(_, untyped any) {
+	obj, err := meta.Accessor(untyped)
+	if err != nil {
+		klog.ErrorS(err, "Can't access object metadata", "Object", untyped)
+		return
+	}
+
+	t.observe(obj, false)
+}
+
+func (t *consistencyHandler) onDelete(untyped any) {
+	if tombstone, ok := untyped.(cache.DeletedFinalStateUnknown); ok {
+		untyped = tombstone.Obj
+	}
+
+	obj, err := meta.Accessor(untyped)
+	if err != nil {
+		klog.ErrorS(err, "Can't access object metadata", "Object", untyped)
+		return
+	}
+
+	t.observe(obj, true)
+}
+
+func parseResourceVersion(resourceVersion string) (int64, error) {
+	rv, err := strconv.ParseInt(resourceVersion, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("can't parse resourceVersion %q: %w", resourceVersion, err)
+	}
+
+	return rv, nil
+}

--- a/pkg/cacheconsistency/consistencyhandler_test.go
+++ b/pkg/cacheconsistency/consistencyhandler_test.go
@@ -1,0 +1,313 @@
+package cacheconsistency
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	testNamespace = "ns"
+	testName      = "cm"
+	testUID       = types.UID("uid-1")
+)
+
+func newConfigMap(rv string, uid types.UID) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       testNamespace,
+			Name:            testName,
+			UID:             uid,
+			ResourceVersion: rv,
+		},
+	}
+}
+
+// listOnlyListerWatcher opts the reflector out of streaming lists, which the fake watcher doesn't implement, so that
+// the informer populates its cache with a plain list.
+type listOnlyListerWatcher struct {
+	*cache.ListWatch
+}
+
+func (lw *listOnlyListerWatcher) IsWatchListSemanticsUnSupported() bool {
+	return true
+}
+
+// testInformer runs a shared informer over a fake watch so that events can be delivered at will.
+type testInformer struct {
+	informer cache.SharedIndexInformer
+	watcher  *watch.RaceFreeFakeWatcher
+	handler  *consistencyHandler
+}
+
+// newTestSharedInformer returns a not yet started shared informer of the given list, fed by the returned fake watcher.
+func newTestSharedInformer(t *testing.T, exampleObject runtime.Object, list runtime.Object) (cache.SharedIndexInformer, *watch.RaceFreeFakeWatcher) {
+	t.Helper()
+
+	watcher := watch.NewRaceFreeFake()
+	lw := &listOnlyListerWatcher{
+		ListWatch: &cache.ListWatch{
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				return list, nil
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				return watcher, nil
+			},
+		},
+	}
+
+	return cache.NewSharedIndexInformer(lw, exampleObject, 0, cache.Indexers{}), watcher
+}
+
+// runTestInformer runs the informer until the test ends and waits for it and the given handlers to sync.
+func runTestInformer(t *testing.T, informer cache.SharedIndexInformer, synced ...cache.InformerSynced) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	go informer.Run(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), append([]cache.InformerSynced{informer.HasSynced}, synced...)...) {
+		t.Fatal("can't sync informer")
+	}
+}
+
+func newTestInformer(t *testing.T, initial ...*corev1.ConfigMap) *testInformer {
+	t.Helper()
+
+	list := &corev1.ConfigMapList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "10"},
+	}
+	for _, cm := range initial {
+		list.Items = append(list.Items, *cm)
+	}
+
+	informer, watcher := newTestSharedInformer(t, &corev1.ConfigMap{}, list)
+
+	handler, err := newConsistencyHandler(informer)
+	if err != nil {
+		t.Fatalf("can't create consistency handler: %v", err)
+	}
+
+	runTestInformer(t, informer, handler.HasSynced)
+
+	return &testInformer{
+		informer: informer,
+		watcher:  watcher,
+		handler:  handler,
+	}
+}
+
+func waitWithTimeout(t *testing.T, handler *consistencyHandler, timeout time.Duration) error {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
+	defer cancel()
+
+	return handler.waitReady(ctx)
+}
+
+func expectWaitBlocks(t *testing.T, handler *consistencyHandler) {
+	t.Helper()
+
+	err := waitWithTimeout(t, handler, 200*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected wait to block until the deadline, got: %v", err)
+	}
+}
+
+func expectWaitReturns(t *testing.T, handler *consistencyHandler) {
+	t.Helper()
+
+	err := waitWithTimeout(t, handler, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected wait to return, got: %v", err)
+	}
+}
+
+func TestConsistencyHandler_WaitWithNothingPending(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestInformer(t, newConfigMap("5", testUID))
+
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_WriteAlreadyObserved(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestInformer(t, newConfigMap("5", testUID))
+
+	ti.handler.wroteAt(testNamespace, testName, "5")
+
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_WriteBlocksUntilObserved(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestInformer(t, newConfigMap("5", testUID))
+
+	ti.handler.wroteAt(testNamespace, testName, "20")
+	expectWaitBlocks(t, ti.handler)
+
+	// An event with a lower resourceVersion doesn't unblock the wait.
+	ti.watcher.Modify(newConfigMap("15", testUID))
+	expectWaitBlocks(t, ti.handler)
+
+	ti.watcher.Modify(newConfigMap("20", testUID))
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_WriteIsUnblockedByAnyEventOfTheKind(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestInformer(t, newConfigMap("5", testUID))
+
+	ti.handler.wroteAt(testNamespace, testName, "20")
+	expectWaitBlocks(t, ti.handler)
+
+	// Events are delivered in resourceVersion order, so observing a higher one for another object proves the write
+	// has been observed too.
+	other := newConfigMap("21", "uid-other")
+	other.Name = "other"
+	ti.watcher.Add(other)
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_CreateBlocksUntilObserved(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestInformer(t)
+
+	ti.handler.wroteAt(testNamespace, testName, "20")
+	expectWaitBlocks(t, ti.handler)
+
+	ti.watcher.Add(newConfigMap("20", testUID))
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_DeleteBlocksUntilGoneFromTheStore(t *testing.T) {
+	t.Parallel()
+
+	cm := newConfigMap("5", testUID)
+	ti := newTestInformer(t, cm)
+
+	ti.handler.deleted(cm)
+	expectWaitBlocks(t, ti.handler)
+
+	deleted := newConfigMap("30", testUID)
+	ti.watcher.Delete(deleted)
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_DeleteIsSatisfiedByDeletionTimestamp(t *testing.T) {
+	t.Parallel()
+
+	cm := newConfigMap("5", testUID)
+	ti := newTestInformer(t, cm)
+
+	ti.handler.deleted(cm)
+	expectWaitBlocks(t, ti.handler)
+
+	// An object with finalizers stays in the store with a deletionTimestamp set.
+	terminating := newConfigMap("30", testUID)
+	terminating.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	terminating.Finalizers = []string{"test/finalizer"}
+	ti.watcher.Modify(terminating)
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_DeleteIsSatisfiedByRecreation(t *testing.T) {
+	t.Parallel()
+
+	cm := newConfigMap("5", testUID)
+	ti := newTestInformer(t, cm)
+
+	ti.handler.deleted(cm)
+	expectWaitBlocks(t, ti.handler)
+
+	// A tombstone can be missed on relist; the store holding a different instance under the same name is enough.
+	ti.watcher.Modify(newConfigMap("30", "uid-2"))
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_DeleteOfTerminatingObjectIsNotRecorded(t *testing.T) {
+	t.Parallel()
+
+	cm := newConfigMap("5", testUID)
+	cm.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	cm.Finalizers = []string{"test/finalizer"}
+	ti := newTestInformer(t, cm)
+
+	ti.handler.deleted(cm)
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_DeleteAndRecreateAreBothRecorded(t *testing.T) {
+	t.Parallel()
+
+	cm := newConfigMap("5", testUID)
+	ti := newTestInformer(t, cm)
+
+	// Mirrors resourceapply recreating an object: delete, then create under the same name.
+	ti.handler.deleted(cm)
+	ti.handler.wroteAt(testNamespace, testName, "40")
+	expectWaitBlocks(t, ti.handler)
+
+	ti.watcher.Delete(newConfigMap("35", testUID))
+	expectWaitBlocks(t, ti.handler)
+
+	ti.watcher.Add(newConfigMap("40", "uid-2"))
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_WaitReportsPendingOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestInformer(t, newConfigMap("5", testUID))
+
+	ti.handler.wroteAt(testNamespace, testName, "20")
+
+	err := waitWithTimeout(t, ti.handler, 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var pendingErr *ConsistencyError
+	if !errors.As(err, &pendingErr) {
+		t.Fatalf("expected a %T, got %T: %v", pendingErr, err, err)
+	}
+	expected := "cache has not observed all writes yet (pending resourceVersions: map[ns/cm:20], pending deletes: map[]): context deadline exceeded"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestConsistencyHandler_UnparsableResourceVersionIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestInformer(t, newConfigMap("5", testUID))
+
+	ti.handler.wroteAt(testNamespace, testName, "not-a-number")
+	expectWaitReturns(t, ti.handler)
+}
+
+func TestConsistencyHandler_WriteIsUnblockedByBookmark(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestInformer(t, newConfigMap("5", testUID))
+
+	ti.handler.wroteAt(testNamespace, testName, "20")
+	expectWaitBlocks(t, ti.handler)
+
+	// A watch bookmark advances the store's resourceVersion without any object event being delivered.
+	ti.watcher.Action(watch.Bookmark, newConfigMap("25", testUID))
+	expectWaitReturns(t, ti.handler)
+}

--- a/pkg/cacheconsistency/consistencystore.go
+++ b/pkg/cacheconsistency/consistencystore.go
@@ -1,0 +1,105 @@
+package cacheconsistency
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ConsistencyStore records the writes of a controller, per kind, and tells when the informer caches have observed all
+// of them. It is the controller-side counterpart of kube-controller-manager's ConsistencyStore. Writes of kinds that
+// have no informer registered are ignored, which lets a controller write objects it doesn't read back from a cache,
+// like PersistentVolumeClaims.
+//
+// Registration is not synchronized with use: all Register calls have to happen before the store is used.
+// A nil *ConsistencyStore is a no-op, so controllers constructed without one keep working.
+type ConsistencyStore struct {
+	handlers map[schema.GroupVersionKind]*consistencyHandler
+}
+
+// NewConsistencyStore returns an empty store.
+func NewConsistencyStore() *ConsistencyStore {
+	return &ConsistencyStore{
+		handlers: map[schema.GroupVersionKind]*consistencyHandler{},
+	}
+}
+
+// Register makes the store record writes of the kind and wait for the informer to observe them.
+func (ts *ConsistencyStore) Register(gvk schema.GroupVersionKind, informer cache.SharedIndexInformer) error {
+	if _, exists := ts.handlers[gvk]; exists {
+		return fmt.Errorf("%s is already registered", gvk)
+	}
+
+	handler, err := newConsistencyHandler(informer)
+	if err != nil {
+		return fmt.Errorf("can't create consistency handler for %s: %w", gvk, err)
+	}
+	ts.handlers[gvk] = handler
+
+	return nil
+}
+
+// HasSynced returns true once the store has been delivered the initial state of all the informers.
+func (ts *ConsistencyStore) HasSynced() bool {
+	if ts == nil {
+		return true
+	}
+
+	for _, handler := range ts.handlers {
+		if !handler.HasSynced() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// WroteAt records a write acknowledged by the API server: the object of the given kind identified by namespace and
+// name now exists at resourceVersion.
+func (ts *ConsistencyStore) WroteAt(gvk schema.GroupVersionKind, namespace, name, resourceVersion string) {
+	if ts == nil {
+		return
+	}
+
+	handler := ts.handlers[gvk]
+	if handler == nil {
+		return
+	}
+
+	handler.wroteAt(namespace, name, resourceVersion)
+}
+
+// Deleted records a delete acknowledged by the API server for the object of the given kind identified by namespace
+// and name. The deleted instance is taken from the informer store.
+func (ts *ConsistencyStore) Deleted(gvk schema.GroupVersionKind, namespace, name string) {
+	if ts == nil {
+		return
+	}
+
+	handler := ts.handlers[gvk]
+	if handler == nil {
+		return
+	}
+
+	handler.deletedByName(namespace, name)
+}
+
+// WaitReady blocks until all the informer caches reflect the recorded writes and deletes, or the context is done.
+func (ts *ConsistencyStore) WaitReady(ctx context.Context) error {
+	if ts == nil {
+		return nil
+	}
+
+	var errs []error
+	for gvk, handler := range ts.handlers {
+		err := handler.waitReady(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't wait for %s cache: %w", gvk.Kind, err))
+		}
+	}
+
+	return apimachineryutilerrors.NewAggregate(errs)
+}

--- a/pkg/cacheconsistency/consistencystore.go
+++ b/pkg/cacheconsistency/consistencystore.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/scylladb/scylla-operator/pkg/resource"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
@@ -27,9 +29,15 @@ func NewConsistencyStore() *ConsistencyStore {
 	}
 }
 
-// Register makes the store record writes of the kind and wait for the informer to observe them.
-func (ts *ConsistencyStore) Register(gvk schema.GroupVersionKind, informer cache.SharedIndexInformer) error {
-	if _, exists := ts.handlers[gvk]; exists {
+// Register makes the store record writes of the kind of obj and wait for the informer to observe them. obj is an
+// example object of the kind, e.g. &corev1.Pod{}, whose kind is resolved through the scheme.
+func (ts *ConsistencyStore) Register(obj runtime.Object, informer cache.SharedIndexInformer) error {
+	gvk, err := resource.GetObjectGVK(obj)
+	if err != nil {
+		return fmt.Errorf("can't determine the kind of %T: %w", obj, err)
+	}
+
+	if _, exists := ts.handlers[*gvk]; exists {
 		return fmt.Errorf("%s is already registered", gvk)
 	}
 
@@ -37,7 +45,7 @@ func (ts *ConsistencyStore) Register(gvk schema.GroupVersionKind, informer cache
 	if err != nil {
 		return fmt.Errorf("can't create consistency handler for %s: %w", gvk, err)
 	}
-	ts.handlers[gvk] = handler
+	ts.handlers[*gvk] = handler
 
 	return nil
 }

--- a/pkg/cacheconsistency/kubeclient.go
+++ b/pkg/cacheconsistency/kubeclient.go
@@ -30,20 +30,6 @@ import (
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 )
 
-// Kinds the recording Kubernetes client records writes for.
-var (
-	podGVK                 = corev1.SchemeGroupVersion.WithKind("Pod")
-	serviceGVK             = corev1.SchemeGroupVersion.WithKind("Service")
-	secretGVK              = corev1.SchemeGroupVersion.WithKind("Secret")
-	configMapGVK           = corev1.SchemeGroupVersion.WithKind("ConfigMap")
-	serviceAccountGVK      = corev1.SchemeGroupVersion.WithKind("ServiceAccount")
-	statefulSetGVK         = appsv1.SchemeGroupVersion.WithKind("StatefulSet")
-	jobGVK                 = batchv1.SchemeGroupVersion.WithKind("Job")
-	ingressGVK             = networkingv1.SchemeGroupVersion.WithKind("Ingress")
-	podDisruptionBudgetGVK = policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget")
-	roleBindingGVK         = rbacv1.SchemeGroupVersion.WithKind("RoleBinding")
-)
-
 // NewRecordingKubeClient returns a kubernetes.Interface that records every write it makes to the kinds registered in store,
 // so that WaitReady on the store covers them. Kinds not registered in the store, and kinds this client doesn't wrap, pass
 // through unrecorded, and so does DeleteCollection.
@@ -112,7 +98,7 @@ type coreV1Client struct {
 func (c *coreV1Client) Pods(namespace string) corev1client.PodInterface {
 	pods := c.CoreV1Interface.Pods(namespace)
 	return &recordingPods{
-		RecordingClientWithApplyAndStatus: NewRecordingClientWithApplyAndStatus[*corev1.Pod, *corev1.PodList, *corev1ac.PodApplyConfiguration](pods, podGVK, namespace, c.store),
+		RecordingClientWithApplyAndStatus: NewRecordingClientWithApplyAndStatus[*corev1.Pod, *corev1.PodList, *corev1ac.PodApplyConfiguration](pods, namespace, c.store),
 		PodExpansion:                      pods,
 		pods:                              pods,
 	}
@@ -143,11 +129,15 @@ func (c *recordingPods) EvictV1(ctx context.Context, eviction *policyv1.Eviction
 	return c.recorder.observeDelete(eviction.Name, c.PodExpansion.EvictV1(ctx, eviction))
 }
 
+func (c *recordingPods) EvictV1beta1(ctx context.Context, eviction *policyv1beta1.Eviction) error {
+	return c.recorder.observeDelete(eviction.Name, c.PodExpansion.EvictV1beta1(ctx, eviction))
+}
+
 func (c *coreV1Client) Services(namespace string) corev1client.ServiceInterface {
 	services := c.CoreV1Interface.Services(namespace)
 	return &recordingServices{
 		RecordingClientWithApplyAndStatus: NewRecordingClientWithApplyAndStatus[*corev1.Service, *corev1.ServiceList, *corev1ac.ServiceApplyConfiguration](
-			serviceClient{ServiceInterface: services}, serviceGVK, namespace, c.store,
+			serviceClient{ServiceInterface: services}, namespace, c.store,
 		),
 		ServiceExpansion: services,
 	}
@@ -170,17 +160,17 @@ type recordingServices struct {
 }
 
 func (c *coreV1Client) Secrets(namespace string) corev1client.SecretInterface {
-	return NewRecordingClientWithApply[*corev1.Secret, *corev1.SecretList, *corev1ac.SecretApplyConfiguration](c.CoreV1Interface.Secrets(namespace), secretGVK, namespace, c.store)
+	return NewRecordingClientWithApply[*corev1.Secret, *corev1.SecretList, *corev1ac.SecretApplyConfiguration](c.CoreV1Interface.Secrets(namespace), namespace, c.store)
 }
 
 func (c *coreV1Client) ConfigMaps(namespace string) corev1client.ConfigMapInterface {
-	return NewRecordingClientWithApply[*corev1.ConfigMap, *corev1.ConfigMapList, *corev1ac.ConfigMapApplyConfiguration](c.CoreV1Interface.ConfigMaps(namespace), configMapGVK, namespace, c.store)
+	return NewRecordingClientWithApply[*corev1.ConfigMap, *corev1.ConfigMapList, *corev1ac.ConfigMapApplyConfiguration](c.CoreV1Interface.ConfigMaps(namespace), namespace, c.store)
 }
 
 func (c *coreV1Client) ServiceAccounts(namespace string) corev1client.ServiceAccountInterface {
 	serviceAccounts := c.CoreV1Interface.ServiceAccounts(namespace)
 	return &recordingServiceAccounts{
-		RecordingClientWithApply: NewRecordingClientWithApply[*corev1.ServiceAccount, *corev1.ServiceAccountList, *corev1ac.ServiceAccountApplyConfiguration](serviceAccounts, serviceAccountGVK, namespace, c.store),
+		RecordingClientWithApply: NewRecordingClientWithApply[*corev1.ServiceAccount, *corev1.ServiceAccountList, *corev1ac.ServiceAccountApplyConfiguration](serviceAccounts, namespace, c.store),
 		serviceAccounts:          serviceAccounts,
 	}
 }
@@ -204,7 +194,7 @@ type appsV1Client struct {
 func (c *appsV1Client) StatefulSets(namespace string) appsv1client.StatefulSetInterface {
 	statefulSets := c.AppsV1Interface.StatefulSets(namespace)
 	return &recordingStatefulSets{
-		RecordingClientWithApplyAndStatus: NewRecordingClientWithApplyAndStatus[*appsv1.StatefulSet, *appsv1.StatefulSetList, *appsv1ac.StatefulSetApplyConfiguration](statefulSets, statefulSetGVK, namespace, c.store),
+		RecordingClientWithApplyAndStatus: NewRecordingClientWithApplyAndStatus[*appsv1.StatefulSet, *appsv1.StatefulSetList, *appsv1ac.StatefulSetApplyConfiguration](statefulSets, namespace, c.store),
 		statefulSets:                      statefulSets,
 	}
 }
@@ -236,7 +226,7 @@ type batchV1Client struct {
 }
 
 func (c *batchV1Client) Jobs(namespace string) batchv1client.JobInterface {
-	return NewRecordingClientWithApplyAndStatus[*batchv1.Job, *batchv1.JobList, *batchv1ac.JobApplyConfiguration](c.BatchV1Interface.Jobs(namespace), jobGVK, namespace, c.store)
+	return NewRecordingClientWithApplyAndStatus[*batchv1.Job, *batchv1.JobList, *batchv1ac.JobApplyConfiguration](c.BatchV1Interface.Jobs(namespace), namespace, c.store)
 }
 
 type networkingV1Client struct {
@@ -245,7 +235,7 @@ type networkingV1Client struct {
 }
 
 func (c *networkingV1Client) Ingresses(namespace string) networkingv1client.IngressInterface {
-	return NewRecordingClientWithApplyAndStatus[*networkingv1.Ingress, *networkingv1.IngressList, *networkingv1ac.IngressApplyConfiguration](c.NetworkingV1Interface.Ingresses(namespace), ingressGVK, namespace, c.store)
+	return NewRecordingClientWithApplyAndStatus[*networkingv1.Ingress, *networkingv1.IngressList, *networkingv1ac.IngressApplyConfiguration](c.NetworkingV1Interface.Ingresses(namespace), namespace, c.store)
 }
 
 type policyV1Client struct {
@@ -254,7 +244,7 @@ type policyV1Client struct {
 }
 
 func (c *policyV1Client) PodDisruptionBudgets(namespace string) policyv1client.PodDisruptionBudgetInterface {
-	return NewRecordingClientWithApplyAndStatus[*policyv1.PodDisruptionBudget, *policyv1.PodDisruptionBudgetList, *policyv1ac.PodDisruptionBudgetApplyConfiguration](c.PolicyV1Interface.PodDisruptionBudgets(namespace), podDisruptionBudgetGVK, namespace, c.store)
+	return NewRecordingClientWithApplyAndStatus[*policyv1.PodDisruptionBudget, *policyv1.PodDisruptionBudgetList, *policyv1ac.PodDisruptionBudgetApplyConfiguration](c.PolicyV1Interface.PodDisruptionBudgets(namespace), namespace, c.store)
 }
 
 type rbacV1Client struct {
@@ -263,5 +253,5 @@ type rbacV1Client struct {
 }
 
 func (c *rbacV1Client) RoleBindings(namespace string) rbacv1client.RoleBindingInterface {
-	return NewRecordingClientWithApply[*rbacv1.RoleBinding, *rbacv1.RoleBindingList, *rbacv1ac.RoleBindingApplyConfiguration](c.RbacV1Interface.RoleBindings(namespace), roleBindingGVK, namespace, c.store)
+	return NewRecordingClientWithApply[*rbacv1.RoleBinding, *rbacv1.RoleBindingList, *rbacv1ac.RoleBindingApplyConfiguration](c.RbacV1Interface.RoleBindings(namespace), namespace, c.store)
 }

--- a/pkg/cacheconsistency/kubeclient.go
+++ b/pkg/cacheconsistency/kubeclient.go
@@ -1,0 +1,267 @@
+package cacheconsistency
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsv1ac "k8s.io/client-go/applyconfigurations/apps/v1"
+	autoscalingv1ac "k8s.io/client-go/applyconfigurations/autoscaling/v1"
+	batchv1ac "k8s.io/client-go/applyconfigurations/batch/v1"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	networkingv1ac "k8s.io/client-go/applyconfigurations/networking/v1"
+	policyv1ac "k8s.io/client-go/applyconfigurations/policy/v1"
+	rbacv1ac "k8s.io/client-go/applyconfigurations/rbac/v1"
+	"k8s.io/client-go/kubernetes"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	networkingv1client "k8s.io/client-go/kubernetes/typed/networking/v1"
+	policyv1client "k8s.io/client-go/kubernetes/typed/policy/v1"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
+)
+
+// Kinds the recording Kubernetes client records writes for.
+var (
+	podGVK                 = corev1.SchemeGroupVersion.WithKind("Pod")
+	serviceGVK             = corev1.SchemeGroupVersion.WithKind("Service")
+	secretGVK              = corev1.SchemeGroupVersion.WithKind("Secret")
+	configMapGVK           = corev1.SchemeGroupVersion.WithKind("ConfigMap")
+	serviceAccountGVK      = corev1.SchemeGroupVersion.WithKind("ServiceAccount")
+	statefulSetGVK         = appsv1.SchemeGroupVersion.WithKind("StatefulSet")
+	jobGVK                 = batchv1.SchemeGroupVersion.WithKind("Job")
+	ingressGVK             = networkingv1.SchemeGroupVersion.WithKind("Ingress")
+	podDisruptionBudgetGVK = policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget")
+	roleBindingGVK         = rbacv1.SchemeGroupVersion.WithKind("RoleBinding")
+)
+
+// NewRecordingKubeClient returns a kubernetes.Interface that records every write it makes to the kinds registered in store,
+// so that WaitReady on the store covers them. Kinds not registered in the store, and kinds this client doesn't wrap, pass
+// through unrecorded, and so does DeleteCollection.
+//
+// The wrapped kinds are Pods, Services, Secrets, ConfigMaps, ServiceAccounts, StatefulSets, Jobs, Ingresses,
+// PodDisruptionBudgets and RoleBindings.
+func NewRecordingKubeClient(client kubernetes.Interface, store *ConsistencyStore) kubernetes.Interface {
+	return &kubeClient{
+		Interface: client,
+		store:     store,
+	}
+}
+
+type kubeClient struct {
+	kubernetes.Interface
+	store *ConsistencyStore
+}
+
+func (c *kubeClient) CoreV1() corev1client.CoreV1Interface {
+	return &coreV1Client{
+		CoreV1Interface: c.Interface.CoreV1(),
+		store:           c.store,
+	}
+}
+
+func (c *kubeClient) AppsV1() appsv1client.AppsV1Interface {
+	return &appsV1Client{
+		AppsV1Interface: c.Interface.AppsV1(),
+		store:           c.store,
+	}
+}
+
+func (c *kubeClient) BatchV1() batchv1client.BatchV1Interface {
+	return &batchV1Client{
+		BatchV1Interface: c.Interface.BatchV1(),
+		store:            c.store,
+	}
+}
+
+func (c *kubeClient) NetworkingV1() networkingv1client.NetworkingV1Interface {
+	return &networkingV1Client{
+		NetworkingV1Interface: c.Interface.NetworkingV1(),
+		store:                 c.store,
+	}
+}
+
+func (c *kubeClient) PolicyV1() policyv1client.PolicyV1Interface {
+	return &policyV1Client{
+		PolicyV1Interface: c.Interface.PolicyV1(),
+		store:             c.store,
+	}
+}
+
+func (c *kubeClient) RbacV1() rbacv1client.RbacV1Interface {
+	return &rbacV1Client{
+		RbacV1Interface: c.Interface.RbacV1(),
+		store:           c.store,
+	}
+}
+
+type coreV1Client struct {
+	corev1client.CoreV1Interface
+	store *ConsistencyStore
+}
+
+func (c *coreV1Client) Pods(namespace string) corev1client.PodInterface {
+	pods := c.CoreV1Interface.Pods(namespace)
+	return &recordingPods{
+		RecordingClientWithApplyAndStatus: NewRecordingClientWithApplyAndStatus[*corev1.Pod, *corev1.PodList, *corev1ac.PodApplyConfiguration](pods, podGVK, namespace, c.store),
+		PodExpansion:                      pods,
+		pods:                              pods,
+	}
+}
+
+// recordingPods adds the Pod-specific verbs to the generic client. Evictions are recorded as deletes.
+type recordingPods struct {
+	*RecordingClientWithApplyAndStatus[*corev1.Pod, *corev1.PodList, *corev1ac.PodApplyConfiguration]
+	corev1client.PodExpansion
+	pods corev1client.PodInterface
+}
+
+func (c *recordingPods) UpdateEphemeralContainers(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error) {
+	updated, err := c.pods.UpdateEphemeralContainers(ctx, podName, pod, opts)
+	return observeWrite(c.recorder, updated, err)
+}
+
+func (c *recordingPods) UpdateResize(ctx context.Context, podName string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error) {
+	updated, err := c.pods.UpdateResize(ctx, podName, pod, opts)
+	return observeWrite(c.recorder, updated, err)
+}
+
+func (c *recordingPods) Evict(ctx context.Context, eviction *policyv1beta1.Eviction) error {
+	return c.recorder.observeDelete(eviction.Name, c.PodExpansion.Evict(ctx, eviction))
+}
+
+func (c *recordingPods) EvictV1(ctx context.Context, eviction *policyv1.Eviction) error {
+	return c.recorder.observeDelete(eviction.Name, c.PodExpansion.EvictV1(ctx, eviction))
+}
+
+func (c *coreV1Client) Services(namespace string) corev1client.ServiceInterface {
+	services := c.CoreV1Interface.Services(namespace)
+	return &recordingServices{
+		RecordingClientWithApplyAndStatus: NewRecordingClientWithApplyAndStatus[*corev1.Service, *corev1.ServiceList, *corev1ac.ServiceApplyConfiguration](
+			serviceClient{ServiceInterface: services}, serviceGVK, namespace, c.store,
+		),
+		ServiceExpansion: services,
+	}
+}
+
+// serviceClient completes the Service client to the generic method set: Services are the one kind without
+// DeleteCollection, so it is rejected here and stays unreachable through the ServiceInterface.
+type serviceClient struct {
+	corev1client.ServiceInterface
+}
+
+func (serviceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	return apierrors.NewMethodNotSupported(corev1.Resource("services"), "deletecollection")
+}
+
+// recordingServices adds the Service-specific verbs to the generic client.
+type recordingServices struct {
+	*RecordingClientWithApplyAndStatus[*corev1.Service, *corev1.ServiceList, *corev1ac.ServiceApplyConfiguration]
+	corev1client.ServiceExpansion
+}
+
+func (c *coreV1Client) Secrets(namespace string) corev1client.SecretInterface {
+	return NewRecordingClientWithApply[*corev1.Secret, *corev1.SecretList, *corev1ac.SecretApplyConfiguration](c.CoreV1Interface.Secrets(namespace), secretGVK, namespace, c.store)
+}
+
+func (c *coreV1Client) ConfigMaps(namespace string) corev1client.ConfigMapInterface {
+	return NewRecordingClientWithApply[*corev1.ConfigMap, *corev1.ConfigMapList, *corev1ac.ConfigMapApplyConfiguration](c.CoreV1Interface.ConfigMaps(namespace), configMapGVK, namespace, c.store)
+}
+
+func (c *coreV1Client) ServiceAccounts(namespace string) corev1client.ServiceAccountInterface {
+	serviceAccounts := c.CoreV1Interface.ServiceAccounts(namespace)
+	return &recordingServiceAccounts{
+		RecordingClientWithApply: NewRecordingClientWithApply[*corev1.ServiceAccount, *corev1.ServiceAccountList, *corev1ac.ServiceAccountApplyConfiguration](serviceAccounts, serviceAccountGVK, namespace, c.store),
+		serviceAccounts:          serviceAccounts,
+	}
+}
+
+// recordingServiceAccounts adds the ServiceAccount-specific verbs to the generic client. Token requests don't change
+// the ServiceAccount, so they pass through unrecorded.
+type recordingServiceAccounts struct {
+	*RecordingClientWithApply[*corev1.ServiceAccount, *corev1.ServiceAccountList, *corev1ac.ServiceAccountApplyConfiguration]
+	serviceAccounts corev1client.ServiceAccountInterface
+}
+
+func (c *recordingServiceAccounts) CreateToken(ctx context.Context, serviceAccountName string, tokenRequest *authenticationv1.TokenRequest, opts metav1.CreateOptions) (*authenticationv1.TokenRequest, error) {
+	return c.serviceAccounts.CreateToken(ctx, serviceAccountName, tokenRequest, opts)
+}
+
+type appsV1Client struct {
+	appsv1client.AppsV1Interface
+	store *ConsistencyStore
+}
+
+func (c *appsV1Client) StatefulSets(namespace string) appsv1client.StatefulSetInterface {
+	statefulSets := c.AppsV1Interface.StatefulSets(namespace)
+	return &recordingStatefulSets{
+		RecordingClientWithApplyAndStatus: NewRecordingClientWithApplyAndStatus[*appsv1.StatefulSet, *appsv1.StatefulSetList, *appsv1ac.StatefulSetApplyConfiguration](statefulSets, statefulSetGVK, namespace, c.store),
+		statefulSets:                      statefulSets,
+	}
+}
+
+// recordingStatefulSets adds the scale subresource verbs to the generic client. The scale subresource carries the
+// resourceVersion of the StatefulSet it scaled, so scale writes are recorded against the StatefulSet.
+type recordingStatefulSets struct {
+	*RecordingClientWithApplyAndStatus[*appsv1.StatefulSet, *appsv1.StatefulSetList, *appsv1ac.StatefulSetApplyConfiguration]
+	statefulSets appsv1client.StatefulSetInterface
+}
+
+func (c *recordingStatefulSets) GetScale(ctx context.Context, statefulSetName string, opts metav1.GetOptions) (*autoscalingv1.Scale, error) {
+	return c.statefulSets.GetScale(ctx, statefulSetName, opts)
+}
+
+func (c *recordingStatefulSets) UpdateScale(ctx context.Context, statefulSetName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	updated, err := c.statefulSets.UpdateScale(ctx, statefulSetName, scale, opts)
+	return observeWrite(c.recorder, updated, err)
+}
+
+func (c *recordingStatefulSets) ApplyScale(ctx context.Context, statefulSetName string, scale *autoscalingv1ac.ScaleApplyConfiguration, opts metav1.ApplyOptions) (*autoscalingv1.Scale, error) {
+	applied, err := c.statefulSets.ApplyScale(ctx, statefulSetName, scale, opts)
+	return observeWrite(c.recorder, applied, err)
+}
+
+type batchV1Client struct {
+	batchv1client.BatchV1Interface
+	store *ConsistencyStore
+}
+
+func (c *batchV1Client) Jobs(namespace string) batchv1client.JobInterface {
+	return NewRecordingClientWithApplyAndStatus[*batchv1.Job, *batchv1.JobList, *batchv1ac.JobApplyConfiguration](c.BatchV1Interface.Jobs(namespace), jobGVK, namespace, c.store)
+}
+
+type networkingV1Client struct {
+	networkingv1client.NetworkingV1Interface
+	store *ConsistencyStore
+}
+
+func (c *networkingV1Client) Ingresses(namespace string) networkingv1client.IngressInterface {
+	return NewRecordingClientWithApplyAndStatus[*networkingv1.Ingress, *networkingv1.IngressList, *networkingv1ac.IngressApplyConfiguration](c.NetworkingV1Interface.Ingresses(namespace), ingressGVK, namespace, c.store)
+}
+
+type policyV1Client struct {
+	policyv1client.PolicyV1Interface
+	store *ConsistencyStore
+}
+
+func (c *policyV1Client) PodDisruptionBudgets(namespace string) policyv1client.PodDisruptionBudgetInterface {
+	return NewRecordingClientWithApplyAndStatus[*policyv1.PodDisruptionBudget, *policyv1.PodDisruptionBudgetList, *policyv1ac.PodDisruptionBudgetApplyConfiguration](c.PolicyV1Interface.PodDisruptionBudgets(namespace), podDisruptionBudgetGVK, namespace, c.store)
+}
+
+type rbacV1Client struct {
+	rbacv1client.RbacV1Interface
+	store *ConsistencyStore
+}
+
+func (c *rbacV1Client) RoleBindings(namespace string) rbacv1client.RoleBindingInterface {
+	return NewRecordingClientWithApply[*rbacv1.RoleBinding, *rbacv1.RoleBindingList, *rbacv1ac.RoleBindingApplyConfiguration](c.RbacV1Interface.RoleBindings(namespace), roleBindingGVK, namespace, c.store)
+}

--- a/pkg/cacheconsistency/kubeclient_test.go
+++ b/pkg/cacheconsistency/kubeclient_test.go
@@ -60,10 +60,10 @@ func newRecordingKubeClientTestEnv(t *testing.T, services []*corev1.Service, sta
 	statefulSetInformer, statefulSetWatcher := newTestSharedInformer(t, &appsv1.StatefulSet{}, statefulSetList)
 
 	store := NewConsistencyStore()
-	if err := store.Register(serviceGVK, serviceInformer); err != nil {
+	if err := store.Register(&corev1.Service{}, serviceInformer); err != nil {
 		t.Fatalf("can't register services: %v", err)
 	}
-	if err := store.Register(statefulSetGVK, statefulSetInformer); err != nil {
+	if err := store.Register(&appsv1.StatefulSet{}, statefulSetInformer); err != nil {
 		t.Fatalf("can't register statefulsets: %v", err)
 	}
 	runTestInformer(t, serviceInformer)
@@ -165,7 +165,7 @@ func TestKubeClient_DeleteOfAnObjectMissingFromTheAPIServerIsRecorded(t *testing
 
 	// Recording the recreated instance as a write makes the wait return only once the cache holds it.
 	env.serviceWatcher.Add(newService("40", "uid-2"))
-	env.store.WroteAt(serviceGVK, testNamespace, testName, "40")
+	env.store.WroteAt(corev1.SchemeGroupVersion.WithKind("Service"), testNamespace, testName, "40")
 	expectStoreWaitReturns(t, env.store)
 
 	err = env.client.CoreV1().Services(testNamespace).Delete(t.Context(), testName, metav1.DeleteOptions{})
@@ -307,7 +307,7 @@ func TestKubeClient_EvictionIsRecordedAsDelete(t *testing.T) {
 	podInformer, podWatcher := newTestSharedInformer(t, &corev1.Pod{}, podList)
 
 	store := NewConsistencyStore()
-	if err := store.Register(podGVK, podInformer); err != nil {
+	if err := store.Register(&corev1.Pod{}, podInformer); err != nil {
 		t.Fatalf("can't register pods: %v", err)
 	}
 	runTestInformer(t, podInformer, store.HasSynced)
@@ -341,7 +341,7 @@ func TestScyllaClient_UpdateStatusIsRecorded(t *testing.T) {
 	sdcInformer, sdcWatcher := newTestSharedInformer(t, &scyllav1alpha1.ScyllaDBDatacenter{}, sdcList)
 
 	store := NewConsistencyStore()
-	if err := store.Register(scyllaDBDatacenterGVK, sdcInformer); err != nil {
+	if err := store.Register(&scyllav1alpha1.ScyllaDBDatacenter{}, sdcInformer); err != nil {
 		t.Fatalf("can't register ScyllaDBDatacenters: %v", err)
 	}
 	runTestInformer(t, sdcInformer, store.HasSynced)

--- a/pkg/cacheconsistency/kubeclient_test.go
+++ b/pkg/cacheconsistency/kubeclient_test.go
@@ -1,0 +1,360 @@
+package cacheconsistency
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	scyllafake "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned/fake"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func newService(rv string, uid types.UID) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       testNamespace,
+			Name:            testName,
+			UID:             uid,
+			ResourceVersion: rv,
+		},
+	}
+}
+
+// recordingKubeClientTestEnv runs Service and StatefulSet informers fed by fake watchers behind a recording client over
+// a fake clientset.
+type recordingKubeClientTestEnv struct {
+	client             kubernetes.Interface
+	store              *ConsistencyStore
+	serviceWatcher     *watch.RaceFreeFakeWatcher
+	statefulSetWatcher *watch.RaceFreeFakeWatcher
+}
+
+func newRecordingKubeClientTestEnv(t *testing.T, services []*corev1.Service, statefulSets []*appsv1.StatefulSet) *recordingKubeClientTestEnv {
+	t.Helper()
+
+	var objects []runtime.Object
+
+	serviceList := &corev1.ServiceList{ListMeta: metav1.ListMeta{ResourceVersion: "10"}}
+	for _, svc := range services {
+		serviceList.Items = append(serviceList.Items, *svc)
+		objects = append(objects, svc)
+	}
+	statefulSetList := &appsv1.StatefulSetList{ListMeta: metav1.ListMeta{ResourceVersion: "10"}}
+	for _, sts := range statefulSets {
+		statefulSetList.Items = append(statefulSetList.Items, *sts)
+		objects = append(objects, sts)
+	}
+
+	serviceInformer, serviceWatcher := newTestSharedInformer(t, &corev1.Service{}, serviceList)
+	statefulSetInformer, statefulSetWatcher := newTestSharedInformer(t, &appsv1.StatefulSet{}, statefulSetList)
+
+	store := NewConsistencyStore()
+	if err := store.Register(serviceGVK, serviceInformer); err != nil {
+		t.Fatalf("can't register services: %v", err)
+	}
+	if err := store.Register(statefulSetGVK, statefulSetInformer); err != nil {
+		t.Fatalf("can't register statefulsets: %v", err)
+	}
+	runTestInformer(t, serviceInformer)
+	runTestInformer(t, statefulSetInformer)
+	if !cache.WaitForCacheSync(t.Context().Done(), store.HasSynced) {
+		t.Fatal("can't sync the consistency store")
+	}
+
+	return &recordingKubeClientTestEnv{
+		client:             NewRecordingKubeClient(fake.NewSimpleClientset(objects...), store),
+		store:              store,
+		serviceWatcher:     serviceWatcher,
+		statefulSetWatcher: statefulSetWatcher,
+	}
+}
+
+func expectStoreWaitBlocks(t *testing.T, store *ConsistencyStore) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	err := store.WaitReady(ctx)
+	if err == nil {
+		t.Fatal("expected wait to block until the deadline")
+	}
+}
+
+func expectStoreWaitReturns(t *testing.T, store *ConsistencyStore) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	err := store.WaitReady(ctx)
+	if err != nil {
+		t.Fatalf("expected wait to return, got: %v", err)
+	}
+}
+
+func TestKubeClient_UpdateIsRecorded(t *testing.T) {
+	t.Parallel()
+
+	env := newRecordingKubeClientTestEnv(t, []*corev1.Service{newService("5", testUID)}, nil)
+
+	// The fake clientset stores the object as given, so the resourceVersion stands in for the one the API server
+	// would assign.
+	_, err := env.client.CoreV1().Services(testNamespace).Update(t.Context(), newService("20", testUID), metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("can't update service: %v", err)
+	}
+	expectStoreWaitBlocks(t, env.store)
+
+	env.serviceWatcher.Modify(newService("20", testUID))
+	expectStoreWaitReturns(t, env.store)
+}
+
+func TestKubeClient_CreateIsRecorded(t *testing.T) {
+	t.Parallel()
+
+	env := newRecordingKubeClientTestEnv(t, nil, nil)
+
+	_, err := env.client.CoreV1().Services(testNamespace).Create(t.Context(), newService("20", testUID), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("can't create service: %v", err)
+	}
+	expectStoreWaitBlocks(t, env.store)
+
+	env.serviceWatcher.Add(newService("20", testUID))
+	expectStoreWaitReturns(t, env.store)
+}
+
+func TestKubeClient_DeleteIsRecordedByTheCachedInstance(t *testing.T) {
+	t.Parallel()
+
+	env := newRecordingKubeClientTestEnv(t, []*corev1.Service{newService("5", testUID)}, nil)
+
+	err := env.client.CoreV1().Services(testNamespace).Delete(t.Context(), testName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("can't delete service: %v", err)
+	}
+	expectStoreWaitBlocks(t, env.store)
+
+	env.serviceWatcher.Delete(newService("30", testUID))
+	expectStoreWaitReturns(t, env.store)
+}
+
+func TestKubeClient_DeleteOfAnObjectMissingFromTheAPIServerIsRecorded(t *testing.T) {
+	t.Parallel()
+
+	// The cache still holds the object, the API server doesn't.
+	env := newRecordingKubeClientTestEnv(t, []*corev1.Service{newService("5", testUID)}, nil)
+	err := env.client.CoreV1().Services(testNamespace).Delete(t.Context(), testName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("can't delete service: %v", err)
+	}
+	env.serviceWatcher.Delete(newService("30", testUID))
+	expectStoreWaitReturns(t, env.store)
+
+	// Recording the recreated instance as a write makes the wait return only once the cache holds it.
+	env.serviceWatcher.Add(newService("40", "uid-2"))
+	env.store.WroteAt(serviceGVK, testNamespace, testName, "40")
+	expectStoreWaitReturns(t, env.store)
+
+	err = env.client.CoreV1().Services(testNamespace).Delete(t.Context(), testName, metav1.DeleteOptions{})
+	if err == nil {
+		t.Fatal("expected a not found error")
+	}
+	expectStoreWaitBlocks(t, env.store)
+
+	env.serviceWatcher.Delete(newService("40", "uid-2"))
+	expectStoreWaitReturns(t, env.store)
+}
+
+func TestKubeClient_DeleteOfAnObjectMissingFromTheCacheIsNotRecorded(t *testing.T) {
+	t.Parallel()
+
+	env := newRecordingKubeClientTestEnv(t, nil, nil)
+
+	err := env.client.CoreV1().Services(testNamespace).Delete(t.Context(), testName, metav1.DeleteOptions{})
+	if err == nil {
+		t.Fatal("expected a not found error")
+	}
+	expectStoreWaitReturns(t, env.store)
+}
+
+func TestKubeClient_UpdateScaleIsRecordedAgainstTheStatefulSet(t *testing.T) {
+	t.Parallel()
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       testNamespace,
+			Name:            testName,
+			UID:             testUID,
+			ResourceVersion: "5",
+		},
+	}
+	env := newRecordingKubeClientTestEnv(t, nil, []*appsv1.StatefulSet{sts})
+
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       testNamespace,
+			Name:            testName,
+			ResourceVersion: "20",
+		},
+		Spec: autoscalingv1.ScaleSpec{Replicas: 1},
+	}
+	_, err := env.client.AppsV1().StatefulSets(testNamespace).UpdateScale(t.Context(), testName, scale, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("can't update scale: %v", err)
+	}
+	expectStoreWaitBlocks(t, env.store)
+
+	scaled := sts.DeepCopy()
+	scaled.ResourceVersion = "20"
+	env.statefulSetWatcher.Modify(scaled)
+	expectStoreWaitReturns(t, env.store)
+}
+
+func TestKubeClient_UnregisteredKindsPassThrough(t *testing.T) {
+	t.Parallel()
+
+	env := newRecordingKubeClientTestEnv(t, nil, nil)
+
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "pvc", ResourceVersion: "20"}}
+	_, err := env.client.CoreV1().PersistentVolumeClaims(testNamespace).Create(t.Context(), pvc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("can't create pvc: %v", err)
+	}
+	err = env.client.CoreV1().PersistentVolumeClaims(testNamespace).Delete(t.Context(), "pvc", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("can't delete pvc: %v", err)
+	}
+	err = env.client.CoreV1().Pods(testNamespace).EvictV1(t.Context(), &policyv1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "pod"}})
+	if err == nil {
+		t.Fatal("expected a not found error")
+	}
+
+	expectStoreWaitReturns(t, env.store)
+}
+
+func TestKubeClient_NilStoreIsNoop(t *testing.T) {
+	t.Parallel()
+
+	client := NewRecordingKubeClient(fake.NewSimpleClientset(newService("5", testUID)), nil)
+
+	_, err := client.CoreV1().Services(testNamespace).Update(t.Context(), newService("20", testUID), metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("can't update service: %v", err)
+	}
+	err = client.CoreV1().Services(testNamespace).Delete(t.Context(), testName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("can't delete service: %v", err)
+	}
+}
+
+func TestKubeClient_PatchIsRecorded(t *testing.T) {
+	t.Parallel()
+
+	env := newRecordingKubeClientTestEnv(t, []*corev1.Service{newService("5", testUID)}, nil)
+
+	// The fake clientset applies the patch to the stored object, so patching the resourceVersion stands in for the
+	// one the API server would assign.
+	_, err := env.client.CoreV1().Services(testNamespace).Patch(t.Context(), testName, types.MergePatchType, []byte(`{"metadata":{"resourceVersion":"20"}}`), metav1.PatchOptions{})
+	if err != nil {
+		t.Fatalf("can't patch service: %v", err)
+	}
+	expectStoreWaitBlocks(t, env.store)
+
+	env.serviceWatcher.Modify(newService("20", testUID))
+	expectStoreWaitReturns(t, env.store)
+}
+
+func TestKubeClient_UpdateStatusIsRecorded(t *testing.T) {
+	t.Parallel()
+
+	env := newRecordingKubeClientTestEnv(t, []*corev1.Service{newService("5", testUID)}, nil)
+
+	_, err := env.client.CoreV1().Services(testNamespace).UpdateStatus(t.Context(), newService("20", testUID), metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("can't update service status: %v", err)
+	}
+	expectStoreWaitBlocks(t, env.store)
+
+	env.serviceWatcher.Modify(newService("20", testUID))
+	expectStoreWaitReturns(t, env.store)
+}
+
+func TestKubeClient_EvictionIsRecordedAsDelete(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       testNamespace,
+			Name:            testName,
+			UID:             testUID,
+			ResourceVersion: "5",
+		},
+	}
+	podList := &corev1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "10"}, Items: []corev1.Pod{*pod}}
+	podInformer, podWatcher := newTestSharedInformer(t, &corev1.Pod{}, podList)
+
+	store := NewConsistencyStore()
+	if err := store.Register(podGVK, podInformer); err != nil {
+		t.Fatalf("can't register pods: %v", err)
+	}
+	runTestInformer(t, podInformer, store.HasSynced)
+
+	client := NewRecordingKubeClient(fake.NewSimpleClientset(pod), store)
+	err := client.CoreV1().Pods(testNamespace).EvictV1(t.Context(), &policyv1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: testName}})
+	if err != nil {
+		t.Fatalf("can't evict pod: %v", err)
+	}
+	expectStoreWaitBlocks(t, store)
+
+	terminating := pod.DeepCopy()
+	terminating.ResourceVersion = "30"
+	terminating.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	podWatcher.Modify(terminating)
+	expectStoreWaitReturns(t, store)
+}
+
+func TestScyllaClient_UpdateStatusIsRecorded(t *testing.T) {
+	t.Parallel()
+
+	sdc := &scyllav1alpha1.ScyllaDBDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       testNamespace,
+			Name:            testName,
+			UID:             testUID,
+			ResourceVersion: "5",
+		},
+	}
+	sdcList := &scyllav1alpha1.ScyllaDBDatacenterList{ListMeta: metav1.ListMeta{ResourceVersion: "10"}, Items: []scyllav1alpha1.ScyllaDBDatacenter{*sdc}}
+	sdcInformer, sdcWatcher := newTestSharedInformer(t, &scyllav1alpha1.ScyllaDBDatacenter{}, sdcList)
+
+	store := NewConsistencyStore()
+	if err := store.Register(scyllaDBDatacenterGVK, sdcInformer); err != nil {
+		t.Fatalf("can't register ScyllaDBDatacenters: %v", err)
+	}
+	runTestInformer(t, sdcInformer, store.HasSynced)
+
+	client := NewRecordingScyllaV1alpha1Client(scyllafake.NewSimpleClientset(sdc).ScyllaV1alpha1(), store)
+	updated := sdc.DeepCopy()
+	updated.ResourceVersion = "20"
+	_, err := client.ScyllaDBDatacenters(testNamespace).UpdateStatus(t.Context(), updated, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("can't update ScyllaDBDatacenter status: %v", err)
+	}
+	expectStoreWaitBlocks(t, store)
+
+	sdcWatcher.Modify(updated)
+	expectStoreWaitReturns(t, store)
+}

--- a/pkg/cacheconsistency/recordingclient.go
+++ b/pkg/cacheconsistency/recordingclient.go
@@ -2,9 +2,14 @@ package cacheconsistency
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
+	"github.com/scylladb/scylla-operator/pkg/kubeinterfaces"
+	"github.com/scylladb/scylla-operator/pkg/resource"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -12,7 +17,7 @@ import (
 
 // Client is the method set client-gen gives every typed client, over the object type T and the list type L.
 // It mirrors k8s.io/client-go/gentype, so the generated typed client interfaces satisfy it structurally.
-type Client[T metav1.Object, L any] interface {
+type Client[T kubeinterfaces.ObjectInterface, L any] interface {
 	Create(ctx context.Context, obj T, opts metav1.CreateOptions) (T, error)
 	Update(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
@@ -24,35 +29,35 @@ type Client[T metav1.Object, L any] interface {
 }
 
 // StatusClient is the verb client-gen adds for kinds with a status subresource.
-type StatusClient[T metav1.Object] interface {
+type StatusClient[T kubeinterfaces.ObjectInterface] interface {
 	UpdateStatus(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error)
 }
 
 // ApplyClient is the verb client-gen adds when apply configurations are generated, over the apply configuration
 // type AC.
-type ApplyClient[T metav1.Object, AC any] interface {
+type ApplyClient[T kubeinterfaces.ObjectInterface, AC any] interface {
 	Apply(ctx context.Context, obj AC, opts metav1.ApplyOptions) (T, error)
 }
 
 // ApplyStatusClient is the verb client-gen adds for kinds with both a status subresource and apply configurations.
-type ApplyStatusClient[T metav1.Object, AC any] interface {
+type ApplyStatusClient[T kubeinterfaces.ObjectInterface, AC any] interface {
 	ApplyStatus(ctx context.Context, obj AC, opts metav1.ApplyOptions) (T, error)
 }
 
 // ClientWithStatus is a Client of a kind with a status subresource.
-type ClientWithStatus[T metav1.Object, L any] interface {
+type ClientWithStatus[T kubeinterfaces.ObjectInterface, L any] interface {
 	Client[T, L]
 	StatusClient[T]
 }
 
 // ClientWithApply is a Client of a kind with apply configurations.
-type ClientWithApply[T metav1.Object, L, AC any] interface {
+type ClientWithApply[T kubeinterfaces.ObjectInterface, L, AC any] interface {
 	Client[T, L]
 	ApplyClient[T, AC]
 }
 
 // ClientWithApplyAndStatus is a Client of a kind with both a status subresource and apply configurations.
-type ClientWithApplyAndStatus[T metav1.Object, L, AC any] interface {
+type ClientWithApplyAndStatus[T kubeinterfaces.ObjectInterface, L, AC any] interface {
 	Client[T, L]
 	StatusClient[T]
 	ApplyClient[T, AC]
@@ -64,6 +69,28 @@ type recorder struct {
 	gvk       schema.GroupVersionKind
 	namespace string
 	store     *ConsistencyStore
+}
+
+// newRecorder resolves the kind of T through the scheme, so that no kind name has to be spelled out for a client.
+// T has to be a pointer to a type registered in the scheme, which holds for every type a typed client is generated
+// for; anything else is a programming error and panics.
+func newRecorder[T kubeinterfaces.ObjectInterface](namespace string, store *ConsistencyStore) *recorder {
+	var zero T
+	obj, ok := reflect.New(reflect.TypeOf(zero).Elem()).Interface().(runtime.Object)
+	if !ok {
+		panic(fmt.Sprintf("cacheconsistency: %T is not a runtime.Object", zero))
+	}
+
+	gvk, err := resource.GetObjectGVK(obj)
+	if err != nil {
+		panic(fmt.Sprintf("cacheconsistency: can't determine the kind of %T: %v", zero, err))
+	}
+
+	return &recorder{
+		gvk:       *gvk,
+		namespace: namespace,
+		store:     store,
+	}
 }
 
 // observeWrite records a successful write of obj.
@@ -84,7 +111,7 @@ func (t *recorder) observeDelete(name string, err error) error {
 }
 
 // observeWrite records a successful write of obj and returns the write's results unchanged.
-func observeWrite[T metav1.Object](t *recorder, obj T, err error) (T, error) {
+func observeWrite[T kubeinterfaces.ObjectInterface](t *recorder, obj T, err error) (T, error) {
 	if err != nil {
 		return obj, err
 	}
@@ -97,22 +124,17 @@ func observeWrite[T metav1.Object](t *recorder, obj T, err error) (T, error) {
 // RecordingClient is a Client that records its writes in the ConsistencyStore it was created with, so that WaitReady
 // on the store covers them. Reads pass through untouched. DeleteCollection passes through unrecorded, as its response
 // doesn't tell what was deleted; the operator doesn't use it.
-type RecordingClient[T metav1.Object, L any] struct {
+type RecordingClient[T kubeinterfaces.ObjectInterface, L any] struct {
 	Client[T, L]
 	recorder *recorder
 }
 
-// NewRecordingClient wraps client, a typed client of the kind gvk scoped to namespace, so that its writes are
-// recorded in store.
-func NewRecordingClient[T metav1.Object, L any](client Client[T, L], gvk schema.GroupVersionKind, namespace string, store *ConsistencyStore) *RecordingClient[T, L] {
-	return newRecordingClient(client, &recorder{
-		gvk:       gvk,
-		namespace: namespace,
-		store:     store,
-	})
+// NewRecordingClient wraps client, a typed client of T scoped to namespace, so that its writes are recorded in store.
+func NewRecordingClient[T kubeinterfaces.ObjectInterface, L any](client Client[T, L], namespace string, store *ConsistencyStore) *RecordingClient[T, L] {
+	return newRecordingClient(client, newRecorder[T](namespace, store))
 }
 
-func newRecordingClient[T metav1.Object, L any](client Client[T, L], t *recorder) *RecordingClient[T, L] {
+func newRecordingClient[T kubeinterfaces.ObjectInterface, L any](client Client[T, L], t *recorder) *RecordingClient[T, L] {
 	return &RecordingClient[T, L]{
 		Client:   client,
 		recorder: t,
@@ -138,7 +160,7 @@ func (c *RecordingClient[T, L]) Delete(ctx context.Context, name string, opts me
 	return c.recorder.observeDelete(name, c.Client.Delete(ctx, name, opts))
 }
 
-type recordingStatusClient[T metav1.Object] struct {
+type recordingStatusClient[T kubeinterfaces.ObjectInterface] struct {
 	StatusClient[T]
 	recorder *recorder
 }
@@ -148,7 +170,7 @@ func (c *recordingStatusClient[T]) UpdateStatus(ctx context.Context, obj T, opts
 	return observeWrite(c.recorder, updated, err)
 }
 
-type recordingApplyClient[T metav1.Object, AC any] struct {
+type recordingApplyClient[T kubeinterfaces.ObjectInterface, AC any] struct {
 	ApplyClient[T, AC]
 	recorder *recorder
 }
@@ -158,7 +180,7 @@ func (c *recordingApplyClient[T, AC]) Apply(ctx context.Context, obj AC, opts me
 	return observeWrite(c.recorder, applied, err)
 }
 
-type recordingApplyStatusClient[T metav1.Object, AC any] struct {
+type recordingApplyStatusClient[T kubeinterfaces.ObjectInterface, AC any] struct {
 	ApplyStatusClient[T, AC]
 	recorder *recorder
 }
@@ -169,19 +191,15 @@ func (c *recordingApplyStatusClient[T, AC]) ApplyStatus(ctx context.Context, obj
 }
 
 // RecordingClientWithStatus is a RecordingClient of a kind with a status subresource.
-type RecordingClientWithStatus[T metav1.Object, L any] struct {
+type RecordingClientWithStatus[T kubeinterfaces.ObjectInterface, L any] struct {
 	*RecordingClient[T, L]
 	*recordingStatusClient[T]
 	recorder *recorder
 }
 
 // NewRecordingClientWithStatus is NewRecordingClient for a kind with a status subresource.
-func NewRecordingClientWithStatus[T metav1.Object, L any](client ClientWithStatus[T, L], gvk schema.GroupVersionKind, namespace string, store *ConsistencyStore) *RecordingClientWithStatus[T, L] {
-	t := &recorder{
-		gvk:       gvk,
-		namespace: namespace,
-		store:     store,
-	}
+func NewRecordingClientWithStatus[T kubeinterfaces.ObjectInterface, L any](client ClientWithStatus[T, L], namespace string, store *ConsistencyStore) *RecordingClientWithStatus[T, L] {
+	t := newRecorder[T](namespace, store)
 	return &RecordingClientWithStatus[T, L]{
 		RecordingClient:       newRecordingClient(client, t),
 		recordingStatusClient: &recordingStatusClient[T]{StatusClient: client, recorder: t},
@@ -190,19 +208,15 @@ func NewRecordingClientWithStatus[T metav1.Object, L any](client ClientWithStatu
 }
 
 // RecordingClientWithApply is a RecordingClient of a kind with apply configurations.
-type RecordingClientWithApply[T metav1.Object, L, AC any] struct {
+type RecordingClientWithApply[T kubeinterfaces.ObjectInterface, L, AC any] struct {
 	*RecordingClient[T, L]
 	*recordingApplyClient[T, AC]
 	recorder *recorder
 }
 
 // NewRecordingClientWithApply is NewRecordingClient for a kind with apply configurations.
-func NewRecordingClientWithApply[T metav1.Object, L, AC any](client ClientWithApply[T, L, AC], gvk schema.GroupVersionKind, namespace string, store *ConsistencyStore) *RecordingClientWithApply[T, L, AC] {
-	t := &recorder{
-		gvk:       gvk,
-		namespace: namespace,
-		store:     store,
-	}
+func NewRecordingClientWithApply[T kubeinterfaces.ObjectInterface, L, AC any](client ClientWithApply[T, L, AC], namespace string, store *ConsistencyStore) *RecordingClientWithApply[T, L, AC] {
+	t := newRecorder[T](namespace, store)
 	return &RecordingClientWithApply[T, L, AC]{
 		RecordingClient:      newRecordingClient(client, t),
 		recordingApplyClient: &recordingApplyClient[T, AC]{ApplyClient: client, recorder: t},
@@ -212,7 +226,7 @@ func NewRecordingClientWithApply[T metav1.Object, L, AC any](client ClientWithAp
 
 // RecordingClientWithApplyAndStatus is a RecordingClient of a kind with both a status subresource and apply
 // configurations.
-type RecordingClientWithApplyAndStatus[T metav1.Object, L, AC any] struct {
+type RecordingClientWithApplyAndStatus[T kubeinterfaces.ObjectInterface, L, AC any] struct {
 	*RecordingClient[T, L]
 	*recordingStatusClient[T]
 	*recordingApplyClient[T, AC]
@@ -222,12 +236,8 @@ type RecordingClientWithApplyAndStatus[T metav1.Object, L, AC any] struct {
 
 // NewRecordingClientWithApplyAndStatus is NewRecordingClient for a kind with both a status subresource and apply
 // configurations.
-func NewRecordingClientWithApplyAndStatus[T metav1.Object, L, AC any](client ClientWithApplyAndStatus[T, L, AC], gvk schema.GroupVersionKind, namespace string, store *ConsistencyStore) *RecordingClientWithApplyAndStatus[T, L, AC] {
-	t := &recorder{
-		gvk:       gvk,
-		namespace: namespace,
-		store:     store,
-	}
+func NewRecordingClientWithApplyAndStatus[T kubeinterfaces.ObjectInterface, L, AC any](client ClientWithApplyAndStatus[T, L, AC], namespace string, store *ConsistencyStore) *RecordingClientWithApplyAndStatus[T, L, AC] {
+	t := newRecorder[T](namespace, store)
 	return &RecordingClientWithApplyAndStatus[T, L, AC]{
 		RecordingClient:            newRecordingClient(client, t),
 		recordingStatusClient:      &recordingStatusClient[T]{StatusClient: client, recorder: t},

--- a/pkg/cacheconsistency/recordingclient.go
+++ b/pkg/cacheconsistency/recordingclient.go
@@ -1,0 +1,238 @@
+package cacheconsistency
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// Client is the method set client-gen gives every typed client, over the object type T and the list type L.
+// It mirrors k8s.io/client-go/gentype, so the generated typed client interfaces satisfy it structurally.
+type Client[T metav1.Object, L any] interface {
+	Create(ctx context.Context, obj T, opts metav1.CreateOptions) (T, error)
+	Update(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (T, error)
+	List(ctx context.Context, opts metav1.ListOptions) (L, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (T, error)
+}
+
+// StatusClient is the verb client-gen adds for kinds with a status subresource.
+type StatusClient[T metav1.Object] interface {
+	UpdateStatus(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error)
+}
+
+// ApplyClient is the verb client-gen adds when apply configurations are generated, over the apply configuration
+// type AC.
+type ApplyClient[T metav1.Object, AC any] interface {
+	Apply(ctx context.Context, obj AC, opts metav1.ApplyOptions) (T, error)
+}
+
+// ApplyStatusClient is the verb client-gen adds for kinds with both a status subresource and apply configurations.
+type ApplyStatusClient[T metav1.Object, AC any] interface {
+	ApplyStatus(ctx context.Context, obj AC, opts metav1.ApplyOptions) (T, error)
+}
+
+// ClientWithStatus is a Client of a kind with a status subresource.
+type ClientWithStatus[T metav1.Object, L any] interface {
+	Client[T, L]
+	StatusClient[T]
+}
+
+// ClientWithApply is a Client of a kind with apply configurations.
+type ClientWithApply[T metav1.Object, L, AC any] interface {
+	Client[T, L]
+	ApplyClient[T, AC]
+}
+
+// ClientWithApplyAndStatus is a Client of a kind with both a status subresource and apply configurations.
+type ClientWithApplyAndStatus[T metav1.Object, L, AC any] interface {
+	Client[T, L]
+	StatusClient[T]
+	ApplyClient[T, AC]
+	ApplyStatusClient[T, AC]
+}
+
+// recorder identifies the kind and namespace of a client and holds the store its writes are recorded in.
+type recorder struct {
+	gvk       schema.GroupVersionKind
+	namespace string
+	store     *ConsistencyStore
+}
+
+// observeWrite records a successful write of obj.
+func (t *recorder) observeWrite(obj metav1.Object) {
+	t.store.WroteAt(t.gvk, obj.GetNamespace(), obj.GetName(), obj.GetResourceVersion())
+}
+
+// observeDelete records a delete that removed the object from the API server, or found it already removed, so that
+// the next read waits for the cache to drop it too. It returns err unchanged.
+func (t *recorder) observeDelete(name string, err error) error {
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	t.store.Deleted(t.gvk, t.namespace, name)
+
+	return err
+}
+
+// observeWrite records a successful write of obj and returns the write's results unchanged.
+func observeWrite[T metav1.Object](t *recorder, obj T, err error) (T, error) {
+	if err != nil {
+		return obj, err
+	}
+
+	t.observeWrite(obj)
+
+	return obj, nil
+}
+
+// RecordingClient is a Client that records its writes in the ConsistencyStore it was created with, so that WaitReady
+// on the store covers them. Reads pass through untouched. DeleteCollection passes through unrecorded, as its response
+// doesn't tell what was deleted; the operator doesn't use it.
+type RecordingClient[T metav1.Object, L any] struct {
+	Client[T, L]
+	recorder *recorder
+}
+
+// NewRecordingClient wraps client, a typed client of the kind gvk scoped to namespace, so that its writes are
+// recorded in store.
+func NewRecordingClient[T metav1.Object, L any](client Client[T, L], gvk schema.GroupVersionKind, namespace string, store *ConsistencyStore) *RecordingClient[T, L] {
+	return newRecordingClient(client, &recorder{
+		gvk:       gvk,
+		namespace: namespace,
+		store:     store,
+	})
+}
+
+func newRecordingClient[T metav1.Object, L any](client Client[T, L], t *recorder) *RecordingClient[T, L] {
+	return &RecordingClient[T, L]{
+		Client:   client,
+		recorder: t,
+	}
+}
+
+func (c *RecordingClient[T, L]) Create(ctx context.Context, obj T, opts metav1.CreateOptions) (T, error) {
+	created, err := c.Client.Create(ctx, obj, opts)
+	return observeWrite(c.recorder, created, err)
+}
+
+func (c *RecordingClient[T, L]) Update(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error) {
+	updated, err := c.Client.Update(ctx, obj, opts)
+	return observeWrite(c.recorder, updated, err)
+}
+
+func (c *RecordingClient[T, L]) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (T, error) {
+	patched, err := c.Client.Patch(ctx, name, pt, data, opts, subresources...)
+	return observeWrite(c.recorder, patched, err)
+}
+
+func (c *RecordingClient[T, L]) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return c.recorder.observeDelete(name, c.Client.Delete(ctx, name, opts))
+}
+
+type recordingStatusClient[T metav1.Object] struct {
+	StatusClient[T]
+	recorder *recorder
+}
+
+func (c *recordingStatusClient[T]) UpdateStatus(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error) {
+	updated, err := c.StatusClient.UpdateStatus(ctx, obj, opts)
+	return observeWrite(c.recorder, updated, err)
+}
+
+type recordingApplyClient[T metav1.Object, AC any] struct {
+	ApplyClient[T, AC]
+	recorder *recorder
+}
+
+func (c *recordingApplyClient[T, AC]) Apply(ctx context.Context, obj AC, opts metav1.ApplyOptions) (T, error) {
+	applied, err := c.ApplyClient.Apply(ctx, obj, opts)
+	return observeWrite(c.recorder, applied, err)
+}
+
+type recordingApplyStatusClient[T metav1.Object, AC any] struct {
+	ApplyStatusClient[T, AC]
+	recorder *recorder
+}
+
+func (c *recordingApplyStatusClient[T, AC]) ApplyStatus(ctx context.Context, obj AC, opts metav1.ApplyOptions) (T, error) {
+	applied, err := c.ApplyStatusClient.ApplyStatus(ctx, obj, opts)
+	return observeWrite(c.recorder, applied, err)
+}
+
+// RecordingClientWithStatus is a RecordingClient of a kind with a status subresource.
+type RecordingClientWithStatus[T metav1.Object, L any] struct {
+	*RecordingClient[T, L]
+	*recordingStatusClient[T]
+	recorder *recorder
+}
+
+// NewRecordingClientWithStatus is NewRecordingClient for a kind with a status subresource.
+func NewRecordingClientWithStatus[T metav1.Object, L any](client ClientWithStatus[T, L], gvk schema.GroupVersionKind, namespace string, store *ConsistencyStore) *RecordingClientWithStatus[T, L] {
+	t := &recorder{
+		gvk:       gvk,
+		namespace: namespace,
+		store:     store,
+	}
+	return &RecordingClientWithStatus[T, L]{
+		RecordingClient:       newRecordingClient(client, t),
+		recordingStatusClient: &recordingStatusClient[T]{StatusClient: client, recorder: t},
+		recorder:              t,
+	}
+}
+
+// RecordingClientWithApply is a RecordingClient of a kind with apply configurations.
+type RecordingClientWithApply[T metav1.Object, L, AC any] struct {
+	*RecordingClient[T, L]
+	*recordingApplyClient[T, AC]
+	recorder *recorder
+}
+
+// NewRecordingClientWithApply is NewRecordingClient for a kind with apply configurations.
+func NewRecordingClientWithApply[T metav1.Object, L, AC any](client ClientWithApply[T, L, AC], gvk schema.GroupVersionKind, namespace string, store *ConsistencyStore) *RecordingClientWithApply[T, L, AC] {
+	t := &recorder{
+		gvk:       gvk,
+		namespace: namespace,
+		store:     store,
+	}
+	return &RecordingClientWithApply[T, L, AC]{
+		RecordingClient:      newRecordingClient(client, t),
+		recordingApplyClient: &recordingApplyClient[T, AC]{ApplyClient: client, recorder: t},
+		recorder:             t,
+	}
+}
+
+// RecordingClientWithApplyAndStatus is a RecordingClient of a kind with both a status subresource and apply
+// configurations.
+type RecordingClientWithApplyAndStatus[T metav1.Object, L, AC any] struct {
+	*RecordingClient[T, L]
+	*recordingStatusClient[T]
+	*recordingApplyClient[T, AC]
+	*recordingApplyStatusClient[T, AC]
+	recorder *recorder
+}
+
+// NewRecordingClientWithApplyAndStatus is NewRecordingClient for a kind with both a status subresource and apply
+// configurations.
+func NewRecordingClientWithApplyAndStatus[T metav1.Object, L, AC any](client ClientWithApplyAndStatus[T, L, AC], gvk schema.GroupVersionKind, namespace string, store *ConsistencyStore) *RecordingClientWithApplyAndStatus[T, L, AC] {
+	t := &recorder{
+		gvk:       gvk,
+		namespace: namespace,
+		store:     store,
+	}
+	return &RecordingClientWithApplyAndStatus[T, L, AC]{
+		RecordingClient:            newRecordingClient(client, t),
+		recordingStatusClient:      &recordingStatusClient[T]{StatusClient: client, recorder: t},
+		recordingApplyClient:       &recordingApplyClient[T, AC]{ApplyClient: client, recorder: t},
+		recordingApplyStatusClient: &recordingApplyStatusClient[T, AC]{ApplyStatusClient: client, recorder: t},
+		recorder:                   t,
+	}
+}

--- a/pkg/cacheconsistency/scyllaclient.go
+++ b/pkg/cacheconsistency/scyllaclient.go
@@ -1,0 +1,36 @@
+package cacheconsistency
+
+import (
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	scyllav1alpha1client "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned/typed/scylla/v1alpha1"
+)
+
+// Kinds the recording Scylla client records writes for.
+var (
+	scyllaDBDatacenterGVK                  = scyllav1alpha1.ScyllaDBDatacenterGVK
+	scyllaDBDatacenterNodesStatusReportGVK = scyllav1alpha1.GroupVersion.WithKind("ScyllaDBDatacenterNodesStatusReport")
+)
+
+// NewRecordingScyllaV1alpha1Client returns a ScyllaV1alpha1Interface that records every write it makes to the kinds registered
+// in store, so that WaitReady on the store covers them. See NewRecordingKubeClient for what passes through unrecorded.
+//
+// The wrapped kinds are ScyllaDBDatacenters and ScyllaDBDatacenterNodesStatusReports.
+func NewRecordingScyllaV1alpha1Client(client scyllav1alpha1client.ScyllaV1alpha1Interface, store *ConsistencyStore) scyllav1alpha1client.ScyllaV1alpha1Interface {
+	return &scyllaV1alpha1Client{
+		ScyllaV1alpha1Interface: client,
+		store:                   store,
+	}
+}
+
+type scyllaV1alpha1Client struct {
+	scyllav1alpha1client.ScyllaV1alpha1Interface
+	store *ConsistencyStore
+}
+
+func (c *scyllaV1alpha1Client) ScyllaDBDatacenters(namespace string) scyllav1alpha1client.ScyllaDBDatacenterInterface {
+	return NewRecordingClientWithStatus[*scyllav1alpha1.ScyllaDBDatacenter, *scyllav1alpha1.ScyllaDBDatacenterList](c.ScyllaV1alpha1Interface.ScyllaDBDatacenters(namespace), scyllaDBDatacenterGVK, namespace, c.store)
+}
+
+func (c *scyllaV1alpha1Client) ScyllaDBDatacenterNodesStatusReports(namespace string) scyllav1alpha1client.ScyllaDBDatacenterNodesStatusReportInterface {
+	return NewRecordingClient[*scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport, *scyllav1alpha1.ScyllaDBDatacenterNodesStatusReportList](c.ScyllaV1alpha1Interface.ScyllaDBDatacenterNodesStatusReports(namespace), scyllaDBDatacenterNodesStatusReportGVK, namespace, c.store)
+}

--- a/pkg/cacheconsistency/scyllaclient.go
+++ b/pkg/cacheconsistency/scyllaclient.go
@@ -5,12 +5,6 @@ import (
 	scyllav1alpha1client "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned/typed/scylla/v1alpha1"
 )
 
-// Kinds the recording Scylla client records writes for.
-var (
-	scyllaDBDatacenterGVK                  = scyllav1alpha1.ScyllaDBDatacenterGVK
-	scyllaDBDatacenterNodesStatusReportGVK = scyllav1alpha1.GroupVersion.WithKind("ScyllaDBDatacenterNodesStatusReport")
-)
-
 // NewRecordingScyllaV1alpha1Client returns a ScyllaV1alpha1Interface that records every write it makes to the kinds registered
 // in store, so that WaitReady on the store covers them. See NewRecordingKubeClient for what passes through unrecorded.
 //
@@ -28,9 +22,9 @@ type scyllaV1alpha1Client struct {
 }
 
 func (c *scyllaV1alpha1Client) ScyllaDBDatacenters(namespace string) scyllav1alpha1client.ScyllaDBDatacenterInterface {
-	return NewRecordingClientWithStatus[*scyllav1alpha1.ScyllaDBDatacenter, *scyllav1alpha1.ScyllaDBDatacenterList](c.ScyllaV1alpha1Interface.ScyllaDBDatacenters(namespace), scyllaDBDatacenterGVK, namespace, c.store)
+	return NewRecordingClientWithStatus[*scyllav1alpha1.ScyllaDBDatacenter, *scyllav1alpha1.ScyllaDBDatacenterList](c.ScyllaV1alpha1Interface.ScyllaDBDatacenters(namespace), namespace, c.store)
 }
 
 func (c *scyllaV1alpha1Client) ScyllaDBDatacenterNodesStatusReports(namespace string) scyllav1alpha1client.ScyllaDBDatacenterNodesStatusReportInterface {
-	return NewRecordingClient[*scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport, *scyllav1alpha1.ScyllaDBDatacenterNodesStatusReportList](c.ScyllaV1alpha1Interface.ScyllaDBDatacenterNodesStatusReports(namespace), scyllaDBDatacenterNodesStatusReportGVK, namespace, c.store)
+	return NewRecordingClient[*scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport, *scyllav1alpha1.ScyllaDBDatacenterNodesStatusReportList](c.ScyllaV1alpha1Interface.ScyllaDBDatacenterNodesStatusReports(namespace), namespace, c.store)
 }

--- a/pkg/controller/scylladbdatacenter/controller.go
+++ b/pkg/controller/scylladbdatacenter/controller.go
@@ -2,11 +2,13 @@ package scylladbdatacenter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	"github.com/scylladb/scylla-operator/pkg/cacheconsistency"
 	scyllav1alpha1client "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned/typed/scylla/v1alpha1"
 	scyllav1alpha1informers "github.com/scylladb/scylla-operator/pkg/client/scylla/informers/externalversions/scylla/v1alpha1"
 	scyllav1alpha1listers "github.com/scylladb/scylla-operator/pkg/client/scylla/listers/scylla/v1alpha1"
@@ -24,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
@@ -50,9 +53,9 @@ import (
 const (
 	ControllerName = "ScyllaDBDatacenterController"
 
-	// defaultStatefulSetCachePropagationDelay is the default value for the delay after applying StatefulSet changes
-	// to let informer caches observe the update.
-	defaultStatefulSetCachePropagationDelay = 10 * time.Second
+	// cacheConsistencyTimeout bounds how long a sync waits for the informer caches to observe the controller's own
+	// writes before it gives up and requeues.
+	cacheConsistencyTimeout = 1 * time.Minute
 )
 
 var (
@@ -90,18 +93,12 @@ type Controller struct {
 
 	keyGetter crypto.KeyGenerator
 
-	statefulSetCachePropagationDelay time.Duration
+	// consistencyStore records the writes the clients make, so that a sync only proceeds once the informer caches
+	// reflect them. See package cacheconsistency.
+	consistencyStore *cacheconsistency.ConsistencyStore
 }
 
 type ControllerOption func(ctrl *Controller)
-
-// WithStatefulSetCachePropagationDelay overrides the delay after applying StatefulSet changes to let informer caches
-// observe the update.
-func WithStatefulSetCachePropagationDelay(delay time.Duration) ControllerOption {
-	return func(c *Controller) {
-		c.statefulSetCachePropagationDelay = delay
-	}
-}
 
 func NewController(
 	kubeClient kubernetes.Interface,
@@ -176,12 +173,41 @@ func NewController(
 
 		keyGetter: keyGetter,
 
-		statefulSetCachePropagationDelay: defaultStatefulSetCachePropagationDelay,
+		consistencyStore: cacheconsistency.NewConsistencyStore(),
 	}
 
 	for _, option := range options {
 		option(sdcc)
 	}
+
+	for _, recorded := range []struct {
+		gvk      schema.GroupVersionKind
+		informer cache.SharedIndexInformer
+	}{
+		{gvk: corev1.SchemeGroupVersion.WithKind("Pod"), informer: podInformer.Informer()},
+		{gvk: corev1.SchemeGroupVersion.WithKind("Service"), informer: serviceInformer.Informer()},
+		{gvk: corev1.SchemeGroupVersion.WithKind("Secret"), informer: secretInformer.Informer()},
+		{gvk: corev1.SchemeGroupVersion.WithKind("ConfigMap"), informer: configMapInformer.Informer()},
+		{gvk: corev1.SchemeGroupVersion.WithKind("ServiceAccount"), informer: serviceAccountInformer.Informer()},
+		{gvk: rbacv1.SchemeGroupVersion.WithKind("RoleBinding"), informer: roleBindingInformer.Informer()},
+		{gvk: statefulSetControllerGVK, informer: statefulSetInformer.Informer()},
+		{gvk: policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget"), informer: pdbInformer.Informer()},
+		{gvk: networkingv1.SchemeGroupVersion.WithKind("Ingress"), informer: ingressInformer.Informer()},
+		{gvk: batchv1.SchemeGroupVersion.WithKind("Job"), informer: jobInformer.Informer()},
+		{gvk: scyllav1alpha1.ScyllaDBDatacenterGVK, informer: scyllaDBDatacenterInformer.Informer()},
+		{gvk: scyllav1alpha1.GroupVersion.WithKind("ScyllaDBDatacenterNodesStatusReport"), informer: scyllaDBDatacenterNodesStatusReportInformer.Informer()},
+	} {
+		err := sdcc.consistencyStore.Register(recorded.gvk, recorded.informer)
+		if err != nil {
+			return nil, fmt.Errorf("can't register %s in the consistency store: %w", recorded.gvk.Kind, err)
+		}
+	}
+	sdcc.cachesToSync = append(sdcc.cachesToSync, sdcc.consistencyStore.HasSynced)
+
+	// Every write the controller makes goes through the recording clients, so the sync can wait for the caches to
+	// observe all of them before deciding.
+	sdcc.kubeClient = cacheconsistency.NewRecordingKubeClient(kubeClient, sdcc.consistencyStore)
+	sdcc.scyllaClient = cacheconsistency.NewRecordingScyllaV1alpha1Client(scyllaClient, sdcc.consistencyStore)
 
 	var err error
 	sdcc.handlers, err = controllerhelpers.NewHandlers[*scyllav1alpha1.ScyllaDBDatacenter](
@@ -306,6 +332,9 @@ func (sdcc *Controller) processNextItem(ctx context.Context) bool {
 
 	case apierrors.IsAlreadyExists(err):
 		klog.V(2).InfoS("Hit already exists, will retry in a bit", "Key", key, "Error", err)
+
+	case errors.As(err, new(*cacheconsistency.ConsistencyError)):
+		klog.V(2).InfoS("Caches have not observed previous writes yet, will retry in a bit", "Key", key, "Error", err)
 
 	default:
 		apimachineryutilruntime.HandleError(fmt.Errorf("syncing key '%v' failed: %v", key, err))

--- a/pkg/controller/scylladbdatacenter/controller.go
+++ b/pkg/controller/scylladbdatacenter/controller.go
@@ -26,7 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apimachineryutilwait "k8s.io/apimachinery/pkg/util/wait"
@@ -180,26 +180,28 @@ func NewController(
 		option(sdcc)
 	}
 
+	// The kinds the controller reads from its listers and writes: their writes are recorded by the recording
+	// clients below, and every sync waits for the caches to observe them.
 	for _, recorded := range []struct {
-		gvk      schema.GroupVersionKind
+		obj      runtime.Object
 		informer cache.SharedIndexInformer
 	}{
-		{gvk: corev1.SchemeGroupVersion.WithKind("Pod"), informer: podInformer.Informer()},
-		{gvk: corev1.SchemeGroupVersion.WithKind("Service"), informer: serviceInformer.Informer()},
-		{gvk: corev1.SchemeGroupVersion.WithKind("Secret"), informer: secretInformer.Informer()},
-		{gvk: corev1.SchemeGroupVersion.WithKind("ConfigMap"), informer: configMapInformer.Informer()},
-		{gvk: corev1.SchemeGroupVersion.WithKind("ServiceAccount"), informer: serviceAccountInformer.Informer()},
-		{gvk: rbacv1.SchemeGroupVersion.WithKind("RoleBinding"), informer: roleBindingInformer.Informer()},
-		{gvk: statefulSetControllerGVK, informer: statefulSetInformer.Informer()},
-		{gvk: policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget"), informer: pdbInformer.Informer()},
-		{gvk: networkingv1.SchemeGroupVersion.WithKind("Ingress"), informer: ingressInformer.Informer()},
-		{gvk: batchv1.SchemeGroupVersion.WithKind("Job"), informer: jobInformer.Informer()},
-		{gvk: scyllav1alpha1.ScyllaDBDatacenterGVK, informer: scyllaDBDatacenterInformer.Informer()},
-		{gvk: scyllav1alpha1.GroupVersion.WithKind("ScyllaDBDatacenterNodesStatusReport"), informer: scyllaDBDatacenterNodesStatusReportInformer.Informer()},
+		{obj: &corev1.Pod{}, informer: podInformer.Informer()},
+		{obj: &corev1.Service{}, informer: serviceInformer.Informer()},
+		{obj: &corev1.Secret{}, informer: secretInformer.Informer()},
+		{obj: &corev1.ConfigMap{}, informer: configMapInformer.Informer()},
+		{obj: &corev1.ServiceAccount{}, informer: serviceAccountInformer.Informer()},
+		{obj: &rbacv1.RoleBinding{}, informer: roleBindingInformer.Informer()},
+		{obj: &appsv1.StatefulSet{}, informer: statefulSetInformer.Informer()},
+		{obj: &policyv1.PodDisruptionBudget{}, informer: pdbInformer.Informer()},
+		{obj: &networkingv1.Ingress{}, informer: ingressInformer.Informer()},
+		{obj: &batchv1.Job{}, informer: jobInformer.Informer()},
+		{obj: &scyllav1alpha1.ScyllaDBDatacenter{}, informer: scyllaDBDatacenterInformer.Informer()},
+		{obj: &scyllav1alpha1.ScyllaDBDatacenterNodesStatusReport{}, informer: scyllaDBDatacenterNodesStatusReportInformer.Informer()},
 	} {
-		err := sdcc.consistencyStore.Register(recorded.gvk, recorded.informer)
+		err := sdcc.consistencyStore.Register(recorded.obj, recorded.informer)
 		if err != nil {
-			return nil, fmt.Errorf("can't register %s in the consistency store: %w", recorded.gvk.Kind, err)
+			return nil, fmt.Errorf("can't register %T in the consistency store: %w", recorded.obj, err)
 		}
 	}
 	sdcc.cachesToSync = append(sdcc.cachesToSync, sdcc.consistencyStore.HasSynced)
@@ -208,7 +210,6 @@ func NewController(
 	// observe all of them before deciding.
 	sdcc.kubeClient = cacheconsistency.NewRecordingKubeClient(kubeClient, sdcc.consistencyStore)
 	sdcc.scyllaClient = cacheconsistency.NewRecordingScyllaV1alpha1Client(scyllaClient, sdcc.consistencyStore)
-
 	var err error
 	sdcc.handlers, err = controllerhelpers.NewHandlers[*scyllav1alpha1.ScyllaDBDatacenter](
 		sdcc.queue,

--- a/pkg/controller/scylladbdatacenter/sync.go
+++ b/pkg/controller/scylladbdatacenter/sync.go
@@ -35,6 +35,13 @@ func (sdcc *Controller) sync(ctx context.Context, key string) error {
 		klog.V(4).InfoS("Finished syncing ScyllaCluster", "ScyllaDBDatacenter", klog.KRef(namespace, name), "duration", time.Since(startTime))
 	}()
 
+	// Decide from state that reflects the controller's own writes: wait for the informer caches to catch up with
+	// everything written by the previous syncs before reading anything from them.
+	err = sdcc.waitForCacheConsistency(ctx)
+	if err != nil {
+		return fmt.Errorf("can't wait for caches to observe previous writes: %w", err)
+	}
+
 	sdc, err := sdcc.scyllaDBDatacenterLister.ScyllaDBDatacenters(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		klog.V(2).InfoS("ScyllaCluster has been deleted", "ScyllaDBDatacenter", klog.KObj(sdc))
@@ -377,4 +384,11 @@ func (sdcc *Controller) sync(ctx context.Context, key string) error {
 	}
 
 	return apimachineryutilerrors.NewAggregate(errs)
+}
+
+func (sdcc *Controller) waitForCacheConsistency(ctx context.Context) error {
+	waitCtx, cancel := context.WithTimeout(ctx, cacheConsistencyTimeout)
+	defer cancel()
+
+	return sdcc.consistencyStore.WaitReady(waitCtx)
 }

--- a/pkg/controller/scylladbdatacenter/sync_ingress.go
+++ b/pkg/controller/scylladbdatacenter/sync_ingress.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncIngresses(
@@ -26,33 +25,18 @@ func (sdcc *Controller) syncIngresses(
 
 	// Delete any excessive Ingresses.
 	// Delete has to be the fist action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, ingress := range ingresses {
-		if ingress.DeletionTimestamp != nil {
-			continue
-		}
-
-		isRequired := false
-		for _, req := range requiredIngresses {
-			if ingress.Name == req.Name {
-				isRequired = true
-			}
-		}
-		if isRequired {
-			continue
-		}
-
-		propagationPolicy := metav1.DeletePropagationBackground
+	prunedIngresses, err := controllerhelpers.PruneObjects(
+		ctx,
+		requiredIngresses,
+		ingresses,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: sdcc.kubeClient.NetworkingV1().Ingresses(sdc.Namespace).Delete,
+		},
+		sdcc.eventRecorder,
+	)
+	for _, ingress := range prunedIngresses {
 		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, ingressControllerProgressingCondition, ingress, "delete", sdc.Generation)
-		err = sdcc.kubeClient.NetworkingV1().Ingresses(ingress.Namespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				UID: &ingress.UID,
-			},
-			PropagationPolicy: &propagationPolicy,
-		})
-		deletionErrors = append(deletionErrors, err)
 	}
-	err = apimachineryutilerrors.NewAggregate(deletionErrors)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't delete ingress(s): %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/sync_pdb.go
+++ b/pkg/controller/scylladbdatacenter/sync_pdb.go
@@ -9,7 +9,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncPodDisruptionBudgets(
@@ -24,27 +23,18 @@ func (sdcc *Controller) syncPodDisruptionBudgets(
 
 	// Delete any excessive PodDisruptionBudgets.
 	// Delete has to be the fist action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, pdb := range pdbs {
-		if pdb.DeletionTimestamp != nil {
-			continue
-		}
-
-		if pdb.Name == requiredPDB.Name {
-			continue
-		}
-
-		propagationPolicy := metav1.DeletePropagationBackground
+	prunedPodDisruptionBudgets, err := controllerhelpers.PruneObjects(
+		ctx,
+		[]*policyv1.PodDisruptionBudget{requiredPDB},
+		pdbs,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: sdcc.kubeClient.PolicyV1().PodDisruptionBudgets(sdc.Namespace).Delete,
+		},
+		sdcc.eventRecorder,
+	)
+	for _, pdb := range prunedPodDisruptionBudgets {
 		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, pdbControllerProgressingCondition, pdb, "delete", sdc.Generation)
-		err = sdcc.kubeClient.PolicyV1().PodDisruptionBudgets(pdb.Namespace).Delete(ctx, pdb.Name, metav1.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				UID: &pdb.UID,
-			},
-			PropagationPolicy: &propagationPolicy,
-		})
-		deletionErrors = append(deletionErrors, err)
 	}
-	err = apimachineryutilerrors.NewAggregate(deletionErrors)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't delete pdb(s): %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/sync_rolebindings.go
+++ b/pkg/controller/scylladbdatacenter/sync_rolebindings.go
@@ -9,7 +9,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncRoleBindings(
@@ -24,27 +23,18 @@ func (sdcc *Controller) syncRoleBindings(
 
 	// Delete any excessive RoleBindings.
 	// Delete has to be the fist action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, rb := range roleBindings {
-		if rb.DeletionTimestamp != nil {
-			continue
-		}
-
-		if rb.Name == requiredRoleBinding.Name {
-			continue
-		}
-
-		propagationPolicy := metav1.DeletePropagationBackground
+	prunedRoleBindings, err := controllerhelpers.PruneObjects(
+		ctx,
+		[]*rbacv1.RoleBinding{requiredRoleBinding},
+		roleBindings,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: sdcc.kubeClient.RbacV1().RoleBindings(sdc.Namespace).Delete,
+		},
+		sdcc.eventRecorder,
+	)
+	for _, rb := range prunedRoleBindings {
 		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, roleBindingControllerProgressingCondition, rb, "delete", sdc.Generation)
-		err = sdcc.kubeClient.RbacV1().RoleBindings(rb.Namespace).Delete(ctx, rb.Name, metav1.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				UID: &rb.UID,
-			},
-			PropagationPolicy: &propagationPolicy,
-		})
-		deletionErrors = append(deletionErrors, err)
 	}
-	err = apimachineryutilerrors.NewAggregate(deletionErrors)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't delete role binding(s): %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/sync_serviceaccounts.go
+++ b/pkg/controller/scylladbdatacenter/sync_serviceaccounts.go
@@ -9,7 +9,6 @@ import (
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func (sdcc *Controller) syncServiceAccounts(
@@ -24,27 +23,18 @@ func (sdcc *Controller) syncServiceAccounts(
 
 	// Delete any excessive ServiceAccounts.
 	// Delete has to be the fist action to avoid getting stuck on quota.
-	var deletionErrors []error
-	for _, sa := range serviceAccounts {
-		if sa.DeletionTimestamp != nil {
-			continue
-		}
-
-		if sa.Name == requiredServiceAccount.Name {
-			continue
-		}
-
-		propagationPolicy := metav1.DeletePropagationBackground
+	prunedServiceAccounts, err := controllerhelpers.PruneObjects(
+		ctx,
+		[]*corev1.ServiceAccount{requiredServiceAccount},
+		serviceAccounts,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: sdcc.kubeClient.CoreV1().ServiceAccounts(sdc.Namespace).Delete,
+		},
+		sdcc.eventRecorder,
+	)
+	for _, sa := range prunedServiceAccounts {
 		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, serviceAccountControllerProgressingCondition, sa, "delete", sdc.Generation)
-		err = sdcc.kubeClient.CoreV1().ServiceAccounts(sa.Namespace).Delete(ctx, sa.Name, metav1.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				UID: &sa.UID,
-			},
-			PropagationPolicy: &propagationPolicy,
-		})
-		deletionErrors = append(deletionErrors, err)
 	}
-	err = apimachineryutilerrors.NewAggregate(deletionErrors)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't delete service account(s): %w", err)
 	}

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -346,37 +346,20 @@ func (sdcc *Controller) pruneStatefulSets(
 	requiredStatefulSets []*appsv1.StatefulSet,
 	statefulSets map[string]*appsv1.StatefulSet,
 ) ([]metav1.Condition, error) {
-	var errs []error
 	var progressingConditions []metav1.Condition
-	for _, sts := range statefulSets {
-		if sts.DeletionTimestamp != nil {
-			continue
-		}
 
-		isRequired := false
-		for _, req := range requiredStatefulSets {
-			if sts.Name == req.Name {
-				isRequired = true
-			}
-		}
-		if isRequired {
-			continue
-		}
-
-		// TODO: Decommission the rack before removal.
-
-		propagationPolicy := metav1.DeletePropagationBackground
+	// TODO: Decommission the rack before removal.
+	prunedStatefulSets, err := controllerhelpers.PruneObjects(
+		ctx,
+		requiredStatefulSets,
+		statefulSets,
+		&controllerhelpers.PruneControlFuncs{
+			DeleteFunc: sdcc.kubeClient.AppsV1().StatefulSets(sdc.Namespace).Delete,
+		},
+		sdcc.eventRecorder,
+	)
+	for _, sts := range prunedStatefulSets {
 		controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, statefulSetControllerProgressingCondition, sts, "delete", sdc.Generation)
-		err := sdcc.kubeClient.AppsV1().StatefulSets(sts.Namespace).Delete(ctx, sts.Name, metav1.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				UID: &sts.UID,
-			},
-			PropagationPolicy: &propagationPolicy,
-		})
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
 
 		rackName, found := sts.Labels[naming.RackNameLabel]
 		if !found {
@@ -390,7 +373,8 @@ func (sdcc *Controller) pruneStatefulSets(
 			return rackStatus.Name == rackName
 		})
 	}
-	return progressingConditions, apimachineryutilerrors.NewAggregate(errs)
+
+	return progressingConditions, err
 }
 
 // checkExistingStatefulSetsRolloutStatus returns progressing conditions for existing StatefulSets that haven't rolled out yet.

--- a/pkg/controller/scylladbdatacenter/sync_statefulsets.go
+++ b/pkg/controller/scylladbdatacenter/sync_statefulsets.go
@@ -781,13 +781,6 @@ func (sdcc *Controller) syncStatefulSets(
 		statefulSets,
 	)
 	progressingConditions = append(progressingConditions, createProgressingConditions...)
-	defer func() {
-		if len(createProgressingConditions) > 0 {
-			// Wait for the informers to catch up.
-			// TODO: Add expectations, not to reconcile sooner then we see this new StatefulSet in our caches. (#682)
-			time.Sleep(sdcc.statefulSetCachePropagationDelay)
-		}
-	}()
 	var createErrs []error
 	if err != nil {
 		createErrs = append(createErrs, fmt.Errorf("can't create StatefulSet(s): %w", err))
@@ -955,7 +948,6 @@ func (sdcc *Controller) syncStatefulSets(
 		case internalapi.RolloutInitUpgradePhase:
 			// Partition all StatefulSet at once to block changes but no Pod update is done yet.
 			var errs []error
-			anyStsChanged := false
 			for _, required := range requiredStatefulSets {
 				existing, ok := statefulSets[required.Name]
 				if !ok {
@@ -976,8 +968,6 @@ func (sdcc *Controller) syncStatefulSets(
 				}
 
 				if changed {
-					anyStsChanged = true
-
 					rackName, ok := updatedSts.Labels[naming.RackNameLabel]
 					if !ok {
 						errs = append(errs, fmt.Errorf(
@@ -998,10 +988,6 @@ func (sdcc *Controller) syncStatefulSets(
 
 					status.Racks[idx] = *calculateRackStatus(sdcc.podLister, sdc, rackName, updatedSts, services)
 				}
-			}
-			if anyStsChanged {
-				// TODO: Add expectations, not to reconcile sooner then we see this new StatefulSet in our caches. (#682)
-				time.Sleep(sdcc.statefulSetCachePropagationDelay)
 			}
 			err = apimachineryutilerrors.NewAggregate(errs)
 			if err != nil {
@@ -1175,13 +1161,6 @@ func (sdcc *Controller) syncStatefulSets(
 	}
 
 	// Begin the update.
-	anyStsChanged := false
-	defer func() {
-		if anyStsChanged {
-			// TODO: Add expectations, not to reconcile sooner then we see this new StatefulSet in our caches. (#682)
-			time.Sleep(sdcc.statefulSetCachePropagationDelay)
-		}
-	}()
 	for _, required := range requiredStatefulSets {
 		// Check for version upgrades first.
 		existing, existingFound := statefulSets[required.Name]
@@ -1245,8 +1224,6 @@ func (sdcc *Controller) syncStatefulSets(
 		}
 
 		if changed {
-			anyStsChanged = true
-
 			controllerhelpers.AddGenericProgressingStatusCondition(&progressingConditions, statefulSetControllerProgressingCondition, required, "apply", sdc.Generation)
 
 			rackName, ok := updatedSts.Labels[naming.RackNameLabel]

--- a/pkg/controllerhelpers/prune.go
+++ b/pkg/controllerhelpers/prune.go
@@ -26,8 +26,17 @@ func (pcf *PruneControlFuncs) Delete(ctx context.Context, name string, opts meta
 
 var _ PruneControlInterface = &PruneControlFuncs{}
 
+// Prune deletes the existing objects that are not required. See PruneObjects.
 func Prune[T kubeinterfaces.ObjectInterface](ctx context.Context, requiredObjects []T, existingObjects map[string]T, control PruneControlInterface, eventRecorder record.EventRecorder) error {
+	_, err := PruneObjects(ctx, requiredObjects, existingObjects, control, eventRecorder)
+	return err
+}
+
+// PruneObjects deletes the existing objects that are not required and are not being deleted already, and returns
+// the objects it deleted. Deletes are guarded by the UID of the existing object.
+func PruneObjects[T kubeinterfaces.ObjectInterface](ctx context.Context, requiredObjects []T, existingObjects map[string]T, control PruneControlInterface, eventRecorder record.EventRecorder) ([]T, error) {
 	var errs []error
+	var pruned []T
 
 	for _, existing := range existingObjects {
 		if existing.GetDeletionTimestamp() != nil {
@@ -59,7 +68,8 @@ func Prune[T kubeinterfaces.ObjectInterface](ctx context.Context, requiredObject
 			errs = append(errs, err)
 			continue
 		}
+		pruned = append(pruned, existing)
 	}
 
-	return apimachineryutilerrors.NewAggregate(errs)
+	return pruned, apimachineryutilerrors.NewAggregate(errs)
 }

--- a/test/envtest/cacheconsistency/cacheconsistency_suite_test.go
+++ b/test/envtest/cacheconsistency/cacheconsistency_suite_test.go
@@ -1,0 +1,20 @@
+//go:build envtest
+
+package cacheconsistency
+
+import (
+	"testing"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	klog.InitFlags(nil)
+}
+
+func TestEnvtest(t *testing.T) {
+	o.RegisterFailHandler(g.Fail)
+	g.RunSpecs(t, "Cache Consistency Suite")
+}

--- a/test/envtest/cacheconsistency/recordingclient_test.go
+++ b/test/envtest/cacheconsistency/recordingclient_test.go
@@ -1,0 +1,383 @@
+//go:build envtest
+
+package cacheconsistency
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	"github.com/scylladb/scylla-operator/pkg/cacheconsistency"
+	"github.com/scylladb/scylla-operator/test/envtest"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	// informerLag keeps the informers behind the API server, so that a read right after a write is provably stale
+	// without WaitReady.
+	informerLag = 1 * time.Second
+
+	waitReadyTimeout = 15 * time.Second
+	// bookmarkWaitTimeout covers the API server's watch bookmark interval, which is how a write the informers can't
+	// observe gets past WaitReady. Bookmarks arrive within seconds here, but the interval is up to a minute.
+	bookmarkWaitTimeout = 2 * time.Minute
+)
+
+// harness runs lagging informers over the spec namespace behind a recording client and a ConsistencyStore, the way a
+// controller would, with no controller around.
+type harness struct {
+	env    *envtest.Environment
+	store  *cacheconsistency.ConsistencyStore
+	client kubernetes.Interface
+
+	configMaps   corev1listers.ConfigMapNamespaceLister
+	pods         corev1listers.PodNamespaceLister
+	statefulSets appsv1listers.StatefulSetNamespaceLister
+}
+
+func newHarness(ctx context.Context, env *envtest.Environment) *harness {
+	g.GinkgoHelper()
+
+	kubeInformers := informers.NewSharedInformerFactoryWithOptions(
+		env.TypedKubeClient(),
+		0,
+		informers.WithNamespace(env.Namespace()),
+		informers.WithTransform(func(obj any) (any, error) {
+			time.Sleep(informerLag)
+			return obj, nil
+		}),
+	)
+
+	store := cacheconsistency.NewConsistencyStore()
+	o.Expect(store.Register(&corev1.ConfigMap{}, kubeInformers.Core().V1().ConfigMaps().Informer())).To(o.Succeed())
+	o.Expect(store.Register(&corev1.Pod{}, kubeInformers.Core().V1().Pods().Informer())).To(o.Succeed())
+	o.Expect(store.Register(&appsv1.StatefulSet{}, kubeInformers.Apps().V1().StatefulSets().Informer())).To(o.Succeed())
+
+	h := &harness{
+		env:          env,
+		store:        store,
+		client:       cacheconsistency.NewRecordingKubeClient(env.TypedKubeClient(), store),
+		configMaps:   kubeInformers.Core().V1().ConfigMaps().Lister().ConfigMaps(env.Namespace()),
+		pods:         kubeInformers.Core().V1().Pods().Lister().Pods(env.Namespace()),
+		statefulSets: kubeInformers.Apps().V1().StatefulSets().Lister().StatefulSets(env.Namespace()),
+	}
+
+	kubeInformers.Start(ctx.Done())
+	g.DeferCleanup(kubeInformers.Shutdown)
+	for informerType, synced := range kubeInformers.WaitForCacheSync(ctx.Done()) {
+		o.Expect(synced).To(o.BeTrue(), "informer %v didn't sync", informerType)
+	}
+	o.Expect(cache.WaitForCacheSync(ctx.Done(), store.HasSynced)).To(o.BeTrue())
+
+	return h
+}
+
+// waitReady is WaitReady with the spec's timeout.
+func (h *harness) waitReady(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, waitReadyTimeout)
+	defer cancel()
+
+	return h.store.WaitReady(ctx)
+}
+
+func newConfigMap(namespace, name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: map[string]string{"key": "value"},
+	}
+}
+
+func newStatefulSet(namespace, name string) *appsv1.StatefulSet {
+	labels := map[string]string{"app": name}
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    ptr.To(int32(1)),
+			ServiceName: name,
+			Selector:    &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "envtest"}},
+				},
+			},
+		},
+	}
+}
+
+func newPod(namespace, name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "envtest"}},
+		},
+	}
+}
+
+func parseResourceVersion(rv string) int64 {
+	g.GinkgoHelper()
+
+	parsed, err := strconv.ParseInt(rv, 10, 64)
+	o.Expect(err).NotTo(o.HaveOccurred(), "resourceVersion %q is not an integer", rv)
+
+	return parsed
+}
+
+// The ConsistencyStore promises that after WaitReady the listers reflect every write made through the recording
+// clients. The unit tests prove the bookkeeping against a fake watch; these specs prove the assumptions that
+// bookkeeping rests on against a real API server: resourceVersions are comparable and observed in order, the scale
+// subresource carries the StatefulSet's resourceVersion, deletes surface as deletions or deletionTimestamps, and
+// server-side apply returns the written object.
+var _ = g.Describe("ConsistencyStore with recording clients", func() {
+	var env *envtest.Environment
+	g.BeforeEach(func(ctx g.SpecContext) {
+		env = envtest.Setup(ctx, envtest.WithoutMonitoringCRDs(), envtest.WithoutMutatingWebhook())
+	})
+
+	g.DescribeTable("should make a ConfigMap write visible to the lister after WaitReady",
+		func(ctx g.SpecContext, write func(ctx context.Context, h *harness, existing *corev1.ConfigMap) *corev1.ConfigMap) {
+			h := newHarness(ctx, env)
+
+			g.By("Creating the ConfigMap and waiting for the lister to see it")
+			created, err := h.client.CoreV1().ConfigMaps(env.Namespace()).Create(ctx, newConfigMap(env.Namespace(), "cm"), metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(h.waitReady(ctx)).To(o.Succeed())
+
+			g.By("Writing through the recording client")
+			written := write(ctx, h, created)
+			o.Expect(parseResourceVersion(written.ResourceVersion)).To(o.BeNumerically(">", parseResourceVersion(created.ResourceVersion)))
+
+			g.By("Verifying the lister is still behind the write")
+			cached, err := h.configMaps.Get("cm")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(cached.ResourceVersion).To(o.Equal(created.ResourceVersion))
+
+			g.By("Verifying the lister has the write after WaitReady")
+			o.Expect(h.waitReady(ctx)).To(o.Succeed())
+			cached, err = h.configMaps.Get("cm")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(cached.ResourceVersion).To(o.Equal(written.ResourceVersion))
+		},
+		g.Entry("update", func(ctx context.Context, h *harness, existing *corev1.ConfigMap) *corev1.ConfigMap {
+			updated := existing.DeepCopy()
+			updated.Data["key"] = "updated"
+			written, err := h.client.CoreV1().ConfigMaps(existing.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			return written
+		}),
+		g.Entry("patch", func(ctx context.Context, h *harness, existing *corev1.ConfigMap) *corev1.ConfigMap {
+			written, err := h.client.CoreV1().ConfigMaps(existing.Namespace).Patch(ctx, existing.Name, types.MergePatchType, []byte(`{"data":{"key":"patched"}}`), metav1.PatchOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			return written
+		}),
+		g.Entry("server-side apply", func(ctx context.Context, h *harness, existing *corev1.ConfigMap) *corev1.ConfigMap {
+			written, err := h.client.CoreV1().ConfigMaps(existing.Namespace).Apply(ctx, corev1ac.ConfigMap(existing.Name, existing.Namespace).WithData(map[string]string{"key": "applied"}), metav1.ApplyOptions{FieldManager: "envtest", Force: true})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			return written
+		}),
+	)
+
+	g.It("should make a created object visible to the lister after WaitReady", func(ctx g.SpecContext) {
+		h := newHarness(ctx, env)
+
+		created, err := h.client.CoreV1().ConfigMaps(env.Namespace()).Create(ctx, newConfigMap(env.Namespace(), "cm"), metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		_, err = h.configMaps.Get("cm")
+		o.Expect(apierrors.IsNotFound(err)).To(o.BeTrue(), "expected the lister to be behind the create, got: %v", err)
+
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+		cached, err := h.configMaps.Get("cm")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cached.UID).To(o.Equal(created.UID))
+	})
+
+	g.It("should make a delete visible to the lister after WaitReady", func(ctx g.SpecContext) {
+		h := newHarness(ctx, env)
+
+		_, err := h.client.CoreV1().ConfigMaps(env.Namespace()).Create(ctx, newConfigMap(env.Namespace(), "cm"), metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+
+		o.Expect(h.client.CoreV1().ConfigMaps(env.Namespace()).Delete(ctx, "cm", metav1.DeleteOptions{})).To(o.Succeed())
+
+		_, err = h.configMaps.Get("cm")
+		o.Expect(err).NotTo(o.HaveOccurred(), "expected the lister to be behind the delete")
+
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+		_, err = h.configMaps.Get("cm")
+		o.Expect(apierrors.IsNotFound(err)).To(o.BeTrue(), "expected the lister to have dropped the object, got: %v", err)
+	})
+
+	g.It("should treat a delete of an object with a finalizer as observed once the lister sees it terminating", func(ctx g.SpecContext) {
+		h := newHarness(ctx, env)
+
+		cm := newConfigMap(env.Namespace(), "cm")
+		cm.Finalizers = []string{"envtest.scylladb.com/hold"}
+		_, err := h.client.CoreV1().ConfigMaps(env.Namespace()).Create(ctx, cm, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+
+		o.Expect(h.client.CoreV1().ConfigMaps(env.Namespace()).Delete(ctx, "cm", metav1.DeleteOptions{})).To(o.Succeed())
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+
+		cached, err := h.configMaps.Get("cm")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cached.DeletionTimestamp).NotTo(o.BeNil())
+
+		g.By("Releasing the finalizer")
+		_, err = h.client.CoreV1().ConfigMaps(env.Namespace()).Patch(ctx, "cm", types.MergePatchType, []byte(`{"metadata":{"finalizers":null}}`), metav1.PatchOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("should tell a recreated object apart from the deleted one by UID", func(ctx g.SpecContext) {
+		h := newHarness(ctx, env)
+
+		first, err := h.client.CoreV1().ConfigMaps(env.Namespace()).Create(ctx, newConfigMap(env.Namespace(), "cm"), metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+
+		o.Expect(h.client.CoreV1().ConfigMaps(env.Namespace()).Delete(ctx, "cm", metav1.DeleteOptions{})).To(o.Succeed())
+		second, err := h.client.CoreV1().ConfigMaps(env.Namespace()).Create(ctx, newConfigMap(env.Namespace(), "cm"), metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(second.UID).NotTo(o.Equal(first.UID))
+
+		cached, err := h.configMaps.Get("cm")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cached.UID).To(o.Equal(first.UID), "expected the lister to still hold the deleted instance")
+
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+		cached, err = h.configMaps.Get("cm")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cached.UID).To(o.Equal(second.UID))
+	})
+
+	g.It("should record a scale subresource write against the StatefulSet", func(ctx g.SpecContext) {
+		h := newHarness(ctx, env)
+
+		created, err := h.client.AppsV1().StatefulSets(env.Namespace()).Create(ctx, newStatefulSet(env.Namespace(), "sts"), metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+
+		scale, err := h.client.AppsV1().StatefulSets(env.Namespace()).UpdateScale(ctx, "sts", &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{Namespace: env.Namespace(), Name: "sts", ResourceVersion: created.ResourceVersion},
+			Spec:       autoscalingv1.ScaleSpec{Replicas: 2},
+		}, metav1.UpdateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(scale.Name).To(o.Equal("sts"))
+		o.Expect(parseResourceVersion(scale.ResourceVersion)).To(o.BeNumerically(">", parseResourceVersion(created.ResourceVersion)))
+
+		cached, err := h.statefulSets.Get("sts")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(*cached.Spec.Replicas).To(o.BeEquivalentTo(1), "expected the lister to be behind the scale")
+
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+		cached, err = h.statefulSets.Get("sts")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(*cached.Spec.Replicas).To(o.BeEquivalentTo(2))
+		o.Expect(cached.ResourceVersion).To(o.Equal(scale.ResourceVersion), "the scale subresource has to carry the StatefulSet's resourceVersion")
+	})
+
+	g.It("should record a status subresource write", func(ctx g.SpecContext) {
+		h := newHarness(ctx, env)
+
+		created, err := h.client.AppsV1().StatefulSets(env.Namespace()).Create(ctx, newStatefulSet(env.Namespace(), "sts"), metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+
+		updated := created.DeepCopy()
+		updated.Status.ObservedGeneration = created.Generation
+		updated.Status.Replicas = 1
+		written, err := h.client.AppsV1().StatefulSets(env.Namespace()).UpdateStatus(ctx, updated, metav1.UpdateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		cached, err := h.statefulSets.Get("sts")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cached.ResourceVersion).To(o.Equal(created.ResourceVersion), "expected the lister to be behind the status write")
+
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+		cached, err = h.statefulSets.Get("sts")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cached.ResourceVersion).To(o.Equal(written.ResourceVersion))
+	})
+
+	g.It("should record an eviction as a delete", func(ctx g.SpecContext) {
+		h := newHarness(ctx, env)
+
+		// With no kubelet to confirm, an evicted Pod stays terminating with a deletionTimestamp, which is what the
+		// store treats as the delete being observed.
+		_, err := h.client.CoreV1().Pods(env.Namespace()).Create(ctx, newPod(env.Namespace(), "pod"), metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+
+		o.Expect(h.client.CoreV1().Pods(env.Namespace()).EvictV1(ctx, &policyv1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "pod"}})).To(o.Succeed())
+
+		cached, err := h.pods.Get("pod")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cached.DeletionTimestamp).To(o.BeNil(), "expected the lister to be behind the eviction")
+
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+		cached, err = h.pods.Get("pod")
+		if err == nil {
+			o.Expect(cached.DeletionTimestamp).NotTo(o.BeNil(), "expected the lister to show the evicted pod terminating")
+		} else {
+			o.Expect(apierrors.IsNotFound(err)).To(o.BeTrue(), "expected the lister to have dropped the evicted pod, got: %v", err)
+		}
+	})
+
+	g.It("should not wait for kinds that are not registered", func(ctx g.SpecContext) {
+		h := newHarness(ctx, env)
+
+		_, err := h.client.CoreV1().Secrets(env.Namespace()).Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: env.Namespace(), Name: "secret"}}, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		start := time.Now()
+		o.Expect(h.waitReady(ctx)).To(o.Succeed())
+		o.Expect(time.Since(start)).To(o.BeNumerically("<", informerLag/2), "expected WaitReady to return without waiting")
+	})
+
+	// A write outside the informers' scope is a misconfiguration WaitReady can't detect: the API server's watch
+	// bookmarks advance the informer store's resourceVersion past the write without delivering it, so WaitReady
+	// returns while the lister never sees the object. The spec pins both the bookmark-driven catch-up, which the
+	// store relies on after relists too, and the limitation.
+	g.It("should catch up through watch bookmarks on a write the informers can't observe", func(ctx g.SpecContext) {
+		h := newHarness(ctx, env)
+
+		g.By("Creating a ConfigMap in a namespace the informers don't watch")
+		other, err := env.TypedKubeClient().CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "unwatched-"}}, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		_, err = h.client.CoreV1().ConfigMaps(other.Name).Create(ctx, newConfigMap(other.Name, "cm"), metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		waitCtx, cancel := context.WithTimeout(ctx, bookmarkWaitTimeout)
+		defer cancel()
+		o.Expect(h.store.WaitReady(waitCtx)).To(o.Succeed())
+
+		_, err = h.configMaps.Get("cm")
+		o.Expect(apierrors.IsNotFound(err)).To(o.BeTrue(), "expected the lister to never see the object, got: %v", err)
+	})
+})

--- a/test/envtest/controllers/scylladbdatacenter_controller_cacheconsistency_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_cacheconsistency_test.go
@@ -1,0 +1,191 @@
+//go:build envtest
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
+	oslices "github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	"github.com/scylladb/scylla-operator/pkg/internalapi"
+	"github.com/scylladb/scylla-operator/pkg/naming"
+	"github.com/scylladb/scylla-operator/test/envtest"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	// informerLag is how far behind the API server the informer of one kind is kept in these specs, on top of the
+	// default lag of all informers: wide enough for a sync deciding from a stale cache to be caught in the act.
+	informerLag = 2 * time.Second
+
+	// laggingEventuallyTimeout pads the default timeout for the syncs that wait for the lagging caches to observe
+	// the controller's writes, one lag per write of the lagging kind.
+	laggingEventuallyTimeout = 60 * time.Second
+
+	// laggingConsistentlyTimeout is long enough for a sync that doesn't wait for the lagging caches to have decided
+	// from the stale ones, and for the caches to have caught up afterwards.
+	laggingConsistentlyTimeout = 3 * informerLag
+)
+
+// withInformerLag lags the informer of the objects selected by lags further behind the API server than the default.
+func withInformerLag(lag time.Duration, lags func(obj any) bool) informers.SharedInformerOption {
+	return informers.WithTransform(informerLagTransform(lag, lags))
+}
+
+// The informer caches don't give read-your-writes: a sync that runs before the informer delivers the controller's
+// own write decides from the state that predates it. Every spec runs the controller with lagging informers; these
+// two lag the informer of one kind far enough to catch a sync deciding from a cache that has not observed the
+// controller's own write, which is the hazard behind each of them.
+var _ = g.Describe("ScyllaDBDatacenter controller with lagging informers", func() {
+	const rackName = "rack-a"
+
+	var env *envtest.Environment
+	g.BeforeEach(func(ctx g.SpecContext) {
+		env = envtest.Setup(ctx)
+	})
+
+	g.It("should not report a rack as rolled out from a StatefulSet cache that has not observed the applied rollout", func(ctx g.SpecContext) {
+		g.By("Running ScyllaDBDatacenter controller with a lagging StatefulSet informer")
+		runScyllaDBDatacenterController(ctx, env, withInformerLag(informerLag, isStatefulSet))
+
+		g.By("Creating ScyllaOperatorConfig singleton")
+		createScyllaOperatorConfig(ctx, env)
+
+		g.By("Creating a ScyllaDBDatacenter with a single rack")
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{rackName})
+		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for the rack StatefulSet to be created and marking it as rolled out")
+		rackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+		rackStatefulSet := waitForStatefulSet(ctx, env, rackStatefulSetName, laggingEventuallyTimeout)
+		markStatefulSetAsRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), rackStatefulSetName)
+		rolledOutGeneration := rackStatefulSet.Generation
+
+		g.By("Waiting for the rack to be reported as rolled out")
+		o.Eventually(func(eo o.Gomega, ctx context.Context) {
+			sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			eo.Expect(sdc.Status.ObservedGeneration).To(o.HaveValue(o.Equal(sdc.Generation)))
+
+			rackStatus := findRackStatus(sdc, rackName)
+			eo.Expect(rackStatus).NotTo(o.BeNil())
+			eo.Expect(rackStatus.Stale).To(o.HaveValue(o.BeFalse()))
+		}).WithContext(ctx).WithTimeout(laggingEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+		g.By("Changing the ScyllaDB arguments to roll the rack StatefulSet out")
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("can't get ScyllaDBDatacenter %q: %w", naming.ManualRef(env.Namespace(), sdc.Name), err)
+			}
+
+			sdc.Spec.ScyllaDB.AdditionalScyllaDBArguments = []string{"--logger-log-level=compaction=debug"}
+			_, err = env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Update(ctx, sdc, metav1.UpdateOptions{})
+			if err != nil {
+				return fmt.Errorf("can't update ScyllaDBDatacenter %q: %w", naming.ObjRef(sdc), err)
+			}
+
+			return nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for the rack StatefulSet to be updated")
+		o.Eventually(func(eo o.Gomega, ctx context.Context) {
+			sts, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, rackStatefulSetName, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			eo.Expect(sts.Generation).To(o.BeNumerically(">", rolledOutGeneration))
+		}).WithContext(ctx).WithTimeout(laggingEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+		// The StatefulSet status is never updated in envtest, so the rack stays stale from the update on. A sync that
+		// recomputed the rack from the StatefulSet cache before it observed the update would report it as not stale
+		// for the new ScyllaDBDatacenter generation.
+		g.By("Verifying the rack is never reported as rolled out for the new generation")
+		o.Consistently(func(co o.Gomega, ctx context.Context) {
+			sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+			co.Expect(err).NotTo(o.HaveOccurred())
+
+			if sdc.Status.ObservedGeneration == nil || *sdc.Status.ObservedGeneration != sdc.Generation {
+				return
+			}
+
+			rackStatus := findRackStatus(sdc, rackName)
+			co.Expect(rackStatus).NotTo(o.BeNil())
+			co.Expect(rackStatus.Stale).To(o.HaveValue(o.BeTrue()), "rack %q was reported as rolled out for generation %d from a StatefulSet cache that has not observed the update", rackName, sdc.Generation)
+		}).WithContext(ctx).WithTimeout(laggingConsistentlyTimeout).WithPolling(50 * time.Millisecond).Should(o.Succeed())
+	})
+
+	g.It("should not scale a rack up over a node whose requested decommission has not been observed yet", func(ctx g.SpecContext) {
+		const initialNodes = int32(3)
+
+		g.By("Running ScyllaDBDatacenter controller with a lagging Service informer")
+		runScyllaDBDatacenterController(ctx, env, withInformerLag(informerLag, isService))
+
+		g.By("Creating ScyllaOperatorConfig singleton")
+		createScyllaOperatorConfig(ctx, env)
+
+		g.By("Creating a ScyllaDBDatacenter with a three-node rack")
+		sdc := makeEnvtestScyllaDBDatacenter(env.Namespace(), []string{rackName}, withRackTemplateNodes(initialNodes))
+		sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Create(ctx, sdc, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for the rack StatefulSet and member Services to be created and marking the StatefulSet as rolled out")
+		rackStatefulSetName := naming.StatefulSetNameForRack(sdc.Spec.Racks[0], sdc)
+		leavingServiceName := naming.MemberServiceName(sdc.Spec.Racks[0], sdc, int(initialNodes-1))
+		waitForStatefulSet(ctx, env, rackStatefulSetName, laggingEventuallyTimeout)
+		waitForService(ctx, env, leavingServiceName, laggingEventuallyTimeout)
+		markStatefulSetAsRolledOut(ctx, env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()), rackStatefulSetName)
+
+		g.By("Scaling the rack down to two nodes")
+		scaleRackTemplate(ctx, env, sdc.Name, initialNodes-1)
+
+		g.By("Waiting for the decommission of the highest node to be requested")
+		o.Eventually(func(eo o.Gomega, ctx context.Context) {
+			svc, err := env.TypedKubeClient().CoreV1().Services(env.Namespace()).Get(ctx, leavingServiceName, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+			eo.Expect(svc.Labels).To(o.HaveKeyWithValue(naming.DecommissionedLabel, naming.LabelValueFalse))
+		}).WithContext(ctx).WithTimeout(laggingEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+
+		// The decommission request is the controller's own write. A sync deciding from a Service cache that has not
+		// observed it yet sees no leaving node and, with the node count above the StatefulSet replicas, scales the
+		// rack up while the node is leaving the cluster.
+		g.By("Raising the node count above the current one while the node is still decommissioning")
+		scaleRackTemplate(ctx, env, sdc.Name, initialNodes+1)
+
+		g.By("Verifying the rack StatefulSet is not scaled up over the leaving node")
+		o.Consistently(func(co o.Gomega, ctx context.Context) {
+			sts, err := env.TypedKubeClient().AppsV1().StatefulSets(env.Namespace()).Get(ctx, rackStatefulSetName, metav1.GetOptions{})
+			co.Expect(err).NotTo(o.HaveOccurred())
+			co.Expect(*sts.Spec.Replicas).To(o.Equal(initialNodes))
+		}).WithContext(ctx).WithTimeout(laggingConsistentlyTimeout).WithPolling(50 * time.Millisecond).Should(o.Succeed())
+
+		g.By("Waiting for the deferred node count change to be reported as progressing")
+		o.Eventually(func(eo o.Gomega, ctx context.Context) {
+			sdc, err := env.ScyllaClient().ScyllaV1alpha1().ScyllaDBDatacenters(env.Namespace()).Get(ctx, sdc.Name, metav1.GetOptions{})
+			eo.Expect(err).NotTo(o.HaveOccurred())
+
+			progressingCondition := apimeta.FindStatusCondition(sdc.Status.Conditions, internalapi.MakeKindControllerCondition("StatefulSet", scyllav1alpha1.ProgressingCondition))
+			eo.Expect(progressingCondition).NotTo(o.BeNil())
+			eo.Expect(progressingCondition.Status).To(o.Equal(metav1.ConditionTrue))
+			eo.Expect(progressingCondition.Reason).To(o.ContainSubstring("DeferringRackNodeCountChange"))
+		}).WithContext(ctx).WithTimeout(laggingEventuallyTimeout).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+	})
+})
+
+func findRackStatus(sdc *scyllav1alpha1.ScyllaDBDatacenter, rackName string) *scyllav1alpha1.RackStatus {
+	rackStatus, _, found := oslices.Find(sdc.Status.Racks, func(rackStatus scyllav1alpha1.RackStatus) bool {
+		return rackStatus.Name == rackName
+	})
+	if !found {
+		return nil
+	}
+
+	return &rackStatus
+}

--- a/test/envtest/controllers/scylladbdatacenter_controller_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_test.go
@@ -39,11 +39,6 @@ import (
 )
 
 const (
-	// scyllaDBDatacenterControllerDisabledStatefulSetCachePropagationDelay disables the production cache-propagation
-	// wait in envtests. Envtest runs the controller and API server in-process, so the default delay only slows tests down.
-	// Tests that need to exercise cache lag should override this.
-	scyllaDBDatacenterControllerDisabledStatefulSetCachePropagationDelay = 0 * time.Second
-
 	scyllaDBDatacenterControllerResyncPeriod = 12 * time.Hour
 
 	// scyllaDBDatacenterControllerDefaultInformerLag is how far behind the API server every informer of the
@@ -920,11 +915,6 @@ func runScyllaDBDatacenterController(ctx context.Context, e *envtest.Environment
 	)
 	keyGenerator := newStaticKeyGenerator()
 
-	options := []scylladbdatacenter.ControllerOption{
-		// The default delay only slows tests down; tests that need to exercise cache lag should override this.
-		scylladbdatacenter.WithStatefulSetCachePropagationDelay(scyllaDBDatacenterControllerDisabledStatefulSetCachePropagationDelay),
-	}
-
 	sdcc, err := scylladbdatacenter.NewController(
 		kubeClient,
 		scyllaClient.ScyllaV1alpha1(),
@@ -944,7 +934,6 @@ func runScyllaDBDatacenterController(ctx context.Context, e *envtest.Environment
 		"scylla/operator:envtest",
 		scylla.DefaultNativeTransportPort,
 		keyGenerator,
-		options...,
 	)
 	o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/envtest/controllers/scylladbdatacenter_controller_test.go
+++ b/test/envtest/controllers/scylladbdatacenter_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -45,14 +46,20 @@ const (
 
 	scyllaDBDatacenterControllerResyncPeriod = 12 * time.Hour
 
+	// scyllaDBDatacenterControllerDefaultInformerLag is how far behind the API server every informer of the
+	// controller is kept in all specs. Informer caches give no read-your-writes and in envtest they would otherwise
+	// catch up within microseconds, hiding any decision the controller makes from a cache that has not observed its
+	// own writes yet. A lagging informer is only a slower informer, so every behavior has to hold with it.
+	scyllaDBDatacenterControllerDefaultInformerLag = 500 * time.Millisecond
+
 	// scyllaDBDatacenterControllerDefaultEventuallyTimeout is the default timeout for async envtest assertions.
-	// Pad accordingly when a test uses a non-zero cache-propagation delay, otherwise Eventually may time out before
-	// the controller resumes reconciliation.
+	// Pad accordingly when a test runs the controller with informer lag, otherwise Eventually may time out before
+	// the controller observes its own writes and resumes reconciliation.
 	scyllaDBDatacenterControllerDefaultEventuallyTimeout = 15 * time.Second
 
 	// scyllaDBDatacenterControllerDefaultConsistentlyTimeout is the default window for stability assertions.
-	// Pad accordingly when a test uses a non-zero cache-propagation delay, otherwise Consistently may pass while the
-	// controller is delayed instead of observing real steady state.
+	// Pad accordingly when a test runs the controller with informer lag, otherwise Consistently may pass while the
+	// controller is waiting for its caches instead of observing real steady state.
 	scyllaDBDatacenterControllerDefaultConsistentlyTimeout = 5 * time.Second
 
 	// envtestServiceFinalizer holds a member Service in a terminating state, so that specs can freeze the window
@@ -851,25 +858,65 @@ func (g *staticKeyGenerator) GetKeyType() crypto.KeyType {
 	return crypto.ECDSAKeyType
 }
 
-func runScyllaDBDatacenterController(ctx context.Context, e *envtest.Environment) {
+// informerLagTransform returns an informer transform that delays every event of the objects selected by lags before
+// it reaches the informer cache, keeping the cache behind the API server by lag. The objects are not modified.
+func informerLagTransform(lag time.Duration, lags func(obj any) bool) cache.TransformFunc {
+	return func(obj any) (any, error) {
+		selected := obj
+		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			selected = tombstone.Obj
+		}
+		if lags(selected) {
+			time.Sleep(lag)
+		}
+
+		return obj, nil
+	}
+}
+
+func anyObject(any) bool {
+	return true
+}
+
+func isStatefulSet(obj any) bool {
+	_, ok := obj.(*appsv1.StatefulSet)
+	return ok
+}
+
+func isService(obj any) bool {
+	_, ok := obj.(*corev1.Service)
+	return ok
+}
+
+// runScyllaDBDatacenterController runs the controller until the context is done. All its informers lag behind the
+// API server by scyllaDBDatacenterControllerDefaultInformerLag; kubeInformerOptions are applied on top to the
+// informers of the Kubernetes objects, e.g. to lag one kind further.
+func runScyllaDBDatacenterController(ctx context.Context, e *envtest.Environment, kubeInformerOptions ...informers.SharedInformerOption) {
 	g.GinkgoHelper()
+
+	defaultLag := informerLagTransform(scyllaDBDatacenterControllerDefaultInformerLag, anyObject)
 
 	kubeClient := e.TypedKubeClient()
 	scyllaClient := e.ScyllaClient()
 	kubeInformers := informers.NewSharedInformerFactoryWithOptions(
 		kubeClient,
 		scyllaDBDatacenterControllerResyncPeriod,
-		informers.WithNamespace(e.Namespace()),
+		append([]informers.SharedInformerOption{
+			informers.WithNamespace(e.Namespace()),
+			informers.WithTransform(defaultLag),
+		}, kubeInformerOptions...)...,
 	)
 	scyllaInformers := scyllainformers.NewSharedInformerFactoryWithOptions(
 		scyllaClient,
 		scyllaDBDatacenterControllerResyncPeriod,
 		scyllainformers.WithNamespace(e.Namespace()),
+		scyllainformers.WithTransform(defaultLag),
 	)
 	scyllaGlobalInformers := scyllainformers.NewSharedInformerFactoryWithOptions(
 		scyllaClient,
 		scyllaDBDatacenterControllerResyncPeriod,
 		scyllainformers.WithNamespace(corev1.NamespaceAll),
+		scyllainformers.WithTransform(defaultLag),
 	)
 	keyGenerator := newStaticKeyGenerator()
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/scylladb/scylla-operator/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to the Scylla Operator! -->

**Description of your changes:**

That's a PoC of implementing read-your-own-writes semantics in the ScyllaDBDatacenter controller. It relies on client-go's `LastStoreSyncResourceVersion`. `ConsistencyStore` is a type to be used by controllers/client to signal that they made a write/delete and later wait for a given action to be observed before taking any actions based on a read from cache.

It unifies how the controller handles pruning so that it's easier to track deletes. Also, where direct client calls were used for writing/deleting, tracking is covered by decorated clients (`NewRecordingKubeClient`, `NewRecordingScyllaV1alpha1Client`) so that any write/delete is covered in the future without making it an explicit call in the controller code.

I tried making the decorated clients code-generated, but it wasn't working well - the codegen script had to be aware of the package structure, as not everything was possible to infer using reflection etc., so I gave up. Ideas welcome, but I guess that it's not a big deal to add some methods if a controller will need them retroactively.
 
**Which issue is resolved by this Pull Request:**
Part of https://scylladb.atlassian.net/browse/OPERATOR-393.
