### PR TITLE
[v1.21] ci: trigger multiversion docs publishing from release branches

### DIFF
--- a/.github/workflows/docs-pages-trigger.yaml
+++ b/.github/workflows/docs-pages-trigger.yaml
@@ -1,0 +1,29 @@
+name: "Docs / Publish (trigger)"
+
+# GitHub reads workflow files from the ref that a push event targets, so a workflow living only on master never runs for
+# a push to a release branch and its branches. This stub is the branch-resident part: it carries no logic of its own
+# and delegates to master's implementation, which rebuilds every version listed in master's docs/source/conf.py.
+
+on:
+  push:
+    branches:
+      - 'v[0-9]+.[0-9]+'
+    # The docs build reads more than docs/: literalinclude pulls from examples/ (e.g.
+    # docs/source/deploy-scylladb/set-up-monitoring/setup.md), and the version_context_substitutions
+    # extension reads assets/config/config.yaml, assets/metadata/metadata.yaml and .gitmodules.
+    paths:
+      - "docs/**"
+      - "examples/**"
+      - "assets/**"
+      - ".gitmodules"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: scylladb/scylla-operator/.github/workflows/docs-pages.yaml@master


### PR DESCRIPTION
Backport of #3656.

Only b666f3946c19c70690acdf97485492ba2ae65658 is being backported. The `docs-pages.yaml` workflow it delegates to is only required on master: GitHub resolves workflow files from the ref of the push event, so master's copy never runs for a push to a release branch, which is why the branch-resident stub exists in the first place. The build itself always checks out master and rebuilds every version listed in master's `docs/source/conf.py`, so a release branch has no use for its own copy of the implementation.

Related to https://scylladb.atlassian.net/browse/OPERATOR-395.

/cc @czeslavo
