### PR TITLE
feat: make ScyllaDB Operator and ScyllaDB Manager namespaces configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
 
 ## Unreleased
 
+### Features & Enhancements
+
+- The ScyllaDB Operator and ScyllaDB Manager namespaces are now configurable. The operator accepts a
+  `--global-scylladb-manager-namespace` flag (default: `scylla-manager`) pointing at the namespace holding the global
+  ScyllaDB Manager instance, the Helm charts template namespaces from the release namespace (with new
+  `scyllaDBManagerNamespace` and `scyllaOperatorNamespace` values), and `must-gather` accepts `--collect-namespaces`.
+  Both components can also be installed into a single shared namespace. Defaults are unchanged.
+  [#3660](https://github.com/scylladb/scylla-operator/pull/3660)
+
 ### Bug fixes
 
 - Fixed the `ScyllaDBDatacenter` controller updating the status in a loop while any member Service was missing its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   `scyllaDBManagerNamespace` and `scyllaOperatorNamespace` values), and `must-gather` accepts `--collect-namespaces`.
   Both components can also be installed into a single shared namespace. Defaults are unchanged.
   [#3660](https://github.com/scylladb/scylla-operator/pull/3660)
+- Node tuning resources (DaemonSets, Jobs, and their RBAC) created by the NodeConfig controller now run in the
+  operator's own namespace instead of the dedicated `scylla-operator-node-tuning` namespace, so no component depends on
+  a fixed namespace name anymore. On upgrade, the operator automatically removes the legacy
+  `scylla-operator-node-tuning` namespace and recreates the tuning resources in its own namespace.
+  [#3660](https://github.com/scylladb/scylla-operator/pull/3660)
 
 ### Bug fixes
 

--- a/docs/source/deploy-scylladb/install-scylladb-manager.md
+++ b/docs/source/deploy-scylladb/install-scylladb-manager.md
@@ -20,12 +20,18 @@ For details on how Manager integrates with the Operator, see [ScyllaDB Manager](
 
 ## Install ScyllaDB Manager
 
-ScyllaDB Manager deploys into the `scylla-manager` namespace.
+ScyllaDB Manager deploys into the `scylla-manager` namespace by default.
 It runs a small internal ScyllaCluster for its own state.
 
 :::{note}
-ScyllaDB Manager must be installed in the `scylla-manager` namespace.
-The Operator expects Manager in this namespace and will not discover it otherwise.
+The Operator expects Manager in the `scylla-manager` namespace by default and will not discover it in a different namespace unless you tell it where to look.
+To install Manager into a custom namespace, you must configure the Operator with the same namespace:
+
+- **Helm**: set the `scyllaDBManagerNamespace` value on the `scylla/scylla-operator` chart, e.g. `--set scyllaDBManagerNamespace=my-manager-namespace`.
+- **GitOps**: pass `--global-scylladb-manager-namespace=my-manager-namespace` to the `scylla-operator operator` command in the Operator Deployment.
+
+When installing the Manager chart into a custom namespace, also set its `scyllaOperatorNamespace` value to the namespace the Operator runs in (default: `scylla-operator`), so the bundled NetworkPolicy admits the Operator's traffic.
+Installing the Operator and Manager into a single shared namespace is also supported.
 :::
 
 ::::{tabs}

--- a/docs/source/install-operator/install-with-helm.md
+++ b/docs/source/install-operator/install-with-helm.md
@@ -12,7 +12,7 @@ Helm does not support managing CustomResourceDefinition resources ([helm#5871](h
 :::
 
 :::{note}
-ScyllaDB Operator must run in the `scylla-operator` namespace.
+ScyllaDB Operator runs in the `scylla-operator` namespace by default. You can install it into a custom namespace by passing a different `--namespace` to `helm install`. If you also deploy ScyllaDB Manager into a custom namespace, you must point the Operator at it by setting the `scyllaDBManagerNamespace` value (see [Deploy ScyllaDB Manager](../deploy-scylladb/install-scylladb-manager.md)).
 :::
 
 ## Prerequisites

--- a/docs/source/troubleshoot/collect-debugging-information/must-gather.md
+++ b/docs/source/troubleshoot/collect-debugging-information/must-gather.md
@@ -131,6 +131,15 @@ The `--namespace` flag affects only ScyllaClusters.
 Other resources related to the Operator installation or cluster state are still collected from other namespaces.
 :::
 
+## Collect from custom installation namespaces
+
+By default, must-gather collects the `scylla-operator`, `scylla-manager`, and `scylla-operator-node-tuning` namespaces.
+If you installed ScyllaDB Operator or ScyllaDB Manager into custom namespaces, override the list with the `--collect-namespaces` flag:
+
+```bash
+scylla-operator must-gather --collect-namespaces="<operator-namespace>,<manager-namespace>,scylla-operator-node-tuning"
+```
+
 ## Collect every resource in the cluster
 
 By default, must-gather collects only a predefined subset of resources.

--- a/docs/source/troubleshoot/collect-debugging-information/must-gather.md
+++ b/docs/source/troubleshoot/collect-debugging-information/must-gather.md
@@ -133,11 +133,11 @@ Other resources related to the Operator installation or cluster state are still 
 
 ## Collect from custom installation namespaces
 
-By default, must-gather collects the `scylla-operator`, `scylla-manager`, and `scylla-operator-node-tuning` namespaces.
+By default, must-gather collects the `scylla-operator` and `scylla-manager` namespaces, plus the legacy `scylla-operator-node-tuning` namespace used by older Operator versions.
 If you installed ScyllaDB Operator or ScyllaDB Manager into custom namespaces, override the list with the `--collect-namespaces` flag:
 
 ```bash
-scylla-operator must-gather --collect-namespaces="<operator-namespace>,<manager-namespace>,scylla-operator-node-tuning"
+scylla-operator must-gather --collect-namespaces="<operator-namespace>,<manager-namespace>"
 ```
 
 ## Collect every resource in the cluster

--- a/docs/source/troubleshoot/troubleshoot-performance.md
+++ b/docs/source/troubleshoot/troubleshoot-performance.md
@@ -24,7 +24,7 @@ kubectl logs <pod-name> -c scylla | grep -E 'overprovisioned|smp|cpuset'
 Check that the `ContainerPerftune` Job ran for each ScyllaDB Pod:
 
 :::{code-block} console
-kubectl -n scylla-operator-node-tuning get jobs \
+kubectl -n scylla-operator get jobs \
   -l scylla-operator.scylladb.com/node-config-job-type=ContainerPerftune
 :::
 

--- a/docs/source/understand/index.md
+++ b/docs/source/understand/index.md
@@ -22,7 +22,7 @@ To make changes, always modify the custom resource spec.
 
 ## Deployments and namespaces
 
-ScyllaDB Operator installs into three namespaces:
+ScyllaDB Operator installs into three namespaces by default (the Operator and Manager namespaces can be customized at installation time; see [Install with Helm](../install-operator/install-with-helm.md) and [Install ScyllaDB Manager](../deploy-scylladb/install-scylladb-manager.md)):
 
 ```{list-table}
 :header-rows: 1

--- a/docs/source/understand/index.md
+++ b/docs/source/understand/index.md
@@ -22,7 +22,7 @@ To make changes, always modify the custom resource spec.
 
 ## Deployments and namespaces
 
-ScyllaDB Operator installs into three namespaces by default (the Operator and Manager namespaces can be customized at installation time; see [Install with Helm](../install-operator/install-with-helm.md) and [Install ScyllaDB Manager](../deploy-scylladb/install-scylladb-manager.md)):
+ScyllaDB Operator installs into two namespaces by default (both can be customized at installation time; see [Install with Helm](../install-operator/install-with-helm.md) and [Install ScyllaDB Manager](../deploy-scylladb/install-scylladb-manager.md)):
 
 ```{list-table}
 :header-rows: 1
@@ -30,11 +30,9 @@ ScyllaDB Operator installs into three namespaces by default (the Operator and Ma
 * - Namespace
   - What runs there
 * - `scylla-operator`
-  - Two Deployments: the **controller manager** (`scylla-operator`) that runs all controllers, and the **webhook server** (`webhook-server`) that validates API requests. Both run with 2 replicas by default and are protected by PodDisruptionBudgets.
+  - Two Deployments: the **controller manager** (`scylla-operator`) that runs all controllers, and the **webhook server** (`webhook-server`) that validates API requests. Both run with 2 replicas by default and are protected by PodDisruptionBudgets. **Node tuning agents** — privileged DaemonSets and Jobs created by the NodeConfig controller to set up disks, filesystems, and performance tuning on Kubernetes nodes — also run here.
 * - `scylla-manager`
   - **ScyllaDB Manager** — a separate component that coordinates repair and backup tasks. It uses a small internal ScyllaDB cluster as its own database. Deployed optionally.
-* - `scylla-operator-node-tuning`
-  - **Node tuning agents** — privileged DaemonSets and Jobs created by the NodeConfig controller to set up disks, filesystems, and performance tuning on Kubernetes nodes.
 ```
 
 Your ScyllaDB clusters run in your own namespaces, separate from the Operator.

--- a/docs/source/understand/manager.md
+++ b/docs/source/understand/manager.md
@@ -5,11 +5,11 @@ ScyllaDB Operator integrates with Manager so that you can define repair and back
 
 ## Deployment model
 
-ScyllaDB Manager runs as a **single, shared Deployment** in the `scylla-manager` namespace.
+ScyllaDB Manager runs as a **single, shared Deployment** in the `scylla-manager` namespace (or a custom namespace configured via the Operator's `--global-scylladb-manager-namespace` flag; see [Install ScyllaDB Manager](../deploy-scylladb/install-scylladb-manager.md)).
 One Manager instance serves all ScyllaDB clusters in the Kubernetes cluster.
 
 Manager requires a small ScyllaDB database to store its own state (task definitions, run history, cluster metadata).
-This is provided by a dedicated `ScyllaCluster` resource named `scylla-manager-cluster` in the `scylla-manager` namespace, running in developer mode with minimal resources (1 node, 1 CPU, 200 MiB memory).
+This is provided by a dedicated `ScyllaCluster` resource named `scylla-manager-cluster` in the same namespace, running in developer mode with minimal resources (1 node, 1 CPU, 200 MiB memory).
 
 :::{note}
 The backing ScyllaCluster has the annotation `scylla-operator.scylladb.com/disable-global-scylladb-manager-integration: "true"` to prevent it from being registered with the very Manager instance it supports.

--- a/docs/source/understand/tuning.md
+++ b/docs/source/understand/tuning.md
@@ -17,7 +17,7 @@ It configures the Kubernetes host for optimal ScyllaDB performance.
 
 ### What runs
 
-The NodeConfig controller creates a privileged DaemonSet in the `scylla-operator-node-tuning` namespace.
+The NodeConfig controller creates a privileged DaemonSet in the namespace ScyllaDB Operator runs in (`scylla-operator` by default).
 This DaemonSet runs on every node that matches the NodeConfig's placement selectors.
 Inside each DaemonSet pod, a controller creates two types of Jobs:
 
@@ -102,8 +102,8 @@ For a step-by-step guide on configuring CPU pinning, see [CPU Pinning](../deploy
 
 ## Tuning namespace and security
 
-All node-level and container-level tuning Jobs run in the `scylla-operator-node-tuning` namespace.
-This namespace is created and managed entirely by the Operator and is only accessible to cluster administrators.
+All node-level and container-level tuning Jobs run in the Operator's own namespace (`scylla-operator` by default), which is only accessible to cluster administrators.
+Older Operator versions used a dedicated `scylla-operator-node-tuning` namespace; on upgrade the Operator removes it automatically.
 
 The tuning system uses four dedicated ServiceAccounts with minimal privileges:
 - `scylla-node-config` — for the DaemonSet pods.

--- a/hack/.ci/manifests/namespaces/minio/50_deployment.yaml
+++ b/hack/.ci/manifests/namespaces/minio/50_deployment.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: minio
         # Final MinIO community release with a published container image; subsequent releases are source-only.
-        image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+        image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
         command:
         - minio
         - server

--- a/helm/scylla-manager/templates/NOTES.txt
+++ b/helm/scylla-manager/templates/NOTES.txt
@@ -1,7 +1,7 @@
 
 The Scylla Manager has been installed. Check its status by running:
 
-  kubectl -n scylla-manager get pods -l "app.kubernetes.io/name=scylla-manager"
+  kubectl -n {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name=scylla-manager"
 
 Visit https://github.com/scylladb/scylla-operator for tutorials on how to
 create and configure Scylla clusters using the Scylla Operator and set up monitoring.

--- a/helm/scylla-manager/templates/manager_configmap.yaml
+++ b/helm/scylla-manager/templates/manager_configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scylla-manager-config
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
 data:
   scylla-manager.yaml: |-
     http: :5080

--- a/helm/scylla-manager/templates/manager_deployment.yaml
+++ b/helm/scylla-manager/templates/manager_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scylla-manager
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
 spec:

--- a/helm/scylla-manager/templates/manager_networkpolicy.yaml
+++ b/helm/scylla-manager/templates/manager_networkpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   name: scylla-manager-and-scylla-operator-to-scylla-pod
 spec:
   policyTypes:
@@ -14,7 +14,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: scylla-manager
+          kubernetes.io/metadata.name: {{ .Release.Namespace }}
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: scylla-operator
+          kubernetes.io/metadata.name: {{ .Values.scyllaOperatorNamespace }}

--- a/helm/scylla-manager/templates/manager_service.yaml
+++ b/helm/scylla-manager/templates/manager_service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
   name: scylla-manager
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: api

--- a/helm/scylla-manager/templates/manager_serviceaccount.yaml
+++ b/helm/scylla-manager/templates/manager_serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-manager.serviceAccountName" . }}
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-manager.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/scylla-manager/templates/manager_servicemonitor.yaml
+++ b/helm/scylla-manager/templates/manager_servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: scylla-manager
-  namespace: scylla-manager
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceMonitor.labels }}
   labels:
     {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}

--- a/helm/scylla-manager/values.schema.json
+++ b/helm/scylla-manager/values.schema.json
@@ -22,6 +22,9 @@
     "logLevel": {
       "type": "string"
     },
+    "scyllaOperatorNamespace": {
+      "type": "string"
+    },
     "nodeSelector": {
       "type": "object"
     },

--- a/helm/scylla-manager/values.schema.template.json
+++ b/helm/scylla-manager/values.schema.template.json
@@ -22,6 +22,9 @@
     "logLevel": {
       "type": "string"
     },
+    "scyllaOperatorNamespace": {
+      "type": "string"
+    },
     "nodeSelector": {
       "type": "object"
     },

--- a/helm/scylla-manager/values.yaml
+++ b/helm/scylla-manager/values.yaml
@@ -9,6 +9,8 @@ image:
   tag: 3.12.0@sha256:b7ac067ab189e05d446d54ba6671da6c1b888e2c8188cbac17d2caa8374ec0ed
 # Scylla Manager log level, allowed values are: error, warn, info, debug, trace
 logLevel: info
+# Namespace in which Scylla Operator is deployed, used to allow its traffic in the NetworkPolicy.
+scyllaOperatorNamespace: scylla-operator
 # Resources allocated to Scylla Manager pods
 resources:
   requests:

--- a/helm/scylla-operator/templates/NOTES.txt
+++ b/helm/scylla-operator/templates/NOTES.txt
@@ -1,7 +1,7 @@
 
 The Scylla Operator has been installed. Check its status by running:
 
-  kubectl -n scylla-operator get pods -l "app.kubernetes.io/name=scylla-operator"
+  kubectl -n {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name=scylla-operator"
 
 Visit https://github.com/scylladb/scylla-operator for tutorials on how to
 create and configure Scylla clusters using the Scylla Operator and set up monitoring.

--- a/helm/scylla-operator/templates/certificate.yaml
+++ b/helm/scylla-operator/templates/certificate.yaml
@@ -3,10 +3,10 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "scylla-operator.certificateName" . }}
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-  - {{ include "scylla-operator.webhookServiceName" . }}.scylla-operator.svc
+  - {{ include "scylla-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
   issuerRef:
     kind: Issuer
     name: scylla-operator-selfsigned-issuer

--- a/helm/scylla-operator/templates/clusterrolebinding.yaml
+++ b/helm/scylla-operator/templates/clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "scylla-operator.serviceAccountName" . }}
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}

--- a/helm/scylla-operator/templates/issuer.yaml
+++ b/helm/scylla-operator/templates/issuer.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: scylla-operator-selfsigned-issuer
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 {{- end }}

--- a/helm/scylla-operator/templates/mutatingwebhook.yaml
+++ b/helm/scylla-operator/templates/mutatingwebhook.yaml
@@ -2,14 +2,14 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: scylla-operator/{{ include "scylla-operator.certificateName" . }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "scylla-operator.certificateName" . }}
   name: scylla-operator
 webhooks:
 - name: mutating.webhook.scylla.scylladb.com
   clientConfig:
     service:
       name: {{ include "scylla-operator.webhookServiceName" . }}
-      namespace: scylla-operator
+      namespace: {{ .Release.Namespace }}
       path: /mutate
   admissionReviewVersions:
   - v1

--- a/helm/scylla-operator/templates/operator.deployment.yaml
+++ b/helm/scylla-operator/templates/operator.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scylla-operator
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-operator.labels" . | nindent 4 }}
 spec:
@@ -39,6 +39,9 @@ spec:
         args:
         - operator
         - --loglevel={{ .Values.logLevel }}
+        {{- if .Values.scyllaDBManagerNamespace }}
+        - --global-scylladb-manager-namespace={{ .Values.scyllaDBManagerNamespace }}
+        {{- end }}
         {{- range $arg := .Values.additionalArgs }}
         - {{ $arg }}
         {{- end }}

--- a/helm/scylla-operator/templates/operator.pdb.yaml
+++ b/helm/scylla-operator/templates/operator.pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: scylla-operator
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:

--- a/helm/scylla-operator/templates/operator.serviceaccount.yaml
+++ b/helm/scylla-operator/templates/operator.serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "scylla-operator.serviceAccountName" . }}
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "scylla-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/scylla-operator/templates/validatingwebhook.yaml
+++ b/helm/scylla-operator/templates/validatingwebhook.yaml
@@ -2,14 +2,14 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: scylla-operator/{{ include "scylla-operator.certificateName" . }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "scylla-operator.certificateName" . }}
   name: scylla-operator
 webhooks:
 - name: webhook.scylla.scylladb.com
   clientConfig:
     service:
       name: {{ include "scylla-operator.webhookServiceName" . }}
-      namespace: scylla-operator
+      namespace: {{ .Release.Namespace }}
       path: /validate
   admissionReviewVersions:
   - v1

--- a/helm/scylla-operator/templates/webhookserver.deployment.yaml
+++ b/helm/scylla-operator/templates/webhookserver.deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   name: webhook-server
   labels:
     app.kubernetes.io/name: webhook-server

--- a/helm/scylla-operator/templates/webhookserver.pdb.yaml
+++ b/helm/scylla-operator/templates/webhookserver.pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-server
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: 1
   selector:

--- a/helm/scylla-operator/templates/webhookserver.service.yaml
+++ b/helm/scylla-operator/templates/webhookserver.service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   name: {{ include "scylla-operator.webhookServiceName" . }}
   labels:
     app.kubernetes.io/name: webhook-server

--- a/helm/scylla-operator/templates/webhookserver.serviceaccount.yaml
+++ b/helm/scylla-operator/templates/webhookserver.serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: scylla-operator
+  namespace: {{ .Release.Namespace }}
   name: webhook-server
   labels:
     app.kubernetes.io/name: webhook-server

--- a/helm/scylla-operator/values.schema.json
+++ b/helm/scylla-operator/values.schema.json
@@ -22,6 +22,9 @@
         "logLevel": {
             "type": "integer"
         },
+        "scyllaDBManagerNamespace": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/helm/scylla-operator/values.yaml
+++ b/helm/scylla-operator/values.yaml
@@ -12,6 +12,10 @@ image:
 
 # Scylla Operator log level, 0-9 (higher number means more detailed logs)
 logLevel: 2
+# Namespace in which the global ScyllaDB Manager instance is deployed.
+# When empty, the operator defaults to "scylla-manager".
+# Set this when installing the scylla-manager chart into a custom namespace.
+scyllaDBManagerNamespace: ""
 # Additional arguments to pass to Scylla Operator container.
 additionalArgs: [ ]
 # Resources allocated to Scylla Operator pods

--- a/pkg/cmd/operator/mustgather.go
+++ b/pkg/cmd/operator/mustgather.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/scylladb/scylla-operator/pkg/gather/collect"
 	"github.com/scylladb/scylla-operator/pkg/genericclioptions"
+	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/signals"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -48,13 +49,15 @@ var (
 type MustGatherOptions struct {
 	*GatherBaseOptions
 
-	AllResources bool
+	AllResources        bool
+	CollectedNamespaces []string
 }
 
 func NewMustGatherOptions(streams genericclioptions.IOStreams) *MustGatherOptions {
 	options := &MustGatherOptions{
-		GatherBaseOptions: NewGatherBaseOptions("scylla-operator-must-gather"),
-		AllResources:      false,
+		GatherBaseOptions:   NewGatherBaseOptions("scylla-operator-must-gather"),
+		AllResources:        false,
+		CollectedNamespaces: defaultCollectedNamespaces,
 	}
 
 	return options
@@ -64,6 +67,7 @@ func (o *MustGatherOptions) AddFlags(flagset *pflag.FlagSet) {
 	o.GatherBaseOptions.AddFlags(flagset)
 
 	flagset.BoolVarP(&o.AllResources, "all-resources", "", o.AllResources, "Gather will discover preferred API resources from the apiserver.")
+	flagset.StringSliceVarP(&o.CollectedNamespaces, "collect-namespaces", "", o.CollectedNamespaces, "Namespaces holding the ScyllaDB Operator stack whose objects are always collected. Adjust when the operator or ScyllaDB Manager are deployed in custom namespaces.")
 }
 
 func NewMustGatherCmd(streams genericclioptions.IOStreams) *cobra.Command {
@@ -184,8 +188,8 @@ var defaultCollectedResourceGroups = []schema.GroupResource{
 
 var defaultCollectedNamespaces = []string{
 	"scylla-operator",
-	"scylla-manager",
-	"scylla-operator-node-tuning",
+	naming.ScyllaManagerNamespace,
+	naming.ScyllaOperatorNodeTuningNamespace,
 }
 
 func (o *MustGatherOptions) run(ctx context.Context) error {
@@ -238,7 +242,7 @@ func (o *MustGatherOptions) collectDefaultResources(ctx context.Context, collect
 		}
 	}
 
-	for _, ns := range defaultCollectedNamespaces {
+	for _, ns := range o.CollectedNamespaces {
 		if err := collector.CollectResourceObject(ctx, &collect.ResourceInfo{
 			Scope:    meta.RESTScopeRoot,
 			Resource: corev1.SchemeGroupVersion.WithResource("namespaces"),

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -69,10 +69,11 @@ type OperatorOptions struct {
 	clusterKubeClient   remoteclient.ClusterClient[kubernetes.Interface]
 	clusterScyllaClient remoteclient.ClusterClient[scyllaversionedclient.Interface]
 
-	ConcurrentSyncs  int
-	OperatorImage    string
-	CQLSIngressPort  int
-	CryptoKeyOptions CryptoKeyOptions
+	ConcurrentSyncs                int
+	OperatorImage                  string
+	CQLSIngressPort                int
+	CryptoKeyOptions               CryptoKeyOptions
+	GlobalScyllaDBManagerNamespace string
 }
 
 func NewOperatorOptions(streams genericclioptions.IOStreams) *OperatorOptions {
@@ -81,10 +82,11 @@ func NewOperatorOptions(streams genericclioptions.IOStreams) *OperatorOptions {
 		InClusterReflection: genericclioptions.InClusterReflection{},
 		LeaderElection:      genericclioptions.NewLeaderElection(),
 
-		ConcurrentSyncs:  50,
-		OperatorImage:    "",
-		CQLSIngressPort:  0,
-		CryptoKeyOptions: DefaultCryptoKeyOptions(),
+		ConcurrentSyncs:                50,
+		OperatorImage:                  "",
+		CQLSIngressPort:                0,
+		CryptoKeyOptions:               DefaultCryptoKeyOptions(),
+		GlobalScyllaDBManagerNamespace: naming.ScyllaManagerNamespace,
 	}
 }
 
@@ -131,6 +133,7 @@ func (o *OperatorOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVarP(&o.ConcurrentSyncs, "concurrent-syncs", "", o.ConcurrentSyncs, "The number of ScyllaCluster objects that are allowed to sync concurrently.")
 	cmd.Flags().StringVarP(&o.OperatorImage, "image", "", o.OperatorImage, "Image of the operator used.")
 	cmd.Flags().IntVarP(&o.CQLSIngressPort, "cqls-ingress-port", "", o.CQLSIngressPort, "Port on which is the ingress controller listening for secure CQL connections.")
+	cmd.Flags().StringVarP(&o.GlobalScyllaDBManagerNamespace, "global-scylladb-manager-namespace", "", o.GlobalScyllaDBManagerNamespace, "Namespace in which the global ScyllaDB Manager instance is deployed.")
 	o.CryptoKeyOptions.AddFlags(cmd)
 }
 
@@ -153,6 +156,11 @@ func (o *OperatorOptions) Validate() error {
 	msg := apimachineryutilvalidation.IsInRange(o.CQLSIngressPort, 0, 65535)
 	if len(msg) != 0 {
 		errs = append(errs, fmt.Errorf("invalid secure cql ingress port %d: %s", o.CQLSIngressPort, msg))
+	}
+
+	nsValidationMsgs := apimachineryutilvalidation.IsDNS1123Label(o.GlobalScyllaDBManagerNamespace)
+	if len(nsValidationMsgs) != 0 {
+		errs = append(errs, fmt.Errorf("invalid global ScyllaDB Manager namespace %q: %v", o.GlobalScyllaDBManagerNamespace, nsValidationMsgs))
 	}
 
 	return apimachineryutilerrors.NewAggregate(errs)
@@ -693,6 +701,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		scyllaInformers.Scylla().V1alpha1().ScyllaDBDatacenters(),
 		scyllaInformers.Scylla().V1alpha1().ScyllaDBClusters(),
 		kubeInformers.Core().V1().Namespaces(),
+		o.GlobalScyllaDBManagerNamespace,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create global ScyllaDB Manager controller: %w", err)
@@ -706,6 +715,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		scyllaInformers.Scylla().V1alpha1().ScyllaDBClusters(),
 		kubeInformers.Core().V1().Secrets(),
 		kubeInformers.Core().V1().Namespaces(),
+		o.GlobalScyllaDBManagerNamespace,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create ScyllaDBManagerClusterRegistration controller: %w", err)
@@ -716,6 +726,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		o.scyllaClient.ScyllaV1alpha1(),
 		scyllaInformers.Scylla().V1alpha1().ScyllaDBManagerTasks(),
 		scyllaInformers.Scylla().V1alpha1().ScyllaDBManagerClusterRegistrations(),
+		o.GlobalScyllaDBManagerNamespace,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create ScyllaDBManagerTask controller: %w", err)

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -404,6 +404,7 @@ func (o *OperatorOptions) run(ctx context.Context, streams genericclioptions.IOS
 		kubeInformers.Core().V1().ServiceAccounts(),
 		kubeInformers.Core().V1().ConfigMaps(),
 		o.OperatorImage,
+		o.Namespace,
 	)
 	if err != nil {
 		return fmt.Errorf("can't create nodeconfig controller: %w", err)

--- a/pkg/controller/globalscylladbmanager/controller.go
+++ b/pkg/controller/globalscylladbmanager/controller.go
@@ -11,7 +11,6 @@ import (
 	scyllav1alpha1listers "github.com/scylladb/scylla-operator/pkg/client/scylla/listers/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
 	"github.com/scylladb/scylla-operator/pkg/controllertools"
-	"github.com/scylladb/scylla-operator/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
 	apimachineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -35,6 +34,8 @@ type Controller struct {
 	scyllaDBDatacenterLister                 scyllav1alpha1listers.ScyllaDBDatacenterLister
 	scyllaDBClusterLister                    scyllav1alpha1listers.ScyllaDBClusterLister
 	namespaceLister                          corev1listers.NamespaceLister
+
+	globalScyllaDBManagerNamespace string
 }
 
 func NewController(
@@ -44,6 +45,7 @@ func NewController(
 	scyllaDBDatacenterInformer scyllav1alpha1informers.ScyllaDBDatacenterInformer,
 	scyllaDBClusterInformer scyllav1alpha1informers.ScyllaDBClusterInformer,
 	namespaceInformer corev1informers.NamespaceInformer,
+	globalScyllaDBManagerNamespace string,
 ) (*Controller, error) {
 	gsmc := &Controller{
 		kubeClient:   kubeClient,
@@ -53,6 +55,8 @@ func NewController(
 		scyllaDBDatacenterLister:                 scyllaDBDatacenterInformer.Lister(),
 		scyllaDBClusterLister:                    scyllaDBClusterInformer.Lister(),
 		namespaceLister:                          namespaceInformer.Lister(),
+
+		globalScyllaDBManagerNamespace: globalScyllaDBManagerNamespace,
 	}
 
 	observer := controllertools.NewObserver(
@@ -310,7 +314,7 @@ func (gsmc *Controller) deleteScyllaDBCluster(obj interface{}) {
 func (gsmc *Controller) addNamespace(obj interface{}) {
 	ns := obj.(*corev1.Namespace)
 
-	if !isGlobalScyllaDBManagerNamespace(ns) {
+	if !gsmc.isGlobalScyllaDBManagerNamespace(ns) {
 		return
 	}
 
@@ -339,7 +343,7 @@ func (gsmc *Controller) updateNamespace(old, cur interface{}) {
 		})
 	}
 
-	if !isGlobalScyllaDBManagerNamespace(currentNS) {
+	if !gsmc.isGlobalScyllaDBManagerNamespace(currentNS) {
 		return
 	}
 
@@ -368,7 +372,7 @@ func (gsmc *Controller) deleteNamespace(obj interface{}) {
 		}
 	}
 
-	if !isGlobalScyllaDBManagerNamespace(ns) {
+	if !gsmc.isGlobalScyllaDBManagerNamespace(ns) {
 		return
 	}
 
@@ -380,6 +384,6 @@ func (gsmc *Controller) deleteNamespace(obj interface{}) {
 	gsmc.Enqueue()
 }
 
-func isGlobalScyllaDBManagerNamespace(ns *corev1.Namespace) bool {
-	return ns.Name == naming.ScyllaManagerNamespace
+func (gsmc *Controller) isGlobalScyllaDBManagerNamespace(ns *corev1.Namespace) bool {
+	return ns.Name == gsmc.globalScyllaDBManagerNamespace
 }

--- a/pkg/controller/globalscylladbmanager/sync_scylladbmanagerclusterregistrations.go
+++ b/pkg/controller/globalscylladbmanager/sync_scylladbmanagerclusterregistrations.go
@@ -10,7 +10,6 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimachineryutilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -26,15 +25,15 @@ func (gsmc *Controller) syncScyllaDBManagerClusterRegistrations(
 	var requiredScyllaDBManagerClusterRegistrations map[string][]*scyllav1alpha1.ScyllaDBManagerClusterRegistration
 	var errs []error
 
-	globalScyllaDBManagerNamespace, err := gsmc.namespaceLister.Get(naming.ScyllaManagerNamespace)
+	globalScyllaDBManagerNamespace, err := gsmc.namespaceLister.Get(gsmc.globalScyllaDBManagerNamespace)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return fmt.Errorf("can't get namespace %q: %w", naming.ScyllaManagerNamespace, err)
+			return fmt.Errorf("can't get namespace %q: %w", gsmc.globalScyllaDBManagerNamespace, err)
 		}
 
-		klog.V(4).InfoS("Global ScyllaDB Manager namespace does not exist, not creating any ScyllaDBManagerClusterRegistration objects for global ScyllaDB Manager instance.", "Namespace", naming.ScyllaManagerNamespace)
+		klog.V(4).InfoS("Global ScyllaDB Manager namespace does not exist, not creating any ScyllaDBManagerClusterRegistration objects for global ScyllaDB Manager instance.", "Namespace", gsmc.globalScyllaDBManagerNamespace)
 	} else if globalScyllaDBManagerNamespace.DeletionTimestamp != nil {
-		klog.V(4).InfoS("Global ScyllaDB Manager namespace is being deleted, not creating any ScyllaDBManagerClusterRegistration objects for global ScyllaDB Manager instance.", "Namespace", naming.ScyllaManagerNamespace)
+		klog.V(4).InfoS("Global ScyllaDB Manager namespace is being deleted, not creating any ScyllaDBManagerClusterRegistration objects for global ScyllaDB Manager instance.", "Namespace", gsmc.globalScyllaDBManagerNamespace)
 	} else {
 		requiredScyllaDBManagerClusterRegistrations, err = makeScyllaDBManagerClusterRegistrations(scyllaDBDatacenters, scyllaDBClusters)
 		if err != nil {

--- a/pkg/controller/nodeconfig/controller.go
+++ b/pkg/controller/nodeconfig/controller.go
@@ -74,6 +74,9 @@ type Controller struct {
 	handlers *controllerhelpers.Handlers[*scyllav1alpha1.NodeConfig]
 
 	operatorImage string
+
+	// namespace is the namespace the node tuning resources are deployed into.
+	namespace string
 }
 
 func isManagedByNodeConfigController(obj kubeinterfaces.ObjectInterface) bool {
@@ -95,6 +98,7 @@ func NewController(
 	serviceAccountInformer corev1informers.ServiceAccountInformer,
 	configMapInformer corev1informers.ConfigMapInformer,
 	operatorImage string,
+	namespace string,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -140,6 +144,8 @@ func NewController(
 		),
 
 		operatorImage: operatorImage,
+
+		namespace: namespace,
 	}
 
 	var err error

--- a/pkg/controller/nodeconfig/resource.go
+++ b/pkg/controller/nodeconfig/resource.go
@@ -17,22 +17,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func makeScyllaOperatorNodeTuningNamespace() *corev1.Namespace {
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: naming.ScyllaOperatorNodeTuningNamespace,
-			Labels: map[string]string{
-				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
-			},
-		},
-	}
-}
-
-func makeNodeConfigServiceAccount() *corev1.ServiceAccount {
+func makeNodeConfigServiceAccount(namespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      naming.NodeConfigAppName,
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
 			},
@@ -40,10 +29,10 @@ func makeNodeConfigServiceAccount() *corev1.ServiceAccount {
 	}
 }
 
-func makePerftuneServiceAccount() *corev1.ServiceAccount {
+func makePerftuneServiceAccount(namespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Name:      naming.PerftuneServiceAccountName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
@@ -52,10 +41,10 @@ func makePerftuneServiceAccount() *corev1.ServiceAccount {
 	}
 }
 
-func makeSysctlsServiceAccount() *corev1.ServiceAccount {
+func makeSysctlsServiceAccount(namespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Name:      naming.SysctlsServiceAccountName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
@@ -64,10 +53,10 @@ func makeSysctlsServiceAccount() *corev1.ServiceAccount {
 	}
 }
 
-func makeRlimitsServiceAccount() *corev1.ServiceAccount {
+func makeRlimitsServiceAccount(namespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Name:      naming.RlimitsJobServiceAccountName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
@@ -79,8 +68,7 @@ func makeRlimitsServiceAccount() *corev1.ServiceAccount {
 func NodeConfigClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.NodeConfigAppName,
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Name: naming.NodeConfigAppName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
 			},
@@ -141,10 +129,10 @@ func NodeConfigClusterRole() *rbacv1.ClusterRole {
 	}
 }
 
-func makePerftuneRole() *rbacv1.Role {
+func makePerftuneRole(namespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Name:      naming.PerftuneServiceAccountName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
@@ -161,10 +149,10 @@ func makePerftuneRole() *rbacv1.Role {
 	}
 }
 
-func makeSysctlsRole() *rbacv1.Role {
+func makeSysctlsRole(namespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Name:      naming.SysctlsServiceAccountName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
@@ -181,10 +169,10 @@ func makeSysctlsRole() *rbacv1.Role {
 	}
 }
 
-func makeRlimitsRole() *rbacv1.Role {
+func makeRlimitsRole(namespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Name:      naming.RlimitsJobServiceAccountName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
@@ -201,11 +189,10 @@ func makeRlimitsRole() *rbacv1.Role {
 	}
 }
 
-func makeNodeConfigClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+func makeNodeConfigClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.NodeConfigAppName,
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Name: naming.NodeConfigAppName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
 			},
@@ -218,17 +205,17 @@ func makeNodeConfigClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+				Namespace: namespace,
 				Name:      naming.NodeConfigAppName,
 			},
 		},
 	}
 }
 
-func makePerftuneRoleBinding() *rbacv1.RoleBinding {
+func makePerftuneRoleBinding(namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Name:      naming.PerftuneServiceAccountName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
@@ -242,17 +229,17 @@ func makePerftuneRoleBinding() *rbacv1.RoleBinding {
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+				Namespace: namespace,
 				Name:      naming.PerftuneServiceAccountName,
 			},
 		},
 	}
 }
 
-func makeSysctlsRoleBinding() *rbacv1.RoleBinding {
+func makeSysctlsRoleBinding(namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Name:      naming.SysctlsServiceAccountName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
@@ -266,17 +253,17 @@ func makeSysctlsRoleBinding() *rbacv1.RoleBinding {
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+				Namespace: namespace,
 				Name:      naming.SysctlsServiceAccountName,
 			},
 		},
 	}
 }
 
-func makeRlimitsRoleBinding() *rbacv1.RoleBinding {
+func makeRlimitsRoleBinding(namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Name:      naming.RlimitsJobServiceAccountName,
 			Labels: map[string]string{
 				naming.NodeConfigNameLabel: naming.NodeConfigAppName,
@@ -290,14 +277,14 @@ func makeRlimitsRoleBinding() *rbacv1.RoleBinding {
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+				Namespace: namespace,
 				Name:      naming.RlimitsJobServiceAccountName,
 			},
 		},
 	}
 }
 
-func makeNodeSetupDaemonSet(nc *scyllav1alpha1.NodeConfig, operatorImage, scyllaImage string) *appsv1.DaemonSet {
+func makeNodeSetupDaemonSet(namespace string, nc *scyllav1alpha1.NodeConfig, operatorImage, scyllaImage string) *appsv1.DaemonSet {
 	if nc.Spec.LocalDiskSetup == nil && nc.Spec.DisableOptimizations {
 		return nil
 	}
@@ -310,7 +297,7 @@ func makeNodeSetupDaemonSet(nc *scyllav1alpha1.NodeConfig, operatorImage, scylla
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-node-setup", nc.Name),
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(nc, nodeConfigControllerGVK),
@@ -516,10 +503,10 @@ exec chroot ./ /scylla-operator/usr/bin/scylla-operator node-setup-daemon \
 	}
 }
 
-func makeConfigMaps(nc *scyllav1alpha1.NodeConfig) ([]*corev1.ConfigMap, error) {
+func makeConfigMaps(namespace string, nc *scyllav1alpha1.NodeConfig) ([]*corev1.ConfigMap, error) {
 	var configMaps []*corev1.ConfigMap
 
-	sysctlConfigMap, err := makeSysctlConfigMap(nc)
+	sysctlConfigMap, err := makeSysctlConfigMap(namespace, nc)
 	if err != nil {
 		return nil, fmt.Errorf("can't make sysctl configmap: %w", err)
 	}
@@ -528,7 +515,7 @@ func makeConfigMaps(nc *scyllav1alpha1.NodeConfig) ([]*corev1.ConfigMap, error) 
 	return configMaps, nil
 }
 
-func makeSysctlConfigMap(nc *scyllav1alpha1.NodeConfig) (*corev1.ConfigMap, error) {
+func makeSysctlConfigMap(namespace string, nc *scyllav1alpha1.NodeConfig) (*corev1.ConfigMap, error) {
 	name, err := naming.NodeConfigSysctlConfigMapName(nc)
 	if err != nil {
 		return nil, fmt.Errorf("can't get sysctl configmap name: %w", err)
@@ -542,7 +529,7 @@ func makeSysctlConfigMap(nc *scyllav1alpha1.NodeConfig) (*corev1.ConfigMap, erro
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				naming.KubernetesNameLabel: naming.NodeConfigAppName,
 				naming.NodeConfigNameLabel: nc.Name,

--- a/pkg/controller/nodeconfig/resource_test.go
+++ b/pkg/controller/nodeconfig/resource_test.go
@@ -73,7 +73,7 @@ func Test_makeSysctlConfigMap(t *testing.T) {
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sysctl-rh5ie",
-					Namespace: "scylla-operator-node-tuning",
+					Namespace: "test-tuning-ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":                        "scylla-node-config",
 						"scylla-operator.scylladb.com/node-config-name": "test",
@@ -110,7 +110,7 @@ func Test_makeSysctlConfigMap(t *testing.T) {
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sysctl-rh5ie",
-					Namespace: "scylla-operator-node-tuning",
+					Namespace: "test-tuning-ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":                        "scylla-node-config",
 						"scylla-operator.scylladb.com/node-config-name": "test",
@@ -172,7 +172,7 @@ func Test_makeSysctlConfigMap(t *testing.T) {
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sysctl-rh5ie",
-					Namespace: "scylla-operator-node-tuning",
+					Namespace: "test-tuning-ns",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":                        "scylla-node-config",
 						"scylla-operator.scylladb.com/node-config-name": "test",
@@ -207,7 +207,7 @@ vm.vfs_cache_pressure = 2000
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := makeSysctlConfigMap(tc.nc)
+			got, err := makeSysctlConfigMap("test-tuning-ns", tc.nc)
 
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Fatalf("expected and actual errors differ: %s", cmp.Diff(tc.expectedErr, err, cmpopts.EquateErrors()))

--- a/pkg/controller/nodeconfig/sync.go
+++ b/pkg/controller/nodeconfig/sync.go
@@ -94,8 +94,8 @@ func (ncc *Controller) sync(ctx context.Context, key string) error {
 		ncSelector,
 		controllerhelpers.ControlleeManagerGetObjectsFuncs[CT, *appsv1.DaemonSet]{
 			GetControllerUncachedFunc: ncc.scyllaClient.NodeConfigs().Get,
-			ListObjectsFunc:           ncc.daemonSetLister.DaemonSets(naming.ScyllaOperatorNodeTuningNamespace).List,
-			PatchObjectFunc:           ncc.kubeClient.AppsV1().DaemonSets(naming.ScyllaOperatorNodeTuningNamespace).Patch,
+			ListObjectsFunc:           ncc.daemonSetLister.DaemonSets(ncc.namespace).List,
+			PatchObjectFunc:           ncc.kubeClient.AppsV1().DaemonSets(ncc.namespace).Patch,
 		},
 	)
 	if err != nil {
@@ -109,8 +109,8 @@ func (ncc *Controller) sync(ctx context.Context, key string) error {
 		ncSelector,
 		controllerhelpers.ControlleeManagerGetObjectsFuncs[CT, *corev1.ConfigMap]{
 			GetControllerUncachedFunc: ncc.scyllaClient.NodeConfigs().Get,
-			ListObjectsFunc:           ncc.configMapLister.ConfigMaps(naming.ScyllaOperatorNodeTuningNamespace).List,
-			PatchObjectFunc:           ncc.kubeClient.CoreV1().ConfigMaps(naming.ScyllaOperatorNodeTuningNamespace).Patch,
+			ListObjectsFunc:           ncc.configMapLister.ConfigMaps(ncc.namespace).List,
+			PatchObjectFunc:           ncc.kubeClient.CoreV1().ConfigMaps(ncc.namespace).Patch,
 		},
 	)
 	if err != nil {

--- a/pkg/controller/nodeconfig/sync_clusterrolebindings.go
+++ b/pkg/controller/nodeconfig/sync_clusterrolebindings.go
@@ -16,7 +16,7 @@ import (
 
 func (ncc *Controller) makeClusterRoleBindings() []*rbacv1.ClusterRoleBinding {
 	clusterRoleBindings := []*rbacv1.ClusterRoleBinding{
-		makeNodeConfigClusterRoleBinding(),
+		makeNodeConfigClusterRoleBinding(ncc.namespace),
 	}
 
 	return clusterRoleBindings

--- a/pkg/controller/nodeconfig/sync_configmaps.go
+++ b/pkg/controller/nodeconfig/sync_configmaps.go
@@ -8,7 +8,6 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +21,7 @@ func (ncc *Controller) syncConfigMaps(
 ) ([]metav1.Condition, error) {
 	var progressingConditions []metav1.Condition
 
-	requiredConfigMaps, err := makeConfigMaps(nc)
+	requiredConfigMaps, err := makeConfigMaps(ncc.namespace, nc)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't make required ConfigMap(s): %w", err)
 	}
@@ -32,7 +31,7 @@ func (ncc *Controller) syncConfigMaps(
 		requiredConfigMaps,
 		configMaps,
 		&controllerhelpers.PruneControlFuncs{
-			DeleteFunc: ncc.kubeClient.CoreV1().ConfigMaps(naming.ScyllaOperatorNodeTuningNamespace).Delete,
+			DeleteFunc: ncc.kubeClient.CoreV1().ConfigMaps(ncc.namespace).Delete,
 		},
 		ncc.eventRecorder)
 	if err != nil {

--- a/pkg/controller/nodeconfig/sync_daemonsets.go
+++ b/pkg/controller/nodeconfig/sync_daemonsets.go
@@ -32,7 +32,7 @@ func (ncc *Controller) syncDaemonSet(
 	scyllaDBUtilsImage := *soc.Status.ScyllaDBUtilsImage
 
 	requiredDaemonSets := []*appsv1.DaemonSet{
-		makeNodeSetupDaemonSet(nc, ncc.operatorImage, scyllaDBUtilsImage),
+		makeNodeSetupDaemonSet(ncc.namespace, nc, ncc.operatorImage, scyllaDBUtilsImage),
 	}
 
 	err := controllerhelpers.Prune(
@@ -40,7 +40,7 @@ func (ncc *Controller) syncDaemonSet(
 		requiredDaemonSets,
 		daemonSets,
 		&controllerhelpers.PruneControlFuncs{
-			DeleteFunc: ncc.kubeClient.AppsV1().DaemonSets(naming.ScyllaOperatorNodeTuningNamespace).Delete,
+			DeleteFunc: ncc.kubeClient.AppsV1().DaemonSets(ncc.namespace).Delete,
 		},
 		ncc.eventRecorder)
 	if err != nil {

--- a/pkg/controller/nodeconfig/sync_namespaces.go
+++ b/pkg/controller/nodeconfig/sync_namespaces.go
@@ -15,11 +15,10 @@ import (
 )
 
 func (ncc *Controller) makeNamespaces() []*corev1.Namespace {
-	namespaces := []*corev1.Namespace{
-		makeScyllaOperatorNodeTuningNamespace(),
-	}
-
-	return namespaces
+	// Node tuning runs in the operator namespace, so no dedicated Namespace is required.
+	// Returning none makes the pruner below clean up the legacy dedicated namespace
+	// (labeled with NodeConfigNameLabel) left behind by older operator versions.
+	return nil
 }
 
 func (ncc *Controller) pruneNamespaces(ctx context.Context, requiredNamespaces []*corev1.Namespace, namespaces map[string]*corev1.Namespace) error {

--- a/pkg/controller/nodeconfig/sync_rolebindings.go
+++ b/pkg/controller/nodeconfig/sync_rolebindings.go
@@ -8,7 +8,6 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,9 +22,9 @@ func (ncc *Controller) syncRoleBindings(
 	var progressingConditions []metav1.Condition
 
 	requiredRoleBindings := []*rbacv1.RoleBinding{
-		makePerftuneRoleBinding(),
-		makeSysctlsRoleBinding(),
-		makeRlimitsRoleBinding(),
+		makePerftuneRoleBinding(ncc.namespace),
+		makeSysctlsRoleBinding(ncc.namespace),
+		makeRlimitsRoleBinding(ncc.namespace),
 	}
 
 	// Delete any excessive RoleBindings.
@@ -35,7 +34,7 @@ func (ncc *Controller) syncRoleBindings(
 		requiredRoleBindings,
 		roleBindings,
 		&controllerhelpers.PruneControlFuncs{
-			DeleteFunc: ncc.kubeClient.RbacV1().RoleBindings(naming.ScyllaOperatorNodeTuningNamespace).Delete,
+			DeleteFunc: ncc.kubeClient.RbacV1().RoleBindings(ncc.namespace).Delete,
 		},
 		ncc.eventRecorder)
 	if err != nil {

--- a/pkg/controller/nodeconfig/sync_roles.go
+++ b/pkg/controller/nodeconfig/sync_roles.go
@@ -8,7 +8,6 @@ import (
 
 	scyllav1alpha1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1alpha1"
 	"github.com/scylladb/scylla-operator/pkg/controllerhelpers"
-	"github.com/scylladb/scylla-operator/pkg/naming"
 	"github.com/scylladb/scylla-operator/pkg/resourceapply"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,9 +18,9 @@ func (ncc *Controller) syncRoles(ctx context.Context, nc *scyllav1alpha1.NodeCon
 	var progressingConditions []metav1.Condition
 
 	requiredRoles := []*rbacv1.Role{
-		makePerftuneRole(),
-		makeSysctlsRole(),
-		makeRlimitsRole(),
+		makePerftuneRole(ncc.namespace),
+		makeSysctlsRole(ncc.namespace),
+		makeRlimitsRole(ncc.namespace),
 	}
 
 	// Delete any excessive Roles.
@@ -31,7 +30,7 @@ func (ncc *Controller) syncRoles(ctx context.Context, nc *scyllav1alpha1.NodeCon
 		requiredRoles,
 		roles,
 		&controllerhelpers.PruneControlFuncs{
-			DeleteFunc: ncc.kubeClient.RbacV1().Roles(naming.ScyllaOperatorNodeTuningNamespace).Delete,
+			DeleteFunc: ncc.kubeClient.RbacV1().Roles(ncc.namespace).Delete,
 		},
 		ncc.eventRecorder)
 	if err != nil {

--- a/pkg/controller/nodeconfig/sync_serviceaccounts.go
+++ b/pkg/controller/nodeconfig/sync_serviceaccounts.go
@@ -16,10 +16,10 @@ import (
 
 func (ncc *Controller) makeServiceAccounts() []*corev1.ServiceAccount {
 	serviceAccounts := []*corev1.ServiceAccount{
-		makeNodeConfigServiceAccount(),
-		makePerftuneServiceAccount(),
-		makeSysctlsServiceAccount(),
-		makeRlimitsServiceAccount(),
+		makeNodeConfigServiceAccount(ncc.namespace),
+		makePerftuneServiceAccount(ncc.namespace),
+		makeSysctlsServiceAccount(ncc.namespace),
+		makeRlimitsServiceAccount(ncc.namespace),
 	}
 
 	return serviceAccounts

--- a/pkg/controller/scylladbmanagerclusterregistration/controller.go
+++ b/pkg/controller/scylladbmanagerclusterregistration/controller.go
@@ -66,6 +66,8 @@ type Controller struct {
 
 	queue    workqueue.TypedRateLimitingInterface[string]
 	handlers *controllerhelpers.Handlers[*scyllav1alpha1.ScyllaDBManagerClusterRegistration]
+
+	globalScyllaDBManagerNamespace string
 }
 
 func NewController(
@@ -76,6 +78,7 @@ func NewController(
 	scyllaDBClusterInformer scyllav1alpha1informers.ScyllaDBClusterInformer,
 	secretInformer corev1informers.SecretInformer,
 	namespaceInformer corev1informers.NamespaceInformer,
+	globalScyllaDBManagerNamespace string,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -107,6 +110,8 @@ func NewController(
 				Name: "scylladbmanagerclusterregistration",
 			},
 		),
+
+		globalScyllaDBManagerNamespace: globalScyllaDBManagerNamespace,
 	}
 
 	var err error
@@ -423,7 +428,7 @@ func (smcrc *Controller) enqueueThroughOwner(depth int, obj kubeinterfaces.Objec
 func (smcrc *Controller) enqueueThroughGlobalScyllaDBManagerNamespace(depth int, obj kubeinterfaces.ObjectInterface, op controllerhelpers.HandlerOperationType) {
 	ns := obj.(*corev1.Namespace)
 
-	if ns.Name != naming.ScyllaManagerNamespace {
+	if ns.Name != smcrc.globalScyllaDBManagerNamespace {
 		return
 	}
 

--- a/pkg/controller/scylladbmanagerclusterregistration/sync_finalizer.go
+++ b/pkg/controller/scylladbmanagerclusterregistration/sync_finalizer.go
@@ -31,10 +31,10 @@ func (smcrc *Controller) syncFinalizer(ctx context.Context, smcr *scyllav1alpha1
 	// We treat the `scylla-manager` namespace as the umbrella resource for the global ScyllaDB Manager instance.
 	// Clusters are considered deleted from global ScyllaDB Manager instance's state when `scylla-manager` namespace is not present.
 	if controllerhelpers.IsManagedByGlobalScyllaDBManagerInstance(smcr) {
-		_, err = smcrc.namespaceLister.Get(naming.ScyllaManagerNamespace)
+		_, err = smcrc.namespaceLister.Get(smcrc.globalScyllaDBManagerNamespace)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
-				return progressingConditions, fmt.Errorf("can't get namespace %q: %w", naming.ScyllaManagerNamespace, err)
+				return progressingConditions, fmt.Errorf("can't get namespace %q: %w", smcrc.globalScyllaDBManagerNamespace, err)
 			}
 
 			err = smcrc.removeFinalizer(ctx, smcr)
@@ -46,7 +46,7 @@ func (smcrc *Controller) syncFinalizer(ctx context.Context, smcr *scyllav1alpha1
 		}
 	}
 
-	managerClient, err := controllerhelpers.GetScyllaDBManagerClient(ctx, smcr)
+	managerClient, err := controllerhelpers.GetScyllaDBManagerClient(ctx, smcr, smcrc.globalScyllaDBManagerNamespace)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't get manager client: %w", err)
 	}

--- a/pkg/controller/scylladbmanagerclusterregistration/sync_manager.go
+++ b/pkg/controller/scylladbmanagerclusterregistration/sync_manager.go
@@ -99,7 +99,7 @@ func (smcrc *Controller) syncManager(
 		return progressingConditions, fmt.Errorf("can't make required ScyllaDB Manager cluster: %w", err)
 	}
 
-	managerClient, err := controllerhelpers.GetScyllaDBManagerClient(ctx, smcr)
+	managerClient, err := controllerhelpers.GetScyllaDBManagerClient(ctx, smcr, smcrc.globalScyllaDBManagerNamespace)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't get manager client: %w", err)
 	}

--- a/pkg/controller/scylladbmanagertask/controller.go
+++ b/pkg/controller/scylladbmanagertask/controller.go
@@ -60,6 +60,8 @@ type Controller struct {
 
 	queue    workqueue.TypedRateLimitingInterface[string]
 	handlers *controllerhelpers.Handlers[*scyllav1alpha1.ScyllaDBManagerTask]
+
+	globalScyllaDBManagerNamespace string
 }
 
 func NewController(
@@ -67,6 +69,7 @@ func NewController(
 	scyllaClient scyllav1alpha1client.ScyllaV1alpha1Interface,
 	scyllaDBManagerTaskInformer scyllav1alpha1informers.ScyllaDBManagerTaskInformer,
 	scylladbManagerClusterRegistrationInformer scyllav1alpha1informers.ScyllaDBManagerClusterRegistrationInformer,
+	globalScyllaDBManagerNamespace string,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -92,6 +95,8 @@ func NewController(
 				Name: "scylladbmanagertask",
 			},
 		),
+
+		globalScyllaDBManagerNamespace: globalScyllaDBManagerNamespace,
 	}
 
 	var err error

--- a/pkg/controller/scylladbmanagertask/sync_finalizer.go
+++ b/pkg/controller/scylladbmanagertask/sync_finalizer.go
@@ -62,7 +62,7 @@ func (smtc *Controller) syncFinalizer(ctx context.Context, smt *scyllav1alpha1.S
 
 	clusterID := *smcr.Status.ClusterID
 
-	managerClient, err := controllerhelpers.GetScyllaDBManagerClient(ctx, smcr)
+	managerClient, err := controllerhelpers.GetScyllaDBManagerClient(ctx, smcr, smtc.globalScyllaDBManagerNamespace)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't get ScyllaDB Manager client: %w", err)
 	}

--- a/pkg/controller/scylladbmanagertask/sync_manager.go
+++ b/pkg/controller/scylladbmanagertask/sync_manager.go
@@ -79,7 +79,7 @@ func (smtc *Controller) syncManager(
 
 	clusterID := *smcr.Status.ClusterID
 
-	managerClient, err := controllerhelpers.GetScyllaDBManagerClient(ctx, smcr)
+	managerClient, err := controllerhelpers.GetScyllaDBManagerClient(ctx, smcr, smtc.globalScyllaDBManagerNamespace)
 	if err != nil {
 		return progressingConditions, fmt.Errorf("can't get manager client: %w", err)
 	}

--- a/pkg/controllerhelpers/scylladbmanager.go
+++ b/pkg/controllerhelpers/scylladbmanager.go
@@ -18,8 +18,8 @@ import (
 
 var httpDefaultTransport = http.DefaultTransport.(*http.Transport).Clone()
 
-func GetScyllaDBManagerClient(_ context.Context, _ *scyllav1alpha1.ScyllaDBManagerClusterRegistration) (*managerclient.Client, error) {
-	url := fmt.Sprintf("http://%s.%s.svc/api/v1", naming.ScyllaManagerServiceName, naming.ScyllaManagerNamespace)
+func GetScyllaDBManagerClient(_ context.Context, _ *scyllav1alpha1.ScyllaDBManagerClusterRegistration, globalScyllaDBManagerNamespace string) (*managerclient.Client, error) {
+	url := fmt.Sprintf("http://%s.%s.svc/api/v1", naming.ScyllaManagerServiceName, globalScyllaDBManagerNamespace)
 	managerClient, err := managerclient.NewClient(url, func(httpClient *http.Client) {
 		httpClient.Transport = httpDefaultTransport
 		// Limit manager calls by default to a higher bound.

--- a/pkg/naming/constants.go
+++ b/pkg/naming/constants.go
@@ -216,6 +216,9 @@ const (
 	ScyllaManagerServiceName                = "scylla-manager"
 	StandaloneScyllaDBManagerControllerName = "scylla-manager-controller"
 
+	// ScyllaOperatorNodeTuningNamespace is the legacy dedicated namespace that older operator versions
+	// created for node tuning resources. Node tuning now runs in the operator's own namespace;
+	// the constant is kept for collecting the legacy namespace in must-gather.
 	ScyllaOperatorNodeTuningNamespace = "scylla-operator-node-tuning"
 
 	ScyllaClusterMemberClusterRoleName = "scyllacluster-member"

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -34,6 +34,10 @@ const (
 	ServiceAccountTokenSecretName        = "e2e-user-token"
 	serviceAccountWaitTimeout            = 1 * time.Minute
 	serviceAccountTokenSecretWaitTimeout = 1 * time.Minute
+
+	// OperatorNamespace is the namespace the tests expect Scylla Operator to be deployed into.
+	// Node tuning resources created by the NodeConfig controller live in the same namespace.
+	OperatorNamespace = "scylla-operator"
 )
 
 type Framework struct {

--- a/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
+++ b/test/e2e/set/nodeconfig/nodeconfig_optimizations.go
@@ -99,7 +99,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.SuiteSerial, func() {
 		verifyNodeConfig(ctx, f.KubeAdminClient(), nc)
 
 		// There should be a tuning job for every scylla node.
-		nodeJobList, err := f.KubeAdminClient().BatchV1().Jobs(naming.ScyllaOperatorNodeTuningNamespace).List(ctx, metav1.ListOptions{
+		nodeJobList, err := f.KubeAdminClient().BatchV1().Jobs(framework.OperatorNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(labels.Set{
 				naming.NodeConfigNameLabel:    nc.Name,
 				naming.NodeConfigJobTypeLabel: string(naming.NodeConfigJobTypeNodePerftune),
@@ -221,7 +221,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.SuiteSerial, func() {
 			ctx,
 			&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: naming.ScyllaOperatorNodeTuningNamespace,
+					Name: framework.OperatorNamespace,
 				},
 			},
 			metav1.CreateOptions{},
@@ -233,7 +233,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.SuiteSerial, func() {
 		rq := &corev1.ResourceQuota{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resourceQuotaName,
-				Namespace: naming.ScyllaOperatorNodeTuningNamespace,
+				Namespace: framework.OperatorNamespace,
 			},
 			Spec: corev1.ResourceQuotaSpec{
 				Hard: corev1.ResourceList{
@@ -254,7 +254,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.SuiteSerial, func() {
 		f.AddCleaners(rqRC)
 		rqRC.DeleteObject(ctx, true)
 
-		rq, err = f.KubeAdminClient().CoreV1().ResourceQuotas(naming.ScyllaOperatorNodeTuningNamespace).Create(
+		rq, err = f.KubeAdminClient().CoreV1().ResourceQuotas(framework.OperatorNamespace).Create(
 			ctx,
 			rq,
 			metav1.CreateOptions{},
@@ -391,7 +391,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.SuiteSerial, func() {
 
 		framework.By("Bumping tuning DaemonSet sync and waiting for it to become healthy")
 
-		dsList, err := f.KubeAdminClient().AppsV1().DaemonSets(naming.ScyllaOperatorNodeTuningNamespace).List(ctx, metav1.ListOptions{
+		dsList, err := f.KubeAdminClient().AppsV1().DaemonSets(framework.OperatorNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.Set{
 				"app.kubernetes.io/name": naming.NodeConfigAppName,
 			}.AsSelector().String(),
@@ -403,7 +403,7 @@ var _ = g.Describe("NodeConfig Optimizations", framework.SuiteSerial, func() {
 		// At this point the DaemonSet controller in kube-controller-manager is notably rate-limited
 		// because of resource quota failures. We have to trigger an event to reset its queue rate limiter,
 		// or there will be a large delay.
-		ds, err = f.KubeAdminClient().AppsV1().DaemonSets(naming.ScyllaOperatorNodeTuningNamespace).Patch(
+		ds, err = f.KubeAdminClient().AppsV1().DaemonSets(framework.OperatorNamespace).Patch(
 			ctx,
 			ds.Name,
 			types.JSONPatchType,

--- a/test/e2e/utils/helpers.go
+++ b/test/e2e/utils/helpers.go
@@ -331,7 +331,7 @@ func GetPodsForStatefulSet(ctx context.Context, client corev1client.CoreV1Interf
 }
 
 func GetDaemonSetsForNodeConfig(ctx context.Context, client appv1client.AppsV1Interface, nc *scyllav1alpha1.NodeConfig) ([]*appsv1.DaemonSet, error) {
-	daemonSetList, err := client.DaemonSets(naming.ScyllaOperatorNodeTuningNamespace).List(ctx, metav1.ListOptions{
+	daemonSetList, err := client.DaemonSets(framework.OperatorNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set{
 			naming.NodeConfigNameLabel: nc.Name,
 		}.AsSelector().String(),


### PR DESCRIPTION
## Description of your changes

Makes the ScyllaDB Operator and ScyllaDB Manager namespaces configurable, so both components can be installed into custom namespaces (including a single shared namespace), while keeping `scylla-operator`/`scylla-manager` as the defaults with a fully backward-compatible upgrade path.

Previous attempts (#801, #2683, #2755) only templated the Helm charts and were rejected because the operator's controllers rely on the hardcoded `scylla-manager` namespace. This PR wires the namespace through the controllers as well:

- New `--global-scylladb-manager-namespace` flag on `scylla-operator operator` (default: `scylla-manager`), plumbed into:
  - the `globalscylladbmanager` controller (namespace-existence check that gates creating `ScyllaDBManagerClusterRegistration` objects, and the namespace event filter),
  - the `scylladbmanagerclusterregistration` controller (global-manager namespace enqueue fan-out and the finalizer's namespace-existence check),
  - the `scylladbmanagertask` controller,
  - `controllerhelpers.GetScyllaDBManagerClient` (the ScyllaDB Manager API URL, previously hardcoded to `http://scylla-manager.scylla-manager.svc/api/v1`).
- `must-gather`: the default collected namespaces can be overridden with `--collect-namespaces`.
- Helm charts: namespace fields templated with `.Release.Namespace` (deployments, service accounts, services, PDBs, cert-manager Issuer/Certificate + webhook CA injection annotations and certificate DNS names, ClusterRoleBinding subject, webhook `clientConfig`), new `scyllaDBManagerNamespace` value on the operator chart (feeds the new flag) and `scyllaOperatorNamespace` value on the manager chart (NetworkPolicy peer selector).
- Docs: lifted the fixed-namespace restriction, documented how to install into custom namespaces.

`deploy/*.yaml` generated manifests are **unchanged** — the Makefile already renders charts with `--namespace=<release name>`, so default output is byte-identical.

Additionally, node tuning no longer uses a dedicated fixed namespace: the NodeConfig controller now deploys its DaemonSets, Jobs, and RBAC into the operator's own namespace. Nothing required the separate namespace technically (SCC access is granted per ServiceAccount, no Pod Security labels were set on it, and the in-pod agents already auto-detect their namespace); it was a fixed name by the same design decision as the others. On upgrade, the legacy `scylla-operator-node-tuning` namespace (labeled by older operators) is pruned automatically and tuning resources are recreated in the operator namespace. With this, no component depends on a fixed namespace name anymore.

Out of scope (unchanged): cluster-scoped object names (webhook configurations, ClusterRoles), which still assume a single operator installation per Kubernetes cluster.

## Testing

Verified on a local kind cluster (`make kind-setup` stack) in three configurations, each checking that a test `ScyllaCluster` gets a `ScyllaDBManagerClusterRegistration` with `status.clusterID` populated and shows up in `sctool cluster list` inside the manager pod:

1. **Defaults (regression)**: stock `deploy/` manifests, operator in `scylla-operator`, manager in `scylla-manager`.
2. **Custom namespaces**: operator chart in `custom-so` (`scyllaDBManagerNamespace=custom-sm`), manager chart in `custom-sm` (`scyllaOperatorNamespace=custom-so`).
3. **Single shared namespace**: both charts in `scylla-stack`.
4. **Node tuning**: a sysctls NodeConfig deploys its node-setup DaemonSet, tuning Jobs, and RBAC into the operator's namespace (verified in the shared-namespace deployment), and a planted legacy `scylla-operator-node-tuning` namespace is pruned automatically.

Unit tests for the affected packages pass; `make update-deploy` produces no changes.

Ref: https://scylladb.atlassian.net/browse/OPERATOR-411
Resolves #2563

## Documentation

Updated:
- `docs/source/install-operator/install-with-helm.md`
- `docs/source/deploy-scylladb/install-scylladb-manager.md`
- `docs/source/understand/index.md`, `docs/source/understand/manager.md`
