### PR TITLE
ci: add a check-required job aggregating GitHub Actions checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,17 @@
+name: PR
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-required:
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: |
+        echo "Some jobs failed or were cancelled."
+        exit 1


### PR DESCRIPTION
We're in the middle of moving CI to GHA, and until GHA gates merges itself tide still does - but tide only knows about contexts it derives from the Prow presubmit config, so with `skip-unknown-contexts: true` every GHA check is optional to it and a PR with red GHA checks merges. A stopgap for the overlap, not the end state.

Rather than list each GHA check in the tide config in another repo, this adds one aggregate, `check-required`. Tide requires that one context; making a GHA job required from here on means adding it to this job's `needs`.

It ships with an empty `needs`, so the merge gate is unchanged for now - `needs.*` expands to nothing and the guard step is skipped. Wiring in `check-changelog` and `e2e-kind-helm` is a follow-up. No `name:` on the job on purpose, so the context is the bare `check-required`.

Merges before the tide change in scylladb/scylla-operator-release, or every open PR here blocks on a context that doesn't exist.

Refs OPERATOR-394.
